### PR TITLE
perf: reuse player instances across episodes (Exo + tvOS mpv)

### DIFF
--- a/shared/src/androidMain/kotlin/com/playbridge/shared/player/ExoPlayerEngine.kt
+++ b/shared/src/androidMain/kotlin/com/playbridge/shared/player/ExoPlayerEngine.kt
@@ -81,18 +81,35 @@ class ExoPlayerEngine(private val context: Context) : PlaybackEngine {
     override suspend fun load(payload: PlayPayload) {
         logger.i(TAG, "load() called with url: ${payload.url}")
         currentPayload = payload
-        release() // Release previous instance if any
-        initializePlayer(payload)
+        val livePlayer = player
+        if (livePlayer != null) {
+            // Episode advance / replacement cast: swap the media on the LIVE player.
+            // Avoids a full release + rebuild (renderers, surface re-attach, decoder
+            // warm-up) per item — the black gap between episodes — and preserves
+            // player-level state like trackSelectionParameters.
+            reloadOnLivePlayer(livePlayer, payload)
+        } else {
+            initializePlayer(payload)
+        }
     }
 
-    private fun initializePlayer(payload: PlayPayload) {
-        val bufCfg = AndroidBufferConfig.compute(context)
-        logger.i(TAG, "Initializing player with buffer config: maxBufferMs=${bufCfg.maxBufferMs}, targetBytes=${bufCfg.targetBytes}")
+    /**
+     * Per-item media source bundle. Headers, the network-stack choice, and HLS
+     * detection all depend on the payload, so they're rebuilt per item — letting
+     * the player itself be reused across items.
+     */
+    private class PerItemSource(
+        val mediaSourceFactory: androidx.media3.exoplayer.source.MediaSource.Factory,
+        val mediaItem: MediaItem,
+    ) {
+        fun createMediaSource() = mediaSourceFactory.createMediaSource(mediaItem)
+    }
 
+    private fun buildPerItemSource(payload: PlayPayload): PerItemSource {
         // 1. Extract credentials and prepare Headers
         var finalUrl = payload.url
         val requestProperties = HashMap<String, String>()
-        
+
         payload.headers.forEach { (key, value) ->
             if (!key.equals("Range", ignoreCase = true) && !key.equals("Accept-Encoding", ignoreCase = true)) {
                 requestProperties[key] = value
@@ -141,6 +158,117 @@ class ExoPlayerEngine(private val context: Context) : PlaybackEngine {
 
         logger.i(TAG, "Final Request Headers: $requestProperties")
 
+        // Network stack:
+        // 1. Browser-captured streams (detectedBy is not null) use the legacy DefaultHttpDataSource for live stream compatibility.
+        // 2. Direct Hub/Debrid streams use OkHttp with IPv4-First DNS for performance.
+        val isBrowserStream = !payload.detected_by.isNullOrEmpty()
+
+        val httpDataSourceFactory = if (isBrowserStream) {
+            logger.i(TAG, "Using Legacy Network Stack (DefaultHttpDataSource) for browser-captured stream: ${payload.detected_by}")
+            DefaultHttpDataSource.Factory()
+                .setUserAgent(userAgent)
+                .setDefaultRequestProperties(requestProperties)
+                .setAllowCrossProtocolRedirects(true)
+                .setConnectTimeoutMs(20_000)
+                .setReadTimeoutMs(20_000)
+        } else {
+            logger.i(TAG, "Using Modern Network Stack (OkHttp) with IPv4-First DNS")
+            val okHttpClient = OkHttpClient.Builder()
+                .dns(IPv4FirstDns())
+                .connectTimeout(20, TimeUnit.SECONDS)
+                .readTimeout(20, TimeUnit.SECONDS)
+                .followRedirects(true)
+                .followSslRedirects(true)
+                .retryOnConnectionFailure(true)
+                .build()
+
+            OkHttpDataSource.Factory(okHttpClient)
+                .setUserAgent(userAgent)
+                .setDefaultRequestProperties(requestProperties)
+        }
+
+        val isHls = (payload.detected_by == "body_content_m3u8") ||
+                    (payload.detected_by == "url_pattern_m3u8") ||
+                    (payload.content_type == "application/vnd.apple.mpegurl") ||
+                    (payload.content_type == "application/x-mpegurl") ||
+                    (payload.content_type == MimeTypes.APPLICATION_M3U8) ||
+                    (payload.content_type.isNullOrEmpty() && (payload.url.contains(".m3u8") || payload.url.contains(".jpg")))
+
+        logger.i(TAG, "Content detection: isHls=$isHls (detectedBy=${payload.detected_by}, contentType=${payload.content_type})")
+
+        val mediaSourceFactory = if (isHls) {
+            logger.i(TAG, "Using HlsMediaSource.Factory")
+            HlsMediaSource.Factory(httpDataSourceFactory)
+                .setAllowChunklessPreparation(true)
+                .setLoadErrorHandlingPolicy(CustomLoadErrorHandlingPolicy())
+        } else {
+            logger.i(TAG, "Using DefaultMediaSourceFactory")
+            val extractorsFactory = androidx.media3.extractor.DefaultExtractorsFactory()
+                .setConstantBitrateSeekingEnabled(true)
+                .setTsExtractorFlags(androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory.FLAG_ENABLE_HDMV_DTS_AUDIO_STREAMS)
+            DefaultMediaSourceFactory(httpDataSourceFactory, extractorsFactory)
+                .setLoadErrorHandlingPolicy(CustomLoadErrorHandlingPolicy())
+        }
+
+        val builder = MediaItem.Builder().setUri(finalUrl)
+        if (payload.title != null) {
+            builder.setMediaId(payload.title!!)
+        }
+        if (isHls) {
+            builder.setMimeType(MimeTypes.APPLICATION_M3U8)
+        } else if (!payload.content_type.isNullOrEmpty()) {
+            builder.setMimeType(payload.content_type)
+        }
+
+        return PerItemSource(mediaSourceFactory, builder.build())
+    }
+
+    /**
+     * Swap the media on the live player (no rebuild). Per-item track preferences
+     * are layered onto the current parameters; stale per-item overrides are
+     * cleared (they reference the previous item's track groups anyway).
+     */
+    private fun reloadOnLivePlayer(exoPlayer: ExoPlayer, payload: PlayPayload) {
+        logger.i(TAG, "Reusing live ExoPlayer for new item (no rebuild)")
+
+        val paramsBuilder = exoPlayer.trackSelectionParameters.buildUpon().clearOverrides()
+        payload.preferred_audio_language?.let {
+            logger.i(TAG, "Applying preferred audio language: $it")
+            paramsBuilder.setPreferredAudioLanguage(it)
+        }
+        payload.preferred_subtitle_language?.let {
+            logger.i(TAG, "Applying preferred subtitle language: $it")
+            paramsBuilder.setPreferredTextLanguage(it)
+            paramsBuilder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
+        }
+        payload.default_video_quality?.let { quality ->
+            val (maxW, maxH) = when (quality.lowercase()) {
+                "720p"        -> 1280 to 720
+                "1080p"       -> 1920 to 1080
+                "2160p", "4k" -> 3840 to 2160
+                else          -> null to null
+            }
+            if (maxW != null && maxH != null) {
+                paramsBuilder.setMaxVideoSize(maxW, maxH)
+            }
+        }
+        payload.max_bitrate_cap_mbps?.let { cap ->
+            paramsBuilder.setMaxVideoBitrate((cap * 1_000_000).toInt())
+        }
+        exoPlayer.trackSelectionParameters = paramsBuilder.build()
+
+        exoPlayer.setMediaSource(buildPerItemSource(payload).createMediaSource())
+        exoPlayer.prepare()
+        exoPlayer.playWhenReady = true
+        startProgressTracker()
+    }
+
+    private fun initializePlayer(payload: PlayPayload) {
+        val bufCfg = AndroidBufferConfig.compute(context)
+        logger.i(TAG, "Initializing player with buffer config: maxBufferMs=${bufCfg.maxBufferMs}, targetBytes=${bufCfg.targetBytes}")
+
+        val perItem = buildPerItemSource(payload)
+
         val loadControl = DefaultLoadControl.Builder()
             .setBufferDurationsMs(
                 15_000, 
@@ -172,35 +300,6 @@ class ExoPlayerEngine(private val context: Context) : PlaybackEngine {
                     }
                 }
             }
-        }
-
-        // Determine which network stack to use: 
-        // 1. Browser-captured streams (detectedBy is not null) use the legacy DefaultHttpDataSource for live stream compatibility.
-        // 2. Direct Hub/Debrid streams use OkHttp with IPv4-First DNS for performance.
-        val isBrowserStream = !payload.detected_by.isNullOrEmpty()
-
-        val httpDataSourceFactory = if (isBrowserStream) {
-            logger.i(TAG, "Using Legacy Network Stack (DefaultHttpDataSource) for browser-captured stream: ${payload.detected_by}")
-            DefaultHttpDataSource.Factory()
-                .setUserAgent(userAgent)
-                .setDefaultRequestProperties(requestProperties)
-                .setAllowCrossProtocolRedirects(true)
-                .setConnectTimeoutMs(20_000)
-                .setReadTimeoutMs(20_000)
-        } else {
-            logger.i(TAG, "Using Modern Network Stack (OkHttp) with IPv4-First DNS")
-            val okHttpClient = OkHttpClient.Builder()
-                .dns(IPv4FirstDns())
-                .connectTimeout(20, TimeUnit.SECONDS)
-                .readTimeout(20, TimeUnit.SECONDS)
-                .followRedirects(true)
-                .followSslRedirects(true)
-                .retryOnConnectionFailure(true)
-                .build()
-
-            OkHttpDataSource.Factory(okHttpClient)
-                .setUserAgent(userAgent)
-                .setDefaultRequestProperties(requestProperties)
         }
 
         val prefs = context.getSharedPreferences("browser_prefs", android.content.Context.MODE_PRIVATE)
@@ -250,35 +349,11 @@ class ExoPlayerEngine(private val context: Context) : PlaybackEngine {
             setParameters(params)
         }
 
-        // 3. Media Source Factory
-        val isHls = (payload.detected_by == "body_content_m3u8") ||
-                    (payload.detected_by == "url_pattern_m3u8") ||
-                    (payload.content_type == "application/vnd.apple.mpegurl") ||
-                    (payload.content_type == "application/x-mpegurl") ||
-                    (payload.content_type == MimeTypes.APPLICATION_M3U8) ||
-                    (payload.content_type.isNullOrEmpty() && (payload.url.contains(".m3u8") || payload.url.contains(".jpg")))
-
-        logger.i(TAG, "Content detection: isHls=$isHls (detectedBy=${payload.detected_by}, contentType=${payload.content_type})")
-
-        val mediaSourceFactory = if (isHls) {
-            logger.i(TAG, "Using HlsMediaSource.Factory")
-            HlsMediaSource.Factory(httpDataSourceFactory)
-                .setAllowChunklessPreparation(true)
-                .setLoadErrorHandlingPolicy(CustomLoadErrorHandlingPolicy())
-        } else {
-            logger.i(TAG, "Using DefaultMediaSourceFactory")
-            val extractorsFactory = androidx.media3.extractor.DefaultExtractorsFactory()
-                .setConstantBitrateSeekingEnabled(true)
-                .setTsExtractorFlags(androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory.FLAG_ENABLE_HDMV_DTS_AUDIO_STREAMS)
-            DefaultMediaSourceFactory(httpDataSourceFactory, extractorsFactory)
-                .setLoadErrorHandlingPolicy(CustomLoadErrorHandlingPolicy())
-        }
-
         player = ExoPlayer.Builder(context)
             .setRenderersFactory(renderersFactory)
             .setLoadControl(loadControl)
             .setTrackSelector(trackSelector!!)
-            .setMediaSourceFactory(mediaSourceFactory)
+            .setMediaSourceFactory(perItem.mediaSourceFactory)
             .setSeekForwardIncrementMs(10_000)
             .setReleaseTimeoutMs(3_000) // Prevent hanging during engine transitions
             // Many proxy/debrid streams reach the end without signalling EOS, so the player sits
@@ -292,20 +367,7 @@ class ExoPlayerEngine(private val context: Context) : PlaybackEngine {
                 exoPlayer.addListener(playerListener)
                 videoFilterManager.setPlayer(exoPlayer)
 
-                val builder = MediaItem.Builder().setUri(finalUrl)
-                if (payload.title != null) {
-                    builder.setMediaId(payload.title)
-                }
-                if (isHls) {
-                    builder.setMimeType(MimeTypes.APPLICATION_M3U8)
-                } else if (!payload.content_type.isNullOrEmpty()) {
-                    builder.setMimeType(payload.content_type)
-                }
-
-                val mediaItem = builder.build()
-                val mediaSource = mediaSourceFactory.createMediaSource(mediaItem)
-
-                exoPlayer.setMediaSource(mediaSource)
+                exoPlayer.setMediaSource(perItem.createMediaSource())
                 exoPlayer.prepare()
                 }
         startProgressTracker()

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
@@ -593,6 +593,9 @@ class ExoPlayerActivity : PlayerActivity() {
     private var playJob: kotlinx.coroutines.Job? = null
     /** Serialises Stremio series navigation. Cancelled before each new nav request. */
     private var navigationJob: kotlinx.coroutines.Job? = null
+    /** The player instance the activity listener is attached to (attach-once guard
+     *  now that the player survives episode advances). */
+    private var listenerAttachedPlayer: androidx.media3.common.Player? = null
 
     private fun playVideo(url: String, title: String?, contentType: String? = null, detectedBy: String? = null, intentHeaders: Map<String, String>? = null, subtitles: ArrayList<String>? = null) {
         
@@ -603,7 +606,13 @@ class ExoPlayerActivity : PlayerActivity() {
         FileLogger.i(TAG, "Content Type: $contentType")
         FileLogger.i(TAG, "===========================================")
 
-        releasePlayer()
+        // Do NOT releasePlayer() here: engine.load() swaps the media source on the
+        // live player (see ExoPlayerEngine.reloadOnLivePlayer), which kills the
+        // per-episode rebuild — black gap, surface re-attach, decoder warm-up.
+        // Full release stays reserved for teardown paths (onStop/onDestroy/engine
+        // switch). Only clear transient per-item callbacks.
+        stuckBufferHandler.removeCallbacksAndMessages(null)
+        cancelPlaybackWatchdog()
 
         playJob?.cancel()
         playJob = lifecycleScope.launch(Dispatchers.Main) {
@@ -704,18 +713,27 @@ class ExoPlayerActivity : PlayerActivity() {
         )
 
         lifecycleScope.launch {
-            // Restore playback position from history if no explicit start position was provided
+            engine?.load(payload)
+
+            // Restore playback position from history if no explicit start position was
+            // provided. This runs AFTER load(): the player is reused across items now,
+            // so a seek issued earlier would land on the *previous* episode still
+            // playing. After load() the player is preparing the new item and the seek
+            // (or the pendingResumePosition stash, if the player is idle) targets it.
             if (pendingResumePosition <= 0L) {
                 FileLogger.d(TAG, "No explicit start position, attempting to restore from history...")
                 progressManager.restoreProgress(url)
             }
 
-            engine?.load(payload)
-
             // Re-apply activity-specific player settings after engine creates the player
             engine?.getExoPlayer()?.let { exoPlayer ->
                 playerView.player = exoPlayer
-                exoPlayer.addListener(createPlayerListener())
+                // The player instance is reused across episodes now — attach the
+                // activity listener once per instance, not once per item.
+                if (listenerAttachedPlayer !== exoPlayer) {
+                    exoPlayer.addListener(createPlayerListener())
+                    listenerAttachedPlayer = exoPlayer
+                }
                 exoPlayer.prepare()
                 exoPlayer.playWhenReady = true
             }
@@ -1100,6 +1118,7 @@ class ExoPlayerActivity : PlayerActivity() {
             FileLogger.e(TAG, "Error releasing player: ${e.message}", e)
         }
         engine = null
+        listenerAttachedPlayer = null
     }
 
     /**

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsOverlay.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsOverlay.kt
@@ -49,18 +49,7 @@ fun PlayerControlsOverlay(
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier.fillMaxSize()) {
-        // PrePlay Overlay (Bottom layer)
-        state.prePlayMetadata?.let { metadata ->
-            com.playbridge.player.preplay.PrePlayScreen(
-                metadata = metadata,
-                isLaunching = state.isPrePlayLaunching,
-                launchCountdown = state.prePlayCountdown,
-                onStartNow = onPrePlayStartNow,
-                onBack = onPrePlayBack
-            )
-        }
-
-        // Main Controls Overlay (Top layer)
+        // Main Controls Overlay
         AnimatedVisibility(
             visible = state.isVisible,
             enter = fadeIn(),
@@ -237,6 +226,19 @@ fun PlayerControlsOverlay(
             SubtitleOverlay(
                 text = state.currentSubtitleText,
                 modifier = Modifier.align(Alignment.BottomCenter)
+            )
+        }
+
+        // PrePlay Overlay — TOP layer, deliberately last: it must cover the
+        // buffering spinner and the subtitle overlay (which otherwise bleed
+        // through while the player pre-buffers a resume position underneath).
+        state.prePlayMetadata?.let { metadata ->
+            com.playbridge.player.preplay.PrePlayScreen(
+                metadata = metadata,
+                isLaunching = state.isPrePlayLaunching,
+                launchCountdown = state.prePlayCountdown,
+                onStartNow = onPrePlayStartNow,
+                onBack = onPrePlayBack
             )
         }
     }

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/MPVPlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/MPVPlayerView.swift
@@ -35,6 +35,24 @@ struct MPVPlayerView: UIViewControllerRepresentable {
 
     func updateUIViewController(_ uiViewController: MPVViewController, context: Context) {
         uiViewController.isPreBuffering = isPreBuffering
+        // Keep callbacks current (they're cheap value assignments).
+        uiViewController.onDismiss = onDismiss
+        uiViewController.onExit = onExit
+        uiViewController.onSwitch = onSwitch
+        uiViewController.onBroadcast = onBroadcast
+        // Episode advance on the LIVE mpv core: the controller (and its initialised
+        // handle, render layer, caches) is reused — `loadfile replace` swaps the
+        // media. This is what makes back-to-back episodes start fast and gapless
+        // instead of paying a full mpv re-init per item.
+        if uiViewController.url != url {
+            uiViewController.loadNewItem(
+                url: url,
+                headers: headers,
+                subtitles: subtitles,
+                initialTime: initialTime,
+                title: title
+            )
+        }
     }
 
     /// Deterministic teardown. SwiftUI calls this when it removes the representable's
@@ -270,6 +288,29 @@ class MPVViewController: UIViewController {
         try? AVAudioSession.sharedInstance().setActive(true)
     }
 
+    /// Swap in the next item on the live mpv core (episode advance). All per-item
+    /// state is reset; the handle, render context, and demuxer caches survive.
+    func loadNewItem(url: URL, headers: [String: String]?, subtitles: [String]?,
+                     initialTime: Double, title: String?) {
+        self.url = url
+        self.headers = headers
+        self.subtitles = subtitles
+        self.initialTime = initialTime
+        self.mediaTitle = title
+
+        // Per-item resets (mirrors what a fresh controller would start with).
+        didApplyTrackPreferences = false
+        ignoreTimeUpdatesUntil = .distantPast
+        playbackState.title = title ?? ""
+        playbackState.currentTime = 0
+        playbackState.duration = 0
+        playbackState.userPaused = false
+        playbackState.audioTracks = []
+        playbackState.subtitleTracks = []
+
+        loadFile(url)
+    }
+
     private func loadFile(_ url: URL) {
         guard mpv != nil else { return }   // re-bound to the live handle inside mpvQueue below
         pendingExternalSubtitles = subtitles ?? []
@@ -292,6 +333,10 @@ class MPVViewController: UIViewController {
 
             if self.initialTime > 0 {
                 mpv_set_property_string(handle, "start", String(format: "%.2f", self.initialTime))
+            } else {
+                // The handle persists across episodes now — clear a previous item's
+                // resume point or the next file would start there too.
+                mpv_set_property_string(handle, "start", "none")
             }
             let path = url.isFileURL ? url.path : url.absoluteString
             self.mpvCommand(handle, ["loadfile", path, "replace"])
@@ -320,6 +365,20 @@ class MPVViewController: UIViewController {
             onFileLoaded()
 
         case MPV_EVENT_END_FILE:
+            // The handle is reused across episodes: our own `loadfile replace`
+            // (advance/loop) also emits END_FILE, with reason STOP/REDIRECT.
+            // Only a natural EOF or a hard error may advance the playlist —
+            // otherwise the replace that *performs* an advance would immediately
+            // trigger another one and skip episodes.
+            if let efPtr = event.data?.assumingMemoryBound(to: mpv_event_end_file.self) {
+                // `reason` is a plain int in the C struct; compare against the
+                // enum's raw values.
+                let reason = UInt32(bitPattern: efPtr.pointee.reason)
+                guard reason == MPV_END_FILE_REASON_EOF.rawValue
+                        || reason == MPV_END_FILE_REASON_ERROR.rawValue else {
+                    break
+                }
+            }
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 if self.playbackState.isLooping {

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/MPVPlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/MPVPlayerView.swift
@@ -371,11 +371,8 @@ class MPVViewController: UIViewController {
             // otherwise the replace that *performs* an advance would immediately
             // trigger another one and skip episodes.
             if let efPtr = event.data?.assumingMemoryBound(to: mpv_event_end_file.self) {
-                // `reason` is a plain int in the C struct; compare against the
-                // enum's raw values.
-                let reason = UInt32(bitPattern: efPtr.pointee.reason)
-                guard reason == MPV_END_FILE_REASON_EOF.rawValue
-                        || reason == MPV_END_FILE_REASON_ERROR.rawValue else {
+                let reason = efPtr.pointee.reason
+                guard reason == MPV_END_FILE_REASON_EOF || reason == MPV_END_FILE_REASON_ERROR else {
                     break
                 }
             }

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/PlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/PlayerView.swift
@@ -151,7 +151,11 @@ struct PlayerView: View {
                     )
                     .ignoresSafeArea()
                     .focused($isPlayerFocused)
-                    .id(currentURL)
+                    // Stable identity: episode advances reuse the live mpv core
+                    // (updateUIViewController issues `loadfile replace`) instead of
+                    // paying a full mpv re-init per item. Switching engines still
+                    // tears it down via the branch change.
+                    .id("mpv-engine")
                 } else {
                     NativePlayerView(
                         url: currentURL,


### PR DESCRIPTION
## Summary

The two big-ticket items from the cross-platform player performance review: stop rebuilding the player per episode. Stacked on #<parity-PR> (`feat/receiver-parity-and-performance`).

### Android — live ExoPlayer reuse (`ExoPlayerEngine` + `ExoPlayerActivity`)
- `load()` now swaps the media on the **live player** (`setMediaSource` + `prepare`) instead of release + full rebuild — kills the black gap, surface re-attach, and decoder warm-up between episodes
- Per-item concerns (headers/auth/referer, legacy-vs-OkHttp network stack, HLS detection, `MediaItem`) extracted into `buildPerItemSource()`, shared by the init and reuse paths
- Per-item track preferences are layered onto the live `trackSelectionParameters`; stale per-item overrides cleared (they reference the previous item's track groups)
- `playVideo()` no longer calls `releasePlayer()` per item — full release stays on teardown paths (`onStop`/`onDestroy`/engine switch)
- Activity listener attaches **once per player instance** — also fixes a pre-existing leak where every episode stacked another `createPlayerListener()`
- History-resume seek moved after `load()`: with a live player it would otherwise seek the *previous* episode still playing

### tvOS — persistent mpv core (`MPVPlayerView` + `PlayerView`)
- MPV branch gets a stable SwiftUI identity (`.id("mpv-engine")`); episode advances flow through `updateUIViewController` → `loadNewItem()` → `loadfile replace` on the live handle — no mpv re-init, no render-context rebuild
- **END_FILE reason guard**: our own `loadfile replace` also emits END_FILE; only EOF/ERROR may advance the playlist (without this, every advance triggers another and skips episodes)
- `start` property cleared when an item has no resume point (it persists on the handle and would leak into the next file)
- Per-item resets in `loadNewItem`: track-preference apply-once guard, HUD state, time/duration
- Engine switching still tears mpv down via the SwiftUI branch change; VLC/AVPlayer unchanged (per-URL identity)

## Testing
- tvOS built in Xcode after fixing an MPVKit type mismatch on the END_FILE reason comparison
- Needs: Gradle builds for TV player **and phone** (`ExoPlayerEngine` is shared), then a binge test on both platforms — advance two episodes and verify: near-instant transition, track picks hold, resume works, loop works, engine-switch mid-episode still works
- Watch for: Android error-fallback paths (decoder fallback, stuck-buffer retry) now retry on the live instance
