### PR TITLE
ci: fix Windows MSVC CRT bundling + disable auto release notes

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -345,7 +345,7 @@ jobs:
 
             > Download the `.apk` for your device's architecture (`arm64-v8a` for most modern devices) and sideload it.
           files: output/phone-release-*/*.apk
-          generate_release_notes: true
+          generate_release_notes: false
           draft: false
 
       - name: Create TV Player release
@@ -364,7 +364,7 @@ jobs:
 
             Or download the `.apk` below (universal APK is recommended) and sideload it manually.
           files: output/tv-player-release-*/*.apk
-          generate_release_notes: true
+          generate_release_notes: false
           draft: false
 
       - name: Create TV Browser release
@@ -381,7 +381,7 @@ jobs:
 
             > Download the `.apk` for your device's architecture (`arm64-v8a` for most modern devices) and sideload it.
           files: output/tv-browser-release-*/*.apk
-          generate_release_notes: true
+          generate_release_notes: false
           draft: false
 
       - name: Publish Phone to Play Store (alpha)

--- a/.github/workflows/desktop_build.yml
+++ b/.github/workflows/desktop_build.yml
@@ -65,7 +65,9 @@ jobs:
       run: |
         $vsPath = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
         $latest = Get-ChildItem "$vsPath\VC\Redist\MSVC" | Where-Object { $_.Name -match '^\d' } | Sort-Object Name -Descending | Select-Object -First 1
-        $x64 = Join-Path $latest.FullName "x64\Microsoft.VC143.CRT"
+        # Don't hard-code the toolset version (VC143/VC144/...) — pick the newest CRT folder present
+        $x64 = Get-ChildItem (Join-Path $latest.FullName "x64") -Filter "Microsoft.VC1*.CRT" | Sort-Object Name -Descending | Select-Object -First 1 -ExpandProperty FullName
+        if (-not $x64) { throw "No MSVC CRT redist folder found under $($latest.FullName)\x64" }
         Copy-Item "$x64\vcruntime140.dll"   "build\windows\x64\runner\Release\"
         Copy-Item "$x64\vcruntime140_1.dll" "build\windows\x64\runner\Release\"
         Copy-Item "$x64\msvcp140.dll"       "build\windows\x64\runner\Release\"
@@ -285,7 +287,7 @@ jobs:
 
           **macOS:** unsigned build — Gatekeeper will warn on first launch. Right-click → Open to bypass, or run `xattr -dr com.apple.quarantine PlayBridge\ Desktop.app`.
         files: output/*
-        generate_release_notes: true
+        generate_release_notes: false
 
     - name: Clean up R2 after release
       if: always()

--- a/.github/workflows/extension_build.yml
+++ b/.github/workflows/extension_build.yml
@@ -133,7 +133,7 @@ jobs:
 
             Install by dragging the `.xpi` file into Firefox, or via `about:addons` → Install Add-on From File.
           files: output/*.xpi
-          generate_release_notes: true
+          generate_release_notes: false
 
       - name: Clean up R2 after release
         if: always()


### PR DESCRIPTION
- Don't hard-code Microsoft.VC143.CRT: newer windows-latest images ship a
  newer toolset; glob Microsoft.VC1*.CRT and pick the latest (fail loudly
  if none found). Fixes the failed desktop releases.
- generate_release_notes: false everywhere — auto notes baseline against
  the repo's most recent release regardless of app, producing wrong PR
  lists and cross-app compare links. The per-project CHANGELOG.md linked
  in each release body is the source of truth.
