### PR TITLE
ci: make path-filtered PR checks always report status

### DIFF
--- a/.github/workflows/android_pr.yml
+++ b/.github/workflows/android_pr.yml
@@ -5,18 +5,14 @@ name: Android PR Checks
 # :shared is the KMP module at repo-root /shared, included by both roots.
 # PR checks build the DEBUG variant only (auto-signed with the debug key),
 # so no release keystore / secrets are required.
+#
+# Runs on every PR to main so the required `phone` / `tv` statuses always
+# report, but the Gradle build only runs when android-relevant paths change
+# (see the paths-filter step). On unrelated PRs each leg is a no-op pass.
 
 on:
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'mobile/android/**'
-      - 'tv/android/**'
-      - 'shared/**'
-      - 'protocol/**'
-      - 'gradle/**'
-      - '.gitmodules'
-      - '.github/workflows/android_pr.yml'
   workflow_dispatch:
 
 concurrency:
@@ -25,6 +21,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   check:
@@ -43,11 +40,26 @@ jobs:
       run:
         working-directory: ./${{ matrix.dir }}
     steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'mobile/android/**'
+              - 'tv/android/**'
+              - 'shared/**'
+              - 'protocol/**'
+              - 'gradle/**'
+              - '.gitmodules'
+              - '.github/workflows/android_pr.yml'
+
       - uses: actions/checkout@v4
+        if: steps.filter.outputs.relevant == 'true'
         with:
           submodules: recursive
 
       - name: Set up JDK 17
+        if: steps.filter.outputs.relevant == 'true'
         uses: actions/setup-java@v4
         with:
           java-version: '17'
@@ -55,6 +67,7 @@ jobs:
           cache: gradle
 
       - name: Grant execute permission for gradlew
+        if: steps.filter.outputs.relevant == 'true'
         run: chmod +x gradlew
 
       # Blocking gate: compile all apps, run unit tests across every module
@@ -62,4 +75,5 @@ jobs:
       # lint issues are recorded in per-module lint-baseline.xml files, so Lint
       # fails only on NEW issues a change introduces.
       - name: Assemble (debug), test & lint
+        if: steps.filter.outputs.relevant == 'true'
         run: ./gradlew assembleDebug check --stacktrace

--- a/.github/workflows/desktop_pr.yml
+++ b/.github/workflows/desktop_pr.yml
@@ -2,15 +2,14 @@ name: Desktop PR Checks
 # Flutter (libmpv/media_kit) desktop receiver.
 # Analyze + test run on a single Linux runner without native builds;
 # the cross-platform release build stays in desktop_build.yml.
+#
+# Runs on every PR to main so the required `desktop` status always reports,
+# but the heavy Flutter steps only execute when desktop-relevant paths change
+# (see the paths-filter step). On unrelated PRs the job is a fast no-op pass.
 
 on:
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'desktop/**'
-      - 'protocol/**'
-      - '.gitmodules'
-      - '.github/workflows/desktop_pr.yml'
   workflow_dispatch:
 
 concurrency:
@@ -19,6 +18,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   check:
@@ -29,23 +29,39 @@ jobs:
       run:
         working-directory: ./desktop
     steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'desktop/**'
+              - 'protocol/**'
+              - '.gitmodules'
+              - '.github/workflows/desktop_pr.yml'
+
       - uses: actions/checkout@v4
+        if: steps.filter.outputs.relevant == 'true'
         with:
           submodules: recursive
 
       - uses: subosito/flutter-action@v2
+        if: steps.filter.outputs.relevant == 'true'
         with:
           channel: stable
           cache: true
 
       - name: Install dependencies
+        if: steps.filter.outputs.relevant == 'true'
         run: flutter pub get
 
       - name: Verify formatting
+        if: steps.filter.outputs.relevant == 'true'
         run: dart format --output=none --set-exit-if-changed .
 
       - name: Analyze
+        if: steps.filter.outputs.relevant == 'true'
         run: flutter analyze
 
       - name: Run tests
+        if: steps.filter.outputs.relevant == 'true'
         run: flutter test

--- a/.github/workflows/extension_pr.yml
+++ b/.github/workflows/extension_pr.yml
@@ -1,14 +1,13 @@
 name: Extension PR Checks
 # protocol submodule: playbridgeapp/playbridge-protocol
+#
+# Runs on every PR to main so the required `extension` status always reports,
+# but the heavy build steps only execute when extension-relevant paths change
+# (see the paths-filter step). On unrelated PRs the job is a fast no-op pass.
 
 on:
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'extension/**'
-      - 'protocol/**'
-      - '.gitmodules'
-      - '.github/workflows/extension_pr.yml'
   workflow_dispatch:
 
 concurrency:
@@ -17,6 +16,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   check:
@@ -27,27 +27,43 @@ jobs:
       run:
         working-directory: ./extension
     steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'extension/**'
+              - 'protocol/**'
+              - '.gitmodules'
+              - '.github/workflows/extension_pr.yml'
+
       - uses: actions/checkout@v4
+        if: steps.filter.outputs.relevant == 'true'
         with:
           submodules: true
 
       - uses: actions/setup-node@v4
+        if: steps.filter.outputs.relevant == 'true'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: extension/package-lock.json
 
       - name: Install dependencies
+        if: steps.filter.outputs.relevant == 'true'
         run: npm ci
 
       # esbuild (npm run build) does NOT type-check, so do it explicitly.
       - name: Type check
+        if: steps.filter.outputs.relevant == 'true'
         run: npx tsc --noEmit
 
       - name: Build
+        if: steps.filter.outputs.relevant == 'true'
         run: npm run build
 
       # Validate the built add-on the same way AMO will before the release
       # signing pipeline runs. Catches manifest / API issues early.
       - name: Lint extension (web-ext)
+        if: steps.filter.outputs.relevant == 'true'
         run: npx --yes web-ext lint --source-dir dist

--- a/.github/workflows/web_pr.yml
+++ b/.github/workflows/web_pr.yml
@@ -1,11 +1,12 @@
 name: Web PR Checks
+#
+# Runs on every PR to main so the required `web` status always reports,
+# but the heavy build steps only execute when web-relevant paths change
+# (see the paths-filter step). On unrelated PRs the job is a fast no-op pass.
 
 on:
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'web/site/**'
-      - '.github/workflows/web_pr.yml'
   workflow_dispatch:
 
 # Cancel superseded runs on the same PR.
@@ -15,6 +16,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   check:
@@ -25,23 +27,37 @@ jobs:
       run:
         working-directory: ./web/site
     steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'web/site/**'
+              - '.github/workflows/web_pr.yml'
+
       - uses: actions/checkout@v4
+        if: steps.filter.outputs.relevant == 'true'
 
       - uses: pnpm/action-setup@v4
+        if: steps.filter.outputs.relevant == 'true'
         with:
           version: 9
 
       - uses: actions/setup-node@v4
+        if: steps.filter.outputs.relevant == 'true'
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: web/site/pnpm-lock.yaml
 
       - name: Install dependencies
+        if: steps.filter.outputs.relevant == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Type & Svelte check
+        if: steps.filter.outputs.relevant == 'true'
         run: pnpm check
 
       - name: Build
+        if: steps.filter.outputs.relevant == 'true'
         run: pnpm build


### PR DESCRIPTION
## Problem

The `desktop`, `extension`, `web`, `phone`, and `tv` PR checks are marked **Required** in branch protection, but each workflow was gated by a trigger `paths:` filter. When a PR doesn't touch a given area, that workflow never runs — so its required status is never reported and the PR sits forever on **"Expected — Waiting for status to be reported."** (Exactly what blocked #7: phone/tv passed, but desktop/extension/web never reported.)

## Fix

For each PR workflow (`android`, `desktop`, `extension`, `web`):
- Remove the trigger `paths:` filter so the workflow runs on **every** PR to `main`.
- Move the path gating into a [`dorny/paths-filter`](https://github.com/dorny/paths-filter) step and guard the heavy build steps with `if: steps.filter.outputs.relevant == 'true'`.

The job always completes (so the required status reports green), but the real build only runs when relevant paths change — unrelated PRs get a fast no-op pass. Check names (`phone`, `tv`, `desktop`, `extension`, `web`) are unchanged, so no branch-protection edits are needed.

For `pull_request` events `dorny/paths-filter` reads changed files via the API (no checkout needed), hence the added `pull-requests: read` permission.

## Note on this PR

Editing each `*_pr.yml` keeps it in its own filter set, so all five checks should actually **run** here and exercise the change. Future unrelated PRs will then no-op-pass instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)