### PR TITLE
fix(tv): prevent crash due to missing overlay permission activity on older Android TV versions

### DIFF
--- a/tv/android/player/app/src/main/java/com/playbridge/player/MainActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/MainActivity.kt
@@ -78,12 +78,18 @@ class MainActivity : ComponentActivity() {
             ServerService.start(this)
         }
 
-        if (!Settings.canDrawOverlays(this)) {
-            val intent = Intent(
-                Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                Uri.parse("package:$packageName")
-            )
-            startActivity(intent)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            if (!Settings.canDrawOverlays(this)) {
+                try {
+                    val intent = Intent(
+                        Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                        Uri.parse("package:$packageName")
+                    )
+                    startActivity(intent)
+                } catch (e: Exception) {
+                    android.util.Log.e("MainActivity", "Failed to launch overlay settings activity", e)
+                }
+            }
         }
 
         // If launched via ACTION_OPEN_PAIRING (e.g. app was not running when a phone connected),


### PR DESCRIPTION
Wrap ACTION_MANAGE_OVERLAY_PERMISSION activity launch in a try-catch block to handle missing settings page on some Android TVs. Additionally, restrict the permission check to Android 14+ (API 34+) where BAL restrictions actually require the overlay window exemption.