### PR TITLE
Receiver parity (desktop/tvOS) + cross-platform player polish

### DIFF
--- a/desktop/lib/engines/mpv_engine.dart
+++ b/desktop/lib/engines/mpv_engine.dart
@@ -59,12 +59,142 @@ class MpvEngine extends PlayerEngine {
   @override
   Track get track => player.state.track;
 
+  // ─── Track selection ────────────────────────────────────────────────────
+  //
+  // Selections are remembered as *language* preferences (plus an explicit
+  // subs-off flag) and re-applied after every item open, so a pick made on
+  // episode 3 carries into episode 4 — track ids differ between files, but
+  // languages don't.
+
+  String? _preferredAudioLang;
+  String? _preferredSubLang;
+  bool _subsOff = false;
+
   @override
-  Future<void> setAudioTrack(dynamic t) =>
-      player.setAudioTrack(t as AudioTrack);
+  Future<void> setAudioTrack(dynamic t) async {
+    final track = t as AudioTrack;
+    _rememberAudioPref(track);
+    await player.setAudioTrack(track);
+  }
+
   @override
-  Future<void> setSubtitleTrack(dynamic t) =>
-      player.setSubtitleTrack(t as SubtitleTrack);
+  Future<void> setSubtitleTrack(dynamic t) async {
+    final track = t as SubtitleTrack;
+    _rememberSubPref(track);
+    await player.setSubtitleTrack(track);
+  }
+
+  void _rememberAudioPref(AudioTrack track) {
+    if (track.id == 'auto') {
+      _preferredAudioLang = null;
+    } else if (track.id != 'no') {
+      final lang = track.language;
+      if (lang != null && lang.isNotEmpty) _preferredAudioLang = lang;
+    }
+  }
+
+  void _rememberSubPref(SubtitleTrack track) {
+    if (track.id == 'no') {
+      _subsOff = true;
+      _preferredSubLang = null;
+    } else if (track.id == 'auto') {
+      _subsOff = false;
+      _preferredSubLang = null;
+    } else {
+      _subsOff = false;
+      final lang = track.language;
+      if (lang != null && lang.isNotEmpty) _preferredSubLang = lang;
+    }
+  }
+
+  String _trackName(String id, String? title, String? language, int n) {
+    if (title != null && title.isNotEmpty) {
+      return language != null && language.isNotEmpty ? '$title ($language)' : title;
+    }
+    if (language != null && language.isNotEmpty) return language;
+    return 'Track $n';
+  }
+
+  bool _isRealTrack(String id) => id != 'auto' && id != 'no';
+
+  @override
+  List<TrackInfo> get audioTrackInfos {
+    final current = player.state.track.audio.id;
+    final real =
+        player.state.tracks.audio.where((t) => _isRealTrack(t.id)).toList();
+    return [
+      for (var i = 0; i < real.length; i++)
+        TrackInfo(
+          id: real[i].id,
+          name: _trackName(real[i].id, real[i].title, real[i].language, i + 1),
+          selected: real[i].id == current,
+        ),
+    ];
+  }
+
+  @override
+  List<TrackInfo> get subtitleTrackInfos {
+    final current = player.state.track.subtitle.id;
+    final real =
+        player.state.tracks.subtitle.where((t) => _isRealTrack(t.id)).toList();
+    return [
+      TrackInfo(id: 'no', name: 'Off', selected: current == 'no'),
+      for (var i = 0; i < real.length; i++)
+        TrackInfo(
+          id: real[i].id,
+          name: _trackName(real[i].id, real[i].title, real[i].language, i + 1),
+          selected: real[i].id == current,
+        ),
+    ];
+  }
+
+  @override
+  Future<void> selectAudioTrackById(String id) async {
+    if (id == 'auto') return setAudioTrack(AudioTrack.auto());
+    if (id == 'no') return setAudioTrack(AudioTrack.no());
+    final match = player.state.tracks.audio.where((t) => t.id == id);
+    if (match.isNotEmpty) await setAudioTrack(match.first);
+  }
+
+  @override
+  Future<void> selectSubtitleTrackById(String id) async {
+    if (id == 'auto') return setSubtitleTrack(SubtitleTrack.auto());
+    if (id == 'no') return setSubtitleTrack(SubtitleTrack.no());
+    final match = player.state.tracks.subtitle.where((t) => t.id == id);
+    if (match.isNotEmpty) await setSubtitleTrack(match.first);
+  }
+
+  /// Re-apply remembered preferences once the new item's tracks are known.
+  /// Called after every open; waits (bounded) for mpv to enumerate tracks.
+  Future<void> _reapplyTrackPrefs() async {
+    if (_preferredAudioLang == null && _preferredSubLang == null && !_subsOff) {
+      return;
+    }
+    var retries = 0;
+    while (player.state.tracks.audio.where((t) => _isRealTrack(t.id)).isEmpty &&
+        retries < 30) {
+      await Future.delayed(const Duration(milliseconds: 100));
+      retries++;
+    }
+
+    final audioLang = _preferredAudioLang;
+    if (audioLang != null) {
+      final match = player.state.tracks.audio
+          .where((t) => _isRealTrack(t.id) && t.language == audioLang);
+      if (match.isNotEmpty) await player.setAudioTrack(match.first);
+    }
+
+    if (_subsOff) {
+      await player.setSubtitleTrack(SubtitleTrack.no());
+    } else {
+      final subLang = _preferredSubLang;
+      if (subLang != null) {
+        final match = player.state.tracks.subtitle
+            .where((t) => _isRealTrack(t.id) && t.language == subLang);
+        if (match.isNotEmpty) await player.setSubtitleTrack(match.first);
+      }
+    }
+  }
 
   @override
   Future<void> open(QueueItem item) => openPlaylist([item], 0);
@@ -94,6 +224,7 @@ class MpvEngine extends PlayerEngine {
       }
     }
     await player.play();
+    unawaited(_reapplyTrackPrefs());
   }
 
   @override
@@ -127,6 +258,17 @@ class MpvEngine extends PlayerEngine {
         await native.setProperty('demuxer-max-bytes', '314572800');
         await native.setProperty('demuxer-max-back-bytes', '104857600');
         await native.setProperty('network-timeout', '60');
+        // Tuning ported from the tvOS receiver (see MPVPlayerView.swift):
+        // - framedrop=decoder+vo: when decode can't keep up (high-bitrate HEVC),
+        //   drop at the decoder too instead of letting A/V drift — the default
+        //   "vo" only drops already-decoded frames.
+        // - demuxer-readahead-secs + audio-buffer: debrid hosts stall in bursts;
+        //   a deeper time-based readahead and a 1s audio buffer ride over them.
+        // (video-sync=display-resync is deliberately NOT set: media_kit's render
+        // API doesn't report vsync timing, so it can't engage and may misbehave.)
+        await native.setProperty('framedrop', 'decoder+vo');
+        await native.setProperty('demuxer-readahead-secs', '30');
+        await native.setProperty('audio-buffer', '1.0');
       } catch (e) {
         debugPrint('[mpv] failed to tune: $e');
       }

--- a/desktop/lib/engines/mpv_engine.dart
+++ b/desktop/lib/engines/mpv_engine.dart
@@ -109,7 +109,9 @@ class MpvEngine extends PlayerEngine {
 
   String _trackName(String id, String? title, String? language, int n) {
     if (title != null && title.isNotEmpty) {
-      return language != null && language.isNotEmpty ? '$title ($language)' : title;
+      return language != null && language.isNotEmpty
+          ? '$title ($language)'
+          : title;
     }
     if (language != null && language.isNotEmpty) return language;
     return 'Track $n';

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -17,6 +17,7 @@ import 'pair_screen.dart';
 import 'player_controller.dart';
 import 'player_engine.dart';
 import 'playback_surface.dart';
+import 'preplay_overlay.dart';
 import 'server.dart';
 import 'settings_screen.dart';
 import 'shader_background.dart';
@@ -88,6 +89,16 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
 
   bool _hadMedia = false;
   String? _lastTrackedUrl;
+
+  /// Last coarse player state the shell was built for. The root builder no
+  /// longer listens to the player directly (see build), so real transitions
+  /// (queue, state, index) trigger a setState here instead.
+  (bool, int, String, int)? _lastCoarse;
+
+  // Pre-play screen state: the item being introduced, and the volume to
+  // restore once playback starts (video buffers muted behind the overlay).
+  QueueItem? _prePlayItem;
+  double? _prePlayPrevVolume;
 
   String _hostInfo = 'starting…';
   String? _serverError;
@@ -161,6 +172,29 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     if (!_showingVideo) {
       setState(() => _showingVideo = true);
     }
+    _maybeShowPrePlay();
+  }
+
+  /// Show the pre-play screen for remote casts that carry visual metadata.
+  /// The video keeps buffering underneath, muted; volume is restored on start.
+  void _maybeShowPrePlay() {
+    final idx = _player.currentIndex;
+    final item = (idx >= 0 && idx < _player.queue.length)
+        ? _player.queue[idx]
+        : null;
+    if (item == null || !item.hasPrePlayMetadata) return;
+    _prePlayPrevVolume ??= _player.volume;
+    unawaited(_player.setVolume(0));
+    setState(() => _prePlayItem = item);
+  }
+
+  void _dismissPrePlay() {
+    final prev = _prePlayPrevVolume;
+    _prePlayPrevVolume = null;
+    if (prev != null) unawaited(_player.setVolume(prev));
+    if (_prePlayItem != null && mounted) {
+      setState(() => _prePlayItem = null);
+    }
   }
 
   void _handlePlayerChange() {
@@ -173,10 +207,24 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
 
     // Falling edge: playback ended → leave video view.
     if (!hasMedia && _hadMedia) {
+      _dismissPrePlay();
       setState(() => _showingVideo = false);
     }
 
     _hadMedia = hasMedia;
+
+    // Coarse shell rebuild on real transitions only (the root builder doesn't
+    // listen to the player; per-frame position ticks stay out of the shell).
+    final coarse = (
+      hasMedia,
+      _player.queue.length,
+      _player.state,
+      _player.currentIndex,
+    );
+    if (coarse != _lastCoarse) {
+      _lastCoarse = coarse;
+      if (mounted) setState(() {});
+    }
 
     // Record history when the active track changes.
     if (hasMedia) {
@@ -356,8 +404,13 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
             autofocus: true,
             child: Scaffold(
               backgroundColor: Colors.transparent,
+              // Deliberately NOT listening to _player here: it notifies on every
+              // ~200ms position tick, and rebuilding the whole shell (backdrop
+              // blurs included) at 5Hz steals frame time from the video. The
+              // controls/status bars listen to the player themselves; structural
+              // changes arrive via the coarse setState in _handlePlayerChange.
               body: AnimatedBuilder(
-                animation: Listenable.merge([_server, _player, _showStats]),
+                animation: Listenable.merge([_server, _showStats]),
                 builder: (context, _) {
                   final hasMedia = _player.queue.isNotEmpty;
                   final hasQueue = _player.queue.length > 1;
@@ -522,6 +575,33 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
                                                 () =>
                                                     _playlistDrawerOpen = false,
                                               ),
+                                            ),
+                                          ),
+                                        // Title scrim along the top — same
+                                        // visibility as the controls bar, so
+                                        // the title is reachable in fullscreen.
+                                        if (_showingVideo && hasMedia)
+                                          Positioned(
+                                            left: 0,
+                                            right: 0,
+                                            top: 0,
+                                            child: _TitleOverlay(
+                                              player: _player,
+                                              visible: _videoHovered ||
+                                                  _playlistDrawerOpen ||
+                                                  _menusOpen > 0,
+                                            ),
+                                          ),
+                                        // Pre-play screen for casts with
+                                        // metadata; sits above everything.
+                                        if (_showingVideo &&
+                                            _prePlayItem != null)
+                                          Positioned.fill(
+                                            child: PrePlayOverlay(
+                                              key: ValueKey(
+                                                  _prePlayItem!.url),
+                                              item: _prePlayItem!,
+                                              onStart: _dismissPrePlay,
                                             ),
                                           ),
                                       ],
@@ -788,6 +868,14 @@ class _StatusBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Self-listening for the live position readout (see _PlayerControlsBar).
+    return ListenableBuilder(
+      listenable: player,
+      builder: (context, _) => _buildBar(context),
+    );
+  }
+
+  Widget _buildBar(BuildContext context) {
     final pos = Duration(milliseconds: player.positionMs);
     final dur = Duration(milliseconds: player.durationMs);
     final phaseLabel = switch (phase) {
@@ -856,6 +944,77 @@ class _StatusBar extends StatelessWidget {
 
 // ─── Player controls bar ─────────────────────────────────────────────────────
 
+/// Auto-hiding title scrim along the top of the video — mirrors the controls
+/// bar visibility so the title is visible in fullscreen on hover.
+class _TitleOverlay extends StatelessWidget {
+  const _TitleOverlay({required this.player, required this.visible});
+
+  final PlayerController player;
+  final bool visible;
+
+  @override
+  Widget build(BuildContext context) {
+    final idx = player.currentIndex;
+    final item = (idx >= 0 && idx < player.queue.length)
+        ? player.queue[idx]
+        : null;
+    final title = item?.title ?? player.currentTitle ?? '';
+    if (title.isEmpty) return const SizedBox.shrink();
+
+    final hasEpisode = item?.season != null && item?.episode != null;
+    final subtitle = hasEpisode
+        ? 'S${item!.season} · E${item.episode}'
+            '${item.episodeTitle != null ? '  ${item.episodeTitle}' : ''}'
+        : null;
+
+    return IgnorePointer(
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 150),
+        opacity: visible ? 1.0 : 0.0,
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 36),
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [Color(0xB3000000), Color(0x00000000)],
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w700,
+                  color: Colors.white,
+                ),
+              ),
+              if (subtitle != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 2),
+                  child: Text(
+                    subtitle,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Colors.white.withValues(alpha: 0.75),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _PlayerControlsBar extends StatefulWidget {
   const _PlayerControlsBar({
     required this.player,
@@ -890,6 +1049,16 @@ class _PlayerControlsBarState extends State<_PlayerControlsBar> {
 
   @override
   Widget build(BuildContext context) {
+    // Self-listening: the shell no longer rebuilds on player ticks, so the
+    // scrubber/buttons subscribe to the player here, scoping the ~5Hz position
+    // rebuilds to just this bar.
+    return ListenableBuilder(
+      listenable: widget.player,
+      builder: (context, _) => _buildBar(context),
+    );
+  }
+
+  Widget _buildBar(BuildContext context) {
     final p = widget.player;
     final dur = p.durationMs.toDouble();
     final pos =

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -179,9 +179,8 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   /// The video keeps buffering underneath, muted; volume is restored on start.
   void _maybeShowPrePlay() {
     final idx = _player.currentIndex;
-    final item = (idx >= 0 && idx < _player.queue.length)
-        ? _player.queue[idx]
-        : null;
+    final item =
+        (idx >= 0 && idx < _player.queue.length) ? _player.queue[idx] : null;
     if (item == null || !item.hasPrePlayMetadata) return;
     _prePlayPrevVolume ??= _player.volume;
     unawaited(_player.setVolume(0));
@@ -598,8 +597,7 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
                                             _prePlayItem != null)
                                           Positioned.fill(
                                             child: PrePlayOverlay(
-                                              key: ValueKey(
-                                                  _prePlayItem!.url),
+                                              key: ValueKey(_prePlayItem!.url),
                                               item: _prePlayItem!,
                                               onStart: _dismissPrePlay,
                                             ),
@@ -955,9 +953,8 @@ class _TitleOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final idx = player.currentIndex;
-    final item = (idx >= 0 && idx < player.queue.length)
-        ? player.queue[idx]
-        : null;
+    final item =
+        (idx >= 0 && idx < player.queue.length) ? player.queue[idx] : null;
     final title = item?.title ?? player.currentTitle ?? '';
     if (title.isEmpty) return const SizedBox.shrink();
 

--- a/desktop/lib/player_controller.dart
+++ b/desktop/lib/player_controller.dart
@@ -82,6 +82,10 @@ class PlayerController extends ChangeNotifier {
   /// auto-advance). The server listens to this to broadcast playlist_status.
   final ValueNotifier<int> indexChanges = ValueNotifier<int>(-1);
 
+  /// Bumped whenever the queue *contents* change without the index moving
+  /// (queue_add, stop). The server also listens to this for playlist_status.
+  final ValueNotifier<int> queueChanges = ValueNotifier<int>(0);
+
   final List<QueueItem> _queue = [];
   int _currentIndex = -1;
 
@@ -110,6 +114,15 @@ class PlayerController extends ChangeNotifier {
   Future<void> setAudioTrack(dynamic t) => _engine.setAudioTrack(t);
   Future<void> setSubtitleTrack(dynamic t) => _engine.setSubtitleTrack(t);
 
+  // Engine-agnostic track surface for the phone remote (`tracks` message +
+  // `audio_track:`/`sub_track:` control commands).
+  List<TrackInfo> get audioTrackInfos => _engine.audioTrackInfos;
+  List<TrackInfo> get subtitleTrackInfos => _engine.subtitleTrackInfos;
+  Future<void> selectAudioTrackById(String id) =>
+      _engine.selectAudioTrackById(id);
+  Future<void> selectSubtitleTrackById(String id) =>
+      _engine.selectSubtitleTrackById(id);
+
   Future<void> playUrl(
     String url, {
     String? title,
@@ -117,20 +130,23 @@ class PlayerController extends ChangeNotifier {
     List<String>? subtitles,
     bool isRemote = false,
   }) async {
-    _queue
-      ..clear()
-      ..add((
-        url: url,
-        title: title ?? url,
-        headers: headers,
-        subtitles: subtitles,
-      ));
-    _setIndex(0);
-    if (isRemote) {
-      playRequests.value++;
-    }
-    await _engine.openPlaylist(_queue, _currentIndex);
+    await playPlaylist(
+      [
+        QueueItem(
+          url: url,
+          title: title ?? url,
+          headers: headers,
+          subtitles: subtitles,
+        ),
+      ],
+      0,
+      isRemote: isRemote,
+    );
   }
+
+  /// Play a single [QueueItem] as a one-item playlist (replaces the queue).
+  Future<void> playItem(QueueItem item, {bool isRemote = false}) =>
+      playPlaylist([item], 0, isRemote: isRemote);
 
   Future<void> playPlaylist(
     List<QueueItem> items,
@@ -146,12 +162,27 @@ class PlayerController extends ChangeNotifier {
       playRequests.value++;
     }
     await _engine.openPlaylist(_queue, _currentIndex);
+    unawaited(_applyStartPosition());
+  }
+
+  /// Append an item to the live queue (`queue_add`). If nothing is playing,
+  /// starts the item directly (preserves the previous desktop behavior;
+  /// Android instead buffers idle queue_adds until the next session).
+  Future<void> queueAdd(QueueItem item, {bool isRemote = false}) async {
+    if (_currentIndex < 0 || _queue.isEmpty) {
+      await playPlaylist([item], 0, isRemote: isRemote);
+      return;
+    }
+    _queue.add(item);
+    queueChanges.value++;
+    notifyListeners();
   }
 
   Future<void> jumpTo(int index) async {
     if (index < 0 || index >= _queue.length) return;
     _setIndex(index);
     await _engine.openPlaylist(_queue, _currentIndex);
+    unawaited(_applyStartPosition());
   }
 
   Future<void> next() async {
@@ -170,6 +201,35 @@ class PlayerController extends ChangeNotifier {
     }
   }
 
+  /// Honour the current item's `start_position_ms` (phone resume store).
+  /// Consumes the value so replaying the same item starts from zero. Waits for
+  /// the engine to report a duration first — mpv can't seek before that — and
+  /// skips the seek when the resume point is past the end (stale store entry).
+  Future<void> _applyStartPosition() async {
+    final item = _currentIndex >= 0 && _currentIndex < _queue.length
+        ? _queue[_currentIndex]
+        : null;
+    final startMs = item?.startPositionMs;
+    if (item == null || startMs == null || startMs <= 0) return;
+    item.startPositionMs = null; // consume
+
+    var retries = 0;
+    while (_engine.durationMs <= 0 && retries < 20) {
+      await Future.delayed(const Duration(milliseconds: 100));
+      retries++;
+    }
+    // Only resume if the item is still the active one and the position is sane.
+    if (_currentIndex < 0 ||
+        _currentIndex >= _queue.length ||
+        !identical(_queue[_currentIndex], item)) {
+      return;
+    }
+    final durMs = _engine.durationMs;
+    if (durMs > 0 && startMs >= durMs) return;
+    debugPrint('[player] resuming at ${startMs}ms');
+    await _engine.seek(Duration(milliseconds: startMs));
+  }
+
   void _setIndex(int i) {
     _currentIndex = i;
     indexChanges.value = i;
@@ -183,12 +243,14 @@ class PlayerController extends ChangeNotifier {
     await _engine.stop();
     _queue.clear();
     _setIndex(-1);
+    queueChanges.value++;
     notifyListeners();
   }
 
   @override
   Future<void> dispose() async {
     indexChanges.dispose();
+    queueChanges.dispose();
     playRequests.dispose();
     await _engine.dispose();
     super.dispose();

--- a/desktop/lib/player_engine.dart
+++ b/desktop/lib/player_engine.dart
@@ -1,11 +1,60 @@
 import 'package:flutter/foundation.dart';
 
-typedef QueueItem = ({
-  String url,
-  String title,
-  Map<String, String>? headers,
-  List<String>? subtitles,
-});
+/// One playlist entry. Carries the playback essentials the engines consume
+/// (url/title/headers/subtitles) plus the protocol metadata the server echoes
+/// back to the phone in `playlist_status` (season/episode/imdbId/bingeGroup)
+/// and the resume point ([startPositionMs]).
+class QueueItem {
+  QueueItem({
+    required this.url,
+    required this.title,
+    this.headers,
+    this.subtitles,
+    this.startPositionMs,
+    this.bingeGroup,
+    this.season,
+    this.episode,
+    this.imdbId,
+    this.backdropUrl,
+    this.posterUrl,
+    this.logoUrl,
+    this.overview,
+    this.year,
+    this.rating,
+    this.runtime,
+    this.episodeTitle,
+  });
+
+  final String url;
+  final String title;
+  final Map<String, String>? headers;
+  final List<String>? subtitles;
+
+  /// Resume point (ms) seeded from the phone's resume store. Mutable because
+  /// it is consumed (nulled) after the first seek, so re-playing this item
+  /// from the playlist overlay starts from the beginning.
+  int? startPositionMs;
+
+  /// Stremio bingeGroup — echoed in `playlist_status` so the phone can
+  /// re-attach its lazy episode queue after a restart.
+  final String? bingeGroup;
+  final int? season;
+  final int? episode;
+  final String? imdbId;
+
+  // Visual metadata for the pre-play screen (from the payload's VisualMetadata).
+  final String? backdropUrl;
+  final String? posterUrl;
+  final String? logoUrl;
+  final String? overview;
+  final String? year;
+  final String? rating;
+  final String? runtime;
+  final String? episodeTitle;
+
+  /// True when there's enough metadata to render a pre-play screen.
+  bool get hasPrePlayMetadata => backdropUrl != null || posterUrl != null;
+}
 
 enum EngineType {
   mpvInternal,
@@ -48,6 +97,15 @@ class PlaybackStats {
   final double? cacheDuration; // seconds of demuxer cache ahead
 }
 
+/// Engine-agnostic description of a selectable track, in the shape the phone
+/// remote expects (`tracks` message: id/name/selected).
+class TrackInfo {
+  const TrackInfo({required this.id, required this.name, this.selected = false});
+  final String id;
+  final String name;
+  final bool selected;
+}
+
 abstract class PlayerEngine extends ChangeNotifier {
   String get state; // idle | buffering | playing | paused | ended
   int get positionMs;
@@ -59,6 +117,15 @@ abstract class PlayerEngine extends ChangeNotifier {
   dynamic get track;
   Future<void> setAudioTrack(dynamic t);
   Future<void> setSubtitleTrack(dynamic t);
+
+  /// Engine-agnostic track lists for the phone remote. Default: none.
+  List<TrackInfo> get audioTrackInfos => const [];
+  List<TrackInfo> get subtitleTrackInfos => const [];
+
+  /// Select a track by the id previously reported in [audioTrackInfos] /
+  /// [subtitleTrackInfos] ("auto"/"no" allowed). Default: no-op.
+  Future<void> selectAudioTrackById(String id) async {}
+  Future<void> selectSubtitleTrackById(String id) async {}
 
   Future<void> open(QueueItem item);
   Future<void> openPlaylist(List<QueueItem> items, int startIndex) =>

--- a/desktop/lib/player_engine.dart
+++ b/desktop/lib/player_engine.dart
@@ -100,7 +100,8 @@ class PlaybackStats {
 /// Engine-agnostic description of a selectable track, in the shape the phone
 /// remote expects (`tracks` message: id/name/selected).
 class TrackInfo {
-  const TrackInfo({required this.id, required this.name, this.selected = false});
+  const TrackInfo(
+      {required this.id, required this.name, this.selected = false});
   final String id;
   final String name;
   final bool selected;

--- a/desktop/lib/preplay_overlay.dart
+++ b/desktop/lib/preplay_overlay.dart
@@ -1,0 +1,290 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import 'player_engine.dart';
+
+/// Cinematic pre-play screen shown over the (muted, buffering) video when a cast
+/// with visual metadata arrives — desktop counterpart of the tvOS PrePlayView and
+/// Android PrePlayActivity. Full-bleed backdrop, gradient scrim, title/logo,
+/// metadata chips, overview, poster, and a 7-second countdown. Clicking anywhere
+/// (or the countdown reaching zero) starts playback via [onStart].
+class PrePlayOverlay extends StatefulWidget {
+  const PrePlayOverlay({
+    super.key,
+    required this.item,
+    required this.onStart,
+    this.countdownSeconds = 7,
+  });
+
+  final QueueItem item;
+  final VoidCallback onStart;
+  final int countdownSeconds;
+
+  @override
+  State<PrePlayOverlay> createState() => _PrePlayOverlayState();
+}
+
+class _PrePlayOverlayState extends State<PrePlayOverlay> {
+  late int _remaining;
+  Timer? _timer;
+  bool _started = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _remaining = widget.countdownSeconds;
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (!mounted) return;
+      setState(() => _remaining--);
+      if (_remaining <= 0) _start();
+    });
+  }
+
+  void _start() {
+    if (_started) return;
+    _started = true;
+    _timer?.cancel();
+    widget.onStart();
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    final backdrop = item.backdropUrl ?? item.posterUrl;
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: _start,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          // Base — covers the buffering video.
+          Container(color: Colors.black),
+
+          // Full-bleed backdrop.
+          if (backdrop != null)
+            ImageFiltered(
+              imageFilter: ImageFilter.blur(sigmaX: 2, sigmaY: 2),
+              child: Image.network(
+                backdrop,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+              ),
+            ),
+
+          // Cinematic scrim: left fade for legibility + bottom/top vignettes.
+          const DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.centerLeft,
+                end: Alignment.centerRight,
+                stops: [0.0, 0.35, 0.65, 1.0],
+                colors: [
+                  Color(0xF7000000),
+                  Color(0xD9000000),
+                  Color(0x8C000000),
+                  Color(0x33000000),
+                ],
+              ),
+            ),
+          ),
+          const DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.bottomCenter,
+                end: Alignment.topCenter,
+                stops: [0.0, 0.4],
+                colors: [Color(0x99000000), Color(0x00000000)],
+              ),
+            ),
+          ),
+
+          // Content. The poster only renders when there's comfortably room for
+          // it next to the text column (e.g. not mid fullscreen transition).
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final showPoster =
+                  item.posterUrl != null && constraints.maxWidth >= 900;
+              final pad = constraints.maxWidth >= 900 ? 72.0 : 32.0;
+              return Padding(
+                padding: EdgeInsets.fromLTRB(pad, 48, pad, 48),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Expanded(child: _contentColumn(item)),
+                    if (showPoster) ...[
+                      const SizedBox(width: 48),
+                      _poster(item.posterUrl!),
+                    ],
+                  ],
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _contentColumn(QueueItem item) {
+    final chips = <String>[
+      if (item.year != null) item.year!,
+      if (item.rating != null) 'IMDb ${item.rating}',
+      if (item.runtime != null) item.runtime!,
+    ];
+    final hasEpisode = item.season != null && item.episode != null;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        // Logo or title text.
+        if (item.logoUrl != null)
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 420, maxHeight: 110),
+            child: Image.network(
+              item.logoUrl!,
+              fit: BoxFit.contain,
+              alignment: Alignment.centerLeft,
+              errorBuilder: (_, __, ___) => _titleText(item.title),
+            ),
+          )
+        else
+          _titleText(item.title),
+        const SizedBox(height: 18),
+
+        if (chips.isNotEmpty)
+          Wrap(
+            spacing: 8,
+            children: [for (final c in chips) _chip(c)],
+          ),
+        if (hasEpisode) ...[
+          const SizedBox(height: 14),
+          Text(
+            'S${item.season} · E${item.episode}'
+            '${item.episodeTitle != null ? '  ${item.episodeTitle}' : ''}',
+            style: const TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+              color: Colors.white,
+            ),
+          ),
+        ],
+        if (item.overview != null) ...[
+          const SizedBox(height: 16),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560),
+            child: Text(
+              item.overview!,
+              maxLines: 5,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 15,
+                height: 1.45,
+                color: Colors.white.withValues(alpha: 0.75),
+              ),
+            ),
+          ),
+        ],
+        const SizedBox(height: 28),
+
+        // Countdown + hint.
+        Row(
+          children: [
+            _countdownRing(),
+            const SizedBox(width: 16),
+            Flexible(
+              child: Text(
+                'Starting in $_remaining…  click to start now',
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 14,
+                  color: Colors.white.withValues(alpha: 0.7),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _titleText(String title) => Text(
+        title,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+        style: const TextStyle(
+          fontSize: 52,
+          fontWeight: FontWeight.w900,
+          color: Colors.white,
+          height: 1.05,
+        ),
+      );
+
+  Widget _chip(String label) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.2)),
+        ),
+        child: Text(
+          label,
+          style: const TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
+        ),
+      );
+
+  Widget _countdownRing() {
+    final progress =
+        widget.countdownSeconds > 0 ? _remaining / widget.countdownSeconds : 0.0;
+    return SizedBox(
+      width: 44,
+      height: 44,
+      child: Stack(
+        fit: StackFit.expand,
+        alignment: Alignment.center,
+        children: [
+          CircularProgressIndicator(
+            value: progress.clamp(0.0, 1.0),
+            strokeWidth: 3,
+            backgroundColor: Colors.white.withValues(alpha: 0.15),
+            valueColor: const AlwaysStoppedAnimation(Colors.white),
+          ),
+          Center(
+            child: Text(
+              '$_remaining',
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: Colors.white,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _poster(String url) => ClipRRect(
+        borderRadius: BorderRadius.circular(12),
+        child: Image.network(
+          url,
+          width: 240,
+          fit: BoxFit.cover,
+          errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+        ),
+      );
+}

--- a/desktop/lib/preplay_overlay.dart
+++ b/desktop/lib/preplay_overlay.dart
@@ -248,8 +248,9 @@ class _PrePlayOverlayState extends State<PrePlayOverlay> {
       );
 
   Widget _countdownRing() {
-    final progress =
-        widget.countdownSeconds > 0 ? _remaining / widget.countdownSeconds : 0.0;
+    final progress = widget.countdownSeconds > 0
+        ? _remaining / widget.countdownSeconds
+        : 0.0;
     return SizedBox(
       width: 44,
       height: 44,

--- a/desktop/lib/protocol.dart
+++ b/desktop/lib/protocol.dart
@@ -17,6 +17,37 @@ extension PlayPayloadX on PlayPayload {
       headers.isEmpty ? null : Map.unmodifiable(headers);
   List<String>? get subtitlesOrNull =>
       subtitles.isEmpty ? null : List.unmodifiable(subtitles);
+  int? get startPositionMsOrNull =>
+      hasStartPositionMs() ? startPositionMs.toInt() : null;
+  String? get bingeGroupOrNull => hasBingeGroup() ? bingeGroup : null;
+  int? get seasonOrNull => hasVisualMetadata() && visualMetadata.hasSeason()
+      ? visualMetadata.season
+      : null;
+  int? get episodeOrNull => hasVisualMetadata() && visualMetadata.hasEpisode()
+      ? visualMetadata.episode
+      : null;
+  String? get imdbIdOrNull => hasVisualMetadata() && visualMetadata.hasImdbId()
+      ? visualMetadata.imdbId
+      : null;
+
+  String? _vm(bool Function(VisualMetadata) has, String Function(VisualMetadata) get) {
+    if (!hasVisualMetadata()) return null;
+    if (!has(visualMetadata)) return null;
+    final v = get(visualMetadata);
+    return v.isEmpty ? null : v;
+  }
+
+  String? get backdropUrlOrNull =>
+      _vm((m) => m.hasBackdropUrl(), (m) => m.backdropUrl);
+  String? get posterUrlOrNull =>
+      _vm((m) => m.hasPosterUrl(), (m) => m.posterUrl);
+  String? get logoUrlOrNull => _vm((m) => m.hasLogoUrl(), (m) => m.logoUrl);
+  String? get overviewOrNull => _vm((m) => m.hasOverview(), (m) => m.overview);
+  String? get yearOrNull => _vm((m) => m.hasYear(), (m) => m.year);
+  String? get ratingOrNull => _vm((m) => m.hasRating(), (m) => m.rating);
+  String? get runtimeOrNull => _vm((m) => m.hasRuntime(), (m) => m.runtime);
+  String? get episodeTitleOrNull =>
+      _vm((m) => m.hasEpisodeTitle(), (m) => m.episodeTitle);
 }
 
 // ==================== Command sealed class ====================
@@ -198,13 +229,52 @@ String statusJson({
       if (title != null) 'title': title,
     });
 
+/// Outgoing `tracks` message: the phone remote renders these as the
+/// audio/subtitle chips and replies with `audio_track:<id>`/`sub_track:<id>`.
+String tracksJson({
+  required List<({String id, String name, bool selected})> audio,
+  required List<({String id, String name, bool selected})> subtitle,
+}) =>
+    jsonEncode({
+      'type': 'tracks',
+      'audio': [
+        for (final t in audio)
+          {'id': t.id, 'name': t.name, 'selected': t.selected},
+      ],
+      'subtitle': [
+        for (final t in subtitle)
+          {'id': t.id, 'name': t.name, 'selected': t.selected},
+      ],
+    });
+
+/// One entry of an outgoing `playlist_status`. The optional metadata mirrors
+/// the Android receiver's echo (season/episode/imdbId/bingeGroup) so the phone
+/// can re-attach its lazy episode queue and match watch progress.
+typedef PlaylistStatusItem = ({
+  int index,
+  String title,
+  int? season,
+  int? episode,
+  String? imdbId,
+  String? bingeGroup,
+});
+
 String playlistStatusJson({
-  required List<({int index, String title})> items,
+  required List<PlaylistStatusItem> items,
   required int currentIndex,
 }) =>
     jsonEncode({
       'type': 'playlist_status',
-      'items': items.map((e) => {'index': e.index, 'title': e.title}).toList(),
+      'items': items
+          .map((e) => {
+                'index': e.index,
+                'title': e.title,
+                if (e.season != null) 'season': e.season,
+                if (e.episode != null) 'episode': e.episode,
+                if (e.imdbId != null) 'imdbId': e.imdbId,
+                if (e.bingeGroup != null) 'bingeGroup': e.bingeGroup,
+              })
+          .toList(),
       'currentIndex': currentIndex,
       'totalCount': items.length,
     });

--- a/desktop/lib/protocol.dart
+++ b/desktop/lib/protocol.dart
@@ -30,7 +30,8 @@ extension PlayPayloadX on PlayPayload {
       ? visualMetadata.imdbId
       : null;
 
-  String? _vm(bool Function(VisualMetadata) has, String Function(VisualMetadata) get) {
+  String? _vm(
+      bool Function(VisualMetadata) has, String Function(VisualMetadata) get) {
     if (!hasVisualMetadata()) return null;
     if (!has(visualMetadata)) return null;
     final v = get(visualMetadata);

--- a/desktop/lib/server.dart
+++ b/desktop/lib/server.dart
@@ -10,6 +10,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 import 'cert_manager.dart';
 import 'pairing_store.dart';
 import 'player_controller.dart';
+import 'player_engine.dart';
 import 'protocol.dart';
 
 const int kDefaultPort = 8765;
@@ -94,6 +95,7 @@ class ReceiverServer extends ChangeNotifier {
 
     player.addListener(_broadcastStatus);
     player.indexChanges.addListener(_broadcastPlaylistStatus);
+    player.queueChanges.addListener(_broadcastPlaylistStatus);
     _statusTimer = Timer.periodic(
       const Duration(milliseconds: 500),
       (_) => _broadcastStatus(),
@@ -164,6 +166,7 @@ class ReceiverServer extends ChangeNotifier {
     _approvalTimeout?.cancel();
     player.removeListener(_broadcastStatus);
     player.indexChanges.removeListener(_broadcastPlaylistStatus);
+    player.queueChanges.removeListener(_broadcastPlaylistStatus);
     for (final c in _all.toList()) {
       await c.sink.close();
     }
@@ -359,14 +362,7 @@ class ReceiverServer extends ChangeNotifier {
         _lastPlayUrl = startUrl;
         _lastPlayAt = now;
         unawaited(player.playPlaylist(
-          items
-              .map((p) => (
-                    url: p.url,
-                    title: p.titleOrNull ?? p.url,
-                    headers: p.headersOrNull,
-                    subtitles: p.subtitlesOrNull,
-                  ))
-              .toList(),
+          items.map(_toQueueItem).toList(),
           startIndex,
           isRemote: true,
         ));
@@ -375,24 +371,55 @@ class ReceiverServer extends ChangeNotifier {
         unawaited(player.jumpTo(index));
         _broadcastPlaylistStatus();
       case QueueAddCmd(:final item):
-        if (player.queue.isEmpty) {
-          unawaited(player.playUrl(
-            item.url,
-            title: item.titleOrNull,
-            headers: item.headersOrNull,
-            subtitles: item.subtitlesOrNull,
-            isRemote: true,
-          ));
-        }
+        // Appends to the live queue; if idle, starts playback.
+        // playlist_status broadcast happens via the queueChanges listener.
+        unawaited(player.queueAdd(_toQueueItem(item), isRemote: true));
       case ControlCmd(:final command):
         debugPrint('[server] control: $command');
+        // Parameterized commands (phone seekbar + track pickers).
+        if (command.startsWith('seek_to:')) {
+          final ms = int.tryParse(command.substring('seek_to:'.length));
+          if (ms != null) {
+            final dur = player.durationMs;
+            var target = ms < 0 ? 0 : ms;
+            if (dur > 0 && target > dur) target = dur;
+            unawaited(player.seek(Duration(milliseconds: target)));
+          }
+          break;
+        }
+        if (command.startsWith('audio_track:')) {
+          unawaited(player
+              .selectAudioTrackById(command.substring('audio_track:'.length)));
+          break;
+        }
+        if (command.startsWith('sub_track:')) {
+          unawaited(player
+              .selectSubtitleTrackById(command.substring('sub_track:'.length)));
+          break;
+        }
         switch (command) {
           case 'play':
             unawaited(player.resume());
           case 'pause':
             unawaited(player.pause());
+          case 'toggle':
+            unawaited(
+                player.state == 'playing' ? player.pause() : player.resume());
           case 'stop':
-            unawaited(player.pause());
+            // Real stop: clear the queue and report idle so the phone's
+            // remote leaves player mode (Android finishes the activity here).
+            unawaited(player.stop());
+            for (final c in _authed) {
+              c.sink.add(contextJson('idle'));
+            }
+          case 'seek_back':
+            final pos = player.positionMs - 10000;
+            unawaited(player.seek(Duration(milliseconds: pos < 0 ? 0 : pos)));
+          case 'seek_forward':
+            final dur = player.durationMs;
+            var target = player.positionMs + 10000;
+            if (dur > 0 && target > dur) target = dur;
+            unawaited(player.seek(Duration(milliseconds: target)));
         }
       case UnknownCmd(:final type):
         debugPrint('[server] unknown command: $type');
@@ -400,6 +427,40 @@ class ReceiverServer extends ChangeNotifier {
         break;
     }
   }
+
+  /// Map an incoming [PlayPayload] onto a [QueueItem], carrying the resume
+  /// point and the metadata echoed back in `playlist_status`.
+  QueueItem _toQueueItem(PlayPayload p) => QueueItem(
+        url: p.url,
+        title: p.titleOrNull ?? p.url,
+        headers: p.headersOrNull,
+        subtitles: p.subtitlesOrNull,
+        startPositionMs: p.startPositionMsOrNull,
+        bingeGroup: p.bingeGroupOrNull,
+        season: p.seasonOrNull,
+        episode: p.episodeOrNull,
+        imdbId: p.imdbIdOrNull,
+        backdropUrl: p.backdropUrlOrNull,
+        posterUrl: p.posterUrlOrNull,
+        logoUrl: p.logoUrlOrNull,
+        overview: p.overviewOrNull,
+        year: p.yearOrNull,
+        rating: p.ratingOrNull,
+        runtime: p.runtimeOrNull,
+        episodeTitle: p.episodeTitleOrNull,
+      );
+
+  List<PlaylistStatusItem> _playlistStatusItems() => [
+        for (var i = 0; i < player.queue.length; i++)
+          (
+            index: i,
+            title: player.queue[i].title,
+            season: player.queue[i].season,
+            episode: player.queue[i].episode,
+            imdbId: player.queue[i].imdbId,
+            bingeGroup: player.queue[i].bingeGroup,
+          ),
+      ];
 
   void _broadcastStatus() {
     if (_authed.isEmpty) return;
@@ -412,16 +473,38 @@ class ReceiverServer extends ChangeNotifier {
     for (final c in _authed) {
       c.sink.add(msg);
     }
+    _broadcastTracksIfChanged();
+  }
+
+  /// Last `tracks` JSON sent, to avoid re-sending an unchanged list on every
+  /// status tick.
+  String? _lastTracksJson;
+
+  String _currentTracksJson() => tracksJson(
+        audio: [
+          for (final t in player.audioTrackInfos)
+            (id: t.id, name: t.name, selected: t.selected),
+        ],
+        subtitle: [
+          for (final t in player.subtitleTrackInfos)
+            (id: t.id, name: t.name, selected: t.selected),
+        ],
+      );
+
+  void _broadcastTracksIfChanged() {
+    if (_authed.isEmpty) return;
+    final msg = _currentTracksJson();
+    if (msg == _lastTracksJson) return;
+    _lastTracksJson = msg;
+    for (final c in _authed) {
+      c.sink.add(msg);
+    }
   }
 
   void _broadcastPlaylistStatus() {
     if (_authed.isEmpty) return;
-    final items = [
-      for (var i = 0; i < player.queue.length; i++)
-        (index: i, title: player.queue[i].title),
-    ];
     final msg = playlistStatusJson(
-      items: items,
+      items: _playlistStatusItems(),
       currentIndex: player.currentIndex.clamp(0, player.queue.length),
     );
     for (final c in _authed) {
@@ -431,13 +514,11 @@ class ReceiverServer extends ChangeNotifier {
 
   void _sendPlaylistStatusTo(WebSocketChannel c) {
     if (player.queue.isEmpty) return;
-    final items = [
-      for (var i = 0; i < player.queue.length; i++)
-        (index: i, title: player.queue[i].title),
-    ];
     c.sink.add(playlistStatusJson(
-      items: items,
+      items: _playlistStatusItems(),
       currentIndex: player.currentIndex.clamp(0, player.queue.length),
     ));
+    // Sync the track pickers too for a client that connected mid-playback.
+    c.sink.add(_currentTracksJson());
   }
 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
@@ -1184,6 +1184,12 @@ class ExoPlayerActivity : PlayerActivity() {
                         .setTrackTypeDisabled(trackType, id == "off")
                         .clearOverridesOfType(trackType)
                         .build()
+                    // Drop the carried language preference so the next episode's
+                    // player (rebuilt per item) doesn't resurrect the old pick.
+                    when (type) {
+                        "audio" -> preferredAudioLanguage = null
+                        "sub" -> preferredSubtitleLanguage = null
+                    }
                 } else {
                     // Composite ID: "groupIndex:trackIndex"
                     val parts = id.split(":")
@@ -1201,6 +1207,17 @@ class ExoPlayerActivity : PlayerActivity() {
                                 )
                             )
                             .build()
+                        // The override only binds to *this* item's track groups; the
+                        // player is released and rebuilt on episode advance, so carry
+                        // the pick forward as a language preference (re-applied at
+                        // player construction, like the phone's payload preference).
+                        val pickedLanguage = group.getTrackFormat(trackIdx).language
+                        if (!pickedLanguage.isNullOrBlank()) {
+                            when (type) {
+                                "audio" -> preferredAudioLanguage = pickedLanguage
+                                "sub" -> preferredSubtitleLanguage = pickedLanguage
+                            }
+                        }
                     }
                 }
             }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ProgressManager.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ProgressManager.kt
@@ -181,10 +181,19 @@ class ProgressManager(
             return null
         }
 
-        val width = surfaceView.width
-        val height = surfaceView.height
+        val srcWidth = surfaceView.width
+        val srcHeight = surfaceView.height
 
-        if (width <= 0 || height <= 0) return null
+        if (srcWidth <= 0 || srcHeight <= 0) return null
+
+        // Thumbnail-sized capture: PixelCopy scales into the destination bitmap, so
+        // there's no reason to read back the full surface. A ~640px-wide bitmap cuts
+        // the allocation (8MB -> <1MB at 1080p) and the later JPEG encode ~9x — this
+        // runs on the episode auto-advance path, so it must stay cheap.
+        val maxWidth = 640
+        val scale = if (srcWidth > maxWidth) maxWidth.toFloat() / srcWidth else 1f
+        val width = (srcWidth * scale).toInt().coerceAtLeast(1)
+        val height = (srcHeight * scale).toInt().coerceAtLeast(1)
 
         return kotlinx.coroutines.suspendCancellableCoroutine { continuation ->
             try {

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
@@ -76,11 +76,21 @@ class WebSocketServer: ObservableObject {
         set { UserDefaults.standard.set(Array(newValue), forKey: authorizedTokensKey) }
     }
 
+    /// Re-broadcasts `playlist_status` whenever the queue changes — including index moves
+    /// driven by the player UI (next/jump), which never pass through the server.
+    private var playlistCancellable: AnyCancellable?
+
     init(historyStore: HistoryStore? = nil, playlistStore: PlaylistStore? = nil) {
         self.historyStore = historyStore
         self.playlistStore = playlistStore
         self.localIP = getIPAddress()
         self.pairedDevicesList = storedPairedDevices
+
+        // objectWillChange fires *before* the mutation lands; the debounce hop onto the
+        // main queue ensures we serialize the post-mutation queue state.
+        playlistCancellable = playlistStore?.objectWillChange
+            .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
+            .sink { [weak self] _ in self?.broadcastPlaylistStatus() }
 
         NotificationCenter.default.addObserver(
             self,
@@ -456,6 +466,34 @@ class WebSocketServer: ObservableObject {
     /// Posted when a client (re)connects; the active player re-broadcasts status + tracks.
     static let resyncRequest = Notification.Name("PlayBridgeResync")
 
+    /// Broadcast the current queue as `playlist_status`, matching the Android receiver's
+    /// format. Echoes each item's series context (season/episode/imdbId/bingeGroup) so the
+    /// phone can re-attach its lazy episode queue and match watch progress. Always sends —
+    /// even when empty — so the phone clears a stale episode list.
+    func broadcastPlaylistStatus() {
+        guard let store = playlistStore else { return }
+        let items: [[String: Any]] = store.items.enumerated().map { index, item in
+            var obj: [String: Any] = [
+                "index": index,
+                "title": item.titleOrNil ?? "Item \(index + 1)",
+            ]
+            if item.hasVisualMetadata {
+                let vm = item.visualMetadata
+                if vm.hasSeason { obj["season"] = Int(vm.season) }
+                if vm.hasEpisode { obj["episode"] = Int(vm.episode) }
+                if vm.hasImdbID { obj["imdbId"] = vm.imdbID }
+            }
+            if item.hasBingeGroup { obj["bingeGroup"] = item.bingeGroup }
+            return obj
+        }
+        broadcast([
+            "type": "playlist_status",
+            "items": items,
+            "currentIndex": store.items.isEmpty ? 0 : max(store.currentIndex, 0),
+            "totalCount": store.items.count,
+        ])
+    }
+
     /// Send a JSON object to every connected client (now-playing status, tracks, context, …).
     func broadcast(_ json: [String: Any]) {
         guard !connectedConnections.isEmpty,
@@ -493,6 +531,10 @@ class WebSocketServer: ObservableObject {
             // Re-sync now-playing for a client that connected mid-playback: context + a nudge
             // for the active player to re-broadcast its status/tracks.
             self.broadcast(["type": "context", "active": self.currentPlayRequest != nil ? "player" : "idle"])
+            // Sync the queue too, so a re-connecting phone can re-attach its episode queue.
+            if self.playlistStore?.items.isEmpty == false {
+                self.broadcastPlaylistStatus()
+            }
             NotificationCenter.default.post(name: Self.resyncRequest, object: nil)
         }
     }
@@ -617,6 +659,7 @@ class WebSocketServer: ObservableObject {
         print("WebSocket Play: \(payload.titleOrNil ?? "No Title") - \(url)")
         historyStore?.addToHistory(url: url, title: payload.titleOrNil, headers: payload.headersOrNil)
         DispatchQueue.main.async {
+            TrackPreferences.shared.reset() // new cast session — drop carried track picks
             self.playlistStore?.clear()
             self.playlistStore?.addToQueue(item: payload)
             self.currentPlayRequest = payload
@@ -628,6 +671,7 @@ class WebSocketServer: ObservableObject {
         print("WebSocket Playlist: \(valid.count)/\(payload.items.count) items, startIndex: \(payload.startIndex)")
         guard !valid.isEmpty else { return }
         DispatchQueue.main.async {
+            TrackPreferences.shared.reset() // new cast session — drop carried track picks
             self.playlistStore?.setPlaylist(items: valid, startIndex: Int(payload.startIndex))
             if let first = self.playlistStore?.currentItem, let firstURL = first.validURL {
                 self.historyStore?.addToHistory(url: firstURL, title: first.titleOrNil, headers: first.headersOrNil)

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/MPVPlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/MPVPlayerView.swift
@@ -451,6 +451,30 @@ class MPVViewController: UIViewController {
 
     // MARK: - Track Selection
 
+    /// One-shot guard so session track preferences are applied once per item; after that
+    /// the user's live changes win.
+    private var didApplyTrackPreferences = false
+
+    /// Remember an audio pick (by display name) so the next episode — a fresh mpv
+    /// instance — re-applies it. Call on main (reads playbackState).
+    private func recordAudioPreference(id: Int) {
+        if let t = playbackState.audioTracks.first(where: { $0.id == id }) {
+            TrackPreferences.shared.audioName = t.name
+        }
+    }
+
+    /// Remember a subtitle pick or an explicit "off" (see above).
+    private func recordSubtitlePreference(id: Int) {
+        let prefs = TrackPreferences.shared
+        if id < 0 {
+            prefs.subtitlesOff = true
+            prefs.subtitleName = nil
+        } else if let t = playbackState.subtitleTracks.first(where: { $0.id == id }) {
+            prefs.subtitlesOff = false
+            prefs.subtitleName = t.name
+        }
+    }
+
     /// Enumerate tracks. MUST be called on `mpvQueue` (never the main thread): this MPVKit
     /// build's vo=avfoundation does work on the main thread, so a synchronous mpv_* call from
     /// main can deadlock against the video output while it holds mpv's core lock.
@@ -500,6 +524,31 @@ class MPVViewController: UIViewController {
             self.playbackState.subtitleTracks = subtitleTracks
             self.playbackState.currentAudioIndex = Int(currentAid)
             self.playbackState.currentSubtitleIndex = Int(currentSid)
+
+            // Carry the session's track picks (made on a previous episode's instance)
+            // into this item, once, as soon as tracks are known.
+            if !self.didApplyTrackPreferences && !audioTracks.isEmpty {
+                self.didApplyTrackPreferences = true
+                let prefs = TrackPreferences.shared
+                if let name = prefs.audioName,
+                   let t = audioTracks.first(where: { $0.name == name }),
+                   t.id != Int(currentAid) {
+                    self.setPropertyAsync("aid", value: String(t.id))
+                    self.playbackState.currentAudioIndex = t.id
+                }
+                if prefs.subtitlesOff {
+                    if currentSid > 0 {
+                        self.setPropertyAsync("sid", value: "no")
+                        self.playbackState.currentSubtitleIndex = -1
+                    }
+                } else if let name = prefs.subtitleName,
+                          let t = subtitleTracks.first(where: { $0.name == name }),
+                          t.id != Int(currentSid) {
+                    self.setPropertyAsync("sid", value: String(t.id))
+                    self.playbackState.currentSubtitleIndex = t.id
+                }
+            }
+
             self.broadcastTracks()
         }
     }
@@ -579,11 +628,13 @@ class MPVViewController: UIViewController {
                 guard let self else { return }
                 self.setPropertyAsync("sid", value: trackId < 0 ? "no" : String(trackId))
                 self.playbackState.currentSubtitleIndex = trackId
+                self.recordSubtitlePreference(id: trackId)
             },
             onSelectAudio: { [weak self] trackId in
                 guard let self else { return }
                 self.setPropertyAsync("aid", value: String(trackId))
                 self.playbackState.currentAudioIndex = trackId
+                self.recordAudioPreference(id: trackId)
             },
             onTogglePlayPause: { [weak self] in self?.togglePlayPause() },
             onSwitchEngine: { [weak self] in
@@ -956,16 +1007,23 @@ class MPVViewController: UIViewController {
         case let c where c.hasPrefix("audio_track:"):
             let id = String(c.dropFirst("audio_track:".count))
             setPropertyAsync("aid", value: id)
-            if let i = Int(id) { playbackState.currentAudioIndex = i }
+            if let i = Int(id) {
+                playbackState.currentAudioIndex = i
+                recordAudioPreference(id: i)
+            }
             mpvQueue.async { [weak self] in self?.updateTracks() }
         case let c where c.hasPrefix("sub_track:"):
             let id = String(c.dropFirst("sub_track:".count))
             if id == "none" || id == "-1" {
                 setPropertyAsync("sid", value: "no")
                 playbackState.currentSubtitleIndex = -1
+                recordSubtitlePreference(id: -1)
             } else {
                 setPropertyAsync("sid", value: id)
-                if let i = Int(id) { playbackState.currentSubtitleIndex = i }
+                if let i = Int(id) {
+                    playbackState.currentSubtitleIndex = i
+                    recordSubtitlePreference(id: i)
+                }
             }
             mpvQueue.async { [weak self] in self?.updateTracks() }
         case let c where c.hasPrefix("add_subtitle:"):

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/NativePlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/NativePlayerView.swift
@@ -212,6 +212,7 @@ struct NativePlayerView: UIViewControllerRepresentable {
                     await MainActor.run {
                         self.audioGroup = audio
                         self.subtitleGroup = sub
+                        self.applyPreferredTracks()
                         self.broadcastTracks()
                     }
                 }
@@ -291,12 +292,63 @@ struct NativePlayerView: UIViewControllerRepresentable {
         private func selectTrack(_ characteristic: AVMediaCharacteristic, id: String) {
             guard let item = player?.currentItem else { return }
             guard let group = (characteristic == .audible) ? audioGroup : subtitleGroup else { return }
+            let prefs = TrackPreferences.shared
             if id == "none" || id == "-1" {
                 item.select(nil, in: group)  // deselect (e.g. subtitles off)
+                if characteristic == .legible {
+                    prefs.subtitlesOff = true
+                    prefs.subtitleLanguage = nil
+                    prefs.subtitleName = nil
+                }
             } else if let index = Int(id), group.options.indices.contains(index) {
-                item.select(group.options[index], in: group)
+                let option = group.options[index]
+                item.select(option, in: group)
+                // Remember the pick so the next episode's (new) player re-applies it.
+                let lang = option.locale?.identifier ?? option.extendedLanguageTag
+                if characteristic == .audible {
+                    prefs.audioLanguage = lang
+                    prefs.audioName = option.displayName
+                } else {
+                    prefs.subtitlesOff = false
+                    prefs.subtitleLanguage = lang
+                    prefs.subtitleName = option.displayName
+                }
             }
             broadcastTracks()
+        }
+
+        /// Re-apply the session's track preferences once the selection groups are loaded,
+        /// so picks carry across episodes (each item gets a fresh AVPlayer).
+        private func applyPreferredTracks() {
+            guard let item = player?.currentItem else { return }
+            let prefs = TrackPreferences.shared
+
+            func match(in group: AVMediaSelectionGroup?, language: String?, name: String?)
+                -> AVMediaSelectionOption?
+            {
+                guard let group else { return nil }
+                if let language,
+                   let m = group.options.first(where: {
+                       $0.locale?.identifier == language || $0.extendedLanguageTag == language
+                   }) { return m }
+                if let name, let m = group.options.first(where: { $0.displayName == name }) {
+                    return m
+                }
+                return nil
+            }
+
+            if let group = audioGroup,
+               let option = match(in: group, language: prefs.audioLanguage, name: prefs.audioName) {
+                item.select(option, in: group)
+            }
+            if let group = subtitleGroup {
+                if prefs.subtitlesOff {
+                    item.select(nil, in: group)
+                } else if let option = match(
+                    in: group, language: prefs.subtitleLanguage, name: prefs.subtitleName) {
+                    item.select(option, in: group)
+                }
+            }
         }
     }
 }

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/PlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/PlayerView.swift
@@ -1,5 +1,31 @@
 import SwiftUI
 
+/// Session-scoped track preferences shared by all three engines, so a pick made on one
+/// episode carries into the next — the player views (and their underlying players) are
+/// recreated per item, losing any in-player selection state. AVPlayer matches by language
+/// tag, VLC/MPV by track display name (stable across episodes of the same release).
+/// Reset by the WebSocket server when a new cast session starts.
+final class TrackPreferences {
+    static let shared = TrackPreferences()
+
+    /// Language tag of the picked track (AVPlayer; locale id or extended language tag).
+    var audioLanguage: String?
+    var subtitleLanguage: String?
+    /// Display name of the picked track (VLC/MPV).
+    var audioName: String?
+    var subtitleName: String?
+    /// Explicit "subtitles off" pick — also carried forward.
+    var subtitlesOff = false
+
+    func reset() {
+        audioLanguage = nil
+        subtitleLanguage = nil
+        audioName = nil
+        subtitleName = nil
+        subtitlesOff = false
+    }
+}
+
 struct PlayerView: View {
     let payload: Playbridge_PlayPayload
     let onDismiss: () -> Void
@@ -49,7 +75,27 @@ struct PlayerView: View {
         return preferredPlayer
     }
 
+    /// Initial seek for `item` (seconds): an engine-switch resume wins; otherwise honor
+    /// the phone's `start_position_ms` resume point seeded from its resume store.
+    private func initialSeekTime(for item: Playbridge_PlayPayload) -> Double {
+        if resumeTime > 0 { return resumeTime }
+        if item.hasStartPositionMs, item.startPositionMs > 0 {
+            return Double(item.startPositionMs) / 1000.0
+        }
+        return 0
+    }
+
+    /// Consume the start position of the item at `index` once we navigate away from it,
+    /// so jumping back to it later starts from the beginning (matches the other receivers).
+    private func consumeStartPosition(at index: Int) {
+        guard index >= 0, index < playlistStore.items.count else { return }
+        if playlistStore.items[index].hasStartPositionMs {
+            playlistStore.items[index].clearStartPositionMs()
+        }
+    }
+
     private func handleNext() {
+        consumeStartPosition(at: playlistStore.currentIndex)
         if let nextRequest = playlistStore.next(), let nextURL = nextRequest.validURL {
             historyStore.addToHistory(url: nextURL, title: nextRequest.titleOrNil, headers: nextRequest.headersOrNil)
             resumeTime = 0
@@ -59,6 +105,7 @@ struct PlayerView: View {
     }
 
     private func handleJump(to index: Int) {
+        consumeStartPosition(at: playlistStore.currentIndex)
         if let jumpRequest = playlistStore.jumpTo(index: index), let jumpURL = jumpRequest.validURL {
             historyStore.addToHistory(url: jumpURL, title: jumpRequest.titleOrNil, headers: jumpRequest.headersOrNil)
             resumeTime = 0
@@ -78,7 +125,7 @@ struct PlayerView: View {
                         url: currentURL,
                         headers: currentRequest.headersOrNil,
                         subtitles: currentRequest.subtitlesOrNil,
-                        initialTime: resumeTime,
+                        initialTime: initialSeekTime(for: currentRequest),
                         isPreBuffering: isPreBuffering,
                         title: currentRequest.titleOrNil,
                         onDismiss: handleNext,
@@ -94,7 +141,7 @@ struct PlayerView: View {
                         url: currentURL,
                         headers: currentRequest.headersOrNil,
                         subtitles: currentRequest.subtitlesOrNil,
-                        initialTime: resumeTime,
+                        initialTime: initialSeekTime(for: currentRequest),
                         isPreBuffering: isPreBuffering,
                         title: currentRequest.titleOrNil,
                         onDismiss: handleNext,
@@ -109,7 +156,7 @@ struct PlayerView: View {
                     NativePlayerView(
                         url: currentURL,
                         headers: currentRequest.headersOrNil,
-                        initialTime: resumeTime,
+                        initialTime: initialSeekTime(for: currentRequest),
                         isPreBuffering: isPreBuffering,
                         title: currentRequest.titleOrNil,
                         onDismiss: handleNext,  // end-of-video → try next item

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/VLCPlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/VLCPlayerView.swift
@@ -182,19 +182,47 @@ struct VLCPlayerView: UIViewControllerRepresentable {
         }
 
         /// Select a subtitle track by list index, or turn subtitles off when index < 0.
+        /// Records the pick in [TrackPreferences] so the next episode (fresh player)
+        /// re-applies it by track name.
         private func selectSubtitleTrack(at index: Int) {
             if index < 0 {
                 mediaPlayer.deselectAllTextTracks()
+                TrackPreferences.shared.subtitlesOff = true
+                TrackPreferences.shared.subtitleName = nil
             } else {
                 let textTracks = mediaPlayer.textTracks
-                if textTracks.indices.contains(index) { textTracks[index].isSelectedExclusively = true }
+                if textTracks.indices.contains(index) {
+                    textTracks[index].isSelectedExclusively = true
+                    TrackPreferences.shared.subtitlesOff = false
+                    TrackPreferences.shared.subtitleName = textTracks[index].trackName
+                }
             }
         }
 
-        /// Select an audio track by list index.
+        /// Select an audio track by list index. Records the pick (see above).
         private func selectAudioTrack(at index: Int) {
             let audioTracks = mediaPlayer.audioTracks
-            if audioTracks.indices.contains(index) { audioTracks[index].isSelectedExclusively = true }
+            if audioTracks.indices.contains(index) {
+                audioTracks[index].isSelectedExclusively = true
+                TrackPreferences.shared.audioName = audioTracks[index].trackName
+            }
+        }
+
+        /// Re-apply the session's track preferences (by display name) once tracks are
+        /// enumerated, so picks carry across episodes. Selects directly — bypassing the
+        /// recording setters — so applying never overwrites the stored preference.
+        private func applyPreferredTracks() {
+            let prefs = TrackPreferences.shared
+            if let name = prefs.audioName,
+               let idx = mediaPlayer.audioTracks.firstIndex(where: { $0.trackName == name }) {
+                mediaPlayer.audioTracks[idx].isSelectedExclusively = true
+            }
+            if prefs.subtitlesOff {
+                mediaPlayer.deselectAllTextTracks()
+            } else if let name = prefs.subtitleName,
+                      let idx = mediaPlayer.textTracks.firstIndex(where: { $0.trackName == name }) {
+                mediaPlayer.textTracks[idx].isSelectedExclusively = true
+            }
         }
 
         private func updateAudioTracks() {
@@ -520,9 +548,14 @@ struct VLCPlayerView: UIViewControllerRepresentable {
                 // appear — every playable file has audio, so this self-terminates instead of
                 // re-enumerating tracks (and taking the player lock) on every tick forever.
                 if !self.didFetchTracks {
+                    if !self.mediaPlayer.audioTracks.isEmpty {
+                        self.didFetchTracks = true
+                        // Carry the session's track picks into this episode before the
+                        // lists are published to the overlay/phone.
+                        self.applyPreferredTracks()
+                    }
                     self.updateSubtitleTracks()
                     self.updateAudioTracks()
-                    if !self.mediaPlayer.audioTracks.isEmpty { self.didFetchTracks = true }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Closes the receiver feature gaps between Android TV and the desktop/tvOS apps, plus a round of performance fixes from a cross-platform player review.

### Desktop receiver
- **`queue_add` appends to the live queue** — was silently dropped unless idle, breaking the phone's lazy episode queue
- **Resume support**: honors `start_position_ms`, consumed per item (waits for duration, skips stale positions past EOF)
- **Full control surface**: `toggle`, real `stop` (clears queue + broadcasts idle context), `seek_back`/`seek_forward`, `seek_to:<ms>` (phone seekbar), `audio_track:`/`sub_track:` selection
- **`tracks` broadcast** (change-detected, synced to newly authed clients) — phone remote track pickers now work
- **Metadata-rich `playlist_status`** (season/episode/imdbId/bingeGroup, matching Android) — enables phone queue re-attach + watch-progress matching
- **Track picks persist across episodes** — remembered as language prefs in `MpvEngine`, re-applied per item open
- **Pre-play screen** (backdrop/poster/logo/chips/overview/7s countdown; video buffers muted underneath) + **fullscreen title scrim**
- **Perf**: app shell no longer rebuilds on ~5Hz position ticks (controls/status bars self-listen; coarse-diffed setState for structure); mpv tuned with `framedrop=decoder+vo`, `demuxer-readahead-secs=30`, `audio-buffer=1.0` (ported from the tvOS receiver)

### tvOS receiver
- **Resume support**: `start_position_ms` honored in all three engines via the existing `initialTime` plumbing; consumed when navigating away
- **`playlist_status` emission** (Android format incl. bingeGroup) on queue changes (Combine-debounced, catches player-driven jumps) and on client (re)connect
- **Track picks persist across episodes** via session-scoped `TrackPreferences` (reset per cast session): language-tag matching for AVPlayer, name matching for VLC/MPV — survives the per-item player recreation

### Android TV
- **ExoPlayer track stickiness**: picked track language carried into `preferredAudioLanguage`/`preferredSubtitleLanguage` so selections survive the per-episode player rebuild (MPV already persisted via mpv options)
- **Thumbnail capture downscaled to ~640px** — PixelCopy scales during readback; cuts ~8MB alloc + 9x JPEG encode cost off the episode auto-advance path

## Known caveats
- AVPlayer picks made through the native tvOS transport-bar menu aren't captured for stickiness (bypasses our selection path)
- VLC/MPV track matching is by display name — reliable within a binge session, not across differently-named releases
- Desktop `queue_add` into an idle player starts playback (preserves prior desktop behavior; Android buffers instead)

## Testing
- Desktop built and ran on macOS (`flutter run -d macos`); cast/resume/track-pick/preplay verified manually; fixed an overflow in the preplay layout at small window sizes
- tvOS/Android changes compile-reviewed only — need an Xcode build and a Gradle build (`cd tv/android && ./gradlew :player:app:assembleDebug`) before merge
