### PR TITLE
chore: uprev phone to 0.2.7, tv-player to 0.2.8

### DIFF
--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.7] — 2026-06-15 (versionCode 207)
+
+### Added
+- **Phone Files revamp**: Added SAF file picker, search, sort sheet (name/size/modified), and a per-tab folder row. Play locally via 'This Device' or cast to the active target. Hoist screen state so it survives navigation. (#34)
+- **Cast bar**: Permanent three-state (playing/idle) cast bar with quick navigation to Remote or Device Picker. (#34)
+- Hard 'Exit PlayBridge' button on the Dashboard. (#34)
+
+### Changed
+- Overhauled back button navigation rules to return to Dashboard from primary screens, and double-tap Dashboard back button to soft exit. (#34)
+- Multi-language subtitle delivery: sends all available subtitle tracks, prioritizing preferred languages and matching release names to ensure better auto-sync. (#32)
+
+### Removed
+- Video filter remote controls and settings. (#31)
+
 ## [0.2.6] — 2026-06-13 (versionCode 206)
 
 ### Added

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 206
-        versionName = "0.2.6"
+        versionCode = 207
+        versionName = "0.2.7"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,19 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [0.2.8] — 2026-06-15 (versionCode 208)
+
+### Added
+- Dedicated subtitle selection overlay with live dialogue line previews, fine/coarse sync control, and language grouping. (#32)
+- Save and persist playback progress every ~5 seconds to survive force-kill events. (#31)
+
+### Changed
+- TV history now stores raw playlist payloads, ensuring subtitles, audio language, and headers are fully restored on replay. (#31)
+- Replaced on-pause screenshot capture with poster/backdrop art. (#31)
+
+### Removed
+- Video filters feature end-to-end from TV engine, UI, and settings. (#31)
+
 ## Player [0.2.7] — 2026-06-13 (versionCode 207)
 
 ### Added

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 207
-        versionName = "0.2.7"
+        versionCode = 208
+        versionName = "0.2.8"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
Uprevs phone sender and tv-player projects to reflect latest changes and updates their changelogs.