### PR TITLE
refactor(mobile): adopt AC EngineMiddleware architecture + browser re…

### DIFF
--- a/mobile/android/ENGINE_MIGRATION_NOTES.md
+++ b/mobile/android/ENGINE_MIGRATION_NOTES.md
@@ -1,0 +1,55 @@
+# EngineMiddleware Migration (Fenix-style session ownership)
+
+Date: 2026-06-11. Not yet compiled/tested on-device — run a build first.
+
+## What changed
+
+`BrowserStore` is now created with `EngineMiddleware.create(engine, trimMemoryAutomatically = false)`
+(`Components.kt`). The middleware owns the engine-session lifecycle:
+
+- `EngineAction.CreateEngineSessionAction(tabId)` creates a session, restores
+  `tab.engineState.engineSessionState` automatically, or loads the tab URL when
+  there is no state (LinkingMiddleware).
+- `EngineAction.SuspendEngineSessionAction(tabId)` hibernates a tab (state kept in store).
+- Tab removal closes sessions (TabsRemovedMiddleware).
+- Content-process crash/kill marks the tab crashed / suspends it (CrashMiddleware).
+- EngineObserver syncs URL/title/back-forward/session-state into the store for
+  EVERY tab (fixes the stale-background-tab-URL bug).
+
+`TabManager` no longer creates, restores, reloads, or closes sessions. It now:
+
+- mirrors `engineState.engineSession` → `sessions` map and `content.canGoBack/Forward`
+  → `navigationStates` for Compose consumers (`start(store)`, called from
+  `Components.initialize`),
+- ensures the selected tab always has a live session: dispatches
+  `CreateEngineSessionAction` when missing, `CrashAction.RestoreCrashedSessionAction`
+  when crashed (automatic white-page recovery),
+- keeps the LRU and hibernates evicted tabs via `SuspendEngineSessionAction`,
+- serializes state with public APIs: `EngineSessionState.writeTo(JsonWriter)` /
+  `GeckoEngineSessionState.fromJSON` — including a read-shim for legacy DB rows
+  (raw gecko JSON without the `GECKO_STATE` envelope).
+
+Deleted: `savedStates`, `engineStates`, `justRestored`, `needsReloadOnSelect`,
+restore-then-reload hacks, all state-serialization reflection
+(`getActualState`, `GeckoEngineSessionState` ctor), manual per-tab observers,
+`handleCrashedSession`. Find-in-page now uses `EngineSession.findAll/findNext`.
+
+Popups (`SessionObserverSetup` + BrowserActivity allow-path) link their session via
+`EngineAction.LinkEngineSessionAction(tabId, session, skipLoading = true)`.
+
+## Verify after building
+
+1. Fresh start restores tabs from DB with history (legacy rows + new rows).
+2. Tab switch beyond max-alive-tabs hibernates and restores with history, no reload flash.
+3. Background kill (developer options → no background processes) → reselect tab → page restores.
+4. Popup open (allowed + blocked-then-allowed) gets URL/title sync and persistence.
+5. Close tab → reopen closed tab restores history.
+6. Back/forward buttons reflect store state after restore.
+
+## Known follow-ups
+
+- Crash storms: recovery is automatic with no retry limit; if a page crashes the
+  content process deterministically, the selected tab could loop
+  (restore → create → crash). Consider a per-tab retry cap + error UI.
+- `getGeckoSession` reflection remains (delegate proxies in SessionObserverSetup).
+- Old `TabEntity.sessionState` rows are migrated on read; new writes use the AC format.

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.PlayBridge"
-            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboard|keyboardHidden"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboard|keyboardHidden|uiMode|density"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -249,8 +249,8 @@ fun AppNavHost(
                     if (isFullscreen) {
                         BackHandler {
                             onIsFullscreenChange(false)
-                            val gs = tabManager.getGeckoSession(session)
-                            gs?.exitFullScreen()
+                            // Public AC API instead of reflection into GeckoSession.
+                            session?.exitFullScreenMode()
                         }
                     }
                     BackHandler(enabled = !isFullscreen && !isEditing) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
@@ -201,7 +201,12 @@ class BrowserActivity : ComponentActivity() {
     private val connectionCoordinator: ConnectionCoordinator by inject()
     private val addonRepository: com.playbridge.sender.data.library.AddonRepository by inject()
     private val browserViewModel: com.playbridge.sender.browser.BrowserViewModel by viewModel()
-    private val tabManager = TabManager()
+
+    /**
+     * Process-wide singleton — live EngineSessions survive Activity recreation
+     * (theme change, system-initiated recreation). See [Components.tabManager].
+     */
+    private val tabManager: TabManager get() = Components.tabManager
 
     override fun onResume() {
         super.onResume()
@@ -249,9 +254,6 @@ class BrowserActivity : ComponentActivity() {
                 requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), 1001)
             }
         }
-
-        // Set tabManager reference for resolving Kotlin tab IDs from extension messages
-        Components.tabManager = tabManager
 
         // Install the bundled video detector extension
         Components.installBundledExtension()
@@ -1796,22 +1798,16 @@ class BrowserActivity : ComponentActivity() {
                     fun openPopupTab() {
                         scope.launch(Dispatchers.Main) {
                             val tabId = tabManager.createTab(url = popup.popupUrl, store = store, parentId = selectedTab?.id, select = true)
-                            tabManager.sessions[tabId] = popup.engineSession
-
-                            // Register standard observer for popup tab
-                            popup.engineSession.register(object : EngineSession.Observer {
-                                override fun onStateUpdated(state: mozilla.components.concept.engine.EngineSessionState) {
-                                    tabManager.engineStates[tabId] = state
-                                    tabManager.onAnyStateUpdated?.invoke(tabId)
-                                }
-                                override fun onNavigationStateChange(canGoBack: Boolean?, canGoForward: Boolean?) {
-                                    val current = tabManager.navigationStates[tabId] ?: TabNavigationState()
-                                    tabManager.navigationStates[tabId] = current.copy(
-                                        canGoBack = canGoBack ?: current.canGoBack,
-                                        canGoForward = canGoForward ?: current.canGoForward
-                                    )
-                                }
-                            })
+                            // Link the popup's engine session in the store —
+                            // EngineMiddleware's EngineObserver takes over
+                            // URL/title/nav/state sync and crash handling.
+                            store.dispatch(
+                                mozilla.components.browser.state.action.EngineAction.LinkEngineSessionAction(
+                                    tabId,
+                                    popup.engineSession,
+                                    skipLoading = true
+                                )
+                            )
                         }
                     }
                     Box(modifier = Modifier.fillMaxSize().padding(bottom = innerPadding.calculateBottomPadding()), contentAlignment = androidx.compose.ui.Alignment.BottomCenter) {
@@ -1824,7 +1820,11 @@ class BrowserActivity : ComponentActivity() {
                                  pendingPopup = null
                                  pendingPopupState.value = null
                              },
-                            onDismiss = { popup.rawGeckoSession.close(); pendingPopup = null; pendingPopupState.value = null }
+                            onDismiss = {
+                                try { popup.engineSession.close() } catch (_: Exception) {}
+                                pendingPopup = null
+                                pendingPopupState.value = null
+                            }
                         )
                     }
                 }
@@ -1914,19 +1914,48 @@ class BrowserActivity : ComponentActivity() {
 
     override fun onDestroy() {
         Log.d("PB_STARTUP", "onDestroy: isFinishing=$isFinishing, sessions=${tabManager.sessions.size}")
-        tabManager.sessions.values.forEach { it.close() }
+        // Only tear sessions down when the Activity is actually finishing.
+        // On configuration-change recreation (theme, split screen, etc.) the
+        // singleton TabManager keeps the live sessions and the new Activity
+        // re-renders them — closing them here caused blank tabs + lost history.
+        if (isFinishing) {
+            tabManager.closeAllSessions()
+        }
         super.onDestroy()
     }
 
     @Composable
     fun BrowserView(session: EngineSession, onLongPressLink: (String) -> Unit) {
-        key(session) {
-            AndroidView(
-                modifier = Modifier.fillMaxSize(),
-                factory = { context -> GeckoEngineView(context).apply { render(session) } },
-                update = { view -> view.render(session) }
-            )
-        }
+        // ONE persistent GeckoEngineView for all tabs (Fenix-style):
+        // SessionFeature/EngineViewPresenter observes the store and renders
+        // whatever tab is selected — creating engine sessions on demand,
+        // releasing the view for crashed tabs, and re-rendering on session
+        // changes. No more per-tab view recreation (the old `key(session)`
+        // AndroidView), which caused surface churn on every tab switch.
+        // `session` is unused for rendering but kept for callsite compatibility.
+        val featureHolder = remember { arrayOfNulls<mozilla.components.feature.session.SessionFeature>(1) }
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { context ->
+                GeckoEngineView(context).also { view ->
+                    featureHolder[0] = mozilla.components.feature.session.SessionFeature(
+                        Components.store,
+                        Components.sessionUseCases.goBack,
+                        Components.sessionUseCases.goForward,
+                        view
+                    ).also { it.start() }
+                }
+            },
+            onRelease = {
+                // release() stops the presenter and releases the engine view.
+                try {
+                    featureHolder[0]?.release()
+                } catch (e: Exception) {
+                    Log.e(TAG, "BrowserView: error releasing session feature", e)
+                }
+                featureHolder[0] = null
+            }
+        )
     }
 
     @Composable

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import mozilla.components.browser.state.state.ContentState
+import mozilla.components.browser.state.state.EngineState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.store.BrowserStore
 
@@ -125,18 +126,19 @@ class BrowserViewModel(
                             TabSessionState(
                                 id = entity.id,
                                 content = ContentState(url = entity.url, title = entity.title ?: ""),
-                                parentId = entity.parentId
+                                parentId = entity.parentId,
+                                // EngineMiddleware restores history/state from this when
+                                // the tab needs an engine session (handles both the AC
+                                // format and legacy raw-gecko-JSON DB rows).
+                                engineState = EngineState(
+                                    engineSessionState = TabManager.bytesToEngineState(entity.sessionState)
+                                )
                             )
                         }
                         val selectedId = savedTabs.find { it.isSelected }?.id
-                        
+
                         withContext(Dispatchers.Main) {
-                            Log.d("PB_STARTUP", "Populating savedStates and calling restoreTabs on Main thread")
-                            savedTabs.forEach { entity ->
-                                entity.sessionState?.let { bytes ->
-                                    tabManager.savedStates[entity.id] = bytes
-                                }
-                            }
+                            Log.d("PB_STARTUP", "Calling restoreTabs on Main thread")
                             tabManager.restoreTabs(sessionTabs, selectedId, store)
                             Log.d("PB_STARTUP", "restoreTabs done — store now has ${store.state.tabs.size} tabs")
                         }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/Components.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/Components.kt
@@ -43,9 +43,63 @@ object Components {
     private const val TAG = "Components"
     private lateinit var appContext: Context
     
-    // Reference to TabManager for resolving Kotlin tab IDs from extension messages
-    var tabManager: TabManager? = null
+    /**
+     * Process-wide TabManager singleton. Owning it here (instead of per-Activity)
+     * means live EngineSessions survive Activity recreation (theme change, split
+     * screen, system-initiated recreation) instead of being closed and rebuilt
+     * from scratch — which previously lost history and produced blank tabs.
+     */
+    val tabManager: TabManager = TabManager()
     var onBridgeCastRequest: ((items: List<PlayPayload>, startIndex: Int, playlistMetadata: VisualMetadata?) -> Unit)? = null
+
+    /**
+     * Hooks for the engine-level [requestInterceptor] (set by SessionObserverSetup).
+     * Magnet/Stremio links are intercepted for ALL tabs at the engine level —
+     * previously this only worked on the selected tab via a delegate proxy.
+     */
+    @Volatile var onMagnetDetected: ((String) -> Unit)? = null
+    @Volatile var onStremioAddonDetected: ((String) -> Unit)? = null
+
+    /**
+     * Engine-level request interceptor (Fenix-style): serves friendly error
+     * pages on load failures and intercepts magnet:/stremio: scheme links.
+     * Replaces the old per-session NavigationDelegate reflection proxy.
+     */
+    private val requestInterceptor = object : mozilla.components.concept.engine.request.RequestInterceptor {
+        override fun onLoadRequest(
+            engineSession: mozilla.components.concept.engine.EngineSession,
+            uri: String,
+            lastUri: String?,
+            hasUserGesture: Boolean,
+            isSameDomain: Boolean,
+            isRedirect: Boolean,
+            isDirectNavigation: Boolean,
+            isSubframeRequest: Boolean,
+        ): mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse? {
+            if (uri.startsWith("magnet:?")) {
+                Log.d(TAG, "Intercepted magnet link: $uri")
+                Handler(Looper.getMainLooper()).post { onMagnetDetected?.invoke(uri) }
+                return mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse.Deny
+            }
+            if (uri.startsWith("stremio://")) {
+                Log.d(TAG, "Intercepted Stremio addon link: $uri")
+                Handler(Looper.getMainLooper()).post { onStremioAddonDetected?.invoke(uri) }
+                return mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse.Deny
+            }
+            return null
+        }
+
+        override fun onErrorRequest(
+            session: mozilla.components.concept.engine.EngineSession,
+            errorType: mozilla.components.browser.errorpages.ErrorType,
+            uri: String?,
+        ): mozilla.components.concept.engine.request.RequestInterceptor.ErrorResponse {
+            Log.e(TAG, "Load error for $uri: $errorType")
+            return mozilla.components.concept.engine.request.RequestInterceptor.ErrorResponse(
+                ErrorPageUtils.generateErrorPage(uri ?: "unknown", "NETWORK_ERROR", errorType.name)
+            )
+        }
+    }
 
     /**
      * Mirrors the "detect videos" setting. Detection messages from the extension
@@ -64,28 +118,86 @@ object Components {
     
     // GeckoRuntime - the core Gecko engine
     val runtime: GeckoRuntime by lazy {
+        // BuildConfig generation is disabled by default on AGP 8+; the
+        // debuggable flag is the dependency-free equivalent of BuildConfig.DEBUG.
+        val isDebugBuild = (appContext.applicationInfo.flags and
+                android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0
         val settings = GeckoRuntimeSettings.Builder()
             .aboutConfigEnabled(true)
             .webManifest(true)
             .javaScriptEnabled(true)
-            .remoteDebuggingEnabled(true)
-            .consoleOutput(true)
+            // Remote debugging only in debug builds — it was previously
+            // always-on, exposing a debugging surface in release builds.
+            .remoteDebuggingEnabled(isDebugBuild)
+            .consoleOutput(isDebugBuild)
+            // Run extensions in their own process (Fenix does the same) so a
+            // video-detector crash can't take web content down with it.
+            .extensionsProcessEnabled(true)
+            .extensionsWebAPIEnabled(true)
             .build()
         val r = GeckoRuntime.create(appContext, settings)
+        // If the runtime dies (Gecko crash/exit), every session is dead and all
+        // tabs would render as permanent white pages — GeckoView does NOTHING
+        // by default when no delegate is set. Exit the process instead: the
+        // next launch starts a fresh runtime and restores tabs from the DB.
+        r.delegate = GeckoRuntime.Delegate {
+            Log.e(TAG, "GeckoRuntime shut down — exiting process for a clean restart")
+            kotlin.system.exitProcess(0)
+        }
         r.warmUp()
         r
     }
     
     // GeckoEngine wrapper for Mozilla Components
     val engine: GeckoEngine by lazy {
-        GeckoEngine(appContext, runtime = runtime)
+        val isDarkMode = (appContext.resources.configuration.uiMode and
+                android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
+                android.content.res.Configuration.UI_MODE_NIGHT_YES
+        val defaultSettings = mozilla.components.concept.engine.DefaultSettings(
+            // Tracking protection is OFF by default (pre-2026-06 behavior).
+            // recommended() would also enable cookie isolation (dFPI) + purging,
+            // which risks breaking embedded players on streaming sites — the
+            // core PlayBridge use case. If TP is wanted, expose it as a user
+            // setting with per-site exceptions rather than flipping the default.
+            trackingProtectionPolicy = mozilla.components.concept.engine.EngineSession
+                .TrackingProtectionPolicy.none(),
+            // Paint the surface with a theme-appropriate color before first paint
+            // instead of flashing white (a major contributor to perceived
+            // "white blank page" moments, especially in dark mode).
+            clearColor = if (isDarkMode) 0xFF1C1B1F.toInt() else 0xFFFFFFFF.toInt(),
+            // Let websites see the system color scheme (dark mode sites).
+            preferredColorScheme = mozilla.components.concept.engine.mediaquery.PreferredColorScheme.System,
+            // Background tab playback is a core PlayBridge feature.
+            suspendMediaWhenInactive = false,
+            // Error pages + magnet:/stremio: scheme handling for all tabs.
+            requestInterceptor = requestInterceptor,
+        )
+        GeckoEngine(appContext, defaultSettings = defaultSettings, runtime = runtime)
     }
     
     // Central state store for tabs, sessions, etc.
+    // EngineMiddleware OWNS engine session lifecycle (Fenix-style): it creates
+    // sessions on CreateEngineSessionAction (restoring state automatically),
+    // suspends them on SuspendEngineSessionAction, closes them when tabs are
+    // removed, syncs URL/title/back-forward/session-state into the store via
+    // EngineObserver, and marks tabs crashed on content-process death.
+    // trimMemoryAutomatically=false matches Fenix: rely on GeckoView/OS for
+    // memory pressure instead of suspending sessions behind the user's back.
     val store: BrowserStore by lazy {
-        BrowserStore()
+        BrowserStore(
+            middleware = mozilla.components.browser.state.engine.EngineMiddleware.create(
+                engine = engine,
+                trimMemoryAutomatically = false,
+            )
+        )
     }
     
+    // Session use cases (goBack/goForward/loadUrl/reload via the store; used by
+    // SessionFeature rendering and anywhere a tab might not have a live session).
+    val sessionUseCases by lazy {
+        mozilla.components.feature.session.SessionUseCases(store)
+    }
+
     // HTTP client for addon downloads
     val client: Client by lazy {
         OkHttpClient()
@@ -135,6 +247,10 @@ object Components {
 
     fun initialize(context: Context) {
         appContext = context.applicationContext
+
+        // Start mirroring store state (engine sessions, nav state) into
+        // TabManager and ensuring the selected tab has a live session.
+        tabManager.start(store)
 
         // Configure Coil with explicit memory + disk cache so poster images survive
         // screen rotations (memory) and app restarts (disk) without re-downloading.
@@ -272,9 +388,6 @@ object Components {
                     // Set up message delegate on the extension instance to receive messages
                     extension.setMessageDelegate(globalMessageDelegate, "browser")
                     Log.i(TAG, "Message delegate registered on Extension instance: ${extension.id}")
-
-                    // Connect to extension port for bidirectional messaging
-                    connectToExtension(extension)
                 } else {
                     Log.e(TAG, "ensureBuiltIn returned null extension")
                 }
@@ -294,45 +407,12 @@ object Components {
         }
     }
     
-    // Store extension and port for later use
+    // Store extension reference for later use
     private var videoDetectorExtension: GeckoWebExtension? = null
 
-    /**
-     * Connect to extension for bidirectional messaging
-     */
-    private fun connectToExtension(extension: GeckoWebExtension) {
-        Log.i(TAG, "Connecting to extension port...")
-        
-        startVideoPolling()
-    }
-    
-    private var pollingHandler: Handler? = null
-    private val pollingRunnable = object : Runnable {
-        override fun run() {
-            requestVideosFromExtension()
-            pollingHandler?.postDelayed(this, 2000) // Poll every 2 seconds
-        }
-    }
-    
-    /**
-     * Start polling for videos from extension storage
-     */
-    private fun startVideoPolling() {
-        Log.i(TAG, "Starting video polling...")
-        pollingHandler = Handler(Looper.getMainLooper())
-        pollingHandler?.postDelayed(pollingRunnable, 1000)
-    }
-    
-    /**
-     * Request videos from extension - currently not possible to directly call
-     * extension from native side, so we rely on extension pushing updates
-     */
-    private fun requestVideosFromExtension() {
-        // GeckoView doesn't support native -> extension messaging directly
-        // The extension must push updates via the port connection
-        Log.d(TAG, "Polling for video updates...")
-    }
-    
+    // NOTE: the old 2-second "video polling" Handler was removed — it was a
+    // no-op (native→extension messaging isn't possible; the extension pushes
+    // detections itself) that ran forever, including in the background.
 
     /**
      * Process incoming message from extension.
@@ -361,9 +441,9 @@ object Components {
                     Handler(Looper.getMainLooper()).post {
                         // Find the session for the tab and load error page
                         val sessionToLoad = if (tabId != null) {
-                            tabManager?.sessions?.get(resolveKotlinTabId(jsonObject))
+                            tabManager.sessions[resolveKotlinTabId(jsonObject)]
                         } else {
-                            tabManager?.sessions?.get(store.state.selectedTabId)
+                            store.state.selectedTabId?.let { tabManager.sessions[it] }
                         }
 
                         sessionToLoad?.loadUrl(ErrorPageUtils.generateErrorPage(url, statusCode))
@@ -426,21 +506,32 @@ object Components {
             val originUrl = message["originUrl"]?.jsonPrimitive?.content
             if (!originUrl.isNullOrEmpty()) {
                 val state = store.state
-                // Try exact match first
-                val matchedTab = state.tabs.find { tab ->
-                    tab.content.url == originUrl ||
-                    tab.content.url.substringBefore("#") == originUrl.substringBefore("#")
+                // Since EngineMiddleware, ALL tabs have live URLs in the store —
+                // multiple tabs can share a URL/domain. Prefer the selected tab
+                // when it matches, so detections aren't misfiled to a background
+                // tab and the cast sheet (keyed by selected tab) misses them.
+                val selectedTab = state.selectedTabId?.let { id -> state.tabs.find { it.id == id } }
+                fun urlMatches(tabUrl: String) =
+                    tabUrl == originUrl || tabUrl.substringBefore("#") == originUrl.substringBefore("#")
+
+                if (selectedTab != null && urlMatches(selectedTab.content.url)) {
+                    return selectedTab.id
                 }
+                val matchedTab = state.tabs.find { urlMatches(it.content.url) }
                 if (matchedTab != null) {
                     return matchedTab.id
                 }
-                
-                // Try domain match as fallback
+
+                // Try domain match as fallback — selected tab first
                 val originDomain = try { java.net.URI(originUrl).host } catch (e: Exception) { null }
                 if (originDomain != null) {
-                    val domainMatch = state.tabs.find { tab ->
-                        try { java.net.URI(tab.content.url).host == originDomain } catch (e: Exception) { false }
+                    fun domainMatches(tabUrl: String) =
+                        try { java.net.URI(tabUrl).host == originDomain } catch (e: Exception) { false }
+
+                    if (selectedTab != null && domainMatches(selectedTab.content.url)) {
+                        return selectedTab.id
                     }
+                    val domainMatch = state.tabs.find { domainMatches(it.content.url) }
                     if (domainMatch != null) {
                         return domainMatch.id
                     }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/SheetOverlayContainer.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/SheetOverlayContainer.kt
@@ -141,7 +141,9 @@ fun SheetOverlayContainer(
                 subtitleService = subtitleService,
                 contentPayload = pendingContentPayload,
                 onContentClick = onContentClick,
-                onQueueContent = onQueueContent
+                onQueueContent = onQueueContent,
+                detectionEnabled = detectVideosEnabled,
+                onEnableDetection = if (!detectVideosEnabled) onToggleVideoDetect else null
             )
         }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/TabManager.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/TabManager.kt
@@ -1,19 +1,31 @@
 package com.playbridge.sender.browser
 import com.playbridge.sender.cast.*
 
+import android.util.JsonWriter
 import android.util.Log
 import androidx.compose.runtime.mutableStateMapOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import mozilla.components.browser.engine.gecko.GeckoEngineSession
+import mozilla.components.browser.engine.gecko.GeckoEngineSessionState
+import mozilla.components.browser.state.action.CrashAction
+import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.ContentState
+import mozilla.components.browser.state.state.EngineState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSessionState
+import mozilla.components.lib.state.ext.flow
+import org.json.JSONObject
 import org.mozilla.geckoview.GeckoSession
+import java.io.StringWriter
 import java.util.UUID
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.delay
 
 /** Data class representing the navigation capabilities of a tab. */
 data class TabNavigationState(
@@ -22,22 +34,87 @@ data class TabNavigationState(
 )
 
 /**
- * Manages browser tab lifecycle and engine sessions.
+ * Manages browser tab UI state on top of Mozilla Components' EngineMiddleware.
  *
- * Centralises tab creation/removal, session-to-tab synchronisation,
- * GeckoSession reflection helpers, and find-in-page operations.
+ * Engine session ownership lives in [BrowserStore] (via `EngineMiddleware`,
+ * see [Components.store]): the middleware creates sessions on
+ * [EngineAction.CreateEngineSessionAction] (restoring `engineSessionState`
+ * automatically, or loading the tab URL when there is no state), suspends them
+ * on [EngineAction.SuspendEngineSessionAction] (state preserved in the store),
+ * closes them when tabs are removed, and marks tabs crashed on content-process
+ * death.
+ *
+ * TabManager's responsibilities are now limited to:
+ * - mirroring `tab.engineState.engineSession` into [sessions] and
+ *   back/forward state into [navigationStates] for Compose consumers
+ *   (via [start]),
+ * - ensuring the selected tab always has a live engine session (recreating it
+ *   after hibernation or a content-process crash/kill),
+ * - the session LRU ("max alive tabs") which hibernates background tabs,
+ * - tab list operations (create/close/select/reopen/duplicate) and the
+ *   closed-tabs / selection stacks,
+ * - serializing engine session state for Room persistence via public AC APIs.
  */
 class TabManager {
 
     companion object {
         private const val TAG = "TabManager"
+        private const val GECKO_STATE_KEY = "GECKO_STATE"
+
+        /** Crash-loop guard: max automatic restores per tab within [CRASH_WINDOW_MS]. */
+        private const val MAX_CRASH_RESTORES = 3
+        private const val CRASH_WINDOW_MS = 30_000L
+
+        /**
+         * Serialize an [EngineSessionState] using the public
+         * `EngineSessionState.writeTo(JsonWriter)` API.
+         * Produces `{"GECKO_STATE": "<gecko session JSON>"}`.
+         */
+        fun engineStateToBytes(state: EngineSessionState?): ByteArray? {
+            if (state == null) return null
+            return try {
+                val stringWriter = StringWriter()
+                JsonWriter(stringWriter).use { state.writeTo(it) }
+                val json = stringWriter.toString()
+                if (json.isEmpty() || json == "{}") null else json.toByteArray(Charsets.UTF_8)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to serialize EngineSessionState", e)
+                null
+            }
+        }
+
+        /**
+         * Deserialize an [EngineSessionState] from persisted bytes.
+         * Supports both the AC format (`{"GECKO_STATE": ...}`) and the legacy
+         * PlayBridge format (raw `GeckoSession.SessionState` JSON) so existing
+         * user databases keep restoring after the EngineMiddleware migration.
+         */
+        fun bytesToEngineState(bytes: ByteArray?): EngineSessionState? {
+            if (bytes == null) return null
+            return try {
+                val json = String(bytes, Charsets.UTF_8)
+                val obj = JSONObject(json)
+                if (obj.has(GECKO_STATE_KEY)) {
+                    GeckoEngineSessionState.fromJSON(obj)
+                } else {
+                    // Legacy rows: raw gecko state JSON — wrap it in the AC envelope.
+                    GeckoEngineSessionState.fromJSON(JSONObject().put(GECKO_STATE_KEY, json))
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to deserialize EngineSessionState", e)
+                null
+            }
+        }
     }
 
-    /** Map of tab-id → live EngineSession. Observable by Compose. */
+    /**
+     * Mirror of `tab.engineState.engineSession` for all tabs, kept in sync by
+     * [start]. Observable by Compose. Do NOT insert sessions here directly —
+     * link them in the store with [EngineAction.LinkEngineSessionAction].
+     */
     val sessions = mutableStateMapOf<String, EngineSession>()
 
-
-    /** The maximum number of EngineSessions to keep alive to prevent OOM errors. */
+    /** The maximum number of live EngineSessions; others are suspended (hibernated). */
     var maxAliveSessions = 5
 
     /** LRU tracker for recently active tab IDs (engine-session lifetime). */
@@ -46,7 +123,7 @@ class TabManager {
     private data class ClosedTab(
         val url: String,
         val parentId: String?,
-        val capturedState: ByteArray?,
+        val engineSessionState: EngineSessionState?,
         val title: String
     )
 
@@ -61,36 +138,148 @@ class TabManager {
     /** Set of tab IDs currently playing media (audio/video). Observable by Compose. */
     val playingTabIds = mutableStateMapOf<String, Boolean>()
 
-    /** Serialized GeckoSession state for hibernated tabs (or tabs loaded from DB). */
-    val savedStates = mutableMapOf<String, ByteArray>()
-
-    /** Latest EngineSessionState received from observers for each tab. */
-    internal val engineStates = mutableMapOf<String, mozilla.components.concept.engine.EngineSessionState>()
-
-    /** Navigation capabilities (back/forward) for each tab ID. Observable by Compose. */
+    /** Navigation capabilities (back/forward) per tab, mirrored from store content state. */
     val navigationStates = mutableStateMapOf<String, TabNavigationState>()
 
-    /**
-     * Tabs that were just restored from a saved state. While this flag is set,
-     * spurious `onNavigationStateChange(false, false)` events from GeckoView's
-     * initial repaint are ignored so they don't clobber the pre-calculated
-     * back/forward state derived from `currentIndex`.
-     */
-    private val justRestored = mutableSetOf<String>()
-
-    /** Tabs that need a reload triggered upon selection (because they were restored in the background). */
-    private val needsReloadOnSelect = mutableSetOf<String>()
-
-    /** Map of tab-id -> parent-id. Decouples parent-child relationships from the store state to ensure stable restoration order. */
+    /** Map of tab-id -> parent-id. Decouples parent-child relationships from the store state. */
     val parentIds = mutableMapOf<String, String>()
 
     /**
-     * Optional callback invoked whenever any tab's `onStateUpdated` fires.
-     * BrowserActivity wires this to a debounced DB persistence trigger so
-     * navigation state isn't lost when the process is killed before
-     * `onPause` runs.
+     * Optional callback invoked whenever a tab's engine session state changes
+     * in the store. BrowserActivity wires this to a debounced DB persistence
+     * trigger so navigation state isn't lost if the process is killed.
      */
     var onAnyStateUpdated: ((tabId: String) -> Unit)? = null
+
+    /** Serializes [syncSessions]. */
+    private val syncMutex = Mutex()
+
+    /** Tracks last-seen engineSessionState per tab to detect changes for [onAnyStateUpdated]. */
+    private val lastSessionStates = HashMap<String, EngineSessionState?>()
+
+    /** Timestamps of recent automatic crash-restores per tab (crash-loop guard). */
+    private val crashRestoreTimes = HashMap<String, ArrayDeque<Long>>()
+
+    /**
+     * Tabs where auto-recovery gave up because the page crashed the content
+     * process repeatedly. Re-armed when the user selects a different tab
+     * (returning to the tab is a deliberate retry).
+     */
+    private val crashGivenUp = mutableSetOf<String>()
+
+    private var mirrorScope: CoroutineScope? = null
+
+    // ── Store mirroring ──────────────────────────────────────────────
+
+    /**
+     * Start mirroring [store] state. Idempotent; called once from
+     * [Components.initialize]. Keeps [sessions]/[navigationStates] in sync,
+     * fires [onAnyStateUpdated] on engine-state changes, and makes sure the
+     * selected tab always has a live engine session — including automatic
+     * recovery after content-process crashes/kills (the store marks the tab
+     * crashed / suspends it; we restore + recreate, which EngineMiddleware
+     * does from the last saved state).
+     */
+    fun start(store: BrowserStore) {
+        if (mirrorScope != null) return
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+        mirrorScope = scope
+        scope.launch {
+            store.flow().collect { state ->
+                val liveTabIds = mutableSetOf<String>()
+                state.tabs.forEach { tab ->
+                    liveTabIds.add(tab.id)
+
+                    // 1. Mirror engine sessions for Compose consumers. When a NEW
+                    // session appears for a tab, register the media bridge on it —
+                    // covers every tab, incl. background playback. (The session
+                    // unregisters all observers when closed.)
+                    val engineSession = tab.engineState.engineSession
+                    if (engineSession != null) {
+                        if (sessions[tab.id] !== engineSession) {
+                            sessions[tab.id] = engineSession
+                            engineSession.register(
+                                MediaSessionObserver(
+                                    context = Components.applicationContext,
+                                    tabId = tab.id,
+                                    tabManager = this@TabManager,
+                                    engineSession = engineSession,
+                                )
+                            )
+                        }
+                    } else {
+                        sessions.remove(tab.id)
+                    }
+
+                    // 2. Mirror back/forward state (EngineObserver keeps content state updated).
+                    val nav = TabNavigationState(tab.content.canGoBack, tab.content.canGoForward)
+                    if (navigationStates[tab.id] != nav) navigationStates[tab.id] = nav
+
+                    // 3. Detect engine-session-state updates for debounced persistence.
+                    val sessionState = tab.engineState.engineSessionState
+                    if (lastSessionStates[tab.id] !== sessionState) {
+                        lastSessionStates[tab.id] = sessionState
+                        if (sessionState != null) onAnyStateUpdated?.invoke(tab.id)
+                    }
+                }
+                // Drop mirror entries for tabs that no longer exist.
+                sessions.keys.toList().forEach { if (it !in liveTabIds) sessions.remove(it) }
+                lastSessionStates.keys.retainAll(liveTabIds)
+
+                // Re-arm crash recovery for tabs the user has switched away from.
+                val selectedId = state.selectedTabId
+                if (selectedId != null) crashGivenUp.retainAll(setOf(selectedId)) else crashGivenUp.clear()
+
+                // 4. Ensure the selected tab has a live engine session.
+                val selected = selectedId?.let { id -> state.tabs.find { it.id == id } }
+                if (selected != null) {
+                    when {
+                        selected.engineState.crashed -> {
+                            // Clear the crashed flag; the next emission recreates the
+                            // session from the pre-crash state (CrashMiddleware suspended it).
+                            // Guarded against crash storms (page that kills the content
+                            // process on every load would otherwise loop forever).
+                            if (shouldAutoRestoreCrashed(selected.id)) {
+                                store.dispatch(CrashAction.RestoreCrashedSessionAction(selected.id))
+                            }
+                        }
+                        selected.engineState.engineSession == null &&
+                            !selected.engineState.initializing -> {
+                            // Hibernated / restored-from-DB / killed-in-background tab:
+                            // EngineMiddleware creates the session, restores its state,
+                            // or loads the tab URL if there is no state.
+                            store.dispatch(EngineAction.CreateEngineSessionAction(selected.id))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Crash-loop guard: allow up to [MAX_CRASH_RESTORES] automatic restores
+     * per tab within [CRASH_WINDOW_MS]; beyond that, give up until the user
+     * selects another tab and comes back.
+     */
+    private fun shouldAutoRestoreCrashed(tabId: String): Boolean {
+        if (tabId in crashGivenUp) return false
+        val now = android.os.SystemClock.elapsedRealtime()
+        val times = crashRestoreTimes.getOrPut(tabId) { ArrayDeque() }
+        while (times.isNotEmpty() && now - times.first() > CRASH_WINDOW_MS) times.removeFirst()
+        return if (times.size >= MAX_CRASH_RESTORES) {
+            crashGivenUp.add(tabId)
+            Log.e(
+                TAG,
+                "Tab $tabId crashed $MAX_CRASH_RESTORES times in ${CRASH_WINDOW_MS / 1000}s — " +
+                    "pausing auto-recovery until the tab is reselected"
+            )
+            false
+        } else {
+            times.addLast(now)
+            Log.w(TAG, "Selected tab $tabId crashed — restoring (attempt ${times.size}/$MAX_CRASH_RESTORES)")
+            true
+        }
+    }
 
     // ── Tab operations ───────────────────────────────────────────────
 
@@ -104,6 +293,9 @@ class TabManager {
     /**
      * Create a new tab with [url], optionally set [parentId], and select it.
      *
+     * If [engineSessionState] is provided (reopen/duplicate), the engine
+     * session is restored from it instead of loading [url] from scratch.
+     *
      * If [parentId] is provided and matches an existing tab, the new tab is
      * inserted directly after the parent (Chrome-style "next to current")
      * instead of appended to the end of the list.
@@ -112,7 +304,8 @@ class TabManager {
         url: String,
         store: BrowserStore,
         parentId: String? = null,
-        select: Boolean = true
+        select: Boolean = true,
+        engineSessionState: EngineSessionState? = null
     ): String {
         val tabId = UUID.randomUUID().toString()
         store.dispatch(
@@ -120,7 +313,8 @@ class TabManager {
                 tab = TabSessionState(
                     id = tabId,
                     content = ContentState(url = url),
-                    parentId = parentId
+                    parentId = parentId,
+                    engineState = EngineState(engineSessionState = engineSessionState)
                 ),
                 select = select
             )
@@ -140,20 +334,20 @@ class TabManager {
     /**
      * Remove a tab by id. Before removing, choose the next tab to select by
      * popping the selection stack — falling back to BrowserStore's default
-     * behaviour if no prior selection is still alive.
+     * behaviour if no prior selection is still alive. The engine session is
+     * closed by EngineMiddleware (TabsRemovedMiddleware) on removal.
      */
     fun closeTab(tabId: String, store: BrowserStore) {
         val wasSelected = store.state.selectedTabId == tabId
 
-        // Capture state and save to closed tabs stack before purging
+        // Save to closed tabs stack before removal (state comes from the store).
         val sourceTab = store.state.tabs.find { it.id == tabId }
         if (sourceTab != null) {
-            val capturedState = captureSessionState(tabId)
             closedTabsStack.addLast(
                 ClosedTab(
                     url = sourceTab.content.url,
                     parentId = parentIds[tabId] ?: sourceTab.parentId,
-                    capturedState = capturedState,
+                    engineSessionState = sourceTab.engineState.engineSessionState,
                     title = sourceTab.content.title
                 )
             )
@@ -189,16 +383,13 @@ class TabManager {
     fun reopenClosedTab(store: BrowserStore): String? {
         if (closedTabsStack.isEmpty()) return null
         val closedTab = closedTabsStack.removeLast()
-        val newTabId = createTab(
+        return createTab(
             url = closedTab.url,
             store = store,
             parentId = closedTab.parentId,
-            select = true
+            select = true,
+            engineSessionState = closedTab.engineSessionState
         )
-        closedTab.capturedState?.let {
-            savedStates[newTabId] = it
-        }
-        return newTabId
     }
 
     /**
@@ -220,7 +411,11 @@ class TabManager {
         selectionStack.addLast(tabId)
     }
 
-    /** Restore a list of tabs to the store. */
+    /**
+     * Restore a list of tabs to the store. Tabs may carry
+     * `engineState.engineSessionState` (set by BrowserViewModel from the DB);
+     * EngineMiddleware restores from it when each tab needs a session.
+     */
     fun restoreTabs(tabs: List<TabSessionState>, selectedId: String?, store: BrowserStore) {
         tabs.forEach { tab ->
             tab.parentId?.let { pId ->
@@ -242,85 +437,77 @@ class TabManager {
         playingTabIds[tabId] = true
     }
 
-    /** Drop all per-tab state for [tabId]. Called when a tab is closed. */
+    /**
+     * Suspend every live engine session, preserving state in the store.
+     * Called when the Activity is actually finishing (NOT on configuration
+     * change). A relaunch within the same process restores tabs from the
+     * store; a new process restores them from the DB.
+     */
+    fun closeAllSessions() {
+        Components.store.state.tabs.forEach { tab ->
+            if (tab.engineState.engineSession != null) {
+                Components.store.dispatch(EngineAction.SuspendEngineSessionAction(tab.id))
+            }
+        }
+        recentlyActiveTabIds.clear()
+    }
+
+    /** Drop all per-tab UI state for [tabId]. Called when a tab is closed. */
     fun purgeTabState(tabId: String) {
-        savedStates.remove(tabId)
-        engineStates.remove(tabId)
         navigationStates.remove(tabId)
         playingTabIds.remove(tabId)
         recentlyActiveTabIds.remove(tabId)
         selectionStack.remove(tabId)
-        justRestored.remove(tabId)
-        needsReloadOnSelect.remove(tabId)
         parentIds.remove(tabId)
+        lastSessionStates.remove(tabId)
+        crashRestoreTimes.remove(tabId)
+        crashGivenUp.remove(tabId)
+        sessions.remove(tabId)
         VideoDetector.clearTab(tabId)
-        val session = sessions.remove(tabId)
-        if (session != null) {
-            try {
-                session.stopLoading()
-                val gs = getGeckoSession(session)
-                gs?.close()
-            } catch (e: Exception) {
-                Log.e(TAG, "purgeTabState: error closing session for $tabId", e)
-            }
-        }
+        // NOTE: the engine session itself is closed by EngineMiddleware
+        // (TabsRemovedMiddleware) when the tab is removed from the store.
     }
 
     /**
-     * Sync per-tab state with the current set of live tabs in BrowserStore.
-     * Drops state for any tab id no longer present. Called from a store
-     * observer in BrowserActivity so externally-dispatched RemoveTabActions
-     * (e.g. Mozilla components, tests) don't leak.
+     * Sync per-tab UI state with the current set of live tabs in BrowserStore.
+     * Drops state for any tab id no longer present.
      */
     fun reconcileWithStoreTabs(liveTabIds: Set<String>) {
-        val stale = (savedStates.keys + engineStates.keys + navigationStates.keys +
-                playingTabIds.keys + sessions.keys)
+        val stale = (navigationStates.keys + playingTabIds.keys + sessions.keys)
             .toSet() - liveTabIds
         stale.forEach { purgeTabState(it) }
         selectionStack.retainAll(liveTabIds)
         recentlyActiveTabIds.retainAll(liveTabIds)
     }
 
-    // ── Session synchronisation ──────────────────────────────────────
+    // ── Session LRU (hibernation) ────────────────────────────────────
 
     /**
-     * Create engine sessions for tabs that don't have one yet and
-     * clean up sessions whose tabs have been closed or hiberated.
+     * Maintain the LRU of live engine sessions and hibernate tabs that fall
+     * outside the window by dispatching [EngineAction.SuspendEngineSessionAction]
+     * — EngineMiddleware preserves their state in the store and they are
+     * recreated automatically (with history) on next selection by [start].
+     *
+     * Session *creation* is no longer done here; the store mirror in [start]
+     * dispatches [EngineAction.CreateEngineSessionAction] for the selected tab.
      */
-    suspend fun syncSessions(tabs: List<TabSessionState>, selectedTabId: String? = null) {
+    suspend fun syncSessions(tabs: List<TabSessionState>, selectedTabId: String? = null) = syncMutex.withLock {
         if (tabs.isEmpty() && selectedTabId == null) {
-            Log.d(TAG, "syncSessions: called with empty tabs + null selectedTabId — skipping to avoid clearing LRU")
-            return
+            return@withLock
         }
 
         val allValidTabIds = tabs.map { it.id }.toSet()
 
-        Log.d(TAG, "syncSessions START — tabCount=${tabs.size}, selectedTabId=$selectedTabId, recentlyActive=${recentlyActiveTabIds.size}, existingSessions=${sessions.size}")
-
-        // 1. Maintain LRU tracker — done before any suspension point so it is never lost
-        // if this coroutine is cancelled (e.g. rapid store updates cancel the previous call).
+        // 1. Maintain LRU tracker.
         if (selectedTabId != null && allValidTabIds.contains(selectedTabId)) {
             // Re-adding at the end of a LinkedHashSet moves it to the most-recently-used position
             recentlyActiveTabIds.remove(selectedTabId)
             recentlyActiveTabIds.add(selectedTabId)
             recordSelection(selectedTabId)
-            Log.d(TAG, "syncSessions: added selectedTabId to LRU — recentlyActive=${recentlyActiveTabIds.size}")
-        } else {
-            Log.d(TAG, "syncSessions: selectedTabId=$selectedTabId not added to LRU (null or not in tabs)")
         }
-
-        // Yield to allow UI to draw first frame
-        delay(10)
-
-        // 1b. Background media pausing removed per user request to allow background playback
-        // across tab switches.
-
-        // 2. Cull the LRU tracker
-        // Remove any tabs that were closed by the user
         recentlyActiveTabIds.retainAll(allValidTabIds)
 
-        // If we exceed our live limit, remove the oldest (least recently used) tabs that are NOT playing media.
-        // This ensures playing tabs are always kept alive if possible.
+        // 2. Cull the LRU: evict the oldest non-playing, non-selected tabs.
         while (recentlyActiveTabIds.size > maxAliveSessions) {
             val oldestNonPlaying = recentlyActiveTabIds.find { id ->
                 id != selectedTabId && (playingTabIds[id] != true)
@@ -328,167 +515,22 @@ class TabManager {
             if (oldestNonPlaying != null) {
                 recentlyActiveTabIds.remove(oldestNonPlaying)
             } else {
-                // If all tabs in the LRU are either the selected tab or playing media,
-                // we stop culling to satisfy the "always alive" requirement for media.
+                // All remaining tabs are selected or playing media — stop culling.
                 break
             }
         }
-
-        // The intersection of our tracking limit and the currently available tabs
         val activeTabIds = recentlyActiveTabIds.toSet()
-        Log.d(TAG, "syncSessions: activeTabIds=${activeTabIds.size} (selectedTabId in active=${activeTabIds.contains(selectedTabId)})")
 
-        // 3. Create sessions for tabs that are active but have no EngineSession yet
-        var createdCount = 0
-        tabs.forEach { tab ->
-            if (activeTabIds.contains(tab.id) && !sessions.containsKey(tab.id)) {
-                // Give a short breather to the main thread between session creations
-                delay(10)
-
-                // Re-check after suspension to prevent double-creation if another coroutine created it during delay
-                if (sessions.containsKey(tab.id)) {
-                    return@forEach
-                }
-
-                val newSession = Components.engine.createSession()
-                val url = tab.content.url.ifEmpty { "about:blank" }
-
-                sessions[tab.id] = newSession
-                createdCount++
-
-                // Restore saved state if available (history, backstack, etc.)
-                val savedBytes = savedStates[tab.id]
-
-                if (savedBytes != null) {
-                    Log.d(TAG, "Restoring GeckoSession state for tab ${tab.id} (bytes=${savedBytes.size})")
-                    try {
-                        val geckoState = bytesToGeckoState(savedBytes)
-                        if (geckoState != null) {
-                            // Pre-calculate navigation state from history backstack metadata
-                            val canGoBack = geckoState.currentIndex > 0
-                            val canGoForward = geckoState.currentIndex < geckoState.size - 1
-                            navigationStates[tab.id] = TabNavigationState(canGoBack, canGoForward)
-                            // Mark as "just restored" so the observer below ignores the
-                            // initial (false,false) GeckoView fires before the history
-                            // is wired back up internally.
-                            justRestored.add(tab.id)
-                            Log.d(TAG, "Restored initial nav state for tab ${tab.id}: back=$canGoBack, fwd=$canGoForward (size=${geckoState.size}, index=${geckoState.currentIndex})")
-
-                            val engineState = wrapGeckoState(geckoState)
-                            if (engineState != null) {
-                                newSession.restoreState(engineState)
-                                Log.d(TAG, "Successfully called restoreState for tab ${tab.id}")
-                                // Some restores leave the view blank until the next paint;
-                                // a reload on the selected tab fixes that without changing
-                                // history.
-                                if (tab.id == selectedTabId && geckoState.size > 0) {
-                                    try {
-                                        newSession.reload()
-                                        Log.d(TAG, "Reloaded restored tab ${tab.id} immediately as it is selected")
-                                    } catch (_: Exception) {}
-                                } else if (geckoState.size > 0) {
-                                    needsReloadOnSelect.add(tab.id)
-                                    Log.d(TAG, "Added tab ${tab.id} to needsReloadOnSelect")
-                                }
-                            } else {
-                                Log.e(TAG, "Failed to wrap GeckoState for tab ${tab.id}")
-                                if (url != "about:blank") newSession.loadUrl(url)
-                            }
-                        } else {
-                            Log.e(TAG, "Failed to deserialize GeckoState for tab ${tab.id}")
-                            if (url != "about:blank") newSession.loadUrl(url)
-                        }
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Failed to restore state for tab ${tab.id}", e)
-                        if (url != "about:blank") newSession.loadUrl(url)
-                    }
-                } else {
-                    Log.d(TAG, "Created/Restored EngineSession for tab ${tab.id} url=$url (no saved state)")
-                    if (url != "about:blank") {
-                        newSession.loadUrl(url)
-                    }
-                }
-
-                // Attach a permanent observer to track navigation state in TabManager.
-                // We do this AFTER restoreState. Even so, GeckoView often fires
-                // onNavigationStateChange(false,false) once the page actually
-                // starts loading after restore — gated by `justRestored`.
-                newSession.register(object : EngineSession.Observer {
-                    override fun onStateUpdated(state: mozilla.components.concept.engine.EngineSessionState) {
-                        engineStates[tab.id] = state
-                        onAnyStateUpdated?.invoke(tab.id)
-                    }
-                    override fun onNavigationStateChange(canGoBack: Boolean?, canGoForward: Boolean?) {
-                        val current = navigationStates[tab.id] ?: TabNavigationState()
-                        // If the tab was just restored and both values come back false,
-                        // assume this is the spurious initial event and keep the
-                        // pre-calculated state. Clear the flag the moment we see a
-                        // "true" or a non-default state.
-                        if (justRestored.contains(tab.id)) {
-                            val bothFalse = (canGoBack == false || canGoBack == null) &&
-                                    (canGoForward == false || canGoForward == null)
-                            if (bothFalse && (current.canGoBack || current.canGoForward)) {
-                                Log.d(TAG, "Ignoring spurious (false,false) nav event for just-restored tab ${tab.id}")
-                                return
-                            }
-                            justRestored.remove(tab.id)
-                        }
-                        navigationStates[tab.id] = current.copy(
-                            canGoBack = canGoBack ?: current.canGoBack,
-                            canGoForward = canGoForward ?: current.canGoForward
-                        )
-                        Log.d(TAG, "Navigation state updated for tab ${tab.id}: canGoBack=${canGoBack ?: "null(preserved)"}, canGoForward=${canGoForward ?: "null(preserved)"} -> final=(${navigationStates[tab.id]?.canGoBack}, ${navigationStates[tab.id]?.canGoForward})")
-                    }
-                })
-            }
-        }
-        Log.d(TAG, "syncSessions: created $createdCount new sessions, total sessions=${sessions.size}")
-
-        // 4. Cleanup sessions for closed or hibernated tabs.
-        // NOTE: we only iterate sessions that exist for *live* tabs but are not in
-        // the active LRU window — i.e. real hibernation. Sessions whose tab was
-        // actually removed are torn down by `purgeTabState` / `reconcileWithStoreTabs`.
-        val hibernatedIds = sessions.keys.filter { it !in activeTabIds && it in allValidTabIds }
-
-        hibernatedIds.forEach { id ->
-            val session = sessions[id]
-            if (session != null) {
-                try {
-                    session.stopLoading()
-                    val geckoEngineSession = session as? GeckoEngineSession
-                    if (geckoEngineSession != null) {
-                        val bytes = captureSessionState(id)
-                        if (bytes != null) {
-                            savedStates[id] = bytes
-                            Log.d(TAG, "Saved GeckoSession state for hibernated tab $id (bytes=${bytes.size})")
-                        }
-                        val internalSession = getGeckoSession(geckoEngineSession)
-                        internalSession?.close()
-                        Log.d(TAG, "Closed/Hibernated GeckoSession for tab $id")
-                    }
-                } catch (e: Exception) {
-                    Log.e(TAG, "Error closing session for tab $id", e)
-                }
-            }
-            sessions.remove(id)
-            playingTabIds.remove(id)
-            // navigationStates is intentionally retained so the UI can still
-            // show back/forward affordances for hibernated tabs.
-
-            VideoDetector.clearTab(id)
-        }
-
-        // If the selected tab needs reload, trigger it now that its session is active
-        if (selectedTabId != null && needsReloadOnSelect.contains(selectedTabId)) {
-            val session = sessions[selectedTabId]
-            if (session != null) {
-                needsReloadOnSelect.remove(selectedTabId)
-                try {
-                    session.reload()
-                    Log.d(TAG, "Reloaded restored tab $selectedTabId upon selection to prevent blank screen")
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to reload restored tab $selectedTabId", e)
-                }
+        // 3. Hibernate live sessions outside the active window (read fresh store state).
+        Components.store.state.tabs.forEach { tab ->
+            if (tab.id !in activeTabIds &&
+                tab.engineState.engineSession != null &&
+                tab.id != selectedTabId &&
+                playingTabIds[tab.id] != true
+            ) {
+                Log.d(TAG, "Hibernating tab ${tab.id} (suspend via EngineMiddleware)")
+                Components.store.dispatch(EngineAction.SuspendEngineSessionAction(tab.id))
+                VideoDetector.clearTab(tab.id)
             }
         }
     }
@@ -514,9 +556,6 @@ class TabManager {
     /**
      * Pause all `<video>` and `<audio>` elements in [session] by executing
      * a javascript: URI via the underlying GeckoSession.
-     *
-     * This is the GeckoView-public replacement for the removed
-     * `EngineSession.evaluateJavascript` API.
      */
     fun pauseMedia(session: EngineSession) {
         val geckoSession = getGeckoSession(session) ?: return
@@ -532,39 +571,44 @@ class TabManager {
     // ── Find in page ─────────────────────────────────────────────────
 
     /**
-     * Trigger a find-in-page operation.
-     * @param text  the query text
-     * @param direction  0 = forward / highlight, 1 = backwards
+     * Trigger a find-in-page operation using the public EngineSession API.
+     * @param text  the query text; empty repeats the last search
+     * @param direction  0 = forward, 1 = backwards
      */
     fun findInPage(session: EngineSession?, text: String, direction: Int = 0) {
-        val geckoSession = getGeckoSession(session) ?: return
+        if (session == null) return
         try {
-            val finderClass = Class.forName("org.mozilla.geckoview.GeckoSession\$Finder")
-            val findDisplayHighlights = finderClass.getField("FIND_DISPLAY_HIGHLIGHTS").getInt(null)
-            val findBackwards = finderClass.getField("FIND_BACKWARDS").getInt(null)
-
-            val flags = if (direction == 0) findDisplayHighlights
-            else findDisplayHighlights or findBackwards
-
-            geckoSession.finder.find(text, flags)
+            when {
+                text.isNotEmpty() -> session.findAll(text)
+                else -> session.findNext(forward = direction == 0)
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Error finding in page", e)
-            try { geckoSession.finder.find(text, 0) } catch (_: Exception) {}
         }
     }
 
     /** Clear find-in-page highlights. */
     fun clearFind(session: EngineSession?) {
-        getGeckoSession(session)?.finder?.clear()
+        try {
+            session?.clearFindMatches()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error clearing find matches", e)
+        }
     }
 
-    /** Capture current state of all active sessions and merge with hibernated states. */
+    // ── State capture (persistence) ──────────────────────────────────
+
+    /**
+     * Serialize the engine session state of every tab from the store.
+     * Live tabs' states are continuously updated by EngineObserver
+     * (`onStateUpdated` → `UpdateEngineSessionStateAction`); suspended tabs
+     * retain their last state.
+     */
     fun captureAllStates(): Map<String, ByteArray> {
-        val allStates = savedStates.toMutableMap()
-        sessions.keys.forEach { id ->
-            val bytes = captureSessionState(id)
-            if (bytes != null) {
-                allStates[id] = bytes
+        val allStates = mutableMapOf<String, ByteArray>()
+        Components.store.state.tabs.forEach { tab ->
+            engineStateToBytes(tab.engineState.engineSessionState)?.let {
+                allStates[tab.id] = it
             }
         }
         Log.d(TAG, "captureAllStates: returning ${allStates.size} states")
@@ -572,106 +616,17 @@ class TabManager {
     }
 
     /**
-     * Capture the persisted state of [id] by serialising the most recent
-     * `EngineSessionState` we received via `onStateUpdated`. This avoids
-     * the race in `GeckoSession.flushSessionState()` (which is async) +
-     * reading `mStateCache` immediately, which was returning stale or
-     * empty data.
-     */
-    internal fun captureSessionState(id: String): ByteArray? {
-        return try {
-            val engineState = engineStates[id]
-            val geckoState = getGeckoState(engineState)
-            val bytes = geckoStateToBytes(geckoState)
-            if (bytes != null) {
-                Log.d(TAG, "captured state for tab $id from onStateUpdated cache (bytes=${bytes.size})")
-                return bytes
-            }
-            // Last resort: previously-saved bytes (e.g. hibernated tab whose
-            // engineStates entry was already purged).
-            savedStates[id]
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to capture state for tab $id", e)
-            savedStates[id]
-        }
-    }
-
-    /**
-     * Duplicate a tab, capturing its history and state, creating a new tab
-     * right next to it, and restoring the captured state on the new session.
+     * Duplicate a tab: create a new tab next to it restoring the source tab's
+     * current engine session state (history included).
      */
     fun duplicateTab(sourceTabId: String, store: BrowserStore): String? {
         val sourceTab = store.state.tabs.find { it.id == sourceTabId } ?: return null
-        val capturedState = captureSessionState(sourceTabId)
-        val newTabId = createTab(
+        return createTab(
             url = sourceTab.content.url,
             store = store,
             parentId = sourceTabId,
-            select = false
+            select = false,
+            engineSessionState = sourceTab.engineState.engineSessionState
         )
-        capturedState?.let {
-            savedStates[newTabId] = it
-        }
-        return newTabId
-    }
-
-    // ── Serialization helpers ────────────────────────────────────────
-
-    private fun getGeckoState(engineState: mozilla.components.concept.engine.EngineSessionState?): GeckoSession.SessionState? {
-        if (engineState == null) return null
-        return try {
-            // Find the getter method dynamically to avoid issues with Kotlin internal name mangling
-            // module suffixes (e.g. $browser_engine_gecko_debug vs $browser_engine_gecko_release).
-            val method = engineState.javaClass.declaredMethods.firstOrNull {
-                it.returnType == GeckoSession.SessionState::class.java || it.name.startsWith("getActualState")
-            }
-            if (method != null) {
-                method.isAccessible = true
-                method.invoke(engineState) as? GeckoSession.SessionState
-            } else {
-                Log.e(TAG, "getGeckoState: could not find getActualState method via reflection")
-                null
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to extract GeckoSession.SessionState from EngineSessionState", e)
-            null
-        }
-    }
-
-    private fun wrapGeckoState(geckoState: GeckoSession.SessionState): mozilla.components.concept.engine.EngineSessionState? {
-        return try {
-            // The GeckoEngineSessionState constructor is internal, so we use reflection to instantiate it.
-            val clazz = Class.forName("mozilla.components.browser.engine.gecko.GeckoEngineSessionState")
-            val constructor = clazz.getDeclaredConstructor(GeckoSession.SessionState::class.java)
-            constructor.isAccessible = true
-            constructor.newInstance(geckoState) as? mozilla.components.concept.engine.EngineSessionState
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to wrap GeckoSession.SessionState in GeckoEngineSessionState", e)
-            null
-        }
-    }
-
-    private fun geckoStateToBytes(state: GeckoSession.SessionState?): ByteArray? {
-        if (state == null) return null
-        return try {
-            // GeckoSession.SessionState.toString() returns the state as a JSON string
-            val json = state.toString()
-            if (json.isEmpty() || json == "{}") return null
-            json.toByteArray(Charsets.UTF_8)
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to serialize GeckoState to string", e)
-            null
-        }
-    }
-
-    private fun bytesToGeckoState(bytes: ByteArray?): GeckoSession.SessionState? {
-        if (bytes == null) return null
-        return try {
-            val json = String(bytes, Charsets.UTF_8)
-            GeckoSession.SessionState.fromString(json)
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to deserialize GeckoState from string", e)
-            null
-        }
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/TabsScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/TabsScreen.kt
@@ -451,7 +451,7 @@ fun TabsScreen(
                 }
             }
 
-            val playingTabIds = Components.tabManager?.playingTabIds ?: emptyMap<String, Boolean>()
+            val playingTabIds = Components.tabManager.playingTabIds
             val scope = rememberCoroutineScope()
 
             val showScrollToTop by remember {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheet.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheet.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.VideocamOff
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
@@ -87,7 +88,9 @@ fun CastSheet(
     subtitleService: StremioSubtitleService = StremioSubtitleService(),
     contentPayload: playbridge.PlayPayload? = null,
     onContentClick: (playbridge.PlayPayload) -> Unit = {},
-    onQueueContent: (playbridge.PlayPayload) -> Unit = {}
+    onQueueContent: (playbridge.PlayPayload) -> Unit = {},
+    detectionEnabled: Boolean = true,
+    onEnableDetection: (() -> Unit)? = null
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val context = LocalContext.current
@@ -614,7 +617,8 @@ fun CastSheet(
 
             if (selectedTab == 0) {
                 if (playableVideos.isEmpty() && contentPayload == null) {
-                    // Empty state
+                    // Empty state — explain WHY it's empty when detection is off,
+                    // instead of a silently empty sheet.
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -622,23 +626,37 @@ fun CastSheet(
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         Icon(
-                            Icons.Default.PlayArrow,
+                            if (detectionEnabled) Icons.Default.PlayArrow else Icons.Default.VideocamOff,
                             contentDescription = null,
                             modifier = Modifier.size(64.dp),
                             tint = MaterialTheme.colorScheme.outline
                         )
                         Spacer(modifier = Modifier.height(16.dp))
                         Text(
-                            "No videos detected yet",
+                            if (detectionEnabled) "No videos detected yet" else "Video detection is disabled",
                             style = MaterialTheme.typography.bodyLarge,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                         Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            "Browse a page with video content",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.outline
-                        )
+                        if (detectionEnabled) {
+                            Text(
+                                "Browse a page with video content",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.outline
+                            )
+                        } else {
+                            Text(
+                                "Videos on pages won't be found while it's off",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.outline
+                            )
+                            if (onEnableDetection != null) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                                TextButton(onClick = onEnableDetection) {
+                                    Text("Enable video detection")
+                                }
+                            }
+                        }
                     }
                 } else {
                     // Video list

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/MediaSessionDelegate.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/MediaSessionDelegate.kt
@@ -4,48 +4,55 @@ import com.playbridge.sender.browser.*
 import android.content.Context
 import android.util.Log
 import kotlinx.coroutines.*
-import org.mozilla.geckoview.GeckoSession
-import org.mozilla.geckoview.MediaSession
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.mediasession.MediaSession
 
 /**
- * Bridges GeckoView MediaSession events to our MediaPlaybackService.
+ * Bridges media session events from an [EngineSession] to MediaPlaybackService
+ * and TabManager's playing-tab state.
+ *
+ * Registered once per engine session by TabManager's store mirror — so it
+ * covers EVERY tab, including background ones (the old GeckoView
+ * `MediaSession.Delegate`, set via reflection, only covered the selected tab
+ * and was detached on tab switch).
  */
-class MediaSessionDelegate(
+class MediaSessionObserver(
     private val context: Context,
     private val tabId: String,
-    private val tabManager: TabManager
-) : MediaSession.Delegate {
+    private val tabManager: TabManager,
+    private val engineSession: EngineSession,
+) : EngineSession.Observer {
 
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var controlJob: Job? = null
     private var isActive = false
 
-    override fun onActivated(session: GeckoSession, mediaSession: MediaSession) {
-        Log.d(TAG, "onActivated (tabId=$tabId)")
+    override fun onMediaActivated(mediaSessionController: MediaSession.Controller) {
+        Log.d(TAG, "onMediaActivated (tabId=$tabId)")
         isActive = true
         tabManager.markTabAsPlaying(tabId)
         MediaPlaybackService.start(context)
-        
+
         controlJob?.cancel()
         controlJob = scope.launch {
             MediaControlChannel.actions.collect { action ->
                 if (!isActive) return@collect
                 Log.d(TAG, "Received action from channel: $action")
                 when (action) {
-                    MediaControlChannel.Action.PLAY -> mediaSession.play()
+                    MediaControlChannel.Action.PLAY -> mediaSessionController.play()
                     MediaControlChannel.Action.PAUSE -> {
-                        mediaSession.pause()
+                        mediaSessionController.pause()
                         // Fallback: pause all media elements via JS injection
-                        session.loadUri("javascript:document.querySelectorAll('video,audio').forEach(function(m){try{m.pause();}catch(e){}});void 0;")
+                        tabManager.pauseMedia(engineSession)
                     }
-                    MediaControlChannel.Action.STOP -> mediaSession.stop()
+                    MediaControlChannel.Action.STOP -> mediaSessionController.stop()
                 }
             }
         }
     }
 
-    override fun onDeactivated(session: GeckoSession, mediaSession: MediaSession) {
-        Log.d(TAG, "onDeactivated (tabId=$tabId)")
+    override fun onMediaDeactivated() {
+        Log.d(TAG, "onMediaDeactivated (tabId=$tabId)")
         isActive = false
         tabManager.playingTabIds.remove(tabId)
         controlJob?.cancel()
@@ -53,9 +60,8 @@ class MediaSessionDelegate(
         MediaPlaybackService.stop(context)
     }
 
-    override fun onMetadata(session: GeckoSession, mediaSession: MediaSession, metadata: MediaSession.Metadata) {
+    override fun onMediaMetadataChanged(metadata: MediaSession.Metadata) {
         Log.d(TAG, "Media metadata changed: ${metadata.title} - ${metadata.artist}")
-        
         MediaPlaybackService.sendMetadataUpdate(
             context,
             title = metadata.title,
@@ -63,40 +69,23 @@ class MediaSessionDelegate(
         )
     }
 
-    override fun onPlay(session: GeckoSession, mediaSession: MediaSession) {
-        Log.d(TAG, "onPlay (tabId=$tabId)")
-        tabManager.markTabAsPlaying(tabId)
-        MediaPlaybackService.sendStateUpdate(context, true)
-    }
-
-    override fun onPause(session: GeckoSession, mediaSession: MediaSession) {
-        Log.d(TAG, "onPause (tabId=$tabId)")
-        tabManager.playingTabIds.remove(tabId)
-        MediaPlaybackService.sendStateUpdate(context, false)
-    }
-
-    override fun onStop(session: GeckoSession, mediaSession: MediaSession) {
-        Log.d(TAG, "onStop (tabId=$tabId)")
-        tabManager.playingTabIds.remove(tabId)
-        MediaPlaybackService.sendStateUpdate(context, false)
-    }
-
-    override fun onFeatures(session: GeckoSession, mediaSession: MediaSession, features: Long) {
-        // e.g. can seek, can play/pause
-    }
-
-    override fun onPositionState(session: GeckoSession, mediaSession: MediaSession, positionState: MediaSession.PositionState) {
-        Log.d(TAG, "onPositionState: playbackRate=${positionState.playbackRate}")
-        if (positionState.playbackRate == 0.0) {
-            tabManager.playingTabIds.remove(tabId)
-            MediaPlaybackService.sendStateUpdate(context, false)
-        } else {
-            tabManager.markTabAsPlaying(tabId)
-            MediaPlaybackService.sendStateUpdate(context, true)
+    override fun onMediaPlaybackStateChanged(playbackState: MediaSession.PlaybackState) {
+        Log.d(TAG, "onMediaPlaybackStateChanged (tabId=$tabId): $playbackState")
+        when (playbackState) {
+            MediaSession.PlaybackState.PLAYING -> {
+                tabManager.markTabAsPlaying(tabId)
+                MediaPlaybackService.sendStateUpdate(context, true)
+            }
+            MediaSession.PlaybackState.PAUSED,
+            MediaSession.PlaybackState.STOPPED -> {
+                tabManager.playingTabIds.remove(tabId)
+                MediaPlaybackService.sendStateUpdate(context, false)
+            }
+            else -> Unit
         }
     }
 
     companion object {
-        private const val TAG = "MediaSessionDelegate"
+        private const val TAG = "MediaSessionObserver"
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/SessionObserverSetup.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/SessionObserverSetup.kt
@@ -4,44 +4,59 @@ import com.playbridge.sender.browser.*
 import com.playbridge.sender.downloads.PendingDownload
 import com.playbridge.sender.downloads.PendingPopup
 import android.app.AlertDialog
-import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.text.InputType
 import android.util.Log
 import android.widget.EditText
-import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import mozilla.components.browser.engine.gecko.GeckoEngineSession
-import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.HitResult
+import mozilla.components.concept.engine.mediasession.MediaSession
+import mozilla.components.concept.engine.permission.Permission
+import mozilla.components.concept.engine.permission.PermissionRequest
+import mozilla.components.concept.engine.prompt.Choice
+import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.concept.fetch.Response
-import org.mozilla.geckoview.GeckoResult
-import org.mozilla.geckoview.GeckoSession
-import org.mozilla.geckoview.MediaSession
 import com.playbridge.sender.data.history.HistoryDao
 import com.playbridge.sender.data.history.HistoryEntity
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.LaunchedEffect
 import org.koin.compose.koinInject
+import java.security.cert.X509Certificate
 
 /**
- * Sets up the [EngineSession.Observer] and GeckoSession delegate proxies
- * (NavigationDelegate, ContentDelegate) for the active browser session.
+ * Registers a single [EngineSession.Observer] on the active browser session.
  *
- * This composable encapsulates ~300 lines that were previously inline inside
- * `BrowserActivity.onCreate`.
+ * Everything here uses public Android Components observer APIs. The previous
+ * implementation replaced GeckoSession delegates via `java.lang.reflect.Proxy`
+ * and field reflection — fragile across AC/GeckoView upgrades and R8. The
+ * mapping is:
+ *
+ * - NavigationDelegate.onNewSession  → [EngineSession.Observer.onWindowRequest]
+ * - NavigationDelegate.onLoadError   → engine-level RequestInterceptor ([Components])
+ * - NavigationDelegate.onLoadRequest (magnet/stremio) → RequestInterceptor
+ * - ContentDelegate.onContextMenu    → [EngineSession.Observer.onLongPress]
+ * - ContentDelegate.onFullScreen     → onFullScreenChange / onMediaFullscreenChanged
+ *   (the portrait check now uses media element dimensions instead of the old
+ *   `javascript:` location-hash injection hack)
+ * - PermissionDelegate (autoplay/DRM) → onContentPermissionRequest
+ * - ProgressDelegate (loading/security) → onLoadingStateChange / onSecurityChange
+ * - PromptDelegate (alert/confirm/prompt/<select>) → onPromptRequest
+ * - MediaSession.Delegate → MediaSessionObserver (registered per tab by TabManager)
  */
 @Composable
 fun SessionObserverSetup(
@@ -76,6 +91,20 @@ fun SessionObserverSetup(
     val whitelistState = rememberUpdatedState(whitelist)
     val blacklistState = rememberUpdatedState(blacklist)
     val selectedTabState = rememberUpdatedState(selectedTab)
+    val fullScreenCb = rememberUpdatedState(onFullScreenChange)
+
+    // Magnet/Stremio links are intercepted at the engine level (RequestInterceptor
+    // in Components) so they work in every tab; wire its callbacks here.
+    val magnetHandler = rememberUpdatedState(onMagnetDetected)
+    val stremioHandler = rememberUpdatedState(onStremioAddonDetected)
+    DisposableEffect(Unit) {
+        Components.onMagnetDetected = { uri -> magnetHandler.value(uri) }
+        Components.onStremioAddonDetected = { uri -> stremioHandler.value(uri) }
+        onDispose {
+            Components.onMagnetDetected = null
+            Components.onStremioAddonDetected = null
+        }
+    }
 
     // Apply desktop user agent when the session changes (tab switch) — no reload,
     // since the page isn't loaded in desktop mode yet anyway.
@@ -88,24 +117,16 @@ fun SessionObserverSetup(
         session.toggleDesktopMode(isDesktopMode, reload = shouldReload)
         Log.d(TAG, "${if (isDesktopMode) "Enabled" else "Disabled"} Desktop Mode (reload=$shouldReload)")
     }
+
     DisposableEffect(session, selectedTab?.id) {
         val observer = object : EngineSession.Observer {
-            override fun onLocationChange(url: String, hasUserGesture: Boolean) {
-                if (url.contains("#playbridge-fullscreen-portrait=")) {
-                    val isPortrait = url.substringAfter("#playbridge-fullscreen-portrait=").toBoolean()
-                    onFullScreenChange(true, isPortrait)
-                    return
-                }
 
-                // Update store state to keep it in sync
-                if (selectedTab != null) {
-                    store.dispatch(
-                        ContentAction.UpdateUrlAction(
-                            sessionId = selectedTab.id,
-                            url = url
-                        )
-                    )
-                }
+            /** Portrait-ness of the last fullscreened media element. */
+            private var lastMediaIsPortrait = false
+
+            override fun onLocationChange(url: String, hasUserGesture: Boolean) {
+                // NOTE: the store's URL is updated by EngineMiddleware's
+                // EngineObserver (for every tab, not just the selected one).
 
                 // Get base URL without hash/fragment
                 val baseUrl = url.substringBefore("#")
@@ -114,7 +135,7 @@ fun SessionObserverSetup(
                 // Record history
                 if (baseUrl != previousBaseUrl && !url.startsWith("about:")) {
                     scope.launch(Dispatchers.IO) {
-                        val title = selectedTab?.content?.title
+                        val title = selectedTabState.value?.content?.title
                         historyDao.insert(
                             HistoryEntity(
                                 url = url,
@@ -127,32 +148,23 @@ fun SessionObserverSetup(
 
                 currentUrl.value = url
                 previousUrl.value = url
-
-                // NOTE: detected videos are no longer cleared here. Reset happens
-                // in two places that both cover reloads (same-URL loads):
-                //  - ProgressDelegate.onPageStart below (precise, local)
-                //  - the extension's webNavigation.onCommitted handler, which also
-                //    clears the extension's own per-tab seen-URL state so videos
-                //    are re-reported on the fresh page (Components.processMessage
-                //    "navigation").
-                // Video detections themselves arrive via native messaging
-                // (Components.processMessage), not the old URL-hash signal.
             }
 
             override fun onLoadingStateChange(loading: Boolean) {
                 isLoading.value = loading
+                if (loading) {
+                    // Reset detected videos on every top-level page load start —
+                    // including reloads of the same URL. Does not fire for
+                    // same-document (hash/pushState) navigations, so SPA route
+                    // changes keep their detected videos. (Was ProgressDelegate
+                    // onPageStart.)
+                    selectedTabState.value?.id?.let { VideoDetector.clearTab(it) }
+                }
             }
 
             override fun onTitleChange(title: String) {
                 Log.d(TAG, "Title changed: $title")
-                if (selectedTab != null) {
-                    store.dispatch(
-                        ContentAction.UpdateTitleAction(
-                            sessionId = selectedTab.id,
-                            title = title
-                        )
-                    )
-                }
+                // Store title is updated by EngineMiddleware's EngineObserver.
 
                 // Update the history database item with the loaded page title
                 val url = currentUrl.value
@@ -169,7 +181,140 @@ fun SessionObserverSetup(
                 }
             }
 
-            // Intercept downloads - this catches XPI files from AMO
+            override fun onSecurityChange(
+                secure: Boolean,
+                host: String?,
+                issuer: String?,
+                certificate: X509Certificate?
+            ) {
+                isSecureConnection.value = secure
+                val certIssuer = certificate?.issuerX500Principal?.name?.let { parseCN(it) } ?: issuer
+                val certValidUntil = certificate?.notAfter?.let {
+                    java.text.SimpleDateFormat("MMM d, yyyy", java.util.Locale.getDefault()).format(it)
+                }
+                siteSecurityInfo.value = SiteSecurityInfo(
+                    isSecure = secure,
+                    host = host ?: "",
+                    certIssuer = certIssuer,
+                    certValidUntil = certValidUntil
+                )
+                Log.d(TAG, "Security changed: isSecure=$secure, host=$host, issuer=$certIssuer")
+            }
+
+            // ── Fullscreen ────────────────────────────────────────────
+
+            override fun onMediaFullscreenChanged(
+                fullscreen: Boolean,
+                elementMetadata: MediaSession.ElementMetadata?
+            ) {
+                val isPortrait = elementMetadata != null &&
+                    elementMetadata.width > 0L && elementMetadata.height > 0L &&
+                    elementMetadata.height > elementMetadata.width
+                lastMediaIsPortrait = isPortrait
+                scope.launch(Dispatchers.Main) {
+                    fullScreenCb.value(fullscreen, fullscreen && isPortrait)
+                }
+            }
+
+            override fun onFullScreenChange(enabled: Boolean) {
+                // DOM element fullscreen (non-media or media without a media
+                // session). Use the last known media orientation as the hint.
+                scope.launch(Dispatchers.Main) {
+                    fullScreenCb.value(enabled, enabled && lastMediaIsPortrait)
+                }
+            }
+
+            // ── Long-press context menu ───────────────────────────────
+
+            override fun onLongPress(hitResult: HitResult) {
+                val link = when (hitResult) {
+                    is HitResult.UNKNOWN -> hitResult.src
+                    is HitResult.IMAGE_SRC -> hitResult.uri
+                    is HitResult.IMAGE -> hitResult.src
+                    is HitResult.VIDEO -> hitResult.src
+                    is HitResult.AUDIO -> hitResult.src
+                    else -> null
+                }
+                if (!link.isNullOrEmpty() && (link.startsWith("http://") || link.startsWith("https://"))) {
+                    scope.launch(Dispatchers.Main) { contextMenuUrl.value = link }
+                }
+            }
+
+            // ── Permissions (autoplay + DRM auto-grant) ───────────────
+
+            override fun onContentPermissionRequest(permissionRequest: PermissionRequest) {
+                val granted = permissionRequest.grantIf { perm ->
+                    perm is Permission.ContentAutoPlayAudible ||
+                        perm is Permission.ContentAutoPlayInaudible ||
+                        perm is Permission.ContentMediaKeySystemAccess
+                }
+                if (granted) {
+                    Log.d(TAG, "Granted media permission(s): ${permissionRequest.permissions}")
+                } else {
+                    permissionRequest.reject()
+                }
+            }
+
+            // ── Popups (window.open / target=_blank) ──────────────────
+
+            override fun onWindowRequest(windowRequest: WindowRequest) {
+                if (windowRequest.type == WindowRequest.Type.CLOSE) {
+                    // window.close(): close the tab hosting this session.
+                    val closing = windowRequest.prepare()
+                    val tabId = tabManager.sessions.entries.find { it.value === closing }?.key
+                    if (tabId != null) {
+                        scope.launch(Dispatchers.Main) { tabManager.closeTab(tabId, store) }
+                    }
+                    return
+                }
+
+                val uri = windowRequest.url
+                val popupSession = windowRequest.prepare()
+                val openerUrl = currentUrl.value
+                val openerHost = try {
+                    java.net.URI(openerUrl).host ?: openerUrl
+                } catch (e: Exception) { openerUrl }
+
+                val isWhitelisted = isHostMatch(openerHost, whitelistState.value)
+                val isBlacklisted = isHostMatch(openerHost, blacklistState.value)
+                val shouldBlock = when {
+                    isWhitelisted -> false
+                    isBlacklisted -> true
+                    else -> blockPopupsState.value
+                }
+
+                scope.launch(Dispatchers.Main) {
+                    if (shouldBlock) {
+                        if (isBlacklisted) {
+                            Log.d(TAG, "Popup silently blocked (blacklist) from $openerHost: $uri")
+                            try { popupSession.close() } catch (_: Exception) {}
+                        } else {
+                            Log.d(TAG, "Popup blocked from $openerHost: $uri")
+                            pendingPopup.value = PendingPopup(
+                                openerHost = openerHost,
+                                popupUrl = uri,
+                                engineSession = popupSession,
+                            )
+                        }
+                    } else {
+                        Log.d(TAG, "Auto-opening new tab for popup: $uri")
+                        val tabId = tabManager.createTab(
+                            url = uri,
+                            store = store,
+                            parentId = selectedTabState.value?.id,
+                            select = true
+                        )
+                        // EngineMiddleware registers its EngineObserver on link —
+                        // URL/title/nav/state sync and crash handling for free.
+                        store.dispatch(
+                            EngineAction.LinkEngineSessionAction(tabId, popupSession, skipLoading = true)
+                        )
+                    }
+                }
+            }
+
+            // ── Downloads (XPI install / torrent / general) ───────────
+
             override fun onExternalResource(
                 url: String,
                 fileName: String?,
@@ -184,7 +329,6 @@ fun SessionObserverSetup(
             ) {
                 Log.d(TAG, "Download intercepted: $url, type: $contentType, file: $fileName")
 
-                // Check if this is an XPI file (Firefox extension)
                 if (url.endsWith(".xpi") || contentType == "application/x-xpinstall") {
                     Log.d(TAG, "XPI detected, installing addon from: $url")
                     onXpiDetected(url)
@@ -202,7 +346,6 @@ fun SessionObserverSetup(
                         }
                     }
                 } else {
-                    // General download interception
                     scope.launch(Dispatchers.Main) {
                         if (pendingDownload.value?.url != url) {
                             pendingDownload.value = PendingDownload(
@@ -218,539 +361,132 @@ fun SessionObserverSetup(
                 }
             }
 
-            override fun onStateUpdated(state: mozilla.components.concept.engine.EngineSessionState) {
-                if (selectedTab != null) {
-                    tabManager.engineStates[selectedTab.id] = state
+            // ── Prompts (alert / confirm / prompt / <select>) ─────────
+
+            override fun onPromptRequest(promptRequest: PromptRequest) {
+                Handler(Looper.getMainLooper()).post {
+                    showPrompt(promptRequest)
                 }
             }
-        }
-        session.register(observer)
 
-        // Set up GeckoSession delegates using reflection
-        val geckoEngineSession = session as? GeckoEngineSession
+            private fun showPrompt(promptRequest: PromptRequest) {
+                when (promptRequest) {
+                    is PromptRequest.SingleChoice ->
+                        showSingleChoice(promptRequest.choices, promptRequest.onConfirm, promptRequest.onDismiss)
 
-        var originalNavDelegate: GeckoSession.NavigationDelegate? = null
-        var originalContentDelegate: GeckoSession.ContentDelegate? = null
-        var originalPermissionDelegate: GeckoSession.PermissionDelegate? = null
-        var originalPromptDelegate: GeckoSession.PromptDelegate? = null
-        var originalProgressDelegate: GeckoSession.ProgressDelegate? = null
-        var originalMediaDelegate: MediaSession.Delegate? = null
-        var geckoSessionInstance: GeckoSession? = null
+                    is PromptRequest.MenuChoice ->
+                        showSingleChoice(promptRequest.choices, promptRequest.onConfirm, promptRequest.onDismiss)
 
-        if (geckoEngineSession != null) {
-            try {
-                val field = GeckoEngineSession::class.java.getDeclaredField("geckoSession")
-                field.isAccessible = true
-                val internalSession = field.get(geckoEngineSession) as? GeckoSession
-                geckoSessionInstance = internalSession
-
-                internalSession?.let { gs ->
-                    // NavigationDelegate proxy for onNewSession (open in new tab)
-                    val existingNav = gs.navigationDelegate
-                    originalNavDelegate = existingNav
-
-                    originalMediaDelegate = gs.mediaSessionDelegate
-                    selectedTab?.id?.let { tid ->
-                        gs.mediaSessionDelegate = MediaSessionDelegate(context, tid, tabManager)
-                    }
-
-                    val navProxy = java.lang.reflect.Proxy.newProxyInstance(
-                        GeckoSession.NavigationDelegate::class.java.classLoader,
-                        arrayOf(GeckoSession.NavigationDelegate::class.java)
-                    ) { _, method, args ->
-                        if (method.name == "onNewSession" && args != null && args.size >= 2) {
-                            val uri = args[1] as? String
-                            if (uri != null) {
-                                val openerUrl = currentUrl.value
-                                val openerHost = try {
-                                    java.net.URI(openerUrl).host ?: openerUrl
-                                } catch (e: Exception) { openerUrl }
-
-                                val isWhitelisted = isHostMatch(openerHost, whitelistState.value)
-                                val isBlacklisted = isHostMatch(openerHost, blacklistState.value)
-
-                                val shouldBlock = when {
-                                    isWhitelisted -> false
-                                    isBlacklisted -> true
-                                    else -> blockPopupsState.value
-                                }
-
-                                if (shouldBlock) {
-                                    Log.d(TAG, "Popup blocked from $openerHost: $uri")
-                                    val rawGeckoSession = GeckoSession()
-                                    val newEngineSession = GeckoEngineSession(
-                                        runtime = Components.runtime,
-                                        geckoSessionProvider = { rawGeckoSession },
-                                        openGeckoSession = false
-                                    )
-                                    if (!isBlacklisted) {
-                                        scope.launch(Dispatchers.Main) {
-                                            pendingPopup.value = PendingPopup(
-                                                openerHost = openerHost,
-                                                popupUrl = uri,
-                                                rawGeckoSession = rawGeckoSession,
-                                                engineSession = newEngineSession,
-                                            )
-                                        }
-                                    }
-                                    return@newProxyInstance GeckoResult.fromValue(rawGeckoSession)
-                                }
-
-                                Log.d(TAG, "Auto-opening new tab for popup: $uri")
-                                val rawGeckoSession = GeckoSession()
-                                val newEngineSession = GeckoEngineSession(
-                                    runtime = Components.runtime,
-                                    geckoSessionProvider = { rawGeckoSession },
-                                    openGeckoSession = false
+                    is PromptRequest.MultipleChoice -> {
+                        val flat = flattenChoices(promptRequest.choices)
+                        val labels = flat.map { it.label }.toTypedArray()
+                        val checked = flat.map { it.selected }.toBooleanArray()
+                        AlertDialog.Builder(context)
+                            .setMultiChoiceItems(labels, checked) { _, which, isChecked ->
+                                checked[which] = isChecked
+                            }
+                            .setPositiveButton(android.R.string.ok) { _, _ ->
+                                promptRequest.onConfirm(
+                                    flat.filterIndexed { i, _ -> checked[i] }.toTypedArray()
                                 )
-                                scope.launch(Dispatchers.Main) {
-                                    val tabId = tabManager.createTab(
-                                        url = uri,
-                                        store = store,
-                                        parentId = selectedTab?.id,
-                                        select = true
-                                    )
-                                    tabManager.sessions[tabId] = newEngineSession
-
-                                    // Register standard observer for popup tab
-                                    newEngineSession.register(object : EngineSession.Observer {
-                                        override fun onStateUpdated(state: mozilla.components.concept.engine.EngineSessionState) {
-                                            tabManager.engineStates[tabId] = state
-                                            tabManager.onAnyStateUpdated?.invoke(tabId)
-                                        }
-                                        override fun onNavigationStateChange(canGoBack: Boolean?, canGoForward: Boolean?) {
-                                            val current = tabManager.navigationStates[tabId] ?: TabNavigationState()
-                                            tabManager.navigationStates[tabId] = current.copy(
-                                                canGoBack = canGoBack ?: current.canGoBack,
-                                                canGoForward = canGoForward ?: current.canGoForward
-                                            )
-                                        }
-                                    })
-                                }
-                                return@newProxyInstance GeckoResult.fromValue(rawGeckoSession)
                             }
-                        }
-
-                        if (method.name == "onLoadError" && args != null && args.size >= 3) {
-                            val uri = args[1] as? String ?: "unknown"
-                            val error = args[2] // WebRequestError
-                            Log.e(TAG, "Load error for $uri: $error")
-
-                            // error is a WebRequestError — it has a code, but the error URI must not be http/https
-                            // we'll return a data URI generated from ErrorPageUtils
-                            return@newProxyInstance GeckoResult.fromValue(
-                                ErrorPageUtils.generateErrorPage(uri, "NETWORK_ERROR", error.toString())
-                            )
-                        }
-                        
-                        if (method.name == "onLoadRequest" && args != null && args.size >= 2) {
-                            val request = args[1]
-                            if (request != null) {
-                                try {
-                                    val uriField = request.javaClass.getField("uri")
-                                    val uri = uriField.get(request) as? String
-                                    if (uri != null && uri.startsWith("magnet:?")) {
-                                        Log.d(TAG, "Intercepted magnet link: $uri")
-                                        scope.launch(Dispatchers.Main) {
-                                            onMagnetDetected(uri)
-                                        }
-                                        return@newProxyInstance GeckoResult.fromValue(org.mozilla.geckoview.AllowOrDeny.DENY)
-                                    }
-                                    if (uri != null && uri.startsWith("stremio://")) {
-                                        Log.d(TAG, "Intercepted Stremio addon link: $uri")
-                                        scope.launch(Dispatchers.Main) {
-                                            onStremioAddonDetected(uri)
-                                        }
-                                        return@newProxyInstance GeckoResult.fromValue(org.mozilla.geckoview.AllowOrDeny.DENY)
-                                    }
-                                } catch (e: Exception) {
-                                    Log.e(TAG, "Error inspecting load request", e)
-                                }
-                            }
-                        }
-
-                        // Forward to original delegate for everything else
-                        if (existingNav != null) {
-                            try {
-                                if (args != null) method.invoke(existingNav, *args)
-                                else method.invoke(existingNav)
-                            } catch (e: java.lang.reflect.InvocationTargetException) {
-                                throw e.targetException
-                            }
-                        } else {
-                            null
-                        }
-                    } as GeckoSession.NavigationDelegate
-                    gs.navigationDelegate = navProxy
-
-                    // ContentDelegate proxy for context menus
-                    val existingContent = gs.contentDelegate
-                    originalContentDelegate = existingContent
-
-                    if (existingContent != null) {
-                        val contentProxy = java.lang.reflect.Proxy.newProxyInstance(
-                            GeckoSession.ContentDelegate::class.java.classLoader,
-                            arrayOf(GeckoSession.ContentDelegate::class.java)
-                        ) { _, method, args ->
-                            if (method.name == "onContextMenuItemSelected" && args != null && args.size >= 2) {
-                                val item = args[1]
-                                if (item != null) {
-                                    try {
-                                        val idField = item.javaClass.getField("id")
-                                        val id = idField.getInt(item)
-                                        val idOpenInNewTabField = item.javaClass.getField("ID_OPEN_IN_NEW_TAB")
-                                        val idOpenInNewTab = idOpenInNewTabField.getInt(null)
-                                        if (id == idOpenInNewTab) {
-                                            // Actually open the link in a new tab next to current.
-                                            val url = contextMenuUrl.value
-                                            if (!url.isNullOrEmpty()) {
-                                                scope.launch(Dispatchers.Main) {
-                                                    tabManager.createTab(
-                                                        url = url,
-                                                        store = store,
-                                                        parentId = selectedTab?.id,
-                                                        select = false
-                                                    )
-                                                }
-                                            }
-                                            return@newProxyInstance true
-                                        }
-                                    } catch (_: Exception) {}
-                                }
-                            }
-                            if (method.name == "onContextMenu" && args != null && args.size >= 4) {
-                                val element = args[3]
-                                if (element != null) {
-                                    try {
-                                        val linkUriField = element.javaClass.getField("linkUri")
-                                        val linkUri = linkUriField.get(element) as? String
-                                        if (linkUri != null) {
-                                            contextMenuUrl.value = linkUri
-                                        }
-                                    } catch (_: Exception) {}
-                                }
-                            }
-                            if (method.name == "onFullScreen" && args != null && args.size >= 2) {
-                                val fullScreen = args[1] as? Boolean ?: false
-                                val internalGs = gs
-                                scope.launch(Dispatchers.Main) {
-                                    onFullScreenChange(fullScreen, false)
-                                    if (fullScreen && internalGs != null) {
-                                        try {
-                                            val js = """
-                                                javascript:(function() {
-                                                    var el = document.fullscreenElement || document.body;
-                                                    var video = el.tagName === 'VIDEO' ? el : el.querySelector('video');
-                                                    if (!video) {
-                                                        video = document.querySelector('video');
-                                                    }
-                                                    var isPortrait = false;
-                                                    if (video && video.videoWidth && video.videoHeight) {
-                                                        isPortrait = video.videoWidth < video.videoHeight;
-                                                    }
-                                                    window.location.replace(window.location.href.split('#')[0] + '#playbridge-fullscreen-portrait=' + isPortrait);
-                                                    setTimeout(function() {
-                                                        history.replaceState(null, '', window.location.href.split('#')[0]);
-                                                    }, 100);
-                                                })()
-                                            """.trimIndent()
-                                            internalGs.loadUri(js)
-                                        } catch (e: Exception) {
-                                            Log.e(TAG, "Error executing loadUri for fullscreen check", e)
-                                        }
-                                    }
-                                }
-                            }
-                            try {
-                                if (args != null) method.invoke(existingContent, *args)
-                                else method.invoke(existingContent)
-                            } catch (e: java.lang.reflect.InvocationTargetException) {
-                                throw e.targetException
-                            }
-                        } as GeckoSession.ContentDelegate
-                        gs.contentDelegate = contentProxy
-                    } else {
-                        // No existing content delegate — create a minimal one for fullscreen
-                        val fullscreenDelegate = object : GeckoSession.ContentDelegate {
-                            override fun onFullScreen(session: GeckoSession, fullScreen: Boolean) {
-                                scope.launch(Dispatchers.Main) {
-                                    onFullScreenChange(fullScreen, false)
-                                    if (fullScreen) {
-                                        try {
-                                            val js = """
-                                                javascript:(function() {
-                                                    var el = document.fullscreenElement || document.body;
-                                                    var video = el.tagName === 'VIDEO' ? el : el.querySelector('video');
-                                                    if (!video) {
-                                                        video = document.querySelector('video');
-                                                    }
-                                                    var isPortrait = false;
-                                                    if (video && video.videoWidth && video.videoHeight) {
-                                                        isPortrait = video.videoWidth < video.videoHeight;
-                                                    }
-                                                    window.location.replace(window.location.href.split('#')[0] + '#playbridge-fullscreen-portrait=' + isPortrait);
-                                                    setTimeout(function() {
-                                                        history.replaceState(null, '', window.location.href.split('#')[0]);
-                                                    }, 100);
-                                                })()
-                                            """.trimIndent()
-                                            session.loadUri(js)
-                                        } catch (e: Exception) {
-                                            Log.e(TAG, "Error executing loadUri for fullscreen check", e)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        gs.contentDelegate = fullscreenDelegate
+                            .setNegativeButton(android.R.string.cancel) { _, _ -> promptRequest.onDismiss() }
+                            .setOnCancelListener { promptRequest.onDismiss() }
+                            .show()
                     }
-                    
-                    val existingPermission = gs.permissionDelegate
-                    originalPermissionDelegate = existingPermission
-                    gs.permissionDelegate = java.lang.reflect.Proxy.newProxyInstance(
-                        GeckoSession.PermissionDelegate::class.java.classLoader,
-                        arrayOf(GeckoSession.PermissionDelegate::class.java)
-                    ) { _, method, args ->
-                        if (method.name == "onContentPermissionRequest" && args != null && args.size >= 2) {
-                            val perm = args[1] as? GeckoSession.PermissionDelegate.ContentPermission
-                            if (perm != null) {
-                                when (perm.permission) {
-                                    GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_AUDIBLE,
-                                    GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_INAUDIBLE,
-                                    GeckoSession.PermissionDelegate.PERMISSION_MEDIA_KEY_SYSTEM_ACCESS -> {
-                                        Log.d(TAG, "Granting media permission: ${perm.permission} for ${perm.uri}")
-                                        return@newProxyInstance GeckoResult.fromValue(GeckoSession.PermissionDelegate.ContentPermission.VALUE_ALLOW)
-                                    }
-                                }
-                            }
+
+                    is PromptRequest.Alert -> {
+                        AlertDialog.Builder(context)
+                            .setTitle(promptRequest.title.takeIf { it.isNotBlank() })
+                            .setMessage(promptRequest.message)
+                            .setPositiveButton(android.R.string.ok) { _, _ -> promptRequest.onConfirm(false) }
+                            .setOnCancelListener { promptRequest.onDismiss() }
+                            .show()
+                    }
+
+                    is PromptRequest.Confirm -> {
+                        AlertDialog.Builder(context)
+                            .setTitle(promptRequest.title.takeIf { it.isNotBlank() })
+                            .setMessage(promptRequest.message)
+                            .setPositiveButton(
+                                promptRequest.positiveButtonTitle.ifBlank { context.getString(android.R.string.ok) }
+                            ) { _, _ -> promptRequest.onConfirmPositiveButton(false) }
+                            .setNegativeButton(
+                                promptRequest.negativeButtonTitle.ifBlank { context.getString(android.R.string.cancel) }
+                            ) { _, _ -> promptRequest.onConfirmNegativeButton(false) }
+                            .setOnCancelListener { promptRequest.onDismiss() }
+                            .show()
+                    }
+
+                    is PromptRequest.TextPrompt -> {
+                        val input = EditText(context).apply {
+                            inputType = InputType.TYPE_CLASS_TEXT
+                            setText(promptRequest.inputValue)
                         }
-
-                        // Forward to original delegate
-                        if (existingPermission != null) {
-                            try {
-                                if (args != null) method.invoke(existingPermission, *args)
-                                else method.invoke(existingPermission)
-                            } catch (e: java.lang.reflect.InvocationTargetException) {
-                                throw e.targetException
+                        AlertDialog.Builder(context)
+                            .setTitle(promptRequest.title.takeIf { it.isNotBlank() })
+                            .setMessage(promptRequest.inputLabel.takeIf { it.isNotBlank() })
+                            .setView(input)
+                            .setPositiveButton(android.R.string.ok) { _, _ ->
+                                promptRequest.onConfirm(false, input.text.toString())
                             }
-                        } else {
-                            if (method.name == "onContentPermissionRequest") {
-                                GeckoResult.fromValue(GeckoSession.PermissionDelegate.ContentPermission.VALUE_DENY)
-                            } else {
-                                null
-                            }
-                        }
-                    } as GeckoSession.PermissionDelegate
+                            .setNegativeButton(android.R.string.cancel) { _, _ -> promptRequest.onDismiss() }
+                            .setOnCancelListener { promptRequest.onDismiss() }
+                            .show()
+                    }
 
-                    // ProgressDelegate for Security/SSL status and preserving engine session state updates
-                    val existingProgress = gs.progressDelegate
-                    originalProgressDelegate = existingProgress
-                    gs.progressDelegate = java.lang.reflect.Proxy.newProxyInstance(
-                        GeckoSession.ProgressDelegate::class.java.classLoader,
-                        arrayOf(GeckoSession.ProgressDelegate::class.java)
-                    ) { _, method, args ->
-                        // Execute our custom logic for specific callbacks
-                        if (args != null) {
-                            when (method.name) {
-                                "onPageStart" -> {
-                                    isLoading.value = true
-                                    // Reset detected videos on every top-level page
-                                    // load start — including reloads of the same URL,
-                                    // which the old baseUrl-diff check missed. The
-                                    // sheet count starts at 0 and repopulates as the
-                                    // page loads. onPageStart does not fire for
-                                    // same-document (hash/pushState) navigations, so
-                                    // SPA route changes keep their detected videos.
-                                    selectedTabState.value?.id?.let { tabId ->
-                                        VideoDetector.clearTab(tabId)
-                                    }
-                                }
-                                "onPageStop" -> {
-                                    isLoading.value = false
-                                }
-                                "onSecurityChange" -> {
-                                    val securityInfo = args[1] as? GeckoSession.ProgressDelegate.SecurityInformation
-                                    if (securityInfo != null) {
-                                        isSecureConnection.value = securityInfo.isSecure
-                                        val cert = securityInfo.certificate
-                                        val certIssuer = cert?.issuerX500Principal?.name?.let { parseCN(it) }
-                                        val certValidUntil = cert?.notAfter?.let {
-                                            java.text.SimpleDateFormat("MMM d, yyyy", java.util.Locale.getDefault()).format(it)
-                                        }
-                                        siteSecurityInfo.value = SiteSecurityInfo(
-                                            isSecure = securityInfo.isSecure,
-                                            host = securityInfo.host ?: "",
-                                            certIssuer = certIssuer,
-                                            certValidUntil = certValidUntil
-                                        )
-                                        Log.d(TAG, "Security changed: isSecure=${securityInfo.isSecure}, host=${securityInfo.host}, issuer=$certIssuer")
-                                    }
-                                }
-                            }
-                        }
+                    is PromptRequest.BeforeUnload -> {
+                        AlertDialog.Builder(context)
+                            .setTitle(promptRequest.title.takeIf { it.isNotBlank() } ?: "Leave site?")
+                            .setMessage("Changes you made may not be saved.")
+                            .setPositiveButton("Leave") { _, _ -> promptRequest.onLeave() }
+                            .setNegativeButton("Stay") { _, _ -> promptRequest.onStay() }
+                            .setOnCancelListener { promptRequest.onDismiss() }
+                            .show()
+                    }
 
-                        // Forward call to the original delegate so GeckoEngineSession can track state/navigation updates
-                        if (existingProgress != null) {
-                            try {
-                                if (args != null) method.invoke(existingProgress, *args)
-                                else method.invoke(existingProgress)
-                            } catch (e: java.lang.reflect.InvocationTargetException) {
-                                throw e.targetException
-                            }
-                        } else {
-                            null
-                        }
-                    } as GeckoSession.ProgressDelegate
-
-                    // PromptDelegate — required for HTML <select> dropdowns, alert(), confirm(), prompt().
-                    // Without this, GeckoView silently drops all prompts and dropdowns never open.
-                    originalPromptDelegate = gs.promptDelegate
-                    gs.promptDelegate = object : GeckoSession.PromptDelegate {
-
-                        /**
-                         * Flattens a Choice array, recursing into optgroup sub-items.
-                         * Separator entries (optgroup headers) are skipped — they have no
-                         * selectable value and would produce a wrong confirm() call.
-                         */
-                        private fun flattenChoices(
-                            choices: Array<GeckoSession.PromptDelegate.ChoicePrompt.Choice>
-                        ): List<GeckoSession.PromptDelegate.ChoicePrompt.Choice> {
-                            val flat = mutableListOf<GeckoSession.PromptDelegate.ChoicePrompt.Choice>()
-                            for (c in choices) {
-                                if (!c.separator) flat.add(c)
-                                c.items?.let { flat.addAll(flattenChoices(it)) }
-                            }
-                            return flat
-                        }
-
-                        override fun onChoicePrompt(
-                            session: GeckoSession,
-                            prompt: GeckoSession.PromptDelegate.ChoicePrompt
-                        ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse>? {
-                            val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
-                            val flat = flattenChoices(prompt.choices)
-                            val labels = flat.map { it.label ?: "" }.toTypedArray()
-
-                            Handler(Looper.getMainLooper()).post {
-                                val builder = AlertDialog.Builder(context)
-                                    .setTitle(prompt.title?.takeIf { it.isNotBlank() })
-                                    .setOnCancelListener { result.complete(prompt.dismiss()) }
-
-                                when (prompt.type) {
-                                    GeckoSession.PromptDelegate.ChoicePrompt.Type.SINGLE,
-                                    GeckoSession.PromptDelegate.ChoicePrompt.Type.MENU -> {
-                                        val preSelected = flat.indexOfFirst { it.selected }.coerceAtLeast(0)
-                                        builder.setSingleChoiceItems(labels, preSelected) { dialog, which ->
-                                            result.complete(prompt.confirm(flat[which]))
-                                            dialog.dismiss()
-                                        }
-                                    }
-                                    GeckoSession.PromptDelegate.ChoicePrompt.Type.MULTIPLE -> {
-                                        val checked = flat.map { it.selected }.toBooleanArray()
-                                        builder.setMultiChoiceItems(labels, checked) { _, which, isChecked ->
-                                            checked[which] = isChecked
-                                        }
-                                        builder.setPositiveButton(android.R.string.ok) { _, _ ->
-                                            val selected = flat.filterIndexed { i, _ -> checked[i] }.toTypedArray()
-                                            result.complete(prompt.confirm(selected))
-                                        }
-                                        builder.setNegativeButton(android.R.string.cancel) { _, _ ->
-                                            result.complete(prompt.dismiss())
-                                        }
-                                    }
-                                    else -> {
-                                        result.complete(prompt.dismiss())
-                                        return@post
-                                    }
-                                }
-                                builder.show()
-                            }
-                            return result
-                        }
-
-                        override fun onAlertPrompt(
-                            session: GeckoSession,
-                            prompt: GeckoSession.PromptDelegate.AlertPrompt
-                        ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse> {
-                            val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
-                            Handler(Looper.getMainLooper()).post {
-                                AlertDialog.Builder(context)
-                                    .setTitle(prompt.title?.takeIf { it.isNotBlank() })
-                                    .setMessage(prompt.message)
-                                    .setPositiveButton(android.R.string.ok) { _, _ -> result.complete(prompt.dismiss()) }
-                                    .setOnCancelListener { result.complete(prompt.dismiss()) }
-                                    .show()
-                            }
-                            return result
-                        }
-
-                        override fun onButtonPrompt(
-                            session: GeckoSession,
-                            prompt: GeckoSession.PromptDelegate.ButtonPrompt
-                        ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse> {
-                            val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
-                            Handler(Looper.getMainLooper()).post {
-                                AlertDialog.Builder(context)
-                                    .setTitle(prompt.title?.takeIf { it.isNotBlank() })
-                                    .setMessage(prompt.message)
-                                    .setPositiveButton(android.R.string.ok) { _, _ ->
-                                        result.complete(prompt.confirm(GeckoSession.PromptDelegate.ButtonPrompt.Type.POSITIVE))
-                                    }
-                                    .setNegativeButton(android.R.string.cancel) { _, _ ->
-                                        result.complete(prompt.confirm(GeckoSession.PromptDelegate.ButtonPrompt.Type.NEGATIVE))
-                                    }
-                                    .setOnCancelListener {
-                                        result.complete(prompt.confirm(GeckoSession.PromptDelegate.ButtonPrompt.Type.NEGATIVE))
-                                    }
-                                    .show()
-                            }
-                            return result
-                        }
-
-                        override fun onTextPrompt(
-                            session: GeckoSession,
-                            prompt: GeckoSession.PromptDelegate.TextPrompt
-                        ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse> {
-                            val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
-                            Handler(Looper.getMainLooper()).post {
-                                val input = EditText(context).apply {
-                                    inputType = InputType.TYPE_CLASS_TEXT
-                                    setText(prompt.defaultValue ?: "")
-                                }
-                                AlertDialog.Builder(context)
-                                    .setTitle(prompt.title?.takeIf { it.isNotBlank() })
-                                    .setMessage(prompt.message)
-                                    .setView(input)
-                                    .setPositiveButton(android.R.string.ok) { _, _ ->
-                                        result.complete(prompt.confirm(input.text.toString()))
-                                    }
-                                    .setNegativeButton(android.R.string.cancel) { _, _ ->
-                                        result.complete(prompt.dismiss())
-                                    }
-                                    .setOnCancelListener { result.complete(prompt.dismiss()) }
-                                    .show()
-                            }
-                            return result
-                        }
+                    else -> {
+                        // Unhandled prompt types (file pickers, auth, color, date,
+                        // logins, …) — dismiss so the page doesn't hang waiting.
+                        (promptRequest as? PromptRequest.Dismissible)?.onDismiss?.invoke()
                     }
                 }
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to setup GeckoSession delegates", e)
+            }
+
+            private fun showSingleChoice(
+                choices: Array<Choice>,
+                onConfirm: (Choice) -> Unit,
+                onDismiss: () -> Unit
+            ) {
+                val flat = flattenChoices(choices)
+                val labels = flat.map { it.label }.toTypedArray()
+                val preSelected = flat.indexOfFirst { it.selected }.coerceAtLeast(0)
+                AlertDialog.Builder(context)
+                    .setSingleChoiceItems(labels, preSelected) { dialog, which ->
+                        onConfirm(flat[which])
+                        dialog.dismiss()
+                    }
+                    .setOnCancelListener { onDismiss() }
+                    .show()
+            }
+
+            /**
+             * Flattens a Choice array, recursing into optgroup children.
+             * Separator/group-header entries are skipped — they have no
+             * selectable value.
+             */
+            private fun flattenChoices(choices: Array<Choice>): List<Choice> {
+                val flat = mutableListOf<Choice>()
+                for (c in choices) {
+                    if (!c.isASeparator && !c.isGroupType) flat.add(c)
+                    c.children?.let { flat.addAll(flattenChoices(it)) }
+                }
+                return flat
             }
         }
 
-        onDispose {
-            session.unregister(observer)
-            // Restore original delegates
-            geckoSessionInstance?.let { gs ->
-                if (originalNavDelegate != null) gs.navigationDelegate = originalNavDelegate
-                if (originalContentDelegate != null) gs.contentDelegate = originalContentDelegate
-                if (originalPermissionDelegate != null) gs.permissionDelegate = originalPermissionDelegate
-                if (originalProgressDelegate != null) gs.progressDelegate = originalProgressDelegate
-                gs.promptDelegate = originalPromptDelegate
-                gs.mediaSessionDelegate = originalMediaDelegate
-            }
-        }
+        session.register(observer)
+        onDispose { session.unregister(observer) }
     }
 }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/backup/BackupUtils.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/backup/BackupUtils.kt
@@ -140,7 +140,7 @@ object BackupUtils {
                         )
                     }
                     withContext(Dispatchers.Main) {
-                        Components.tabManager?.restoreTabs(sessionTabs, null, Components.store)
+                        Components.tabManager.restoreTabs(sessionTabs, null, Components.store)
                     }
                     ImportResult.Success(null, hasDuplicates = false)
                 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/downloads/DownloadConfirmDialog.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/downloads/DownloadConfirmDialog.kt
@@ -16,22 +16,20 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.widget.Toast
 import androidx.compose.ui.platform.LocalContext
-import mozilla.components.browser.engine.gecko.GeckoEngineSession
-import org.mozilla.geckoview.GeckoSession
+import mozilla.components.concept.engine.EngineSession
 
 /**
  * State for a blocked popup awaiting user decision.
  *
- * [rawGeckoSession] and [engineSession] are created upfront and returned to
- * GeckoView in [onNewSession], so GeckoView replays the original navigation
- * (preserving POST body, cookies, headers) in the background while the user
- * decides. On allow → wire the sessions into a new tab. On dismiss → close them.
+ * [engineSession] comes from `WindowRequest.prepare()`: GeckoView replays the
+ * original popup navigation (preserving POST body, cookies, headers) into it
+ * in the background while the user decides. On allow → link the session into
+ * a new tab. On dismiss → close it.
  */
 data class PendingPopup(
     val openerHost: String,
     val popupUrl: String,
-    val rawGeckoSession: GeckoSession,
-    val engineSession: GeckoEngineSession,
+    val engineSession: EngineSession,
 )
 
 /** State for a pending download awaiting user confirmation. */

--- a/mobile/android/app/src/main/java/com/playbridge/sender/settings/ImportExportSettingsScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/settings/ImportExportSettingsScreen.kt
@@ -482,7 +482,7 @@ fun ImportExportSettingsScreen(onBack: () -> Unit) {
                             parentId = tab.parentId
                         )
                     }
-                    Components.tabManager?.restoreTabs(sessionTabs, null, Components.store)
+                    Components.tabManager.restoreTabs(sessionTabs, null, Components.store)
                     importedTabsToRestore = null
                 }) { Text("Import All") }
             },
@@ -499,7 +499,7 @@ fun ImportExportSettingsScreen(onBack: () -> Unit) {
                                 parentId = tab.parentId
                             )
                         }
-                        Components.tabManager?.restoreTabs(sessionTabs, null, Components.store)
+                        Components.tabManager.restoreTabs(sessionTabs, null, Components.store)
                         Toast.makeText(context, "Imported ${newTabs.size} new tabs", Toast.LENGTH_SHORT).show()
                     } else {
                         Toast.makeText(context, "No new tabs to import", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
Migrates the phone browser to Mozilla Android Components' store-owned session
architecture (Fenix-style) and fixes the white-blank-page / tab-not-loading
class of bugs.

## Session lifecycle

- `BrowserStore` now runs **EngineMiddleware**: creates engine sessions on
  demand (restoring state automatically), suspends/hibernates, closes on tab
  removal, marks tabs crashed, and syncs URL/title/nav/session-state into the
  store for *every* tab (fixes stale background-tab URLs)
- `TabManager` reduced to a store mirror + LRU + tab-list ops; deleted the
  restore-then-reload hacks, `justRestored`/`needsReloadOnSelect`, and all
  state-serialization reflection (now `EngineSessionState.writeTo`, with a
  legacy-format read shim so existing user DBs keep restoring)
- **Crash recovery**: crashed/killed tabs auto-restore from saved state,
  capped at 3 attempts/30s to prevent crash-storm loops
- **GeckoRuntime shutdown delegate**: exit the process on runtime death
  instead of leaving a white-tab zombie app
- Sessions survive Activity recreation (singleton TabManager, `isFinishing`
  guard, `uiMode|density` in configChanges)

## De-reflection (public AC APIs replace `java.lang.reflect.Proxy`)

| Before (reflection proxy) | After (public API) |
|---|---|
| `onNewSession` popup handling | `onWindowRequest` (+ `window.close()` now works) |
| `onLoadError` / magnet:/stremio: interception | engine-level `RequestInterceptor` (all tabs, not just selected) |
| fullscreen portrait via `javascript:` hash injection | `onMediaFullscreenChanged` element dimensions |
| `PermissionDelegate` autoplay/DRM | `onContentPermissionRequest.grantIf` |
| `PromptDelegate` dialogs / `<select>` | `onPromptRequest` (+ new `BeforeUnload` handling) |
| `ContentDelegate` context menu | `onLongPress(HitResult)` |
| `ProgressDelegate` security info | `onSecurityChange` |
| `MediaSession.Delegate` (selected tab only) | `MediaSessionObserver` per tab — background tabs keep playing-state + notification controls |
| per-tab `AndroidView` recreation | one persistent `GeckoEngineView` via `SessionFeature` |

## Misc

- Engine `DefaultSettings`: theme-aware `clearColor` (no white flash), system color scheme
- Cast sheet explains when video detection is disabled + enable button
- Remote debugging / console output gated to debug builds
- Extensions run in their own process (`extensionsProcessEnabled`)
- Removed no-op 2s video polling handler

## Tested

- [x] Tab restore from DB (incl. pre-migration session-state rows)
- [x] Hibernation round-trip beyond max-alive-tabs with history intact
- [x] Background process kill → tab restores instead of white page
- [x] Popups (allow / block / allow-from-bar), reopen closed tab, back/forward state
- [x] `window.close()`, JS dialogs + `<select>` dropdowns
- [x] Fullscreen video orientation (portrait video → portrait fullscreen)
- [x] Long-press link menu, error pages, magnet/stremio links
- [x] Background-tab audio + notification media controls