### PR TITLE
TV subtitle overlay with live previews, sync control, and smarter sourcing

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -881,7 +881,8 @@ fun AppNavHost(
                                         payload.visual_metadata?.imdb_id,
                                         payload.visual_metadata?.season,
                                         payload.visual_metadata?.episode,
-                                        preferredSubLang
+                                        preferredSubLang,
+                                        videoRelease = subtitleService.filenameFromUrl(payload.url)
                                     )
                                 }
 
@@ -949,7 +950,8 @@ fun AppNavHost(
                                         current.visual_metadata?.imdb_id,
                                         current.visual_metadata?.season,
                                         current.visual_metadata?.episode,
-                                        preferredSubLang
+                                        preferredSubLang,
+                                        videoRelease = subtitleService.filenameFromUrl(current.url)
                                     )
                                 }
                                 // Ensure connected before sending
@@ -1104,10 +1106,12 @@ fun AppNavHost(
                             }
                             scope.launch {
                                 // Fetch the start episode's subtitles in parallel with connecting.
-                                val startVm = playlist.items.getOrNull(playlist.start_index)?.visual_metadata
+                                val startItem = playlist.items.getOrNull(playlist.start_index)
+                                val startVm = startItem?.visual_metadata
                                 val startSubsDeferred = async {
                                     subtitleService.getAllSubtitleUrls(
-                                        startVm?.imdb_id, startVm?.season, startVm?.episode, preferredSubLang
+                                        startVm?.imdb_id, startVm?.season, startVm?.episode, preferredSubLang,
+                                        videoRelease = subtitleService.filenameFromUrl(startItem?.url)
                                     )
                                 }
                                 // Ensure connected before sending

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/TvQueueCoordinator.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/TvQueueCoordinator.kt
@@ -167,7 +167,7 @@ class TvQueueCoordinator(
             val url = resolveBest(p, idx)
             if (url != null) {
                 val tmpl = p.items[idx].template
-                val subs = fetchSubtitlesFor(tmpl)
+                val subs = fetchSubtitlesFor(tmpl, url)
                 val payload = tmpl.copy(url = url, subtitles = (tmpl.subtitles + subs).distinct())
                 if (!webSocketClient.send(createQueueAddCommandJson(payload))) {
                     // Send failed (socket dropped) — leave nextToResolve so we retry on the next tick.
@@ -184,10 +184,13 @@ class TvQueueCoordinator(
     }
 
     /** Preferred-language addon subtitles for an episode (from its template's visual_metadata). */
-    private suspend fun fetchSubtitlesFor(tmpl: playbridge.PlayPayload): List<String> {
+    private suspend fun fetchSubtitlesFor(tmpl: playbridge.PlayPayload, resolvedUrl: String?): List<String> {
         val pref = runCatching { settingsRepository.preferredSubtitleLang.first() }.getOrDefault("")
         val vm = tmpl.visual_metadata
-        return subtitleService.getAllSubtitleUrls(vm?.imdb_id, vm?.season, vm?.episode, pref)
+        return subtitleService.getAllSubtitleUrls(
+            vm?.imdb_id, vm?.season, vm?.episode, pref,
+            videoRelease = subtitleService.filenameFromUrl(resolvedUrl)
+        )
     }
 
     private suspend fun resolveBest(p: TvEpisodeQueuePlan, index: Int): String? =

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/library/StremioSubtitleService.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/library/StremioSubtitleService.kt
@@ -95,7 +95,9 @@ class StremioSubtitleService(
         season: Int?,
         episode: Int?,
         preferredLang: String = "",
-        limit: Int = 40
+        videoRelease: String? = null,
+        perLanguageLimit: Int = 5,
+        limit: Int = 30
     ): List<String> {
         if (imdbId.isNullOrBlank()) return emptyList()
         return runCatching {
@@ -103,12 +105,46 @@ class StremioSubtitleService(
                 getSubtitlesForEpisode(imdbId, season, episode)
             else getSubtitlesForMovie(imdbId)
             val pref = preferredLang.lowercase()
-            streams
-                .mapNotNull { s -> s.url?.let { url -> Triple(url, subtitleLabel(s), pref.isNotBlank() && matchesLang(s, pref)) } }
-                .distinctBy { it.first }
-                .sortedByDescending { it.third }  // preferred language first
+            // Release-match profile of the actual video file (from the selected stream's
+            // filename). Metadata-rich addons (e.g. AIOStreams) put the release name in the
+            // subtitle `title`, so we can pick the sub whose release matches the video —
+            // killing the BluRay-vs-WEB ~90s recap mismatch. Empty when no release/title.
+            val videoTokens = videoRelease?.let { normReleaseTokens(it) }.orEmpty()
+
+            data class Cand(
+                val url: String, val label: String, val prefLang: Boolean,
+                val score: Int, val dedupeKey: String, val lang: String
+            )
+            val ranked = streams
+                .mapNotNull { s ->
+                    val url = s.url ?: return@mapNotNull null
+                    val subRelease = s.title ?: s.name
+                    val score = if (videoTokens.isEmpty() || subRelease.isNullOrBlank()) 0
+                                else releaseMatchScore(videoRelease!!, videoTokens, subRelease)
+                    // Collapse the many re-uploads of the same release (per language) into one.
+                    val releaseKey = subRelease?.let { normReleaseTokens(it).sorted().joinToString(".") }
+                        ?.ifBlank { null } ?: url
+                    // Enrich the label with a short source/quality tag so same-language options
+                    // are distinguishable in the TV picker (e.g. "English · BLURAY 1080p").
+                    val tag = subReleaseTag(subRelease)
+                    val label = subtitleLabel(s) + (tag?.let { " · $it" } ?: "")
+                    Cand(url, label, pref.isNotBlank() && matchesLang(s, pref), score, "${s.lang}|$releaseKey", s.lang ?: "")
+                }
+                // Preferred language first, then best release match — so distinctBy keeps the
+                // best-scored copy of each release. sortedWith is stable.
+                .sortedWith(compareByDescending<Cand> { it.prefLang }.thenByDescending { it.score })
+                .distinctBy { it.dedupeKey }
+
+            // Keep ALL languages so the TV can offer a language picker (NuvioTV-style), but cap
+            // per language and overall so we don't flood it. Preferred language stays first.
+            val perLang = HashMap<String, Int>()
+            ranked
+                .filter { c ->
+                    val n = perLang.getOrDefault(c.lang, 0)
+                    if (n >= perLanguageLimit) false else { perLang[c.lang] = n + 1; true }
+                }
                 .take(limit)
-                .map { (url, label, _) -> "$url#${java.net.URLEncoder.encode(label, "UTF-8")}" }
+                .map { "${it.url}#${java.net.URLEncoder.encode(it.label, "UTF-8")}" }
         }.getOrDefault(emptyList())
     }
 
@@ -182,5 +218,94 @@ class StremioSubtitleService(
                 emptyList()
             }
         }
+    }
+
+    // ==================== Release matching ====================
+    // Score a subtitle's release name (`title`) against the video file's release name so the
+    // best-matched subtitle sorts first. The release group is decisive (same group = same
+    // timing); a BluRay-vs-WEB/HDTV source conflict is penalised because that's the usual
+    // cause of a constant ~90s "Previously on" recap offset.
+
+    private object Release {
+        val BLURAY = setOf("bluray", "blu", "bdrip", "brrip", "bdremux", "bd", "brip", "remux")
+        val WEB = setOf("web", "webdl", "webrip", "amzn", "nf", "dsnp", "hmax", "atvp", "hulu")
+        val HDTV = setOf("hdtv", "pdtv", "hdtvrip")
+        val DVD = setOf("dvdrip", "dvd", "dvdr")
+        val GROUP_STOP = setOf(
+            "dl", "web", "webdl", "webrip", "hdtv", "bluray", "bdrip", "brrip", "remux",
+            "x264", "x265", "h264", "h265", "hevc", "avc", "xvid", "dd", "ddp", "aac", "dts",
+            "ma", "hd", "atmos", "truehd", "264", "265", "720p", "1080p", "2160p", "480p",
+            "mkv", "mp4", "uhd", "4k", "dv", "hdr", "hdr10", "10bit", "multi", "dual", "esub",
+            "en", "eng", "nordic"
+        )
+        val EXT = Regex("\\.(mkv|mp4|avi|m2ts|ts|srt|vtt|ssa|ass)$", RegexOption.IGNORE_CASE)
+        val SEP = Regex("[^a-z0-9]+")
+    }
+
+    private fun normReleaseTokens(s: String): Set<String> =
+        s.lowercase().split(Release.SEP).filterTo(HashSet()) { it.isNotBlank() }
+
+    private fun sourceClass(t: Set<String>): String? = when {
+        t.any { it in Release.BLURAY } -> "bluray"
+        t.any { it in Release.WEB } -> "web"
+        t.any { it in Release.HDTV } -> "hdtv"
+        t.any { it in Release.DVD } -> "dvd"
+        else -> null
+    }
+
+    private fun resolutionClass(t: Set<String>): String? = when {
+        "2160p" in t -> "2160p"
+        "1080p" in t || "1080i" in t -> "1080p"
+        "720p" in t -> "720p"
+        "480p" in t -> "480p"
+        "4k" in t || "uhd" in t -> "2160p"
+        else -> null
+    }
+
+    private fun codecClass(t: Set<String>): String? = when {
+        t.any { it in setOf("x265", "h265", "hevc", "265") } -> "hevc"
+        t.any { it in setOf("x264", "h264", "avc", "264") } -> "avc"
+        "xvid" in t -> "xvid"
+        else -> null
+    }
+
+    /** The trailing release-group token (after the final `-`), or null if absent/ambiguous. */
+    private fun releaseGroup(name: String?): String? {
+        if (name.isNullOrBlank()) return null
+        val base = name.replace(Release.EXT, "")
+        if ('-' !in base) return null
+        val after = base.substringAfterLast('-').trim()
+        val tok = after.split(Release.SEP).firstOrNull { it.isNotBlank() }?.lowercase() ?: return null
+        return if (tok.length < 3 || tok in Release.GROUP_STOP) null else tok
+    }
+
+    private fun releaseMatchScore(videoRelease: String, videoTokens: Set<String>, subRelease: String): Int {
+        val st = normReleaseTokens(subRelease)
+        var score = 0
+        val vSrc = sourceClass(videoTokens); val sSrc = sourceClass(st)
+        if (vSrc != null && sSrc != null) score += if (vSrc == sSrc) 50 else -40
+        val vRes = resolutionClass(videoTokens); val sRes = resolutionClass(st)
+        if (vRes != null && sRes != null && vRes == sRes) score += 15
+        val vCodec = codecClass(videoTokens); val sCodec = codecClass(st)
+        if (vCodec != null && sCodec != null && vCodec == sCodec) score += 10
+        val vGroup = releaseGroup(videoRelease); val sGroup = releaseGroup(subRelease)
+        if (!vGroup.isNullOrBlank() && vGroup == sGroup) score += 60
+        return score
+    }
+
+    /** A short, human source/quality tag for a subtitle's release (e.g. "BLURAY 1080p"), or null. */
+    private fun subReleaseTag(title: String?): String? {
+        if (title.isNullOrBlank()) return null
+        val t = normReleaseTokens(title)
+        val parts = listOfNotNull(sourceClass(t)?.uppercase(), resolutionClass(t))
+        return parts.joinToString(" ").ifBlank { null }
+    }
+
+    /** Last path segment of a URL, decoded, as a release-name hint for [getAllSubtitleUrls]. */
+    fun filenameFromUrl(url: String?): String? {
+        if (url.isNullOrBlank()) return null
+        val seg = url.substringBefore('#').substringBefore('?').substringAfterLast('/')
+        if (seg.isBlank()) return null
+        return runCatching { java.net.URLDecoder.decode(seg, "UTF-8") }.getOrDefault(seg)
     }
 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
@@ -280,9 +280,13 @@ class ExoPlayerActivity : PlayerActivity() {
                     PlayerControlsOverlay(
                         state = state,
                         onTogglePlay = { controlsViewModel.togglePlayPause() },
-                        onTrackSelection = { 
+                        onTrackSelection = {
                             updateUnifiedTracks()
-                            controlsViewModel.showSettings(SettingsTab.AUDIO) 
+                            controlsViewModel.showSettings(SettingsTab.AUDIO)
+                        },
+                        onSubtitles = {
+                            updateUnifiedTracks()
+                            controlsViewModel.showSubtitles()
                         },
                         onPlaylist = { showPlaylistOverlay() },
                         onPrev = { navigationJob?.cancel(); navigationJob = lifecycleScope.launch { coordinator.previous() } },
@@ -331,7 +335,8 @@ class ExoPlayerActivity : PlayerActivity() {
                             switchPlayer(playerId)
                         },
                         onToggleAudioBoost = { controlsViewModel.toggleAudioBoost() },
-                        onAdjustSubtitleDelay = { controlsViewModel.adjustSubtitleDelay(it) }
+                        onAdjustSubtitleDelay = { controlsViewModel.adjustSubtitleDelay(it) },
+                        onPreloadSubtitles = { controlsViewModel.preloadSubtitleCues(it) }
                     )
                 }
             }
@@ -734,6 +739,8 @@ class ExoPlayerActivity : PlayerActivity() {
             // Handle manual subtitles (Nuvio-style Compose rendering)
             this@ExoPlayerActivity.subtitleUrls = subtitles ?: emptyList()
             this@ExoPlayerActivity.subtitleHeaders = intentHeaders
+            controlsViewModel.subtitleRequestHeaders = intentHeaders
+            SubtitleCueLoader.clear()
             if (subtitleUrls.isNotEmpty()) {
                 val subUrl = subtitleUrls[0]
                 currentSubtitleUrl = subUrl

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
@@ -265,9 +265,13 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
                     PlayerControlsOverlay(
                         state = state,
                         onTogglePlay = { controlsViewModel.togglePlayPause() },
-                        onTrackSelection = { 
+                        onTrackSelection = {
                             updateUnifiedTracks()
-                            controlsViewModel.showSettings(SettingsTab.AUDIO) 
+                            controlsViewModel.showSettings(SettingsTab.AUDIO)
+                        },
+                        onSubtitles = {
+                            updateUnifiedTracks()
+                            controlsViewModel.showSubtitles()
                         },
                         onPlaylist = { showPlaylistOverlay() },
                         onPrev = { navigationJob?.cancel(); navigationJob = lifecycleScope.launch { coordinator.previous() } },
@@ -308,7 +312,8 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
                             switchPlayer(playerId)
                         },
                         onToggleAudioBoost = { controlsViewModel.toggleAudioBoost() },
-                        onAdjustSubtitleDelay = { controlsViewModel.adjustSubtitleDelay(it) }
+                        onAdjustSubtitleDelay = { controlsViewModel.adjustSubtitleDelay(it) },
+                        onPreloadSubtitles = { controlsViewModel.preloadSubtitleCues(it) }
                     )
                 }
             }
@@ -789,6 +794,8 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
             currentSubtitleUrl = subtitles.firstOrNull()
         }
         this.currentHeaders = headers
+        controlsViewModel.subtitleRequestHeaders = headers
+        SubtitleCueLoader.clear()
         playVideo(url, headers, subtitles = subtitles)
     }
 

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/SubtitleManager.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/SubtitleManager.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.launch
 import okhttp3.Request
 import java.io.IOException
 import java.util.Collections
-import java.util.regex.Pattern
 
 class SubtitleManager(
     private val coroutineScope: CoroutineScope,
@@ -49,16 +48,11 @@ class SubtitleManager(
         subtitleJob = coroutineScope.launch(Dispatchers.IO) {
             try {
                 val bytes = downloadUrlBytes(url, headers)
-                // Simple encoding detection
-                val content = detectEncodingAndDecode(bytes)
-                
-                val parsedCues = if (url.endsWith(".vtt", true)) {
-                    parseVtt(content)
-                } else {
-                    parseSrt(content)
-                }
-                
-                cues.addAll(parsedCues)
+                val content = SubtitleParser.decode(bytes)
+                val isVtt = url.substringBefore('#').endsWith(".vtt", true) || content.startsWith("WEBVTT")
+                val parsed = SubtitleParser.parse(content, isVtt)
+
+                cues.addAll(parsed.map { Cue(it.startMs, it.endMs, it.text) })
                 Collections.sort(cues)
                 Log.i(TAG, "Loaded ${cues.size} cues")
 
@@ -93,7 +87,7 @@ class SubtitleManager(
             if (lastCueText != combinedText) {
                 lastCueText = combinedText
                 // Strip HTML tags for clean Compose rendering
-                val cleanText = stripHtml(combinedText)
+                val cleanText = SubtitleParser.stripHtml(combinedText)
                 onCueChanged(cleanText)
             }
         } else {
@@ -123,119 +117,6 @@ class SubtitleManager(
         client.newCall(request).execute().use { response ->
             if (!response.isSuccessful) throw IOException("Unexpected HTTP code: " + response.code)
             return response.body?.bytes() ?: ByteArray(0)
-        }
-    }
-
-    private fun detectEncodingAndDecode(bytes: ByteArray): String {
-        if (bytes.size >= 3 && bytes[0] == 0xEF.toByte() && bytes[1] == 0xBB.toByte() && bytes[2] == 0xBF.toByte()) {
-            return String(bytes, 3, bytes.size - 3, Charsets.UTF_8)
-        }
-        // Very basic heuristic: if it contains many nulls, it's probably UTF-16
-        if (bytes.size >= 2) {
-            if (bytes[0] == 0xFF.toByte() && bytes[1] == 0xFE.toByte()) return String(bytes, 2, bytes.size - 2, Charsets.UTF_16LE)
-            if (bytes[0] == 0xFE.toByte() && bytes[1] == 0xFF.toByte()) return String(bytes, 2, bytes.size - 2, Charsets.UTF_16BE)
-        }
-        
-        // Default to UTF-8 but fallback to Windows-1252 if it looks like typical western encoding
-        // In a full Nuvio impl, we would use juniversalchardet here.
-        return try {
-            val utf8 = String(bytes, Charsets.UTF_8)
-            // If it contains "replacement characters", it likely wasn't UTF-8
-            if (utf8.contains("\uFFFD")) throw Exception("Invalid UTF-8")
-            utf8
-        } catch (e: Exception) {
-            String(bytes, java.nio.charset.Charset.forName("Windows-1252"))
-        }
-    }
-
-    private fun stripHtml(text: String): String {
-        // Simple regex to remove tags like <b>, <i>, <font color="...">
-        return text.replace(Regex("<[^>]*>"), "").trim()
-    }
-
-    private fun parseSrt(content: String): List<Cue> {
-        val parsedCues = ArrayList<Cue>()
-        var currentStart = -1L
-        var currentEnd = -1L
-        val currentText = StringBuilder()
-        
-        val iterator = content.lineSequence().iterator()
-        while (iterator.hasNext()) {
-            val rawLine = iterator.next()
-            val trimmedLine = rawLine.trim()
-
-            if (trimmedLine.isEmpty()) {
-                if (currentStart != -1L && currentEnd != -1L && currentText.isNotEmpty()) {
-                    parsedCues.add(Cue(currentStart, currentEnd, currentText.toString().trimEnd()))
-                }
-                currentStart = -1L
-                currentEnd = -1L
-                currentText.clear()
-            } else if (trimmedLine.contains("-->")) {
-                val times = trimmedLine.split("-->")
-                if (times.size == 2) {
-                    currentStart = parseTimestamp(times[0].trim().replace(',', '.').substringBefore(' '))
-                    currentEnd = parseTimestamp(times[1].trim().replace(',', '.').substringBefore(' '))
-                }
-            } else if (currentStart != -1L) {
-                currentText.append(rawLine).append("\n")
-            }
-        }
-        if (currentStart != -1L && currentEnd != -1L && currentText.isNotEmpty()) {
-            parsedCues.add(Cue(currentStart, currentEnd, currentText.toString().trimEnd()))
-        }
-        return parsedCues
-    }
-
-    private fun parseVtt(content: String): List<Cue> {
-        val parsedCues = ArrayList<Cue>()
-        val iterator = content.lineSequence().iterator()
-        while (iterator.hasNext()) {
-            val line = iterator.next().trim()
-            if (line.contains("-->")) {
-                val times = line.split("-->")
-                if (times.size == 2) {
-                    val start = parseTimestamp(times[0].trim().substringBefore(' '))
-                    val end = parseTimestamp(times[1].trim().substringBefore(' '))
-                    
-                    val textBuilder = StringBuilder()
-                    while (iterator.hasNext()) {
-                        val textLine = iterator.next()
-                        if (textLine.trim().isEmpty()) break
-                        textBuilder.append(textLine).append("\n")
-                    }
-                    val text = textBuilder.toString().trim()
-                    
-                    if (start != -1L && end != -1L && text.isNotEmpty()) {
-                        parsedCues.add(Cue(start, end, text))
-                    }
-                }
-            }
-        }
-        return parsedCues
-    }
-
-    private fun parseTimestamp(timestamp: String): Long {
-        try {
-            val parts = timestamp.split(':')
-            var hours = 0L
-            var minutes = 0L
-            var seconds = 0.0
-            
-            if (parts.size == 3) {
-                hours = parts[0].toLong()
-                minutes = parts[1].toLong()
-                seconds = parts[2].replace(',', '.').toDouble()
-            } else if (parts.size == 2) {
-                minutes = parts[0].toLong()
-                seconds = parts[1].replace(',', '.').toDouble()
-            } else {
-                return -1
-            }
-            
-            return (hours * 3600000 + minutes * 60000 + (seconds * 1000)).toLong()
-        } catch (e: Exception) {
-            return -1
         }
     }
 

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/SubtitlePreview.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/SubtitlePreview.kt
@@ -1,0 +1,169 @@
+package com.playbridge.player.player
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Request
+import java.util.concurrent.ConcurrentHashMap
+
+/** A single subtitle cue (times in ms). */
+data class SubtitleCue(val startMs: Long, val endMs: Long, val text: String)
+
+/**
+ * Canonical SRT/VTT parser shared by the live renderer ([SubtitleManager]) and the subtitle
+ * preview loader. Times in milliseconds.
+ */
+object SubtitleParser {
+
+    fun parse(content: String, isVtt: Boolean): List<SubtitleCue> =
+        if (isVtt) parseVtt(content) else parseSrt(content)
+
+    fun decode(bytes: ByteArray): String {
+        if (bytes.size >= 3 && bytes[0] == 0xEF.toByte() && bytes[1] == 0xBB.toByte() && bytes[2] == 0xBF.toByte()) {
+            return String(bytes, 3, bytes.size - 3, Charsets.UTF_8)
+        }
+        if (bytes.size >= 2) {
+            if (bytes[0] == 0xFF.toByte() && bytes[1] == 0xFE.toByte()) return String(bytes, 2, bytes.size - 2, Charsets.UTF_16LE)
+            if (bytes[0] == 0xFE.toByte() && bytes[1] == 0xFF.toByte()) return String(bytes, 2, bytes.size - 2, Charsets.UTF_16BE)
+        }
+        return try {
+            val utf8 = String(bytes, Charsets.UTF_8)
+            if (utf8.contains("�")) throw Exception("Invalid UTF-8")
+            utf8
+        } catch (e: Exception) {
+            String(bytes, java.nio.charset.Charset.forName("Windows-1252"))
+        }
+    }
+
+    fun stripHtml(text: String): String = text.replace(Regex("<[^>]*>"), "").trim()
+
+    private fun parseSrt(content: String): List<SubtitleCue> {
+        val cues = ArrayList<SubtitleCue>()
+        var start = -1L
+        var end = -1L
+        val text = StringBuilder()
+        for (rawLine in content.lineSequence()) {
+            val line = rawLine.trim()
+            if (line.isEmpty()) {
+                if (start != -1L && end != -1L && text.isNotEmpty()) cues.add(SubtitleCue(start, end, text.toString().trimEnd()))
+                start = -1L; end = -1L; text.clear()
+            } else if (line.contains("-->")) {
+                val times = line.split("-->")
+                if (times.size == 2) {
+                    start = parseTimestamp(times[0].trim().replace(',', '.').substringBefore(' '))
+                    end = parseTimestamp(times[1].trim().replace(',', '.').substringBefore(' '))
+                }
+            } else if (start != -1L) {
+                text.append(rawLine).append("\n")
+            }
+        }
+        if (start != -1L && end != -1L && text.isNotEmpty()) cues.add(SubtitleCue(start, end, text.toString().trimEnd()))
+        return cues
+    }
+
+    private fun parseVtt(content: String): List<SubtitleCue> {
+        val cues = ArrayList<SubtitleCue>()
+        val it = content.lineSequence().iterator()
+        while (it.hasNext()) {
+            val line = it.next().trim()
+            if (line.contains("-->")) {
+                val times = line.split("-->")
+                if (times.size == 2) {
+                    val start = parseTimestamp(times[0].trim().substringBefore(' '))
+                    val end = parseTimestamp(times[1].trim().substringBefore(' '))
+                    val sb = StringBuilder()
+                    while (it.hasNext()) {
+                        val t = it.next()
+                        if (t.trim().isEmpty()) break
+                        sb.append(t).append("\n")
+                    }
+                    val txt = sb.toString().trim()
+                    if (start != -1L && end != -1L && txt.isNotEmpty()) cues.add(SubtitleCue(start, end, txt))
+                }
+            }
+        }
+        return cues
+    }
+
+    private fun parseTimestamp(timestamp: String): Long {
+        return try {
+            val parts = timestamp.split(':')
+            var hours = 0L; var minutes = 0L; var seconds = 0.0
+            when (parts.size) {
+                3 -> { hours = parts[0].toLong(); minutes = parts[1].toLong(); seconds = parts[2].replace(',', '.').toDouble() }
+                2 -> { minutes = parts[0].toLong(); seconds = parts[1].replace(',', '.').toDouble() }
+                else -> return -1
+            }
+            (hours * 3600000 + minutes * 60000 + (seconds * 1000)).toLong()
+        } catch (e: Exception) {
+            -1
+        }
+    }
+}
+
+/**
+ * Downloads + parses subtitle files for the on-demand preview in the subtitle overlay, caching
+ * parsed cues by URL so re-selecting a language (or nudging the sync offset) never re-fetches.
+ */
+object SubtitleCueLoader {
+
+    private const val TAG = "SubtitleCueLoader"
+    private val cache = ConcurrentHashMap<String, List<SubtitleCue>>()
+    private val inFlight = ConcurrentHashMap.newKeySet<String>()
+
+    /** Parsed cues if already loaded, else null. Cheap, non-blocking — used during render. */
+    fun cached(url: String): List<SubtitleCue>? = cache[url]
+
+    fun isLoading(url: String): Boolean = url in inFlight
+
+    /** Drop cached previews (call when new media loads to avoid unbounded growth on a binge). */
+    fun clear() {
+        cache.clear()
+        inFlight.clear()
+    }
+
+    /** Download + parse (once). Returns cues, or null on failure. */
+    suspend fun load(url: String, headers: Map<String, String>?): List<SubtitleCue>? {
+        cache[url]?.let { return it }
+        if (!inFlight.add(url)) return cache[url]
+        return try {
+            withContext(Dispatchers.IO) {
+                val bytes = download(url, headers)
+                val content = SubtitleParser.decode(bytes)
+                val isVtt = url.substringBefore('#').endsWith(".vtt", true) || content.startsWith("WEBVTT")
+                val cues = SubtitleParser.parse(content, isVtt)
+                cache[url] = cues
+                cues
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "preview load failed for $url: ${e.message}")
+            null
+        } finally {
+            inFlight.remove(url)
+        }
+    }
+
+    /**
+     * Up to [count] cue texts (HTML-stripped) starting from the cue active at [atMs] (or the next
+     * upcoming cue), for previewing what this subtitle shows at the current scene.
+     */
+    fun preview(cues: List<SubtitleCue>, atMs: Long, count: Int = 5): List<String> {
+        if (cues.isEmpty()) return emptyList()
+        var startIdx = cues.indexOfFirst { it.endMs >= atMs }
+        if (startIdx < 0) startIdx = (cues.size - count).coerceAtLeast(0)
+        return cues.drop(startIdx).take(count)
+            .map { SubtitleParser.stripHtml(it.text).replace("\n", " ") }
+            .filter { it.isNotBlank() }
+    }
+
+    private fun download(url: String, headers: Map<String, String>?): ByteArray {
+        val sniffer = ContentSniffer()
+        val client = sniffer.getOkHttpClient(trustAllCerts = sniffer.isLocalUrl(url))
+        val builder = Request.Builder().url(url).header("User-Agent", "Mozilla/5.0")
+        headers?.forEach { (k, v) -> if (!k.equals("Host", true)) builder.header(k, v) }
+        client.newCall(builder.build()).execute().use { resp ->
+            if (!resp.isSuccessful) throw java.io.IOException("HTTP ${resp.code}")
+            return resp.body?.bytes() ?: ByteArray(0)
+        }
+    }
+}

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/ControlActionButtons.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/ControlActionButtons.kt
@@ -21,6 +21,7 @@ fun ControlActionButtons(
     hasMultipleStreams: Boolean,
     onTogglePlay: () -> Unit,
     onTrackSelection: () -> Unit,
+    onSubtitles: () -> Unit,
     onPlaylist: () -> Unit,
     onStreams: () -> Unit,
     onPrev: () -> Unit,
@@ -104,6 +105,12 @@ fun ControlActionButtons(
                 onClick = onStreams
             )
         }
+
+        PlayerIconButton(
+            iconRes = R.drawable.ic_subtitles,
+            contentDescription = "Subtitles",
+            onClick = onSubtitles
+        )
 
         PlayerIconButton(
             iconRes = R.drawable.ic_loop,

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/MediaSettingsPanel.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/MediaSettingsPanel.kt
@@ -31,7 +31,6 @@ fun MediaSettingsPanel(
     onSpeedSelected: (Float) -> Unit,
     onScalingSelected: (String) -> Unit,
     onToggleAudioBoost: () -> Unit,
-    onAdjustSubtitleDelay: (Long) -> Unit,
     onDismiss: () -> Unit
 ) {
     val activeTab = state.activeSettingsTab
@@ -79,7 +78,6 @@ fun MediaSettingsPanel(
                 val tabs = listOf(
                     SettingsTab.VIDEO to "Video",
                     SettingsTab.AUDIO to "Audio",
-                    SettingsTab.SUBTITLES to "Subtitles",
                     SettingsTab.SPEED to "Speed",
                     SettingsTab.SCALING to "Scaling"
                 )
@@ -110,12 +108,6 @@ fun MediaSettingsPanel(
                         AudioBoostItem(isEnabled = state.isAudioBoostEnabled, onClick = onToggleAudioBoost)
                         Box(modifier = Modifier.weight(1f)) {
                             UnifiedTrackList(state.audioTracks, onTrackSelected)
-                        }
-                    }
-                    SettingsTab.SUBTITLES -> Column {
-                        SubtitleDelayControl(delayMs = state.subtitleDelayMs, onAdjust = onAdjustSubtitleDelay)
-                        Box(modifier = Modifier.weight(1f)) {
-                            UnifiedTrackList(state.subtitleTracks, onTrackSelected)
                         }
                     }
                     SettingsTab.SPEED -> SpeedSettingsList(state.playbackSpeed, onSpeedSelected)
@@ -381,78 +373,3 @@ private fun AudioBoostItem(
     }
 }
 
-@OptIn(ExperimentalTvMaterial3Api::class)
-@Composable
-private fun SubtitleDelayControl(
-    delayMs: Long,
-    onAdjust: (Long) -> Unit
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 8.dp, bottom = 12.dp)
-            .background(Color.White.copy(alpha = 0.05f), RoundedCornerShape(8.dp))
-            .padding(12.dp)
-    ) {
-        Text(
-            text = "Subtitle Sync",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-            fontWeight = FontWeight.Bold
-        )
-        
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Button(
-                onClick = { onAdjust(-50L) },
-                contentPadding = PaddingValues(horizontal = 12.dp),
-                shape = ButtonDefaults.shape(RoundedCornerShape(4.dp)),
-                colors = ButtonDefaults.colors(
-                    containerColor = Color.White.copy(alpha = 0.1f),
-                    contentColor = Color.White
-                )
-            ) {
-                Text("-50ms", style = MaterialTheme.typography.labelSmall)
-            }
-
-            Text(
-                text = if (delayMs == 0L) "Synced" else "${delayMs}ms",
-                style = MaterialTheme.typography.labelLarge,
-                color = if (delayMs != 0L) Color(0xFF00D9FF) else Color.White,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.weight(1f),
-                textAlign = androidx.compose.ui.text.style.TextAlign.Center
-            )
-
-            Button(
-                onClick = { onAdjust(50L) },
-                contentPadding = PaddingValues(horizontal = 12.dp),
-                shape = ButtonDefaults.shape(RoundedCornerShape(4.dp)),
-                colors = ButtonDefaults.colors(
-                    containerColor = Color.White.copy(alpha = 0.1f),
-                    contentColor = Color.White
-                )
-            ) {
-                Text("+50ms", style = MaterialTheme.typography.labelSmall)
-            }
-        }
-        
-        if (delayMs != 0L) {
-            Button(
-                onClick = { onAdjust(-delayMs) },
-                modifier = Modifier.align(Alignment.CenterHorizontally),
-                scale = ButtonDefaults.scale(focusedScale = 1.05f),
-                colors = ButtonDefaults.colors(
-                    containerColor = Color.Transparent,
-                    contentColor = Color.Gray
-                )
-            ) {
-                Text("Reset to 0", style = MaterialTheme.typography.labelSmall)
-            }
-        }
-    }
-}

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsOverlay.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsOverlay.kt
@@ -24,6 +24,7 @@ fun PlayerControlsOverlay(
     state: PlayerControlsState,
     onTogglePlay: () -> Unit,
     onTrackSelection: () -> Unit,
+    onSubtitles: () -> Unit,
     onPlaylist: () -> Unit,
     onPrev: () -> Unit,
     onNext: () -> Unit,
@@ -42,6 +43,7 @@ fun PlayerControlsOverlay(
     onPlayerSwitched: (String) -> Unit = {},
     onToggleAudioBoost: () -> Unit = {},
     onAdjustSubtitleDelay: (Long) -> Unit = {},
+    onPreloadSubtitles: (List<String>) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -71,11 +73,28 @@ fun PlayerControlsOverlay(
                         onSpeedSelected = onSpeedSelected,
                         onScalingSelected = onScalingSelected,
                         onToggleAudioBoost = onToggleAudioBoost,
-                        onAdjustSubtitleDelay = onAdjustSubtitleDelay,
                         onDismiss = onSettingsDismiss
                     )
                 }
 
+                // Subtitle Overlay (Language → Options → Sync)
+                AnimatedVisibility(
+                    visible = state.activeOverlay == ActiveOverlay.SUBTITLES,
+                    enter = fadeIn(),
+                    exit = fadeOut(),
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    SubtitleSelectionOverlay(
+                        subtitleTracks = state.subtitleTracks,
+                        subtitleDelayMs = state.subtitleDelayMs,
+                        previewPositionMs = state.currentPosition,
+                        cuesVersion = state.subtitleCuesVersion,
+                        onPreloadLanguage = onPreloadSubtitles,
+                        onTrackSelected = onTrackSelected,
+                        onAdjustDelay = onAdjustSubtitleDelay,
+                        onDismiss = onOverlayDismiss
+                    )
+                }
 
                 // Playlist Picker Overlay
                 AnimatedVisibility(
@@ -172,6 +191,7 @@ fun PlayerControlsOverlay(
                                 hasMultipleStreams = false,
                                 onTogglePlay = onTogglePlay,
                                 onTrackSelection = onTrackSelection,
+                                onSubtitles = onSubtitles,
                                 onPlaylist = onPlaylist,
                                 onStreams = {},
                                 onPrev = onPrev,

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsState.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsState.kt
@@ -3,11 +3,11 @@ package com.playbridge.player.ui.player
 import androidx.compose.runtime.Immutable
 
 enum class SettingsTab {
-    VIDEO, AUDIO, SUBTITLES, SPEED, SCALING
+    VIDEO, AUDIO, SPEED, SCALING
 }
 
 enum class ActiveOverlay {
-    NONE, SETTINGS, PLAYLIST_PICKER, SWITCH_PLAYER
+    NONE, SETTINGS, SUBTITLES, PLAYLIST_PICKER, SWITCH_PLAYER
 }
 
 @Immutable
@@ -59,5 +59,8 @@ data class PlayerControlsState(
     // High Performance Features
     val subtitleDelayMs: Long = 0,
     val isAudioBoostEnabled: Boolean = false,
-    val currentSubtitleText: String? = null
+    val currentSubtitleText: String? = null,
+    // Bumped whenever a subtitle preview finishes loading, so the overlay re-reads the
+    // SubtitleCueLoader cache. The cues themselves live in the loader, not in state.
+    val subtitleCuesVersion: Int = 0
 )

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsViewModel.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import android.util.Log
 import com.playbridge.player.player.SubtitleManager
+import com.playbridge.player.player.SubtitleCueLoader
 
 class PlayerControlsViewModel : ViewModel() {
     private val _controlsState = MutableStateFlow(PlayerControlsState())
@@ -20,6 +21,24 @@ class PlayerControlsViewModel : ViewModel() {
     private var progressUpdateJob: Job? = null
     private var engine: PlayerEngineAdapter? = null
     private var subtitleManager: SubtitleManager? = null
+
+    /** Request headers for fetching subtitle files (set by the activity when media loads). */
+    var subtitleRequestHeaders: Map<String, String>? = null
+
+    /**
+     * Lazily download + parse the given subtitle URLs (for the live preview in the overlay).
+     * Cached in [SubtitleCueLoader], so this no-ops for already-loaded ones. Bumps a version
+     * flag on completion so the overlay re-reads the cache.
+     */
+    fun preloadSubtitleCues(urls: List<String>) {
+        urls.forEach { url ->
+            if (SubtitleCueLoader.cached(url) != null || SubtitleCueLoader.isLoading(url)) return@forEach
+            viewModelScope.launch {
+                SubtitleCueLoader.load(url, subtitleRequestHeaders)
+                _controlsState.update { it.copy(subtitleCuesVersion = it.subtitleCuesVersion + 1) }
+            }
+        }
+    }
 
     fun setEngine(playerEngine: PlayerEngineAdapter, engineType: String) {
         this.engine = playerEngine
@@ -220,6 +239,11 @@ class PlayerControlsViewModel : ViewModel() {
 
     fun hideSettings() {
         hideOverlay()
+    }
+
+    /** Open the dedicated subtitle overlay (Language → Options → Sync). */
+    fun showSubtitles() {
+        showOverlay(ActiveOverlay.SUBTITLES)
     }
 
 

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/SubtitleSelectionOverlay.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/SubtitleSelectionOverlay.kt
@@ -1,0 +1,452 @@
+@file:OptIn(ExperimentalTvMaterial3Api::class)
+
+package com.playbridge.player.ui.player
+
+import androidx.activity.compose.BackHandler
+import com.playbridge.player.player.SubtitleCueLoader
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
+import androidx.tv.material3.ClickableSurfaceDefaults
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Surface
+import androidx.tv.material3.Text
+
+private const val OFF_KEY = "__off__"
+private const val EXTERNAL_KEY = "__external__"
+
+private data class SubLangGroup(
+    val key: String,
+    val label: String,
+    val tracks: List<UnifiedTrack>,
+    val hasSelected: Boolean,
+)
+
+// token (lowercased language name or ISO code) -> display name. Used to decide whether a
+// subtitle entry carries a real language. Library/embedded subs do (e.g. "English · BluRay",
+// "English • EN"); browser-detected subs are sniffed .vtt/.srt URLs with NO language, so their
+// label is just a filename — those collapse into a single "External" group rather than one
+// group per filename.
+private val LANG_TOKENS: Map<String, String> = buildMap {
+    fun add(display: String, vararg tokens: String) { tokens.forEach { put(it, display) } }
+    add("English", "english", "en", "eng")
+    add("Spanish", "spanish", "es", "spa", "esp")
+    add("French", "french", "fr", "fre", "fra")
+    add("German", "german", "de", "ger", "deu")
+    add("Italian", "italian", "it", "ita")
+    add("Japanese", "japanese", "ja", "jpn")
+    add("Korean", "korean", "ko", "kor")
+    add("Chinese", "chinese", "zh", "chi", "zho")
+    add("Russian", "russian", "ru", "rus")
+    add("Portuguese", "portuguese", "pt", "por")
+    add("Portuguese (BR)", "portuguese (br)", "pob", "pt-br", "ptbr")
+    add("Arabic", "arabic", "ar", "ara")
+    add("Hindi", "hindi", "hi", "hin")
+    add("Dutch", "dutch", "nl", "dut", "nld")
+    add("Swedish", "swedish", "sv", "swe")
+    add("Turkish", "turkish", "tr", "tur")
+    add("Polish", "polish", "pl", "pol")
+    add("Romanian", "romanian", "ro", "ron", "rum")
+    add("Greek", "greek", "el", "ell", "gre")
+    add("Czech", "czech", "cs", "cze", "ces")
+    add("Danish", "danish", "da", "dan")
+    add("Hungarian", "hungarian", "hu", "hun")
+    add("Bulgarian", "bulgarian", "bg", "bul")
+    add("Slovenian", "slovenian", "sl", "slv")
+    add("Indonesian", "indonesian", "id", "ind")
+    add("Hebrew", "hebrew", "he", "heb")
+    add("Finnish", "finnish", "fi", "fin")
+    add("Serbian", "serbian", "sr", "srp")
+    add("Croatian", "croatian", "hr", "hrv")
+    add("Norwegian", "norwegian", "no", "nor")
+    add("Ukrainian", "ukrainian", "uk", "ukr")
+    add("Thai", "thai", "th", "tha")
+    add("Vietnamese", "vietnamese", "vi", "vie")
+    add("Persian", "persian", "farsi", "fa", "per", "fas")
+}
+
+private fun languageOf(segment: String): String? = LANG_TOKENS[segment.trim().lowercase()]
+
+private data class SubInfo(val langKey: String, val langDisplay: String, val optionLabel: String)
+
+/** Decide a subtitle's language group + option label. No recognizable language → External. */
+private fun classify(t: UnifiedTrack): SubInfo {
+    val segs = t.name.split(" · ", " • ").map { it.trim() }.filter { it.isNotEmpty() }
+    val lang = segs.firstNotNullOfOrNull { languageOf(it) }
+    return if (lang != null) {
+        val rest = segs.filter { languageOf(it) == null }.joinToString(" • ")
+        val opt = rest.ifBlank { if (t.type == "external_sub") "Add-on" else "Embedded" }
+        SubInfo(lang.lowercase(), lang, opt)
+    } else {
+        // Browser-detected / unlabeled: bucket together; the filename distinguishes options.
+        SubInfo(EXTERNAL_KEY, "External", t.name.ifBlank { "Subtitle" })
+    }
+}
+
+private fun optionLabel(t: UnifiedTrack): String = classify(t).optionLabel
+
+private fun sourceLabel(t: UnifiedTrack): String =
+    if (t.type == "external_sub") "EXTERNAL" else "EMBEDDED"
+
+private fun groupSubtitleTracks(tracks: List<UnifiedTrack>): List<SubLangGroup> {
+    val off = tracks.firstOrNull { it.id == "off" }
+    val byLang = LinkedHashMap<String, Pair<String, MutableList<UnifiedTrack>>>()
+    tracks.filter { it.id != "off" }.forEach { t ->
+        val info = classify(t)
+        byLang.getOrPut(info.langKey) { info.langDisplay to mutableListOf() }.second.add(t)
+    }
+    val groups = mutableListOf<SubLangGroup>()
+    if (off != null) groups.add(SubLangGroup(OFF_KEY, "Off", listOf(off), off.isSelected))
+    // Real languages first (encounter order), the External bucket last.
+    byLang.filterKeys { it != EXTERNAL_KEY }.forEach { (k, v) ->
+        groups.add(SubLangGroup(k, v.first, v.second, v.second.any { it.isSelected }))
+    }
+    byLang[EXTERNAL_KEY]?.let { (display, list) ->
+        groups.add(SubLangGroup(EXTERNAL_KEY, display, list, list.any { it.isSelected }))
+    }
+    return groups
+}
+
+/**
+ * Fullscreen, NuvioTV-style subtitle overlay: Language rail → Options for that language → Sync.
+ * Reads the unified subtitle track list (Off + embedded + external) already produced by the
+ * player activities, so selection routes through the existing [onTrackSelected] path.
+ */
+@Composable
+fun SubtitleSelectionOverlay(
+    subtitleTracks: List<UnifiedTrack>,
+    subtitleDelayMs: Long,
+    previewPositionMs: Long,
+    cuesVersion: Int,
+    onPreloadLanguage: (List<String>) -> Unit,
+    onTrackSelected: (UnifiedTrack) -> Unit,
+    onAdjustDelay: (Long) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    BackHandler { onDismiss() }
+
+    // Freeze the scene position when the overlay opens so every option is previewed at the same
+    // moment; the offset slider then re-windows that frozen position live.
+    val frozenPos = remember { previewPositionMs }
+
+    val groups = remember(subtitleTracks) { groupSubtitleTracks(subtitleTracks) }
+    val initialLangKey = remember(groups) {
+        groups.firstOrNull { g -> g.tracks.any { it.isSelected } && g.key != OFF_KEY }?.key
+            ?: groups.firstOrNull { it.key != OFF_KEY }?.key
+            ?: groups.firstOrNull()?.key
+    }
+    var selectedLangKey by remember(groups) { mutableStateOf(initialLangKey) }
+    val currentGroup = groups.firstOrNull { it.key == selectedLangKey }
+
+    val initialFocus = remember { FocusRequester() }
+    LaunchedEffect(Unit) { runCatching { initialFocus.requestFocus() } }
+
+    // Fetch previews only for the selected language's external subs (lazy, cached).
+    LaunchedEffect(selectedLangKey, groups) {
+        currentGroup?.takeIf { it.key != OFF_KEY }?.let { g ->
+            onPreloadLanguage(g.tracks.filter { it.type == "external_sub" }.map { it.id })
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.62f))
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 48.dp, end = 48.dp, top = 40.dp, bottom = 56.dp),
+            verticalArrangement = Arrangement.Top
+        ) {
+            Text(
+                text = "Subtitles",
+                style = MaterialTheme.typography.headlineMedium,
+                color = Color.White,
+                modifier = Modifier.padding(bottom = 14.dp)
+            )
+
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                // ---- Language rail ----
+                RailColumn(title = "Language", width = 220.dp) {
+                    LazyColumn(
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                        modifier = Modifier.heightIn(max = 460.dp)
+                    ) {
+                        items(groups, key = { it.key }) { g ->
+                            SubCard(
+                                title = g.label,
+                                meta = null,
+                                source = null,
+                                trailingCount = (g.tracks.size).takeIf { g.key != OFF_KEY && it > 0 },
+                                checked = g.hasSelected,
+                                highlighted = g.key == selectedLangKey,
+                                focusRequester = if (g.key == initialLangKey) initialFocus else null,
+                                onFocused = { selectedLangKey = g.key },
+                                onClick = {
+                                    if (g.key == OFF_KEY) {
+                                        onTrackSelected(g.tracks.first())
+                                        onDismiss()
+                                    } else {
+                                        selectedLangKey = g.key
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+
+                // ---- Options rail ----
+                RailColumn(title = "Subtitles", width = 380.dp) {
+                    if (currentGroup == null || currentGroup.key == OFF_KEY) {
+                        EmptyRailCard("Subtitles off")
+                    } else {
+                        LazyColumn(
+                            verticalArrangement = Arrangement.spacedBy(6.dp),
+                            modifier = Modifier.heightIn(max = 460.dp)
+                        ) {
+                            items(currentGroup.tracks, key = { it.id }) { t ->
+                                val isExternal = t.type == "external_sub"
+                                // Re-windows when the offset (subtitleDelayMs) or cache version changes.
+                                val preview = remember(t.id, cuesVersion, subtitleDelayMs) {
+                                    if (!isExternal) null
+                                    else SubtitleCueLoader.cached(t.id)
+                                        ?.let { SubtitleCueLoader.preview(it, frozenPos + subtitleDelayMs) }
+                                }
+                                val loading = isExternal && SubtitleCueLoader.cached(t.id) == null
+                                SubCard(
+                                    title = optionLabel(t),
+                                    meta = null,
+                                    source = sourceLabel(t),
+                                    trailingCount = null,
+                                    checked = t.isSelected,
+                                    highlighted = t.isSelected,
+                                    previewLines = preview,
+                                    loading = loading,
+                                    focusRequester = null,
+                                    onFocused = {},
+                                    onClick = { onTrackSelected(t) }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // ---- Sync rail ----
+                RailColumn(title = "Sync", width = 250.dp) {
+                    SyncControl(delayMs = subtitleDelayMs, onAdjust = onAdjustDelay)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RailColumn(title: String, width: androidx.compose.ui.unit.Dp, content: @Composable () -> Unit) {
+    Column(
+        modifier = Modifier.width(width),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelLarge,
+            color = Color.White.copy(alpha = 0.6f)
+        )
+        content()
+    }
+}
+
+@Composable
+private fun SubCard(
+    title: String,
+    meta: String?,
+    source: String?,
+    trailingCount: Int?,
+    checked: Boolean,
+    highlighted: Boolean,
+    focusRequester: FocusRequester?,
+    onFocused: () -> Unit,
+    onClick: () -> Unit,
+    previewLines: List<String>? = null,
+    loading: Boolean = false,
+) {
+    Surface(
+        onClick = onClick,
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.02f),
+        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp)),
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = if (highlighted) MaterialTheme.colorScheme.primary.copy(alpha = 0.22f)
+                             else Color.White.copy(alpha = 0.06f),
+            focusedContainerColor = MaterialTheme.colorScheme.primary,
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
+            .onFocusChanged { if (it.isFocused) onFocused() }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 9.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                if (source != null) {
+                    Text(
+                        text = source,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color.White.copy(alpha = 0.6f)
+                    )
+                }
+                // Preview mode (subtitle options): show the cue lines at the current scene
+                // instead of a filename, so you can eyeball which one is in sync.
+                val showPreview = loading || previewLines != null
+                if (showPreview) {
+                    when {
+                        loading -> Text(
+                            text = "Loading preview…",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.White.copy(alpha = 0.55f)
+                        )
+                        previewLines!!.isEmpty() -> Text(
+                            text = "— no dialogue at this point —",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.White.copy(alpha = 0.45f)
+                        )
+                        else -> previewLines.forEachIndexed { i, line ->
+                            Text(
+                                text = line,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.White.copy(alpha = if (i == 0) 0.95f else 0.55f),
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+                } else {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = Color.White,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (!meta.isNullOrBlank()) {
+                        Text(
+                            text = meta,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.White.copy(alpha = 0.6f)
+                        )
+                    }
+                }
+            }
+            if (checked) {
+                Text(text = "●", color = Color(0xFF00D9FF))
+            } else if (trailingCount != null) {
+                Text(
+                    text = trailingCount.toString(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color.White.copy(alpha = 0.7f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyRailCard(text: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White.copy(alpha = 0.05f), RoundedCornerShape(12.dp))
+            .padding(horizontal = 12.dp, vertical = 14.dp)
+    ) {
+        Text(text = text, style = MaterialTheme.typography.bodyLarge, color = Color.White.copy(alpha = 0.6f))
+    }
+}
+
+@Composable
+private fun SyncControl(delayMs: Long, onAdjust: (Long) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White.copy(alpha = 0.05f), RoundedCornerShape(12.dp))
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Text(
+            text = if (delayMs == 0L) "Synced" else "${if (delayMs > 0) "+" else ""}${delayMs} ms",
+            style = MaterialTheme.typography.headlineSmall,
+            color = if (delayMs != 0L) Color(0xFF00D9FF) else Color.White,
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center
+        )
+        SyncRow(label = "Fine", minus = "−100ms", plus = "+100ms", step = 100L, onAdjust = onAdjust)
+        SyncRow(label = "Coarse", minus = "−1s", plus = "+1s", step = 1000L, onAdjust = onAdjust)
+        if (delayMs != 0L) {
+            Button(
+                onClick = { onAdjust(-delayMs) },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.colors(
+                    containerColor = Color.White.copy(alpha = 0.1f),
+                    contentColor = Color.White
+                )
+            ) { Text("Reset", style = MaterialTheme.typography.labelMedium) }
+        }
+    }
+}
+
+@Composable
+private fun SyncRow(label: String, minus: String, plus: String, step: Long, onAdjust: (Long) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Button(
+            onClick = { onAdjust(-step) },
+            modifier = Modifier.weight(1f),
+            colors = ButtonDefaults.colors(
+                containerColor = Color.White.copy(alpha = 0.1f),
+                contentColor = Color.White
+            )
+        ) { Text(minus, style = MaterialTheme.typography.labelSmall) }
+        Button(
+            onClick = { onAdjust(step) },
+            modifier = Modifier.weight(1f),
+            colors = ButtonDefaults.colors(
+                containerColor = Color.White.copy(alpha = 0.1f),
+                contentColor = Color.White
+            )
+        ) { Text(plus, style = MaterialTheme.typography.labelSmall) }
+    }
+}

--- a/tv/android/player/app/src/main/res/drawable/ic_subtitles.xml
+++ b/tv/android/player/app/src/main/res/drawable/ic_subtitles.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,4H4C2.9,4 2,4.9 2,6v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V6C22,4.9 21.1,4 20,4zM4,12h4v2H4V12zM14,18H4v-2h10V18zM20,18h-4v-2h4V18zM20,14H10v-2h10V14z" />
+</vector>


### PR DESCRIPTION
## Summary

A dedicated subtitle experience on the TV player, plus a rework of how subtitles are sourced and sent from the phone. ~+859 / −231 across 14 files.

### TV player
- **Dedicated subtitle overlay** (Language → Options → Sync), opened from a new subtitles icon in the player controls. Subtitle selection is **removed from the settings panel**.
- **Live cue previews per option** — each subtitle shows the actual dialogue lines at the current scene, so you pick the in-sync one by eye instead of guessing release names. Fetched **lazily per selected language**, cached, and **re-windowed live as the sync offset changes** (no re-fetch). Request headers threaded so browser-sub fetches don't 403; cue cache cleared on new media.
- **Sync control** (fine ±100ms / coarse ±1s + reset) lives in the overlay.
- **Language grouping**: real languages grouped by name/ISO code; browser-detected / unlabeled subs collapse into a single **External** bucket (no language metadata exists for sniffed `.vtt`/`.srt`).
- Extracted a shared `SubtitleParser` + `SubtitleCueLoader`; `SubtitleManager` now uses the shared parser (one parser, not two).

### Phone
- **Multi-language delivery**: keep all languages (deduped per release, capped per-language and overall), preferred language first, labels enriched with a source/quality tag.
- **Release matcher** orders each language's options against the video's release name so the auto-applied default (`subtitles[0]`) is usually in sync.

## Testing
- [x] `cd tv/android && ./gradlew :player:app:assembleDebug`
- [x] `cd mobile/android && ./gradlew :app:assembleDebug`
- [x] Subtitle icon opens the overlay; D-pad moves Language ↔ Options ↔ Sync; BACK closes.
- [x] Options show live cue lines at the current scene; the in-sync sub matches the audio.
- [x] Adjusting the Sync offset re-windows previews instantly (no re-fetch).
- [x] Select external / embedded / Off — playback updates and the selected ● tracks it.
- [x] Browser-detected subs appear under a single **External** group; library subs group by language.

## Notes / not done
- **Not compiled in the authoring env** (no Android SDK) — build before merge.
- Embedded subs can't be previewed (in-container, no URL) — they show their track label.
- Preview anchors to the live player position when the overlay opens.
- Phone matcher is kept as a default-orderer; now optional given the previews.