### PR TITLE
feat: seed default Cinemeta addon in library

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/library/AddonRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/library/AddonRepository.kt
@@ -64,6 +64,20 @@ class AddonRepository(
 
     init {
         loadCacheFromDisk()
+        seedDefaultAddons()
+    }
+
+    private fun seedDefaultAddons() {
+        ioScope.launch {
+            try {
+                if (addonDao.count() == 0) {
+                    Log.i(TAG, "No addons installed. Seeding default Cinemeta addon...")
+                    installAddon("https://v3-cinemeta.strem.io/manifest.json")
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to seed default addons", e)
+            }
+        }
     }
 
     private fun loadCacheFromDisk() {


### PR DESCRIPTION
This PR automatically seeds the default Cinemeta addon (stremio://v3-cinemeta.strem.io/manifest.json) when the application is launched and the addon database is empty.