### PR TITLE
docs: refresh root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 <p align="center">
   <img src="https://img.shields.io/badge/status-alpha-orange" alt="Status: Alpha">
   <img src="https://img.shields.io/badge/license-GPLv3-blue" alt="License: GPLv3">
+  <a href="https://github.com/playbridgeapp/playbridge/releases"><img src="https://img.shields.io/github/v/release/playbridgeapp/playbridge?label=latest%20release" alt="Latest release"></a>
 </p>
 
 <p align="center">
   <img src="docs/screenshots/cast-flow.png" alt="Find content on your phone, play it on your TV" width="720">
 </p>
 
-PlayBridge is an open-source Android application suite that bridges the gap between your phone and Android TV. Use PlayBridge to play what you want without the troubles of a clunky TV browser. Find your content on your phone, and seamlessly bridge it to your big screen.
+PlayBridge is an open-source casting suite: browse on your phone, play on the big screen. Find your content on your phone — in the built-in browser or your media library — and bridge it to **Android TV / Fire TV**, **Apple TV**, a **desktop receiver** (macOS, Windows, Linux), or any **DLNA-capable TV** with nothing installed on it. Local-network only, no account, no cloud.
 
 > [!WARNING]
 > **PlayBridge is in alpha.** It's under active early development — expect bugs, incomplete features, and breaking changes between releases. Feedback and issue reports are very welcome.
@@ -30,37 +31,42 @@ PlayBridge is an open-source Android application suite that bridges the gap betw
 
 ## Features
 
-- **Send to TV**: Push URLs and content from your phone to your TV.
-- **TV Controls**: Use your phone as a remote control for the TV browser and player.
-- **Browser**: A fully functional web browser on your phone that syncs with your TV.
-- **Open Source**: Built with privacy and transparency in mind.
+- **Browse & detect**: a full phone browser (GeckoView) that detects videos on the page — direct files, HLS, DASH, and MSE/blob players — and casts them with one tap.
+- **Library & discovery**: a Stremio-style library with catalogs, add-ons, and a watchlist; pick an episode and send it straight to the TV.
+- **Cast anywhere**: native receivers for Android TV / Fire TV, Apple TV, and desktop — or cast to any DLNA/UPnP renderer without installing anything on it.
+- **Binge-ready**: episode queue with lazy auto-advance, watch-progress tracking, and resume ("Resume · 23:14") that actually seeks the TV to where you left off.
+- **Phone as remote**: touchpad, D-pad, keyboard, and transport controls, context-aware for the browser and player.
+- **Local files**: cast videos from your phone's storage to any receiver.
+- **Dual player engines**: ExoPlayer and MPV on the TV, with automatic fallback when a stream misbehaves.
+- **Private by design**: everything stays on your local network — no account, no cloud, GPLv3.
 
-## Installation & Usage
+## Installation
 
-### 1. Installation
-* **Android TV / Fire TV (Receiver):** 
-  * Open the **Downloader** app on your TV and enter code `9557748` to download and install the TV Player release directly.
-  * Alternatively, download the latest receiver APK from the [Releases](https://github.com/playbridgeapp/playbridge/releases) page and install it.
-  * *Note:* On first launch, the TV app will request Bluetooth permissions (used for nearby discovery/pairing) and "Display over other apps" (System Alert Window) permissions. These are required for receiver services to run reliably in the background.
-* **Android Phone (Sender):** 
-  * Download the latest sender APK from the [Releases](https://github.com/playbridgeapp/playbridge/releases) page and install it on your mobile device.
+- **Android TV / Fire TV (receiver)**
+  - Open the **Downloader** app on your TV and enter code `9557748` to install the TV Player directly, or
+  - download the latest `tv-player` APK from [Releases](https://github.com/playbridgeapp/playbridge/releases) and sideload it.
+  - *Note:* on first launch the TV app asks for "Display over other apps" — required for the receiver to come to the foreground when a cast arrives.
+  - Optional: the ad-blocked **TV Browser** APK (GeckoView + uBlock Origin) extends the player with web browsing.
+- **Apple TV (receiver)**: no prebuilt binary yet — build and deploy from Xcode; see the [TV README](tv/).
+- **Desktop (receiver)**: download the build for your OS from [Releases](https://github.com/playbridgeapp/playbridge/releases) (`playbridge-desktop-windows-*.zip`, `-linux-*.tar.gz`, `-macos-*.zip`). Linux needs `libmpv2`; the macOS build is unsigned (right-click → Open on first launch).
+- **DLNA TVs**: nothing to install — the phone discovers renderers on your network automatically.
+- **Android Phone (sender)**: download the latest `phone` APK from [Releases](https://github.com/playbridgeapp/playbridge/releases) and install it.
 
-### 2. How to Connect & Cast
-1. Connect both your phone and Android TV to the **same local Wi-Fi network**.
-2. Open the **PlayBridge** app on your TV. It will display a "Ready to Cast" landing screen.
-3. Open the **PlayBridge** app on your phone, and tap the **Cast** icon in the top bar or menu to open the Connection screen.
-4. The phone app will scan the network and display your TV. Tap its name to connect.
-   * *If the TV is not auto-discovered:* Tap **"Manual Connect"** on the phone and enter the TV's IP address (displayed on the TV's screen).
-5. A pairing request will appear on the TV. Select **Allow** using your TV remote.
-6. Once connected, browse any video website using the phone app's built-in web browser. Play a video, and tap the cast option when it detects the stream to play it on the TV!
+## How to connect & cast
+
+1. Connect your phone and receiver to the **same Wi-Fi network**, and open the PlayBridge app on both.
+2. On the phone, tap the **device chip** (top of the Library and browser cast screens) — it lists discovered receivers. Tap yours to connect.
+   - *Not discovered?* Tap **"All devices & manual connect"** and enter the receiver's IP address (shown on its screen).
+3. On first connect, the receiver asks **"Allow device to connect?"** — select **Allow** with your TV remote.
+4. Browse any video site in the phone browser, play a video, and tap cast when PlayBridge detects the stream — or send a movie/episode directly from the Library.
 
 ## Components
 
 PlayBridge is a monorepo; each component has its own README:
 
-1.  **[Phone App](mobile/)** (`mobile/`) — the sender: browses the web, detects videos, and controls the TV.
-2.  **[TV App](tv/)** (`tv/`) — the receiver for Android TV (plus a tvOS variant): plays content and hosts a web browser.
-3.  **[Desktop App](desktop/)** (`desktop/`) — a Flutter desktop receiver that plays casts via libmpv.
+1.  **[Phone App](mobile/)** (`mobile/`) — the sender: browser, library, video detection, remote. [Changelog](mobile/android/CHANGELOG.md)
+2.  **[TV Apps](tv/)** (`tv/`) — receivers for Android TV (player + browser APKs) and Apple TV. [Changelog](tv/android/CHANGELOG.md) · [tvOS changelog](tv/apple/CHANGELOG.md)
+3.  **[Desktop App](desktop/)** (`desktop/`) — a Flutter desktop receiver that plays casts via libmpv. [Changelog](desktop/CHANGELOG.md)
 4.  **[Browser Extension](extension/)** (`extension/`) — a Firefox extension that casts media from desktop browser tabs.
 5.  **[Shared Module](shared/)** (`shared/`) — Kotlin Multiplatform logic, player engines, and protocol bindings.
 6.  **[Protocol](protocol/)** (`protocol/`) — protobuf wire-format definitions (git submodule).
@@ -82,32 +88,35 @@ phone browser. Source: [`web/site/static/cast-demo/`](web/site/static/cast-demo/
 
 ## Build Instructions
 
+> [!IMPORTANT]
+> `protocol/` is a git submodule — clone with `git clone --recursive`, or run
+> `git submodule update --init` in an existing checkout, or the builds will fail.
+
 ### Prerequisites
-- Android Studio Ladybug or later
-- JDK 17+
-- Android SDK 26+
+
+- **Android apps**: Android Studio Ladybug or later, JDK 17+, Android SDK 26+
+- **Desktop**: Flutter SDK (Dart `^3.6`) and libmpv
+- **Apple TV**: Xcode with CocoaPods (see [tv/](tv/))
 
 ### Building
 
-To build the APKs:
-
 ```bash
-# Build Phone App
+# Phone app
 cd mobile/android && ./gradlew :app:assembleDebug
 
-# Build TV App
+# TV player
 cd tv/android && ./gradlew :player:app:assembleDebug
+
+# TV browser
+cd tv/android && ./gradlew :browser:app:assembleDebug
+
+# Desktop
+cd desktop && flutter pub get && flutter run    # -d macos | windows | linux
 ```
 
 ## Contributing
 
-Contributions are welcome! Please follow these steps:
-1.  Fork the repository.
-2.  Create a feature branch.
-3.  Commit your changes.
-4.  Open a Pull Request.
-
-For detailed instructions, see [CONTRIBUTING.md](CONTRIBUTING.md).
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for setup and guidelines.
 
 ## AI Policy
 


### PR DESCRIPTION
- intro covers all receivers (Android TV, Apple TV, desktop, DLNA), not Android-only
- features updated: DLNA casting, library/watchlist, progress tracking + resume,
  episode queue, local files, dual engines
- drop stale Bluetooth permission note (removed in #4)
- install instructions for Apple TV, desktop, DLNA; release badge
- connect flow matches current UI (device chip, 'All devices & manual connect',
  'Allow device to connect?')
- build: submodule warning, desktop/tvOS prerequisites, TV browser command
- link per-project changelogs from Components
