### PR TITLE
chore: uprev all projects + add per-project changelogs

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog — PlayBridge Desktop (receiver)
+
+Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.2.1+13] — 2026-06-12
+
+### Added
+- Honor `start_position_ms` (resume), consumed per queue item. (#12)
+- Full control surface: play/pause toggle, real stop, seek back/forward/to, and `audio_track:` / `sub_track:` selection. (#12)
+- Broadcast track lists (change-detected) and metadata-rich `playlist_status` (season/episode/imdbId/bingeGroup) so phone queue re-attach and watch-progress tracking work. (#12)
+- Pre-play screen (backdrop, poster, chips, overview, countdown) and fullscreen title scrim. (#12)
+
+### Changed
+- Audio/subtitle track picks persist across episodes (language-based re-apply in MpvEngine). (#12)
+- Performance: shell no longer rebuilds on 5 Hz position ticks; mpv tuned (decoder+vo framedrop, 30 s readahead, 1 s audio buffer). (#12)
+- Code style: `dart format` across lib/, lint fixes (`avoid_print`, curly braces). No behavior change.
+
+### Fixed
+- `queue_add` now appends to the live queue (was silently dropped unless idle). (#12)

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: playbridge_desktop
 description: "PlayBridge desktop receiver — accepts cast commands from the phone and plays via libmpv."
 publish_to: 'none'
-version: 0.2.0+12
+version: 0.2.1+13
 
 environment:
   sdk: ^3.6.0

--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog — PlayBridge Sender (Android phone)
+
+All notable changes to the phone app (`com.playbridge.sender`).
+Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.2.5] — 2026-06-12 (versionCode 205)
+
+### Added
+- **DLNA/UPnP casting**: discover renderers via SSDP and cast web videos, HLS streams, and local files through an on-device header-injecting proxy (with HLS playlist rewriting). Unified remote drives both native and DLNA targets. (#7)
+- **Cast sessions**: `CastSessionManager` + foreground service keep casts (native or DLNA) alive through screen-off and activity death, with a live notification and Stop action. (#11)
+- **Automatic watch-progress tracking** on both transports: marks watched at ≥90% or auto-advance, forward-only episode pointer, skip-ahead catch-up, movie/series completion, and a content-keyed resume store ("Resume · 23:14" labels, episode progress bars, actual TV resume via `start_position_ms`). (#11)
+- **DLNA episode auto-advance**: phone-driven queue advances binge sessions on renderers via the shared episode stream resolver. (#11)
+- **Now-playing mini bar** across main screens (poster-accent on library detail), replacing the remote FABs. (#11)
+- **Unified device picker**: one shared DeviceChip + connection sheet across library, detail, cast sheet, and Phone Files; time-boxed discovery with manual rescan and sticky auto-connect; HLS VOD duration derived from `#EXTINF` sums. (#9)
+
+### Changed
+- Browser migrated to Mozilla Android Components' store-owned session architecture (`EngineMiddleware`): on-demand engine session creation/restore, tab hibernation, crash auto-recovery (capped), sessions survive activity recreation, reflection hacks replaced with public AC APIs. (#17)
+- WebSocket auto-retries removed — failures surface immediately; reconnects are on-demand from send paths and startup auto-connect (no more UI flapping). (#11)
+
+### Fixed
+- White-blank-page / tab-not-loading bugs and stale background-tab URLs. (#17)
+- Video detection delivered via native messaging instead of racy URL-hash signaling; detection state resets on navigation; live-stream and MSE/blob detection gaps closed (missing Content-Type, `.mpd` by URL, service-worker requests, JS player config probing). (#15)

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 204
-        versionName = "0.2.4"
+        versionCode = 205
+        versionName = "0.2.5"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog — PlayBridge TV (Android TV)
+
+Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **browser** (`com.playbridge.browser`).
+Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## Player [0.2.6] — 2026-06-12 (versionCode 206)
+
+### Added
+- Honor `start_position_ms` for actual resume playback in both engines (ExoPlayer and MPV), mapped through `EXTRA_START_POSITION`. (#11)
+- `playlist_status` echo enriched with season/episode/imdbId/bingeGroup from visual metadata, enabling phone-side queue re-attach and watch-progress tracking. (#11)
+
+### Changed
+- **Player instances reused across episodes** (ExoPlayer): faster episode transitions in binge sessions. (#14)
+- Engine switches carry the live queue via playlist snapshot, so mid-playlist Exo↔MPV switches keep position in the queue. (#12)
+
+### Removed
+- Unused Bluetooth server and its permissions.
+
+## Browser [0.2.5] — 2026-06-12 (versionCode 205)
+
+### Changed
+- Maintenance release: version alignment with the player; Android Lint now blocking in CI via baselines. No functional changes.

--- a/tv/android/browser/app/build.gradle.kts
+++ b/tv/android/browser/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.playbridge.browser"
         minSdk = 26
         targetSdk = 36
-        versionCode = 204
-        versionName = "0.2.4"
+        versionCode = 205
+        versionName = "0.2.5"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 205
-        versionName = "0.2.5"
+        versionCode = 206
+        versionName = "0.2.6"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/apple/CHANGELOG.md
+++ b/tv/apple/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog — PlayBridge TV (tvOS)
+
+Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [1.0.1] — 2026-06-12 (build 3)
+
+### Added
+- Honor `start_position_ms` (resume) in all three engines — AVPlayer, VLC, and MPV — via initial seek time. (#12)
+- Emit `playlist_status` (Android-compatible format) on queue changes and client connect, enabling phone-side queue re-attach and watch-progress tracking. (#12)
+- Session-scoped track preferences: audio/subtitle picks carry across episodes in all engines despite per-item player recreation. (#12)
+
+### Changed
+- **MPV player instances reused across episodes**: faster episode transitions in binge sessions. (#14)
+
+## [1.0] — 2026-06 (build 2)
+
+Initial tvOS receiver: WebSocket server with pairing, AVPlayer/VLC/MPV engines with in-player switching, now-playing context broadcast, MPVKit/VLCKit 4.0 (AV1) support.

--- a/tv/apple/PlayBridge TV/PlayBridge TV.xcodeproj/project.pbxproj
+++ b/tv/apple/PlayBridge TV/PlayBridge TV.xcodeproj/project.pbxproj
@@ -345,7 +345,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsArbitraryLoadsForMedia = YES;
@@ -358,7 +358,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.playbridge.PlayBridge-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -378,7 +378,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsArbitraryLoadsForMedia = YES;
@@ -391,7 +391,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.playbridge.PlayBridge-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;


### PR DESCRIPTION
- phone 0.2.5 (205), tv-player 0.2.6 (206), tv-browser 0.2.5 (205)
- desktop 0.2.1+13, tvOS 1.0.1 (build 3)
- add CHANGELOG.md to mobile/android, tv/android, tv/apple, desktop