### PR TITLE
Phone Files revamp, persistent cast bar, and navigation/exit overhaul

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -79,6 +79,11 @@ fun AppNavHost(
     onScreenChange: (Screen) -> Unit,
     lastMainScreen: Screen,
     onLastMainScreenChange: (Screen) -> Unit,
+    // Where the Remote screen's Back should return (the screen it was opened from);
+    // defaults to lastMainScreen at the call site when no origin was recorded.
+    remoteReturnScreen: Screen = lastMainScreen,
+    // Where the Dashboard's close (X) should return — the screen it was opened from.
+    dashboardReturnScreen: Screen = lastMainScreen,
     innerPadding: PaddingValues,
 
     // Session & Tab Management
@@ -94,6 +99,8 @@ fun AppNavHost(
     backPressedTime: Long,
     onBackPressedTimeChange: (Long) -> Unit,
     onFinishActivity: () -> Unit,
+    // Full app exit (Dashboard "Exit" button): tears down the cast session/service before finishing.
+    onFullExit: () -> Unit = onFinishActivity,
 
     // Global dialog / Sheet triggers (stateless state bindings)
     showVideoSheet: Boolean,
@@ -206,6 +213,24 @@ fun AppNavHost(
     // Poster dominant color reported by the library detail screen — themes the
     // NowPlayingBar to match while that screen is up.
     var libraryDetailAccent by remember { mutableStateOf<androidx.compose.ui.graphics.Color?>(null) }
+
+    // Phone Files UI state, hoisted here so the user's tab/search/sort/folder/scroll survive
+    // leaving and returning to the screen (AnimatedContent disposes the screen content).
+    val phoneFilesUiState = remember { PhoneFilesUiState() }
+
+    // Device picker opened from the idle cast bar (rendered once at the host level so
+    // it survives screen transitions in the AnimatedContent below).
+    var showDevicePicker by remember { mutableStateOf(false) }
+    if (showDevicePicker) {
+        DeviceConnectionSheet(
+            onDismiss = { showDevicePicker = false },
+            onOpenAllDevices = {
+                showDevicePicker = false
+                onScreenChange(Screen.Connection)
+            },
+            showThisDevice = true,
+        )
+    }
 
     AnimatedContent(
         targetState = currentScreen,
@@ -496,7 +521,7 @@ fun AppNavHost(
                     )
                 }
                 Screen.CastHistory -> {
-                    BackHandler { onScreenChange(lastMainScreen) }
+                    BackHandler { onScreenChange(Screen.Dashboard) }
                     val db = com.playbridge.sender.data.history.DatabaseProvider.getDatabase(context)
                     val commandHistoryFlow = remember { db.commandHistoryDao().getAll() }
                     val commandHistory by commandHistoryFlow.collectAsState(initial = emptyList())
@@ -589,7 +614,7 @@ fun AppNavHost(
                     }
                 }
                 Screen.Connection -> {
-                    BackHandler { onScreenChange(lastMainScreen) }
+                    BackHandler { onScreenChange(Screen.Dashboard) }
                     ConnectionScreen(
                         viewModel = connectionViewModel,
                         onMenuClick = { onScreenChange(Screen.Dashboard) },
@@ -644,7 +669,7 @@ fun AppNavHost(
                 }
                 Screen.Remote -> {
                     BackHandler {
-                        onScreenChange(lastMainScreen)
+                        onScreenChange(remoteReturnScreen)
                     }
                     val dlna = activeDlnaTarget
                     if (dlna != null) {
@@ -652,7 +677,7 @@ fun AppNavHost(
                         // with dlnaMode hiding native-only controls (tracks/volume/loop).
                         RemoteControlScreen(
                             activeContext = "player",
-                            onBack = { onScreenChange(lastMainScreen) },
+                            onBack = { onScreenChange(remoteReturnScreen) },
                             onRemoteKey = {},
                             onMouseMove = { _, _ -> },
                             onMouseClick = {},
@@ -745,7 +770,7 @@ fun AppNavHost(
                             suspendLambda
                         },
                         onBack = {
-                            onScreenChange(lastMainScreen)
+                            onScreenChange(remoteReturnScreen)
                         },
                         onRemoteKey = { key ->
                             connectionViewModel.webSocketClient.send(com.playbridge.shared.protocol.createRemoteCommandJson(key))
@@ -796,7 +821,7 @@ fun AppNavHost(
                         if (selectedTabVal != 0) {
                             libraryViewModel.setSelectedTab(0)
                         } else {
-                            onFinishActivity()
+                            onScreenChange(Screen.Dashboard)
                         }
                     }
                     LibraryScreen(
@@ -1214,7 +1239,17 @@ fun AppNavHost(
                     )
                 }
                 Screen.Dashboard -> {
-                    BackHandler { onScreenChange(lastMainScreen) }
+                    // The Dashboard is "home" — Back here double-taps to exit (soft finish;
+                    // an active cast keeps running in the background).
+                    BackHandler {
+                        val now = System.currentTimeMillis()
+                        if (now - backPressedTime > 2000) {
+                            onBackPressedTimeChange(now)
+                            Toast.makeText(context, "Press back again to exit", Toast.LENGTH_SHORT).show()
+                        } else {
+                            onFinishActivity()
+                        }
+                    }
                     val isConnected = connectionState is WebSocketClient.ConnectionState.Connected
                     DashboardScreen(
                         currentScreen = lastMainScreen,
@@ -1223,19 +1258,22 @@ fun AppNavHost(
                         connectedDeviceName = tvDevice?.name,
                         onNavigate = { screen ->
                             onScreenChange(screen)
-                        }
+                        },
+                        onExit = onFullExit,
+                        onClose = { onScreenChange(dashboardReturnScreen) },
                     )
                 }
                 Screen.PhoneFiles -> {
                     BackHandler { onScreenChange(Screen.Dashboard) }
                     PhoneFilesScreen(
                         viewModel = connectionViewModel,
+                        uiState = phoneFilesUiState,
                         onBack = { onScreenChange(Screen.Dashboard) },
                         onOpenAllDevices = { onScreenChange(Screen.Connection) },
                     )
                 }
                 Screen.DebridLibrary -> {
-                    BackHandler { onFinishActivity() }
+                    BackHandler { onScreenChange(Screen.Dashboard) }
                     DebridLibraryScreen(
                         onMenuClick = { onScreenChange(Screen.Dashboard) },
                         onCopyUrl = { linkUrl ->
@@ -1250,67 +1288,106 @@ fun AppNavHost(
                 }
             }
 
-            // ── Now-playing mini-bar ─────────────────────────────────────────────
-            // Persistent across the main (non-browser) screens while a cast session is
-            // active; tap → Remote. Hidden on Browser (bottom toolbar), Remote
-            // (redundant), and the other full-bleed screens.
-            val showNowPlayingBar = targetScreen == Screen.Dashboard ||
-                targetScreen == Screen.Library ||
-                targetScreen == Screen.Connection ||
+            // ── Cast mini-bar ────────────────────────────────────────────────────
+            // Permanent across the main (non-browser) screens. Two modes:
+            //  • Playing (a cast session has media loaded): title + "on <device>" +
+            //    play/pause; tap → Remote.
+            //  • Idle (nothing playing): shows the current destination (connected TV /
+            //    renderer, or "This Device" when nothing is connected); tap → device picker.
+            // Hidden on Browser (bottom toolbar), Remote (redundant), and full-bleed screens.
+            // Note: excluded on Dashboard (overlays the "Exit" button) and on Connection
+            // (the device picker lives there already).
+            val showNowPlayingBar = targetScreen == Screen.Library ||
                 targetScreen == Screen.PhoneFiles ||
                 targetScreen == Screen.DebridLibrary ||
                 targetScreen is Screen.LibraryDetail
             if (showNowPlayingBar) {
                 val dlnaActive = activeDlnaTarget != null
-                val dlnaHasMedia = dlnaActive && (dlnaMediaTitle != null || dlnaStatus != null)
-                val nativePlaying = tvActiveContext == "player" &&
-                    connectionState is WebSocketClient.ConnectionState.Connected
-                if (dlnaHasMedia || nativePlaying) {
-                    NowPlayingBar(
-                        deviceName = activeDlnaTarget?.name ?: tvDevice?.name ?: "TV",
-                        title = if (dlnaActive) dlnaMediaTitle else tvPlayback?.title,
-                        isPlaying = if (dlnaActive) {
-                            dlnaStatus?.state == PlaybackState.PLAYING
-                        } else {
-                            tvPlayback?.state == "playing"
-                        },
-                        isDlna = dlnaActive,
-                        onPlayPause = {
-                            if (dlnaActive) {
-                                if (dlnaStatus?.state == PlaybackState.PLAYING) {
-                                    connectionViewModel.dlnaPause()
-                                } else {
-                                    connectionViewModel.dlnaPlay()
-                                }
+                // A stopped/ended/errored renderer (incl. after Stop) is not "playing", even
+                // though the status poll keeps reporting a (STOPPED) status.
+                val dlnaState = dlnaStatus?.state
+                val dlnaStopped = dlnaState == PlaybackState.STOPPED ||
+                    dlnaState == PlaybackState.IDLE ||
+                    dlnaState == PlaybackState.ERROR
+                val dlnaHasMedia = dlnaActive && dlnaMediaTitle != null && !dlnaStopped
+                val wsConnected = connectionState is WebSocketClient.ConnectionState.Connected
+                val nativePlaying = tvActiveContext == "player" && wsConnected
+                val playing = dlnaHasMedia || nativePlaying
+
+                val deviceName = activeDlnaTarget?.name ?: tvDevice?.name
+                val leadingIcon = when {
+                    dlnaActive -> Icons.Default.Cast
+                    wsConnected -> Icons.Default.Tv
+                    else -> Icons.Default.Smartphone
+                }
+
+                val primaryText: String
+                val secondaryText: String?
+                when {
+                    playing -> {
+                        primaryText = (if (dlnaActive) dlnaMediaTitle else tvPlayback?.title) ?: "Now playing"
+                        secondaryText = "on ${deviceName ?: "TV"}"
+                    }
+                    dlnaActive || wsConnected -> {
+                        primaryText = deviceName ?: "TV"
+                        secondaryText = "Ready to cast"
+                    }
+                    else -> {
+                        primaryText = "This Device"
+                        secondaryText = "Tap to cast to a device"
+                    }
+                }
+
+                NowPlayingBar(
+                    primaryText = primaryText,
+                    secondaryText = secondaryText,
+                    leadingIcon = leadingIcon,
+                    showPlayPause = playing,
+                    isPlaying = if (dlnaActive) {
+                        dlnaStatus?.state == PlaybackState.PLAYING
+                    } else {
+                        tvPlayback?.state == "playing"
+                    },
+                    onPlayPause = {
+                        if (dlnaActive) {
+                            if (dlnaStatus?.state == PlaybackState.PLAYING) {
+                                connectionViewModel.dlnaPause()
                             } else {
-                                val cmd = if (tvPlayback?.state == "playing") "pause" else "play"
-                                connectionViewModel.webSocketClient.send(
-                                    com.playbridge.shared.protocol.createControlCommandJson(cmd)
-                                )
+                                connectionViewModel.dlnaPlay()
                             }
-                        },
-                        onClick = {
+                        } else {
+                            val cmd = if (tvPlayback?.state == "playing") "pause" else "play"
+                            connectionViewModel.webSocketClient.send(
+                                com.playbridge.shared.protocol.createControlCommandJson(cmd)
+                            )
+                        }
+                    },
+                    onClick = {
+                        if (playing) {
                             if (!dlnaActive) {
                                 connectionViewModel.webSocketClient.send(
                                     com.playbridge.shared.protocol.createContextQueryJson()
                                 )
                             }
                             onScreenChange(Screen.Remote)
-                        },
-                        // Poster-matched accent on the library detail screen (the old FAB's
-                        // dynamic styling); FAB-like primaryContainer elsewhere.
-                        accentColor = if (targetScreen is Screen.LibraryDetail) libraryDetailAccent else null,
-                        modifier = Modifier
-                            .align(Alignment.BottomCenter)
-                            // Clear the system navigation bar, plus the Library's bottom
-                            // NavigationBar (80dp content height) on the Library screen.
-                            .padding(
-                                bottom = WindowInsets.navigationBars.asPaddingValues()
-                                    .calculateBottomPadding() +
-                                    if (targetScreen == Screen.Library) 80.dp else 0.dp
-                            )
-                    )
-                }
+                        } else {
+                            // Idle → choose / switch the cast destination.
+                            showDevicePicker = true
+                        }
+                    },
+                    // Poster-matched accent on the library detail screen (the old FAB's
+                    // dynamic styling); FAB-like primaryContainer elsewhere.
+                    accentColor = if (targetScreen is Screen.LibraryDetail) libraryDetailAccent else null,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        // Clear the system navigation bar, plus the Library's bottom
+                        // NavigationBar (80dp content height) on the Library screen.
+                        .padding(
+                            bottom = WindowInsets.navigationBars.asPaddingValues()
+                                .calculateBottomPadding() +
+                                if (targetScreen == Screen.Library) 80.dp else 0.dp
+                        )
+                )
             }
         }
     }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
@@ -316,6 +316,11 @@ class BrowserActivity : ComponentActivity() {
             }
             // Tracks the last "main" tab so Settings/overlays know where to return
             var lastMainScreen by remember { mutableStateOf(currentScreen) }
+            // The screen the Remote was opened from, so Back returns there (e.g. Phone Files,
+            // Connection) rather than always falling back to the last main tab.
+            var remoteOrigin by remember { mutableStateOf<Screen?>(null) }
+            // The screen the Dashboard was opened from, so its close (X) returns there.
+            var dashboardOrigin by remember { mutableStateOf<Screen?>(null) }
             var isSettingsFromLibrary by remember { mutableStateOf(false) }
             val clipboardManager = LocalClipboardManager.current
             val keyboardController = LocalSoftwareKeyboardController.current
@@ -1175,7 +1180,10 @@ class BrowserActivity : ComponentActivity() {
                                             isLoading = isLoading,
                                             isEditing = isEditing,
                                             isSecure = isSecureConnection,
-                                            onLogoClick = { currentScreen = Screen.Dashboard },
+                                            onLogoClick = {
+                                                dashboardOrigin = currentScreen
+                                                currentScreen = Screen.Dashboard
+                                            },
                                             onSecurityIconClick = { showSiteInfoSheet = true },
                                             onEditingChange = { editing ->
                                                 isEditing = editing
@@ -1456,9 +1464,21 @@ class BrowserActivity : ComponentActivity() {
                     // content
                     AppNavHost(
                         currentScreen = currentScreen,
-                        onScreenChange = { currentScreen = it },
+                        onScreenChange = { target ->
+                            // Remember where Remote / Dashboard were launched from so Back / close
+                            // can return there instead of always the last main tab.
+                            if (target == Screen.Remote && currentScreen != Screen.Remote) {
+                                remoteOrigin = currentScreen
+                            }
+                            if (target == Screen.Dashboard && currentScreen != Screen.Dashboard) {
+                                dashboardOrigin = currentScreen
+                            }
+                            currentScreen = target
+                        },
                         lastMainScreen = lastMainScreen,
                         onLastMainScreenChange = { lastMainScreen = it },
+                        remoteReturnScreen = remoteOrigin ?: lastMainScreen,
+                        dashboardReturnScreen = dashboardOrigin ?: lastMainScreen,
                         innerPadding = innerPadding,
                         session = session,
                         onMagnetDetected = { interceptedMagnet = it },
@@ -1473,6 +1493,13 @@ class BrowserActivity : ComponentActivity() {
                         backPressedTime = backPressedTime,
                         onBackPressedTimeChange = { backPressedTime = it },
                         onFinishActivity = { finish() },
+                        onFullExit = {
+                            // Hard exit: kill the cast foreground service and remove the app from
+                            // recents. We do NOT send a Stop to the TV — the process (and its
+                            // local proxy) just dies, so the TV errors out when it next needs it.
+                            com.playbridge.sender.cast.CastSessionService.stop(this@BrowserActivity)
+                            finishAndRemoveTask()
+                        },
                         showVideoSheet = showVideoSheet,
                         onShowVideoSheetChange = { showVideoSheet = it },
                         forcedVideos = forcedVideos,

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
@@ -223,6 +223,12 @@ class CastSessionManager(
     fun dlnaStop() {
         _dlnaInterrupts.tryEmit(Unit) // explicit stop ends any episode-queue plan
         _dlnaCast.value?.let { t -> scope.launch { runCatching { t.stop() } } }
+        // Treat an explicit Stop as ending the now-playing session: clear the title/meta and
+        // status so the cast bar drops to idle and the Remote no longer shows stale media.
+        // The renderer stays selected (activeDlnaTarget), so the user can cast to it again.
+        _dlnaMediaTitle.value = null
+        _dlnaNowPlayingMeta.value = null
+        _dlnaStatus.value = null
     }
 
     fun dlnaSeek(positionMs: Long) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/NowPlayingBar.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/NowPlayingBar.kt
@@ -9,10 +9,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Cast
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Tv
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -23,25 +21,34 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 /**
- * Persistent "now casting" mini-bar shown across the main screens while a cast session
- * is active (native receiver in player context, or a DLNA renderer with media loaded).
- * Tap → the Remote / now-playing screen; the trailing button toggles play/pause.
+ * Persistent cast mini-bar shown across the main screens. It has two visual modes:
  *
- * Styling follows the old remote FAB it replaces: [accentColor] (e.g. the library
- * detail poster's dominant color) fills the bar with a luminance-picked content color;
- * without an accent it uses the FAB's primaryContainer look.
+ *  - **Playing** ([showPlayPause] = true): a cast session is active with media loaded —
+ *    shows the title + "on <device>" and a play/pause button; tapping opens the Remote.
+ *  - **Idle** ([showPlayPause] = false): no media is playing — shows the current cast
+ *    destination (a connected TV/renderer, or "This Device" when nothing is connected) and
+ *    tapping opens the device picker. No play/pause button.
+ *
+ * The bar is intentionally "dumb": the host computes [primaryText]/[secondaryText]/[leadingIcon]
+ * and the mode flags from the live connection state.
+ *
+ * Styling follows the old remote FAB it replaced: [accentColor] (e.g. the library detail
+ * poster's dominant color) fills the bar with a luminance-picked content color; without an
+ * accent it uses the FAB's primaryContainer look.
  */
 @Composable
 fun NowPlayingBar(
-    deviceName: String,
-    title: String?,
+    primaryText: String,
+    secondaryText: String?,
+    leadingIcon: ImageVector,
+    showPlayPause: Boolean,
     isPlaying: Boolean,
-    isDlna: Boolean,
     onPlayPause: () -> Unit,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -69,34 +76,38 @@ fun NowPlayingBar(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Icon(
-                imageVector = if (isDlna) Icons.Default.Cast else Icons.Default.Tv,
+                imageVector = leadingIcon,
                 contentDescription = null,
                 tint = content,
                 modifier = Modifier.size(20.dp),
             )
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = title ?: "Now playing",
+                    text = primaryText,
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium,
                     color = content,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-                Text(
-                    text = "on $deviceName",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = content.copy(alpha = 0.75f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+                if (secondaryText != null) {
+                    Text(
+                        text = secondaryText,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = content.copy(alpha = 0.75f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
-            IconButton(onClick = onPlayPause) {
-                Icon(
-                    imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                    contentDescription = if (isPlaying) "Pause" else "Play",
-                    tint = content,
-                )
+            if (showPlayPause) {
+                IconButton(onClick = onPlayPause) {
+                    Icon(
+                        imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        contentDescription = if (isPlaying) "Pause" else "Play",
+                        tint = content,
+                    )
+                }
             }
         }
     }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/PhoneFilesScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/PhoneFilesScreen.kt
@@ -1,15 +1,20 @@
 package com.playbridge.sender.cast
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Build
+import android.provider.OpenableColumns
 import android.util.Size
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,28 +31,41 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.Audiotrack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.Movie
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
@@ -60,22 +78,52 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import com.playbridge.sender.R
 import com.playbridge.sender.connection.ConnectionViewModel
+import com.playbridge.sender.connection.WebSocketClient
+import com.playbridge.sender.player.PlayerLauncher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+/** How the Phone Files list is ordered. */
+enum class SortKey { UNSORTED, NAME, SIZE, MODIFIED }
+
 /**
- * Phone Files: in-app Videos/Audio tabs listing on-device media (MediaStore) with
- * thumbnails, each castable to the active target (DLNA renderer or native receiver).
+ * Hoisted UI state for [PhoneFilesScreen]. Held by the navigation host (which stays in
+ * composition) so the user's tab, search, sort, folder selection and scroll position survive
+ * leaving and returning to the screen — e.g. round-tripping through the Remote screen, which
+ * disposes the Phone Files content.
+ */
+class PhoneFilesUiState {
+    var tab by mutableIntStateOf(0) // 0 = Videos, 1 = Audio
+    var query by mutableStateOf("")
+    var searchActive by mutableStateOf(false)
+    var sortKey by mutableStateOf(SortKey.UNSORTED)
+    var ascending by mutableStateOf(true)
+    var selectedFolderId by mutableStateOf<Long?>(null)
+    val listState = LazyListState()
+    val folderScrollState = ScrollState(0)
+}
+
+/**
+ * Phone Files: in-app Videos/Audio tabs listing on-device media (MediaStore) with thumbnails.
+ * Each item is cast to the active target (DLNA renderer or native receiver) when one is
+ * connected, or played in the in-app player ("This Device") when nothing is connected.
+ *
+ * The top bar offers a SAF file picker, search (filters the current tab), and a sort sheet;
+ * a folder row under the tabs filters the current tab by containing folder.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PhoneFilesScreen(
     viewModel: ConnectionViewModel,
+    uiState: PhoneFilesUiState,
     onBack: () -> Unit,
     onOpenAllDevices: () -> Unit = {},
 ) {
@@ -83,6 +131,12 @@ fun PhoneFilesScreen(
     val scope = rememberCoroutineScope()
     val snackbar = remember { SnackbarHostState() }
     var showDevicePicker by remember { mutableStateOf(false) }
+    var showSortSheet by remember { mutableStateOf(false) }
+
+    val connectionState by viewModel.connectionState.collectAsState()
+    val activeDlnaTarget by viewModel.activeDlnaTarget.collectAsState()
+    val hasExternalTarget = activeDlnaTarget != null ||
+        connectionState is WebSocketClient.ConnectionState.Connected
 
     val requiredPerms = remember {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -98,7 +152,6 @@ fun PhoneFilesScreen(
     var granted by remember { mutableStateOf(hasAnyPerm()) }
     var allItems by remember { mutableStateOf<List<PhoneMediaItem>>(emptyList()) }
     var loading by remember { mutableStateOf(false) }
-    var tab by remember { mutableIntStateOf(0) } // 0 = Videos, 1 = Audio
 
     val videos = remember(allItems) { allItems.filter { !it.isAudio } }
     val audio = remember(allItems) { allItems.filter { it.isAudio } }
@@ -116,39 +169,124 @@ fun PhoneFilesScreen(
         }
     }
 
-    fun cast(media: PhoneMediaItem) {
-        val ok = viewModel.castLocalFile(media.uri.toString(), media.mimeType, media.title, media.durationMs)
-        if (ok) {
-            scope.launch { snackbar.showSnackbar("Casting ${media.title}") }
+    // Switch tab and reset the per-tab folder selection (folders differ per tab).
+    fun selectTab(index: Int) {
+        if (uiState.tab != index) {
+            uiState.tab = index
+            uiState.selectedFolderId = null
+        }
+    }
+
+    // Play on the active external target, or in the in-app player ("This Device").
+    fun playOrCast(media: PhoneMediaItem) {
+        if (hasExternalTarget) {
+            val ok = viewModel.castLocalFile(media.uri.toString(), media.mimeType, media.title, media.durationMs)
+            if (ok) {
+                scope.launch { snackbar.showSnackbar("Casting ${media.title}") }
+            } else {
+                // Lost the target between the check and the send — offer the picker.
+                showDevicePicker = true
+            }
         } else {
-            // No active target — open the device picker instead of just complaining.
-            showDevicePicker = true
+            // No cast target → play locally in the in-app player (no proxy needed).
+            PlayerLauncher.start(context, media.uri.toString(), media.title, media.mimeType)
+        }
+    }
+
+    // SAF picker: lets the user cast/play files MediaStore hasn't indexed.
+    val filePicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri: Uri? ->
+        if (uri != null) {
+            // Persist read access so the proxy can still read the file when the TV fetches it.
+            runCatching {
+                context.contentResolver.takePersistableUriPermission(
+                    uri, Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
+            }
+            val mime = context.contentResolver.getType(uri)
+            playOrCast(
+                PhoneMediaItem(
+                    uri = uri,
+                    title = queryDisplayName(context, uri) ?: uri.lastPathSegment ?: "File",
+                    durationMs = 0L,
+                    mimeType = mime,
+                    isAudio = mime?.startsWith("audio") == true,
+                ),
+            )
         }
     }
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Phone Files") },
+                title = {
+                    if (uiState.searchActive) {
+                        TextField(
+                            value = uiState.query,
+                            onValueChange = { uiState.query = it },
+                            placeholder = { Text("Search ${if (uiState.tab == 0) "videos" else "audio"}") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = TextFieldDefaults.colors(
+                                focusedContainerColor = androidx.compose.ui.graphics.Color.Transparent,
+                                unfocusedContainerColor = androidx.compose.ui.graphics.Color.Transparent,
+                            ),
+                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                            keyboardActions = KeyboardActions(),
+                        )
+                    } else {
+                        Text("Phone Files")
+                    }
+                },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    if (uiState.searchActive) {
+                        IconButton(onClick = {
+                            uiState.searchActive = false
+                            uiState.query = ""
+                        }) {
+                            Icon(Icons.Default.Close, contentDescription = "Close search")
+                        }
+                    } else {
+                        // PlayBridge logo → Dashboard, matching the other top-level screens.
+                        IconButton(onClick = onBack) {
+                            Image(
+                                painter = painterResource(id = R.drawable.ic_playbridge_logo),
+                                contentDescription = "PlayBridge",
+                                modifier = Modifier.size(24.dp),
+                            )
+                        }
                     }
                 },
                 actions = {
-                    // Same cast-target chip as the Library / Cast sheet — shows the active
-                    // device (native or DLNA) and opens the device picker on tap.
-                    DeviceChip(
-                        onOpenAllDevices = onOpenAllDevices,
-                        showThisDevice = false,
-                        castStatusLabel = true,
-                        modifier = Modifier.padding(end = 12.dp),
-                    )
+                    IconButton(onClick = {
+                        // OpenDocument takes mime filters; allow video + audio.
+                        filePicker.launch(arrayOf("video/*", "audio/*"))
+                    }) {
+                        Icon(Icons.Default.FolderOpen, contentDescription = "Pick a file")
+                    }
+                    IconButton(onClick = {
+                        uiState.searchActive = !uiState.searchActive
+                        if (!uiState.searchActive) uiState.query = ""
+                    }) {
+                        Icon(Icons.Default.Search, contentDescription = "Search")
+                    }
+                    IconButton(onClick = { showSortSheet = true }) {
+                        Icon(Icons.AutoMirrored.Filled.Sort, contentDescription = "Sort")
+                    }
                 },
             )
         },
-        snackbarHost = { SnackbarHost(snackbar) },
-        // (The remote FAB lived here; replaced by the app-wide NowPlayingBar.)
+        // Lift snackbars above the overlaid cast bar so they aren't hidden behind it.
+        snackbarHost = {
+            SnackbarHost(
+                snackbar,
+                modifier = Modifier.padding(
+                    bottom = WindowInsets.navigationBars.asPaddingValues()
+                        .calculateBottomPadding() + 80.dp
+                ),
+            )
+        },
     ) { pad ->
         Box(modifier = Modifier.padding(pad).fillMaxSize()) {
             when {
@@ -168,29 +306,66 @@ fun PhoneFilesScreen(
                 loading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
 
                 else -> Column(modifier = Modifier.fillMaxSize()) {
-                    TabRow(selectedTabIndex = tab) {
-                        Tab(selected = tab == 0, onClick = { tab = 0 }, text = { Text("Videos (${videos.size})") })
-                        Tab(selected = tab == 1, onClick = { tab = 1 }, text = { Text("Audio (${audio.size})") })
+                    TabRow(selectedTabIndex = uiState.tab) {
+                        Tab(selected = uiState.tab == 0, onClick = { selectTab(0) }, text = { Text("Videos (${videos.size})") })
+                        Tab(selected = uiState.tab == 1, onClick = { selectTab(1) }, text = { Text("Audio (${audio.size})") })
                     }
-                    val shown = if (tab == 0) videos else audio
+
+                    val base = if (uiState.tab == 0) videos else audio
+
+                    // Distinct folders for the current tab (id → display name), preserving order.
+                    val folders = remember(base) {
+                        base.mapNotNull { item ->
+                            item.bucketId?.let { id -> id to (item.bucketName ?: "Folder") }
+                        }.distinctBy { it.first }
+                    }
+                    if (folders.isNotEmpty()) {
+                        FolderRow(
+                            folders = folders,
+                            selectedId = uiState.selectedFolderId,
+                            scrollState = uiState.folderScrollState,
+                            onSelect = { uiState.selectedFolderId = it },
+                        )
+                    }
+
+                    // Folder filter → search filter → sort.
+                    val shown = remember(base, uiState.selectedFolderId, uiState.query, uiState.sortKey, uiState.ascending) {
+                        val filtered = base.asSequence()
+                            .filter { uiState.selectedFolderId == null || it.bucketId == uiState.selectedFolderId }
+                            .filter { uiState.query.isBlank() || it.title.contains(uiState.query, ignoreCase = true) }
+                            .toList()
+                        val sorted = when (uiState.sortKey) {
+                            SortKey.UNSORTED -> filtered.sortedByDescending { it.dateAdded }
+                            SortKey.NAME -> filtered.sortedBy { it.title.lowercase() }
+                            SortKey.SIZE -> filtered.sortedBy { it.sizeBytes }
+                            SortKey.MODIFIED -> filtered.sortedBy { it.dateModified }
+                        }
+                        if (uiState.sortKey != SortKey.UNSORTED && !uiState.ascending) sorted.reversed() else sorted
+                    }
+
                     if (shown.isEmpty()) {
                         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                             Text(
-                                if (tab == 0) "No videos found." else "No audio found.",
+                                when {
+                                    uiState.query.isNotBlank() -> "No matches."
+                                    uiState.tab == 0 -> "No videos found."
+                                    else -> "No audio found."
+                                },
                                 style = MaterialTheme.typography.bodyMedium,
                             )
                         }
                     } else {
                         LazyColumn(
+                            state = uiState.listState,
                             modifier = Modifier.fillMaxSize(),
                             // Keep the last row clear of the system navigation bar and the
-                            // overlaid NowPlayingBar.
+                            // overlaid cast bar.
                             contentPadding = PaddingValues(
                                 bottom = WindowInsets.navigationBars.asPaddingValues()
                                     .calculateBottomPadding() + 84.dp
                             ),
                         ) {
-                            items(shown) { media -> PhoneMediaRow(media) { cast(media) } }
+                            items(shown) { media -> PhoneMediaRow(media) { playOrCast(media) } }
                         }
                     }
                 }
@@ -198,7 +373,17 @@ fun PhoneFilesScreen(
         }
     }
 
-    // Opened when the user taps a file with no active cast target.
+    if (showSortSheet) {
+        SortSheet(
+            sortKey = uiState.sortKey,
+            ascending = uiState.ascending,
+            onSortKeyChange = { uiState.sortKey = it },
+            onAscendingChange = { uiState.ascending = it },
+            onDismiss = { showSortSheet = false },
+        )
+    }
+
+    // Opened when a file is tapped but the cast target was lost mid-flight.
     if (showDevicePicker) {
         DeviceConnectionSheet(
             onDismiss = { showDevicePicker = false },
@@ -206,7 +391,98 @@ fun PhoneFilesScreen(
                 showDevicePicker = false
                 onOpenAllDevices()
             },
-            showThisDevice = false,
+            showThisDevice = true,
+            // Picking "This Device" disconnects WS; also release any active DLNA target so
+            // playback routes to the in-app player rather than the renderer.
+            onPickedThisDevice = {
+                viewModel.dlnaStop()
+                viewModel.clearDlnaTarget()
+            },
+        )
+    }
+}
+
+@Composable
+private fun FolderRow(
+    folders: List<Pair<Long, String>>,
+    selectedId: Long?,
+    scrollState: ScrollState,
+    onSelect: (Long?) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(scrollState)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        FilterChip(
+            selected = selectedId == null,
+            onClick = { onSelect(null) },
+            label = { Text("All") },
+        )
+        folders.forEach { (id, name) ->
+            FilterChip(
+                selected = selectedId == id,
+                onClick = { onSelect(id) },
+                label = { Text(name, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SortSheet(
+    sortKey: SortKey,
+    ascending: Boolean,
+    onSortKeyChange: (SortKey) -> Unit,
+    onAscendingChange: (Boolean) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp).padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                "Sort by",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+            OptionRow("Unsorted", sortKey == SortKey.UNSORTED) { onSortKeyChange(SortKey.UNSORTED) }
+            OptionRow("Name", sortKey == SortKey.NAME) { onSortKeyChange(SortKey.NAME) }
+            OptionRow("Size", sortKey == SortKey.SIZE) { onSortKeyChange(SortKey.SIZE) }
+            OptionRow("Modified date", sortKey == SortKey.MODIFIED) { onSortKeyChange(SortKey.MODIFIED) }
+
+            Text(
+                "Order",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(top = 12.dp, bottom = 8.dp),
+            )
+            OptionRow("Ascending", ascending, enabled = sortKey != SortKey.UNSORTED) { onAscendingChange(true) }
+            OptionRow("Descending", !ascending, enabled = sortKey != SortKey.UNSORTED) { onAscendingChange(false) }
+        }
+    }
+}
+
+@Composable
+private fun OptionRow(label: String, selected: Boolean, enabled: Boolean = true, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        RadioButton(selected = selected, enabled = enabled, onClick = onClick)
+        Text(
+            label,
+            style = MaterialTheme.typography.bodyLarge,
+            color = if (enabled) MaterialTheme.colorScheme.onSurface
+            else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
         )
     }
 }
@@ -278,6 +554,16 @@ private fun MediaThumbnail(media: PhoneMediaItem) {
         }
     }
 }
+
+/** Resolves a human display name for a SAF content URI; null when unavailable. */
+private fun queryDisplayName(context: android.content.Context, uri: Uri): String? = runCatching {
+    context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use { c ->
+        if (c.moveToFirst()) {
+            val idx = c.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (idx >= 0) c.getString(idx) else null
+        } else null
+    }
+}.getOrNull()
 
 private fun clockShort(ms: Long): String {
     val s = (ms / 1000).coerceAtLeast(0)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/PhoneMediaStore.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/PhoneMediaStore.kt
@@ -14,6 +14,16 @@ data class PhoneMediaItem(
     val durationMs: Long,
     val mimeType: String?,
     val isAudio: Boolean,
+    /** File size in bytes (0 when unknown). */
+    val sizeBytes: Long = 0L,
+    /** Last-modified time, epoch seconds (0 when unknown). */
+    val dateModified: Long = 0L,
+    /** Date added to MediaStore, epoch seconds — drives the natural "Unsorted" order. */
+    val dateAdded: Long = 0L,
+    /** Containing folder (bucket) display name, null when unavailable. */
+    val bucketName: String? = null,
+    /** Containing folder (bucket) id, null when unavailable. */
+    val bucketId: Long? = null,
 )
 
 /** Enumerates on-device media (MediaStore) for the Phone Files screen. */
@@ -23,7 +33,9 @@ object PhoneMediaStore {
         val items = mutableListOf<PhoneMediaItem>()
         collect(context, MediaStore.Video.Media.EXTERNAL_CONTENT_URI, isAudio = false, items)
         collect(context, MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, isAudio = true, items)
-        items.sortedBy { it.title.lowercase() }
+        // Return in natural (date-added desc) order; the UI applies the chosen sort so
+        // the "Unsorted" option stays meaningful.
+        items
     }
 
     private fun collect(context: Context, collection: Uri, isAudio: Boolean, out: MutableList<PhoneMediaItem>) {
@@ -32,6 +44,11 @@ object PhoneMediaStore {
             MediaStore.MediaColumns.DISPLAY_NAME,
             MediaStore.MediaColumns.DURATION,
             MediaStore.MediaColumns.MIME_TYPE,
+            MediaStore.MediaColumns.SIZE,
+            MediaStore.MediaColumns.DATE_MODIFIED,
+            MediaStore.MediaColumns.DATE_ADDED,
+            MediaStore.MediaColumns.BUCKET_DISPLAY_NAME,
+            MediaStore.MediaColumns.BUCKET_ID,
         )
         runCatching {
             context.contentResolver.query(
@@ -43,8 +60,14 @@ object PhoneMediaStore {
             )?.use { c ->
                 val idCol = c.getColumnIndexOrThrow(MediaStore.MediaColumns._ID)
                 val nameCol = c.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME)
-                val durCol = c.getColumnIndex(MediaStore.MediaColumns.DURATION) // not present on all OS versions
+                // Columns below are not present on all OS versions — resolve defensively.
+                val durCol = c.getColumnIndex(MediaStore.MediaColumns.DURATION)
                 val mimeCol = c.getColumnIndex(MediaStore.MediaColumns.MIME_TYPE)
+                val sizeCol = c.getColumnIndex(MediaStore.MediaColumns.SIZE)
+                val modifiedCol = c.getColumnIndex(MediaStore.MediaColumns.DATE_MODIFIED)
+                val addedCol = c.getColumnIndex(MediaStore.MediaColumns.DATE_ADDED)
+                val bucketNameCol = c.getColumnIndex(MediaStore.MediaColumns.BUCKET_DISPLAY_NAME)
+                val bucketIdCol = c.getColumnIndex(MediaStore.MediaColumns.BUCKET_ID)
                 while (c.moveToNext()) {
                     val id = c.getLong(idCol)
                     out.add(
@@ -54,6 +77,11 @@ object PhoneMediaStore {
                             durationMs = if (durCol >= 0) c.getLong(durCol) else 0L,
                             mimeType = if (mimeCol >= 0) c.getString(mimeCol) else null,
                             isAudio = isAudio,
+                            sizeBytes = if (sizeCol >= 0) c.getLong(sizeCol) else 0L,
+                            dateModified = if (modifiedCol >= 0) c.getLong(modifiedCol) else 0L,
+                            dateAdded = if (addedCol >= 0) c.getLong(addedCol) else 0L,
+                            bucketName = if (bucketNameCol >= 0) c.getString(bucketNameCol) else null,
+                            bucketId = if (bucketIdCol >= 0 && !c.isNull(bucketIdCol)) c.getLong(bucketIdCol) else null,
                         ),
                     )
                 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/ui/DashboardScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/ui/DashboardScreen.kt
@@ -46,10 +46,15 @@ fun DashboardScreen(
     isConnected: Boolean,
     isSecure: Boolean,
     connectedDeviceName: String?,
-    onNavigate: (Screen) -> Unit
+    onNavigate: (Screen) -> Unit,
+    onExit: () -> Unit = {},
+    // Close the Dashboard (top-left X) → return to the screen it was opened from.
+    // Defaults to the active main screen to preserve the old behavior.
+    onClose: () -> Unit = { onNavigate(currentScreen) },
 ) {
     // ── Entrance animations ─────────────────────────────────────────────────
     var visible by remember { mutableStateOf(false) }
+    var showExitConfirm by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { visible = true }
 
     val logoScale by animateFloatAsState(
@@ -299,6 +304,9 @@ fun DashboardScreen(
             Spacer(modifier = Modifier.height(36.dp))
 
             // ── Navigation Cards Grid ───────────────────────────────────────
+            // Order: hero content (Browser, Library) on top; then Connection (gateway + live
+            // status), Phone Files and Debrid as the other content sources; Cast History — a
+            // passive log — last in the trailing slot.
             val items = listOf(
                 DashboardItem(
                     icon = Icons.Default.Language,
@@ -315,13 +323,6 @@ fun DashboardScreen(
                     gradientColors = listOf(Color(0xFF6A1B9A), Color(0xFF8E24AA))
                 ),
                 DashboardItem(
-                    icon = Icons.Default.Cloud,
-                    title = "Debrid",
-                    subtitle = "Cloud torrents",
-                    screen = Screen.DebridLibrary,
-                    gradientColors = listOf(Color(0xFF00838F), Color(0xFF00ACC1))
-                ),
-                DashboardItem(
                     icon = Icons.Default.Tv,
                     title = "Connection",
                     subtitle = if (isConnected) "Connected" else "Not connected",
@@ -332,18 +333,25 @@ fun DashboardScreen(
                         listOf(Color(0xFF424242), Color(0xFF616161))
                 ),
                 DashboardItem(
-                    icon = Icons.Default.History,
-                    title = "Cast History",
-                    subtitle = "Recent casts",
-                    screen = Screen.CastHistory,
-                    gradientColors = listOf(Color(0xFFE65100), Color(0xFFFB8C00))
-                ),
-                DashboardItem(
                     icon = Icons.Default.Folder,
                     title = "Phone Files",
                     subtitle = "Cast videos & audio",
                     screen = Screen.PhoneFiles,
                     gradientColors = listOf(Color(0xFF4527A0), Color(0xFF5E35B1))
+                ),
+                DashboardItem(
+                    icon = Icons.Default.Cloud,
+                    title = "Debrid",
+                    subtitle = "Cloud torrents",
+                    screen = Screen.DebridLibrary,
+                    gradientColors = listOf(Color(0xFF00838F), Color(0xFF00ACC1))
+                ),
+                DashboardItem(
+                    icon = Icons.Default.History,
+                    title = "Cast History",
+                    subtitle = "Recent casts",
+                    screen = Screen.CastHistory,
+                    gradientColors = listOf(Color(0xFFE65100), Color(0xFFFB8C00))
                 )
             )
 
@@ -389,6 +397,27 @@ fun DashboardScreen(
                 }
             }
 
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // ── Exit ─────────────────────────────────────────────────────────
+            // Fully quits the app (distinct from the top-left "Close Dashboard", which
+            // only dismisses this screen).
+            OutlinedButton(
+                onClick = { showExitConfirm = true },
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.error
+                ),
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.5f)),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.PowerSettingsNew,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Exit PlayBridge", fontWeight = FontWeight.Medium)
+            }
+
             Spacer(modifier = Modifier.height(24.dp))
         }
 
@@ -400,7 +429,7 @@ fun DashboardScreen(
                 .padding(horizontal = 16.dp, vertical = 8.dp)
         ) {
             IconButton(
-                onClick = { onNavigate(currentScreen) },
+                onClick = onClose,
                 modifier = Modifier
                     .align(Alignment.TopStart)
                     .size(40.dp)
@@ -413,6 +442,28 @@ fun DashboardScreen(
                     tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
                 )
             }
+        }
+
+        // Confirm before fully quitting — this is a hard exit, not a background close.
+        if (showExitConfirm) {
+            AlertDialog(
+                onDismissRequest = { showExitConfirm = false },
+                title = { Text("Exit PlayBridge?") },
+                text = { Text("This fully quits the app. Any cast that relies on PlayBridge — phone files, DLNA, or queued playback — will stop or error out.") },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            showExitConfirm = false
+                            onExit()
+                        }
+                    ) {
+                        Text("Exit", color = MaterialTheme.colorScheme.error)
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showExitConfirm = false }) { Text("Cancel") }
+                },
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
Reworks the Phone Files screen, makes the cast bar a permanent two-state surface, and overhauls back-navigation, the Dashboard, and app exit.

## Phone Files
- SAF file picker (cast/play files MediaStore hasn't indexed)
- Search that filters the current tab
- Sort sheet: unsorted / name / size / modified, asc/desc
- Per-tab folder row (Web Video Caster style)
- "This Device" target — plays locally in the in-app player when no external target; releases an active DLNA target when picked
- Tab/search/sort/folder selection + list & folder scroll positions persist across navigation (hoisted state)
- PlayBridge logo in the top bar (matches other screens), snackbars lifted above the cast bar

## Cast bar
- Permanent, two-state (playing / idle): tap opens Remote when playing, the device picker when idle
- Hidden on Dashboard (overlaps Exit) and Connection (picker already there)
- A stopped DLNA renderer is treated as idle; now-playing state is cleared on Stop so the bar/Remote don't show stale media

## Navigation & exit
- Remote Back and the Dashboard close (X) return to the screen they were opened from
- Library / Connection / Phone Files / Debrid / Cast History → Back returns to the Dashboard
- Dashboard Back double-taps to exit (soft finish; an active cast keeps running in the background)
- New "Exit PlayBridge" button on the Dashboard performs a hard exit (stops cast + foreground service, finishAndRemoveTask)
- Dashboard tiles reordered (Browser, Library / Connection, Phone Files, Debrid / Cast History)

## Testing
Not yet compiled in CI/locally at time of writing — build \`:app:assembleDebug\` and run the manual checklist (PHONE_FILES_AND_BAR_TEST_CHECKLIST.md) before merge.

## Notes / out of scope
- Browser and its sub-screens (Settings, Downloads, etc.) keep their existing back behavior
- Possible bottom-padding tweak for content behind the idle bar on Debrid