### PR TITLE
fix(mobile): native-messaging video detection, navigation reset, live-stream gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ Comprehensive project documentation is available:
 - **[Contributing](CONTRIBUTING.md)**: Setup instructions and contribution guidelines.
 - **[Security Policy](SECURITY.md)**: Security considerations and vulnerability reporting.
 
+### Cast demo page
+
+Sites can cast directly into PlayBridge via the injected `window.playbridge.cast()` page bridge.
+A live demo that exercises all payload shapes (single video, HLS, playlist with `startIndex`,
+bare array) plus the browser's video detection paths is hosted at
+**[playbridge.app/cast-demo](https://playbridge.app/cast-demo/)** — open it in the PlayBridge
+phone browser. Source: [`web/site/static/cast-demo/`](web/site/static/cast-demo/index.html).
+
 ## Build Instructions
 
 ### Prerequisites

--- a/mobile/android/app/src/main/assets/extensions/video_detector/background.js
+++ b/mobile/android/app/src/main/assets/extensions/video_detector/background.js
@@ -1,6 +1,9 @@
 // PlayBridge Video Detector - Background Script
-// Detects video URLs per-tab and sends them to content script for storage
-// Uses per-tab Maps so each tab tracks its own videos independently
+// Detects video URLs per-tab via webRequest interception and reports them to the
+// native app over GeckoView native messaging (runtime.sendNativeMessage).
+// Per-tab state is reset on every top-level navigation (including reloads).
+
+const NATIVE_APP_ID = 'browser';
 
 const VIDEO_CONTENT_TYPES = [
     'video/',
@@ -14,7 +17,13 @@ const VIDEO_CONTENT_TYPES = [
     '.srt'
 ];
 
-console.log('[VideoDetector BG] Starting (Per-Tab Mode)...');
+const VIDEO_EXTENSIONS = ['.mp4', '.mkv', '.webm', '.avi', '.mov', '.flv', '.m4v', '.wmv', '.3gp'];
+const SUBTITLE_EXTENSIONS = ['.vtt', '.srt'];
+// HLS/DASH media segments — not playable streams on their own; suppress so they
+// don't flood the detected-videos list before the segment-prefix cleanup in Kotlin.
+const SEGMENT_EXTENSIONS = ['.ts', '.m4s', '.fmp4', '.cmfv', '.cmfa'];
+
+console.log('[VideoDetector BG] Starting (Native Messaging Mode)...');
 
 // Per-tab video storage
 const tabVideos = new Map();           // geckoTabId → [{url, ...}]
@@ -27,6 +36,8 @@ const requestHeadersMap = new Map();
 // Configuration for cleanup
 const CLEANUP_INTERVAL_MS = 30000; // 30 seconds
 const HEADER_TTL_MS = 60000; // 1 minute
+
+const DEBUG = false; // Set to true for verbose logging
 
 // Periodic cleanup to prevent memory leaks from incomplete requests
 setInterval(() => {
@@ -43,6 +54,22 @@ setInterval(() => {
     }
 }, CLEANUP_INTERVAL_MS);
 
+// ── Native messaging ──────────────────────────────────────────────────────────
+// GeckoView routes runtime.sendNativeMessage(NATIVE_APP_ID, ...) to the
+// MessageDelegate registered in Components.kt (processMessage). This replaces
+// the old document.title / localStorage / URL-hash signaling hacks, which were
+// racy (100ms restore window, coalesced location changes) and broke on sites
+// that manage their own hash/history.
+function sendToNative(message) {
+    try {
+        browser.runtime.sendNativeMessage(NATIVE_APP_ID, message).catch((e) => {
+            if (DEBUG) console.log('[VideoDetector BG] sendNativeMessage failed:', e?.message);
+        });
+    } catch (e) {
+        console.error('[VideoDetector BG] sendNativeMessage threw:', e);
+    }
+}
+
 // Helper: get or create per-tab structures
 function getTabVideos(tabId) {
     if (!tabVideos.has(tabId)) tabVideos.set(tabId, []);
@@ -57,12 +84,12 @@ function getTabHeadersCaptured(tabId) {
     return tabHeadersCaptured.get(tabId);
 }
 
-// Clean up state for a closed tab
+// Clean up state for a tab (closed or navigated away)
 function cleanupTab(tabId) {
     tabVideos.delete(tabId);
     tabSeenUrls.delete(tabId);
     tabHeadersCaptured.delete(tabId);
-    console.log(`[VideoDetector BG] Cleaned up tab ${tabId}`);
+    if (DEBUG) console.log(`[VideoDetector BG] Cleaned up tab ${tabId}`);
 }
 
 // Listen for tab removal to free memory
@@ -70,14 +97,42 @@ browser.tabs.onRemoved.addListener((tabId) => {
     cleanupTab(tabId);
 });
 
-// Send video to content script for storage (per-tab)
-function notifyContentScript(video, tabId, headers = null) {
+// ── Navigation reset ──────────────────────────────────────────────────────────
+// On every committed top-level navigation (including reloads and back/forward),
+// clear this tab's detection state so previously-seen URLs are re-reported, and
+// tell the native side to reset its list for the tab. Without this, the
+// seenUrls/headersCaptured sets suppressed re-detection after a reload or when
+// returning to a previously visited page. onCommitted does not fire for
+// same-document navigations (hash changes / pushState), so SPA route changes
+// keep their detected videos.
+browser.webNavigation.onCommitted.addListener((details) => {
+    if (details.frameId !== 0) return;
+    cleanupTab(details.tabId);
+    sendToNative({
+        type: 'navigation',
+        tabId: details.tabId,
+        url: details.url,
+        // originUrl lets the native side resolve the Kotlin tab ID with the
+        // same logic used for video messages.
+        originUrl: details.url,
+        transitionType: details.transitionType || '',
+        timestamp: Date.now()
+    });
+    if (DEBUG) console.log(`[VideoDetector BG] Navigation committed tab=${details.tabId} (${details.transitionType}): ${details.url.substring(0, 80)}`);
+});
+
+// ── Reporting ─────────────────────────────────────────────────────────────────
+// Dedupe per tab, store, and push to the native app. Requests without a real
+// tab ID (e.g. fired from service workers have tabId === -1) are still sent —
+// the native side resolves the Kotlin tab from originUrl, falling back to the
+// selected tab.
+function reportVideo(video, tabId, headers = null) {
     const hasHeaders = headers && Object.keys(headers).length > 0;
     const seenUrls = getTabSeenUrls(tabId);
     const headersCaptured = getTabHeadersCaptured(tabId);
 
     if (seenUrls.has(video.url)) {
-        // If we already saw this URL, check if we're improving it with headers
+        // If we already saw this URL, only continue if we're improving it with headers
         if (headersCaptured.has(video.url) || !hasHeaders) {
             return;
         }
@@ -98,18 +153,13 @@ function notifyContentScript(video, tabId, headers = null) {
         videos.push(video);
     }
 
-    const count = videos.length;
-    console.log('[VideoDetector BG] VIDEO DETECTED tab=' + tabId + ' #' + count + ' (Headers: ' + hasHeaders + '): ' + video.url.substring(0, 80));
+    console.log('[VideoDetector BG] VIDEO DETECTED tab=' + tabId + ' #' + videos.length +
+        ' (Headers: ' + hasHeaders + ', by: ' + video.detectedBy + '): ' + video.url.substring(0, 80));
 
-    // Send to content script in the specific tab only
-    if (tabId && tabId > 0) {
-        browser.tabs.sendMessage(tabId, {
-            type: 'video_detected',
-            ...video
-        }).catch(e => {
-            // Ignore tab closed errors
-        });
-    }
+    sendToNative({
+        type: 'video_detected',
+        ...video
+    });
 
     // Store in extension storage as backup (per-tab)
     const allVideos = [];
@@ -122,10 +172,6 @@ function notifyContentScript(video, tabId, headers = null) {
         count: allVideos.length
     });
 }
-
-
-
-const DEBUG = false; // Set to false to disable verbose logging
 
 // 0. Log all requests (Debug)
 browser.webRequest.onBeforeRequest.addListener(
@@ -141,7 +187,7 @@ browser.webRequest.onBeforeRequest.addListener(
 browser.webRequest.onBeforeSendHeaders.addListener(
     (details) => {
         if (details.method === 'OPTIONS') return;
-        
+
         const headers = {};
         if (details.requestHeaders) {
             details.requestHeaders.forEach(h => {
@@ -165,123 +211,108 @@ browser.webRequest.onBeforeSendHeaders.addListener(
     ["requestHeaders"]
 );
 
-
 // 2. Confirm Video & Merge Headers (Forward)
-// We check the response Content-Type. If it's a video, we retrieve the stored headers.
+// All URL-based checks run even when the response has NO Content-Type header —
+// sketchy live-stream origins frequently omit it, and the old code skipped
+// every check (including the m3u8 body sniffer) in that case.
 browser.webRequest.onHeadersReceived.addListener(
     (details) => {
         const contentTypeHeader = details.responseHeaders?.find(
             h => h.name.toLowerCase() === 'content-type'
         );
+        const contentType = contentTypeHeader ? contentTypeHeader.value.toLowerCase() : '';
+        if (DEBUG) console.log(`[VideoDetector BG] Response: ${details.url} | Content-Type: ${contentType || 'none'}`);
 
-        const contentType = contentTypeHeader ? contentTypeHeader.value.toLowerCase() : 'unknown';
-        if (DEBUG) console.log(`[VideoDetector BG] Response: ${details.url} | Content-Type: ${contentType}`);
-
-        // Always check map for cleanup, but first use it if video
         const storedData = requestHeadersMap.get(details.requestId);
+        const urlFull = details.url.toLowerCase();
+        const urlPath = urlFull.split('?')[0]; // Ignore query params for extension checks
 
-        if (contentTypeHeader) {
-            const isVideoContentType = VIDEO_CONTENT_TYPES.some(type => contentType.includes(type));
-            const isM3u8Url = details.url.toLowerCase().includes('m3u8');
+        // Suppress HLS/DASH media segments early
+        if (SEGMENT_EXTENSIONS.some(ext => urlPath.endsWith(ext))) {
+            if (storedData) requestHeadersMap.delete(details.requestId);
+            return;
+        }
 
-            // Check for common video extensions
-            const videoExtensions = ['.mp4', '.mkv', '.webm', '.avi', '.mov', '.flv', '.m4v', '.wmv', '.3gp'];
-            const urlLower = details.url.toLowerCase().split('?')[0]; // Ignore query params
-            const hasVideoExtension = videoExtensions.some(ext => urlLower.endsWith(ext));
+        const isVideoContentType = contentType !== '' && VIDEO_CONTENT_TYPES.some(type => contentType.includes(type));
+        const isM3u8Url = urlFull.includes('m3u8');
+        // DASH manifests are often served as text/xml or octet-stream, which the
+        // content-type list misses — match the URL like we do for m3u8.
+        const isMpdUrl = urlPath.endsWith('.mpd') || urlFull.includes('.mpd?');
+        const hasVideoExtension = VIDEO_EXTENSIONS.some(ext => urlPath.endsWith(ext));
+        const hasSubtitleExtension = SUBTITLE_EXTENSIONS.some(ext => urlPath.endsWith(ext));
 
-            // Suppress HLS/DASH media segments — they are not playable streams on their own
-            // and would flood the detected-videos list before the segment-prefix cleanup in Kotlin.
-            const segmentExtensions = ['.ts', '.m4s', '.fmp4', '.cmfv', '.cmfa'];
-            if (segmentExtensions.some(ext => urlLower.endsWith(ext))) {
-                if (storedData) requestHeadersMap.delete(details.requestId);
-                return;
-            }
-            
-            // Check for subtitle extensions
-            const subtitleExtensions = ['.vtt', '.srt'];
-            const hasSubtitleExtension = subtitleExtensions.some(ext => urlLower.endsWith(ext));
-            
-            // If it's octet-stream, we MUST rely on extension.
-            // But we can also be more aggressive: if it ends in .mp4, it's a video, period.
-            const isVideoExtensionMatch = hasVideoExtension && (
-                contentType.includes('octet-stream') || 
-                contentType.includes('application/x-google-chrome-pdf') || // sometimes misidentified?
-                contentType.includes('binary') ||
-                !contentType // or no content type?
-            );
+        const isVideo = isVideoContentType || isM3u8Url || isMpdUrl || hasVideoExtension || hasSubtitleExtension;
 
-            const isVideo = isVideoContentType || isM3u8Url || isVideoExtensionMatch || hasVideoExtension || hasSubtitleExtension; 
-            // hasVideoExtension covers cases where server sends wrong type (e.g. text/plain for .mp4)
+        if (isVideo) {
+            if (DEBUG) console.log(`[VideoDetector BG] CONFIRMED VIDEO (Type: ${contentType || 'none'}): ${details.url.substring(0, 50)}...`);
 
-            if (isVideo) {
-                if (DEBUG) console.log(`[VideoDetector BG] CONFIRMED VIDEO (Type: ${contentType}, URL match: ${isM3u8Url || hasVideoExtension}): ${details.url.substring(0, 50)}...`);
+            const headers = storedData ? storedData.headers : null;
 
-                const headers = storedData ? storedData.headers : null;
-                
-                let detectedBy = 'unknown';
-                if (isVideoContentType) detectedBy = 'content_type';
-                else if (isM3u8Url) detectedBy = 'url_pattern_m3u8';
-                else if (hasVideoExtension) detectedBy = 'url_extension';
-                else if (hasSubtitleExtension) detectedBy = 'subtitle_extension';
+            let detectedBy = 'unknown';
+            if (isVideoContentType) detectedBy = 'content_type';
+            else if (isM3u8Url) detectedBy = 'url_pattern_m3u8';
+            else if (isMpdUrl) detectedBy = 'url_pattern_mpd';
+            else if (hasVideoExtension) detectedBy = 'url_extension';
+            else if (hasSubtitleExtension) detectedBy = 'subtitle_extension';
 
-                notifyContentScript({
-                    url: details.url,
-                    tabId: details.tabId,
-                    contentType: contentType,
-                    detectedBy: detectedBy,
-                    originUrl: details.originUrl || '',
-                    timestamp: Date.now()
-                }, details.tabId, headers);
-            } else {
-                // Check if it's a potential hidden M3U8 stream in a generic response type
-                const skipTypes = ['image', 'font', 'stylesheet', 'script'];
-                if (details.statusCode === 200 && !skipTypes.includes(details.type)) {
-                    try {
-                        const filter = browser.webRequest.filterResponseData(details.requestId);
-                        const decoder = new TextDecoder("utf-8");
-                        let checked = false;
-                        let accumulatedData = "";
+            reportVideo({
+                url: details.url,
+                tabId: details.tabId,
+                contentType: contentType || null,
+                detectedBy: detectedBy,
+                originUrl: details.originUrl || '',
+                timestamp: Date.now()
+            }, details.tabId, headers);
+        } else {
+            // Check if it's a potential hidden M3U8 stream in a generic (or absent)
+            // response type by sniffing the first bytes of the body for #EXTM3U.
+            const skipTypes = ['image', 'font', 'stylesheet', 'script'];
+            if (details.statusCode === 200 && !skipTypes.includes(details.type)) {
+                try {
+                    const filter = browser.webRequest.filterResponseData(details.requestId);
+                    const decoder = new TextDecoder("utf-8");
+                    let checked = false;
+                    let accumulatedData = "";
 
-                        filter.ondata = (event) => {
-                            if (checked) {
-                                filter.write(event.data);
-                                return;
+                    filter.ondata = (event) => {
+                        if (checked) {
+                            filter.write(event.data);
+                            return;
+                        }
+
+                        filter.write(event.data); // pass data through unchanged
+                        accumulatedData += decoder.decode(event.data, { stream: true });
+
+                        if (accumulatedData.length >= 7) {
+                            checked = true;
+                            const trimmed = accumulatedData.trim();
+                            if (trimmed.startsWith("#EXTM3U")) {
+                                console.log(`[VideoDetector BG] HIDDEN M3U8 DETECTED in body: ${details.url.substring(0, 50)}...`);
+                                const headers = storedData ? storedData.headers : null;
+                                reportVideo({
+                                    url: details.url,
+                                    tabId: details.tabId,
+                                    contentType: contentType || null,
+                                    detectedBy: 'body_content_m3u8',
+                                    originUrl: details.originUrl || '',
+                                    timestamp: Date.now()
+                                }, details.tabId, headers);
                             }
-                            
-                            filter.write(event.data); // pass data through unchanged
-                            accumulatedData += decoder.decode(event.data, { stream: true });
-                            
-                            if (accumulatedData.length >= 7) {
-                                checked = true;
-                                const trimmed = accumulatedData.trim();
-                                if (trimmed.startsWith("#EXTM3U")) {
-                                    if (DEBUG) console.log(`[VideoDetector BG] HIDDEN M3U8 DETECTED in body: ${details.url.substring(0, 50)}...`);
-                                    const headers = storedData ? storedData.headers : null;
-                                    notifyContentScript({
-                                        url: details.url,
-                                        tabId: details.tabId,
-                                        contentType: contentType,
-                                        detectedBy: 'body_content_m3u8',
-                                        originUrl: details.originUrl || '',
-                                        timestamp: Date.now()
-                                    }, details.tabId, headers);
-                                }
-                                // Stop intercepting further chunks to save resources
-                                filter.disconnect();
-                            }
-                        };
+                            // Stop intercepting further chunks to save resources
+                            filter.disconnect();
+                        }
+                    };
 
-                        filter.onstop = (event) => {
-                            try { filter.disconnect(); } catch (e) {}
-                        };
-                        
-                        filter.onerror = (event) => {
-                            if (DEBUG) console.log(`[VideoDetector BG] Filter error: ${filter.error}`);
-                        };
-                    } catch (e) {
-                         // filterResponseData might throw if request cannot be filtered
-                         if (DEBUG) console.error(`[VideoDetector BG] filterResponseData error:`, e);
-                    }
+                    filter.onstop = (event) => {
+                        try { filter.disconnect(); } catch (e) {}
+                    };
+
+                    filter.onerror = (event) => {
+                        if (DEBUG) console.log(`[VideoDetector BG] Filter error: ${filter.error}`);
+                    };
+                } catch (e) {
+                    // filterResponseData might throw if request cannot be filtered
+                    if (DEBUG) console.error(`[VideoDetector BG] filterResponseData error:`, e);
                 }
             }
         }
@@ -291,18 +322,16 @@ browser.webRequest.onHeadersReceived.addListener(
         if (details.type === 'main_frame' && details.statusCode >= 400) {
             console.log(`[VideoDetector BG] HTTP ERROR detected: ${details.statusCode} for ${details.url}`);
 
-            // We use the "browser" port if available, or just log it.
-            // Native app will listen for messages of type 'http_error'
             const errorMsg = {
                 type: 'http_error',
                 url: details.url,
+                originUrl: details.url,
                 statusCode: details.statusCode,
                 tabId: details.tabId,
                 timestamp: Date.now()
             };
 
-            // Send to native side directly via runtime.sendMessage (Components.kt message delegate)
-            browser.runtime.sendMessage(errorMsg).catch(() => {});
+            sendToNative(errorMsg);
 
             // Also update storage so polling can find it if needed
             browser.storage.local.set({
@@ -323,18 +352,16 @@ browser.webRequest.onHeadersReceived.addListener(
 // Handle messages from content scripts
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // Video element detected by DOM observer in content.js
-    if (message.action === 'dom_video_found') {
-        const tabId = sender.tab?.id;
-        if (tabId && tabId > 0) {
-            notifyContentScript({
-                url: message.url,
-                tabId: tabId,
-                contentType: null,
-                detectedBy: 'dom_video_element',
-                originUrl: message.origin,
-                timestamp: Date.now()
-            }, tabId, null); // headers arrive later via webRequest and will update this entry
-        }
+    if (message.action === 'dom_video_found' || message.action === 'player_video_found') {
+        const tabId = sender.tab?.id ?? -1;
+        reportVideo({
+            url: message.url,
+            tabId: tabId,
+            contentType: null,
+            detectedBy: message.action === 'player_video_found' ? 'player_config' : 'dom_video_element',
+            originUrl: message.origin,
+            timestamp: Date.now()
+        }, tabId, null); // headers arrive later via webRequest and will update this entry
         return false;
     }
     if (message.action === 'getVideos') {
@@ -361,8 +388,8 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.type === 'cast') {
         // Forward to native app (Components.kt onBridgeCastRequest) via GeckoView Port
         try {
-            const port = browser.runtime.connectNative("browser");
-            
+            const port = browser.runtime.connectNative(NATIVE_APP_ID);
+
             // Listen for feedback from native app
             port.onMessage.addListener((response) => {
                 console.log('[VideoDetector BG] Feedback received from native:', response);
@@ -388,4 +415,4 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return false;
 });
 
-console.log('[VideoDetector BG] Loaded (Per-Tab Mode)');
+console.log('[VideoDetector BG] Loaded (Native Messaging Mode)');

--- a/mobile/android/app/src/main/assets/extensions/video_detector/content.js
+++ b/mobile/android/app/src/main/assets/extensions/video_detector/content.js
@@ -6,9 +6,12 @@
 // Listen for messages from background script
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.type === 'bridge_feedback') {
-        window.dispatchEvent(new CustomEvent('PlayBridgeFeedback', {
-            detail: message
-        }));
+        // cloneInto exports the object into the page compartment — without it,
+        // Firefox's Xray wrappers hide `detail` from page-world listeners.
+        const detail = typeof cloneInto === 'function'
+            ? cloneInto(message, window)
+            : message;
+        window.dispatchEvent(new CustomEvent('PlayBridgeFeedback', { detail }));
     }
     return false;
 });

--- a/mobile/android/app/src/main/assets/extensions/video_detector/content.js
+++ b/mobile/android/app/src/main/assets/extensions/video_detector/content.js
@@ -1,92 +1,16 @@
 // Content script - runs in the context of web pages
-// Receives video info from background and communicates with native app via URL hash
-
-let videos = [];
-let seenUrls = new Set();
+// Video detections are reported by the background script directly to the native
+// app via native messaging; this script only handles DOM/player-level detection
+// and the window.playbridge cast bridge.
 
 // Listen for messages from background script
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (message.type === 'video_detected') {
-        console.log('[VideoDetector Content] Received:', message.url.substring(0, 60));
-
-        let video = null;
-        let shouldSignal = false;
-        const existingIndex = videos.findIndex(v => v.url === message.url);
-
-        if (existingIndex === -1) {
-            // New video
-            video = {
-                url: message.url,
-                contentType: message.contentType || '',
-                detectedBy: message.detectedBy || 'unknown',
-                originUrl: message.originUrl,
-                headers: message.headers || {},
-                timestamp: message.timestamp || Date.now()
-            };
-            videos.push(video);
-            seenUrls.add(message.url);
-            shouldSignal = true;
-        } else {
-            // Existing video - check if we need to update headers
-            const newHeaders = message.headers || {};
-            if (Object.keys(newHeaders).length > 0) {
-                console.log('[VideoDetector Content] Updating headers for existing video');
-                // Merge headers
-                videos[existingIndex] = {
-                    ...videos[existingIndex],
-                    headers: newHeaders,
-                    contentType: message.contentType || videos[existingIndex].contentType
-                };
-                video = videos[existingIndex];
-                shouldSignal = true;
-            }
-        }
-
-        if (shouldSignal && video) {
-            const count = videos.length;
-
-            console.log('[VideoDetector Content] Total: ' + count + ', signaling native...');
-
-            // Method 1: Update title
-            const originalTitle = document.title.replace(/\s*\[PlayBridge:\d+\]$/, '');
-            document.title = originalTitle + ' [PlayBridge:' + count + ']';
-
-            // Method 2: localStorage
-            try {
-                localStorage.setItem('playbridge_videos', JSON.stringify(videos));
-                localStorage.setItem('playbridge_video_count', count.toString());
-            } catch (e) { }
-
-            // Method 3: Hash Signal
-            try {
-                const encodedVideo = encodeURIComponent(JSON.stringify(video));
-                const beacon = '#playbridge-video=' + encodedVideo;
-
-                const oldHash = window.location.hash;
-                window.location.replace(window.location.href.split('#')[0] + beacon);
-
-                setTimeout(() => {
-                    if (oldHash) {
-                        window.location.replace(window.location.href.split('#')[0] + oldHash);
-                    } else {
-                        history.replaceState(null, '', window.location.href.split('#')[0]);
-                    }
-                }, 100);
-            } catch (e) {
-                console.log('[VideoDetector Content] Hash signal error:', e.message);
-            }
-        }
-
-        sendResponse({ received: true, count: videos.length });
-    }
-    
     if (message.type === 'bridge_feedback') {
         window.dispatchEvent(new CustomEvent('PlayBridgeFeedback', {
             detail: message
         }));
     }
-
-    return true;
+    return false;
 });
 
 // ── Video element observer ────────────────────────────────────────────────────
@@ -135,10 +59,27 @@ videoObserver.observe(document.documentElement, {
     attributes: true, attributeFilter: ['src']
 });
 
+// ── Player config probe (page world) ─────────────────────────────────────────
+// Reported via the PlayBridgeMediaFound CustomEvent from the injected script
+// below. Finds stream URLs configured in common JS players (JW Player,
+// Video.js, hls.js) before playback starts — these never hit the network (so
+// webRequest can't see them) and use blob: element src under MSE (so the DOM
+// observer can't either).
+window.addEventListener('PlayBridgeMediaFound', (event) => {
+    const url = event.detail && event.detail.url;
+    if (!url || typeof url !== 'string' || !url.startsWith('http')) return;
+    browser.runtime.sendMessage({
+        action: 'player_video_found',
+        url: url,
+        origin: window.location.href
+    }).catch(() => {});
+});
+
 console.log('[VideoDetector Content] Loaded');
 
 // --- PlayBridge JS Bridge ---
-// Injected into the page world to provide window.playbridge.cast()
+// Injected into the page world to provide window.playbridge.cast() and to
+// probe JS player configs for stream URLs.
 (function injectBridge() {
     const bridgeScript = document.createElement('script');
     bridgeScript.textContent = `
@@ -150,28 +91,82 @@ console.log('[VideoDetector Content] Loaded');
                     window.dispatchEvent(new CustomEvent('PlayBridgeCast', { detail: payload }));
                 }
             };
-            
+
             // --- BACKGROUND PLAYBACK FIX ---
             // Override visibility state so sites like YouTube don't pause when backgrounded
             try {
-                Object.defineProperty(document, 'visibilityState', { 
+                Object.defineProperty(document, 'visibilityState', {
                     get: function() { return 'visible'; },
-                    configurable: true 
+                    configurable: true
                 });
-                Object.defineProperty(document, 'hidden', { 
+                Object.defineProperty(document, 'hidden', {
                     get: function() { return false; },
                     configurable: true
                 });
-                
+
                 // Also override the visibilitychange event
                 window.addEventListener('visibilitychange', function(e) {
                     e.stopImmediatePropagation();
                 }, true);
-                
+
                 console.log('[PlayBridge JS Bridge] Shim + Background Fix injected');
             } catch (e) {
                 console.warn('[PlayBridge JS Bridge] Failed to inject background fix', e);
             }
+
+            // --- PLAYER CONFIG PROBE ---
+            // Read stream URLs out of common JS player configs so streams are
+            // detected even before the user presses play.
+            var pbReported = {};
+            function pbReport(url) {
+                if (!url || typeof url !== 'string' || url.indexOf('http') !== 0) return;
+                if (pbReported[url]) return;
+                pbReported[url] = true;
+                window.dispatchEvent(new CustomEvent('PlayBridgeMediaFound', { detail: { url: url } }));
+            }
+            function pbProbePlayers() {
+                // JW Player
+                try {
+                    if (typeof window.jwplayer === 'function') {
+                        var jw = window.jwplayer();
+                        var list = jw && jw.getPlaylist && jw.getPlaylist();
+                        if (list && list.length) {
+                            for (var i = 0; i < list.length; i++) {
+                                var item = list[i];
+                                if (item.file) pbReport(item.file);
+                                var sources = item.sources || [];
+                                for (var j = 0; j < sources.length; j++) {
+                                    if (sources[j].file) pbReport(sources[j].file);
+                                }
+                            }
+                        }
+                    }
+                } catch (e) {}
+                // Video.js
+                try {
+                    var vjs = window.videojs;
+                    if (vjs) {
+                        var players = (vjs.getAllPlayers && vjs.getAllPlayers()) ||
+                            (vjs.players && Object.keys(vjs.players).map(function(k) { return vjs.players[k]; })) || [];
+                        for (var p = 0; p < players.length; p++) {
+                            try {
+                                var player = players[p];
+                                if (!player) continue;
+                                var src = player.currentSrc && player.currentSrc();
+                                if (src) pbReport(src);
+                                var srcObj = player.currentSource && player.currentSource();
+                                if (srcObj && srcObj.src) pbReport(srcObj.src);
+                            } catch (e) {}
+                        }
+                    }
+                } catch (e) {}
+                // hls.js (common global instance pattern)
+                try {
+                    if (window.hls && window.hls.url) pbReport(window.hls.url);
+                } catch (e) {}
+            }
+            // Players initialize at unpredictable times; probe a few times after load.
+            [2000, 5000, 10000, 20000].forEach(function(t) { setTimeout(pbProbePlayers, t); });
         })();
     `;
     (document.head || document.documentElement).appendChild(bridgeScript);
@@ -181,7 +176,7 @@ console.log('[VideoDetector Content] Loaded');
 window.addEventListener('PlayBridgeCast', (event) => {
     const payload = event.detail;
     if (!payload) return;
-    
+
     // Normalize to items array
     let items = [];
     let startIndex = payload.startIndex || 0;
@@ -197,11 +192,11 @@ window.addEventListener('PlayBridgeCast', (event) => {
         // If it's a single item with url/title/metadata, just wrap it
         items = [payload];
     }
-    
+
     if (items.length === 0) return;
-    
+
     console.log('[VideoDetector Content] Bridge Cast Request:', items.length, 'items, startIndex:', startIndex);
-    
+
     // Forward to background script
     browser.runtime.sendMessage({
         type: 'cast',

--- a/mobile/android/app/src/main/assets/extensions/video_detector/manifest.json
+++ b/mobile/android/app/src/main/assets/extensions/video_detector/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "PlayBridge Video Detector",
-    "version": "1.0.9",
+    "version": "1.1.0",
     "description": "Detects video URLs for PlayBridge casting",
     "background": {
         "scripts": [
@@ -24,6 +24,7 @@
         "<all_urls>",
         "webRequest",
         "webRequestBlocking",
+        "webNavigation",
         "storage",
         "tabs",
         "nativeMessaging",

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
@@ -682,6 +682,11 @@ class BrowserActivity : ComponentActivity() {
             }
 
             val detectVideosEnabled by settingsRepository.detectVideos.collectAsState(initial = true)
+            // Detection messages now arrive via native messaging (Components.processMessage),
+            // so the setting is enforced there rather than at the old hash-signal parse site.
+            LaunchedEffect(detectVideosEnabled) {
+                Components.detectVideosEnabled = detectVideosEnabled
+            }
             var isDesktopMode by remember { mutableStateOf(false) }
             var isSecureConnection by remember { mutableStateOf(false) }
             var siteSecurityInfo by remember { mutableStateOf<SiteSecurityInfo?>(null) }
@@ -1091,7 +1096,6 @@ class BrowserActivity : ComponentActivity() {
                 previousUrl = previousUrlState,
                 pendingDownload = pendingDownloadState,
                 isDesktopMode = isDesktopMode,
-                detectVideosEnabled = detectVideosEnabled,
                 isSecureConnection = isSecureConnectionState,
                 siteSecurityInfo = siteSecurityInfoState,
                 pendingPopup = pendingPopupState,
@@ -1129,29 +1133,6 @@ class BrowserActivity : ComponentActivity() {
                 },
                 onTorrentDownloaded = { bytes ->
                     interceptedTorrentBytes = bytes
-                },
-                onVideoHashDetected = { url, kotlinTabId ->
-                    try {
-                        val hashData = url.substringAfter("#playbridge-video=")
-                        val decoded = java.net.URLDecoder.decode(hashData, "UTF-8")
-                        Log.d(TAG, "PlayBridge video signal for tab $kotlinTabId: $decoded")
-
-                        val json = kotlinx.serialization.json.Json.parseToJsonElement(decoded)
-                        if (json is kotlinx.serialization.json.JsonObject) {
-                            VideoDetector.onMessageReceived(kotlinx.serialization.json.JsonObject(mapOf(
-                                "type" to kotlinx.serialization.json.JsonPrimitive("video_detected"),
-                                "url" to (json["url"] ?: kotlinx.serialization.json.JsonPrimitive("")),
-                                "contentType" to (json["contentType"] ?: kotlinx.serialization.json.JsonNull),
-                                "detectedBy" to (json["detectedBy"] ?: kotlinx.serialization.json.JsonPrimitive("unknown")),
-                                "originUrl" to (json["originUrl"] ?: kotlinx.serialization.json.JsonNull),
-                                "headers" to (json["headers"] ?: kotlinx.serialization.json.JsonNull),
-                                "timestamp" to (json["timestamp"] ?: kotlinx.serialization.json.JsonPrimitive(System.currentTimeMillis()))
-                            )), kotlinTabId)
-                            Log.d(TAG, "Video added to VideoDetector for tab $kotlinTabId from hash signal")
-                        }
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Error parsing playbridge-video hash", e)
-                    }
                 },
                 onFullScreenChange = { fullScreen, isPortrait ->
                     isFullscreenVideoPortrait = isPortrait

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/Components.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/Components.kt
@@ -47,6 +47,14 @@ object Components {
     var tabManager: TabManager? = null
     var onBridgeCastRequest: ((items: List<PlayPayload>, startIndex: Int, playlistMetadata: VisualMetadata?) -> Unit)? = null
 
+    /**
+     * Mirrors the "detect videos" setting. Detection messages from the extension
+     * arrive over native messaging regardless of the setting, so they are gated
+     * here. Kept in sync from BrowserActivity.
+     */
+    @Volatile
+    var detectVideosEnabled: Boolean = true
+
     val applicationScope = kotlinx.coroutines.CoroutineScope(
         kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.IO
     )
@@ -387,6 +395,16 @@ object Components {
                             onBridgeCastRequest?.invoke(listOf(PlayPayload(url = url, title = title)), 0, null)
                         }
                     }
+                } else if (type == "navigation") {
+                    // Top-level navigation (including reloads) committed in a tab:
+                    // the extension has cleared its per-tab detection state and
+                    // will re-report videos as the new page loads — reset ours too
+                    // so the cast sheet count starts from 0.
+                    val kotlinTabId = resolveKotlinTabId(jsonObject)
+                    VideoDetector.clearTab(kotlinTabId)
+                    Log.d(TAG, "Navigation committed — cleared detected videos for tab $kotlinTabId")
+                } else if (type == "video_detected" && !detectVideosEnabled) {
+                    Log.d(TAG, "Video detection disabled — ignoring detection message")
                 } else {
                     val kotlinTabId = resolveKotlinTabId(jsonObject)
                     VideoDetector.onMessageReceived(jsonObject, kotlinTabId)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/SessionObserverSetup.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/SessionObserverSetup.kt
@@ -36,8 +36,6 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.LaunchedEffect
 import org.koin.compose.koinInject
 
-private val REGEX_PLAYBRIDGE_TITLE = Regex("\\[PlayBridge:(\\d+)\\]")
-
 /**
  * Sets up the [EngineSession.Observer] and GeckoSession delegate proxies
  * (NavigationDelegate, ContentDelegate) for the active browser session.
@@ -58,7 +56,6 @@ fun SessionObserverSetup(
     previousUrl: MutableState<String>,
     pendingDownload: MutableState<PendingDownload?>,
     isDesktopMode: Boolean,
-    detectVideosEnabled: Boolean,
     isSecureConnection: MutableState<Boolean>,
     siteSecurityInfo: MutableState<SiteSecurityInfo?>,
     pendingPopup: MutableState<PendingPopup?>,
@@ -66,7 +63,6 @@ fun SessionObserverSetup(
     onMagnetDetected: (String) -> Unit,
     onStremioAddonDetected: (String) -> Unit,
     onTorrentDownloaded: (ByteArray) -> Unit,
-    onVideoHashDetected: (String, String) -> Unit,  // (url, kotlinTabId)
     onFullScreenChange: (Boolean, Boolean) -> Unit
 ) {
     val context = LocalContext.current
@@ -130,29 +126,23 @@ fun SessionObserverSetup(
                 }
 
                 currentUrl.value = url
-
-                // Clear detected videos only when navigating to a different page
-                if (baseUrl != previousBaseUrl && previousBaseUrl.isNotEmpty()) {
-                    if (selectedTab != null) {
-                        VideoDetector.clearTab(selectedTab.id)
-                        Log.d(TAG, "Cleared detected videos for tab ${selectedTab.id} - navigated from $previousBaseUrl to $baseUrl")
-                    }
-                }
-
                 previousUrl.value = url
 
-                // Check for playbridge-video hash signal from content script
-                if (detectVideosEnabled && url.contains("#playbridge-video=")) {
-                    val tabId = selectedTab?.id ?: "_unknown"
-                    onVideoHashDetected(url, tabId)
-                }
+                // NOTE: detected videos are no longer cleared here. Reset happens
+                // in two places that both cover reloads (same-URL loads):
+                //  - ProgressDelegate.onPageStart below (precise, local)
+                //  - the extension's webNavigation.onCommitted handler, which also
+                //    clears the extension's own per-tab seen-URL state so videos
+                //    are re-reported on the fresh page (Components.processMessage
+                //    "navigation").
+                // Video detections themselves arrive via native messaging
+                // (Components.processMessage), not the old URL-hash signal.
             }
 
             override fun onLoadingStateChange(loading: Boolean) {
                 isLoading.value = loading
             }
 
-            // Detect video count from page title [PlayBridge:X] marker
             override fun onTitleChange(title: String) {
                 Log.d(TAG, "Title changed: $title")
                 if (selectedTab != null) {
@@ -176,12 +166,6 @@ fun SessionObserverSetup(
                             )
                         )
                     }
-                }
-
-                val match = REGEX_PLAYBRIDGE_TITLE.find(title)
-                if (match != null) {
-                    val count = match.groupValues[1].toIntOrNull() ?: 0
-                    Log.d(TAG, "PlayBridge video count detected: $count")
                 }
             }
 
@@ -570,6 +554,16 @@ fun SessionObserverSetup(
                             when (method.name) {
                                 "onPageStart" -> {
                                     isLoading.value = true
+                                    // Reset detected videos on every top-level page
+                                    // load start — including reloads of the same URL,
+                                    // which the old baseUrl-diff check missed. The
+                                    // sheet count starts at 0 and repopulates as the
+                                    // page loads. onPageStart does not fire for
+                                    // same-document (hash/pushState) navigations, so
+                                    // SPA route changes keep their detected videos.
+                                    selectedTabState.value?.id?.let { tabId ->
+                                        VideoDetector.clearTab(tabId)
+                                    }
                                 }
                                 "onPageStop" -> {
                                     isLoading.value = false

--- a/web/site/static/cast-demo/index.html
+++ b/web/site/static/cast-demo/index.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>PlayBridge Cast Demo</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --card: #161b22;
+    --border: #30363d;
+    --text: #e6edf3;
+    --muted: #8b949e;
+    --accent: #4f8cff;
+    --ok: #3fb950;
+    --warn: #d29922;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.5;
+  }
+  main { max-width: 720px; margin: 0 auto; padding: 24px 16px 64px; }
+  h1 { font-size: 1.5rem; margin: 0 0 4px; }
+  h2 { font-size: 1.05rem; margin: 28px 0 8px; }
+  p.sub { color: var(--muted); margin: 0 0 16px; font-size: .9rem; }
+  .banner {
+    border-radius: 10px;
+    padding: 10px 14px;
+    font-size: .9rem;
+    border: 1px solid var(--border);
+    margin-bottom: 20px;
+  }
+  .banner.ok { border-color: var(--ok); color: var(--ok); }
+  .banner.warn { border-color: var(--warn); color: var(--warn); }
+  .card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 14px;
+    margin-bottom: 12px;
+  }
+  .card h3 { margin: 0 0 4px; font-size: .95rem; }
+  .card p { margin: 0 0 10px; color: var(--muted); font-size: .82rem; }
+  button {
+    background: var(--accent);
+    border: none;
+    color: #fff;
+    border-radius: 8px;
+    padding: 8px 14px;
+    font-size: .85rem;
+    font-weight: 600;
+    cursor: pointer;
+    margin-right: 8px;
+    margin-top: 2px;
+  }
+  button.secondary { background: transparent; border: 1px solid var(--border); color: var(--text); }
+  button:active { opacity: .8; }
+  video { width: 100%; border-radius: 8px; background: #000; }
+  #log {
+    background: #010409;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 10px 12px;
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-size: .75rem;
+    min-height: 90px;
+    max-height: 240px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+  #log .t { color: var(--muted); }
+  #log .ok { color: var(--ok); }
+  code { background: #21262d; border-radius: 4px; padding: 1px 5px; font-size: .8em; }
+</style>
+</head>
+<body>
+<main>
+  <h1>PlayBridge Cast Demo</h1>
+  <p class="sub">
+    Test page for the <code>window.playbridge.cast()</code> page bridge and the browser's
+    video detection. Open it in the PlayBridge phone browser.
+  </p>
+
+  <div id="bridge-banner" class="banner warn">Checking for PlayBridge bridge…</div>
+
+  <h2>Page bridge — <code>window.playbridge.cast()</code></h2>
+
+  <div class="card">
+    <h3>Single video (object form)</h3>
+    <p>One MP4 with full <code>VisualMetadata</code> (title, year, overview, poster).</p>
+    <button onclick="castSingle()">Cast single</button>
+  </div>
+
+  <div class="card">
+    <h3>HLS stream</h3>
+    <p>Casts an HLS master playlist URL — exercises receiver-side manifest handling.</p>
+    <button onclick="castHls()">Cast HLS</button>
+  </div>
+
+  <div class="card">
+    <h3>Playlist with startIndex (items form)</h3>
+    <p>Three episodes with per-item season/episode metadata, starting at the second
+       (<code>startIndex: 1</code>) — exercises the queue.</p>
+    <button onclick="castPlaylist()">Cast playlist</button>
+  </div>
+
+  <div class="card">
+    <h3>Bare array form</h3>
+    <p>Payload is a plain array of items — the third accepted shape.</p>
+    <button onclick="castArray()">Cast array</button>
+  </div>
+
+  <h2>Video detection</h2>
+
+  <div class="card">
+    <h3>DOM <code>&lt;video&gt;</code> element</h3>
+    <p>The element below should appear in the cast sheet via <code>dom_video_element</code>
+       without pressing anything.</p>
+    <video controls preload="none"
+           src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4"
+           poster="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/ForBiggerEscapes.jpg"></video>
+  </div>
+
+  <div class="card">
+    <h3>Network-level HLS fetch</h3>
+    <p>Fetches an <code>.m3u8</code> manifest with XHR — should appear in the cast sheet via
+       <code>url_pattern_m3u8</code> / <code>content_type</code>. Reload the page and confirm
+       the sheet resets to 0, then re-detects after pressing this again.</p>
+    <button class="secondary" onclick="fetchHls()">Fetch HLS manifest</button>
+  </div>
+
+  <h2>Event log</h2>
+  <div id="log"></div>
+</main>
+
+<script>
+  var logEl = document.getElementById('log');
+  function log(msg, cls) {
+    var line = document.createElement('div');
+    var t = new Date().toTimeString().slice(0, 8);
+    line.innerHTML = '<span class="t">' + t + '</span> ' + msg;
+    if (cls) line.className = cls;
+    logEl.appendChild(line);
+    logEl.scrollTop = logEl.scrollHeight;
+  }
+
+  // ── Bridge presence ─────────────────────────────────────────────────────
+  var banner = document.getElementById('bridge-banner');
+  var checks = 0;
+  (function checkBridge() {
+    if (window.playbridge && typeof window.playbridge.cast === 'function') {
+      banner.className = 'banner ok';
+      banner.textContent = '✓ PlayBridge bridge detected — cast buttons are live.';
+      log('Bridge detected (window.playbridge)', 'ok');
+    } else if (++checks < 20) {
+      setTimeout(checkBridge, 250);
+    } else {
+      banner.className = 'banner warn';
+      banner.textContent = '⚠ window.playbridge not found. Open this page in the PlayBridge phone browser. Buttons will log the payload only.';
+      log('Bridge NOT detected after 5s');
+    }
+  })();
+
+  function cast(payload, label) {
+    log('cast(' + label + '): ' + JSON.stringify(payload).slice(0, 140) + '…');
+    if (window.playbridge && window.playbridge.cast) {
+      window.playbridge.cast(payload);
+    } else {
+      log('— no bridge, payload logged only');
+    }
+  }
+
+  // Feedback round-trip from the native app (via background → content script)
+  window.addEventListener('PlayBridgeFeedback', function (e) {
+    var detail = e && e.detail;
+    log('PlayBridgeFeedback: ' + (detail ? JSON.stringify(detail) : '(no detail — Xray-filtered?)'), 'ok');
+  });
+
+  // ── Payloads ────────────────────────────────────────────────────────────
+  var GTV = 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/';
+
+  function castSingle() {
+    cast({
+      url: GTV + 'BigBuckBunny.mp4',
+      title: 'Big Buck Bunny',
+      metadata: {
+        title: 'Big Buck Bunny',
+        year: '2008',
+        overview: 'A giant rabbit takes gentle revenge on three bullying rodents. Blender Foundation open movie.',
+        genres: ['Animation', 'Short'],
+        posterUrl: GTV + 'images/BigBuckBunny.jpg'
+      }
+    }, 'single');
+  }
+
+  function castHls() {
+    cast({
+      url: 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8',
+      title: 'HLS Test Stream (mux.dev)',
+      metadata: { title: 'HLS Test Stream', overview: 'Multi-variant HLS VOD test stream.' }
+    }, 'hls');
+  }
+
+  function castPlaylist() {
+    cast({
+      startIndex: 1,
+      metadata: {
+        title: 'Blender Shorts',
+        overview: 'Demo playlist of Blender Foundation open movies.',
+        posterUrl: GTV + 'images/ElephantsDream.jpg'
+      },
+      items: [
+        { url: GTV + 'BigBuckBunny.mp4',   title: 'S1E1 · Big Buck Bunny',
+          metadata: { title: 'Blender Shorts', season: 1, episode: 1, episodeTitle: 'Big Buck Bunny' } },
+        { url: GTV + 'ElephantsDream.mp4', title: 'S1E2 · Elephants Dream',
+          metadata: { title: 'Blender Shorts', season: 1, episode: 2, episodeTitle: 'Elephants Dream' } },
+        { url: GTV + 'Sintel.mp4',         title: 'S1E3 · Sintel',
+          metadata: { title: 'Blender Shorts', season: 1, episode: 3, episodeTitle: 'Sintel' } }
+      ]
+    }, 'playlist');
+  }
+
+  function castArray() {
+    cast([
+      { url: GTV + 'ForBiggerBlazes.mp4', title: 'For Bigger Blazes' },
+      { url: GTV + 'ForBiggerFun.mp4',    title: 'For Bigger Fun' }
+    ], 'array');
+  }
+
+  function fetchHls() {
+    var url = 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8';
+    log('fetch: ' + url);
+    fetch(url, { mode: 'cors' })
+      .then(function (r) { return r.text(); })
+      .then(function (body) { log('manifest fetched (' + body.length + ' bytes) — check the cast sheet', 'ok'); })
+      .catch(function (e) { log('fetch failed: ' + e.message + ' (request still hit the network — detection may have fired anyway)'); });
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Reworks phone-side video detection to fix missed live-TV streams and the cast sheet not resetting on refresh.

### Delivery: native messaging instead of URL-hash beacon
`video_detected` previously reached Kotlin by writing `#playbridge-video=...` into the page URL and restoring it 100ms later. This raced (rapid detections on live-stream pages overwrote each other, GeckoView coalesces location changes) and broke on sites managing their own hash/history. The background script now calls `runtime.sendNativeMessage("browser", ...)` — the same channel the cast bridge already uses — landing in the existing `Components.processMessage`. The `document.title` `[PlayBridge:n]` and `localStorage` hacks are removed too.

### Reset on refresh / navigation
- The extension's per-tab `seenUrls`/`headersCaptured` sets were only cleared on tab close, so after a reload (or returning to a page) re-detections were suppressed and the sheet could stay stale or show 0. `webNavigation.onCommitted` (frameId 0) now clears extension state and sends a `navigation` message; Kotlin clears its list for the tab.
- Kotlin previously cleared only when the base URL changed, so refreshing the same page never reset the count. It now clears on `ProgressDelegate.onPageStart` — fires for every top-level load including reloads, but not for same-document (SPA hash/pushState) navigations.

### Detection gaps (live streams)
- All URL-based checks and the `#EXTM3U` body sniffer were gated on the response having a `Content-Type` header; responses without one were ignored entirely. Common on sketchy live-stream origins. Checks now run regardless.
- `.mpd` DASH manifests are matched by URL pattern, not just `application/dash` content type (servers often use `text/xml`/octet-stream).
- Requests from service workers (`tabId === -1`) were stored but never forwarded. They're now sent; Kotlin resolves the tab via `originUrl` with selected-tab fallback.

### Player-config probe (pre-play detection)
The injected page-world script now reads stream URLs out of JW Player (`getPlaylist()`), Video.js (`currentSrc`/`currentSource`), and `window.hls.url` at intervals after load (`detectedBy: "player_config"`). These streams use MSE/blob element src and don't hit the network until play, so neither webRequest nor the DOM observer could see them.

### Misc
- The detect-videos setting is enforced in `Components.processMessage` (mirrored from the DataStore flow) since the old hash-parse gate is gone.
- `http_error` now uses `sendNativeMessage` — the old `runtime.sendMessage` went to the extension's own listeners, not native.
- Extension version bumped to 1.1.0; new `webNavigation` permission.

## Test plan
- [x] Normal site with direct mp4 / m3u8: videos appear in cast sheet with headers
- [x] Refresh page: count resets to 0, repopulates as page loads
- [x] Navigate A → B → back to A: videos re-detected on A
- [x] Live-TV site that previously only worked in Web Video Caster: stream detected (check `detectedBy` in logs to see which path caught it)
- [x] SPA hash navigation: detected videos survive
- [x] Detect-videos setting off: no entries appear
- [ ] Cast from page bridge (`window.playbridge.cast`) still works incl. feedback toast
- [x] Background playback shim still active (YouTube keeps playing when backgrounded)

🤖 Generated with Claude
