### PR TITLE
feat: IPTV + Collections, remote seek/volume bar, desktop host volume

### DIFF
--- a/desktop/lib/protocol.dart
+++ b/desktop/lib/protocol.dart
@@ -62,6 +62,13 @@ class ControlCmd extends Command {
   const ControlCmd(this.command);
 }
 
+/// A remote key press from the phone (e.g. `volume_up` / `volume_down`). Most keys
+/// are TV-browser navigation and don't apply to the desktop player; volume does.
+class RemoteCmd extends Command {
+  final String key;
+  const RemoteCmd(this.key);
+}
+
 class PlaylistCmd extends Command {
   final List<PlayPayload> items;
   final int startIndex;
@@ -150,6 +157,8 @@ Command parseCommand(String json) {
         switch (action) {
           case 'control':
             return ControlCmd((payload?['command'] ?? '') as String);
+          case 'remote':
+            return RemoteCmd((payload?['key'] ?? '') as String);
           case 'context_query':
             return const ContextQueryCmd();
           case 'playlist':

--- a/desktop/lib/server.dart
+++ b/desktop/lib/server.dart
@@ -12,6 +12,7 @@ import 'pairing_store.dart';
 import 'player_controller.dart';
 import 'player_engine.dart';
 import 'protocol.dart';
+import 'system_volume.dart';
 
 const int kDefaultPort = 8765;
 
@@ -421,10 +422,50 @@ class ReceiverServer extends ChangeNotifier {
             if (dur > 0 && target > dur) target = dur;
             unawaited(player.seek(Duration(milliseconds: target)));
         }
+      case RemoteCmd(:final key):
+        _handleRemoteKey(key);
       case UnknownCmd(:final type):
         debugPrint('[server] unknown command: $type');
       default:
         break;
+    }
+  }
+
+  /// Apply a phone remote key. Only volume is meaningful for the desktop player;
+  /// other (TV-browser) keys are ignored.
+  void _handleRemoteKey(String key) {
+    switch (key) {
+      case 'volume_up':
+        unawaited(_adjustVolume(up: true));
+      case 'volume_down':
+        unawaited(_adjustVolume(up: false));
+      default:
+        debugPrint('[server] ignoring remote key: $key');
+    }
+  }
+
+  // Drop overlapping volume events: a swipe fires many in a row and each backend
+  // call spawns a process, so we coalesce while one is in flight.
+  bool _volumeBusy = false;
+
+  /// Move the **host/OS** volume one step; fall back to the player's own volume
+  /// only when no system backend is available (e.g. headless Linux).
+  Future<void> _adjustVolume({required bool up}) async {
+    if (_volumeBusy) return;
+    _volumeBusy = true;
+    try {
+      final handled = await SystemVolume.step(up: up);
+      if (!handled) {
+        const step = 0.05;
+        final next =
+            (player.volume + (up ? step : -step)).clamp(0.0, 1.0).toDouble();
+        await player.setVolume(next);
+        debugPrint('[server] player volume -> $next (no system backend)');
+      } else {
+        debugPrint('[server] system volume ${up ? 'up' : 'down'}');
+      }
+    } finally {
+      _volumeBusy = false;
     }
   }
 

--- a/desktop/lib/system_volume.dart
+++ b/desktop/lib/system_volume.dart
@@ -30,10 +30,14 @@ class SystemVolume {
   static Future<bool> _macStep(bool up) async {
     final delta = up ? stepPercent : -stepPercent;
     final r = await Process.run('osascript', [
-      '-e', 'set v to (output volume of (get volume settings)) + ($delta)',
-      '-e', 'if v > 100 then set v to 100',
-      '-e', 'if v < 0 then set v to 0',
-      '-e', 'set volume output volume v',
+      '-e',
+      'set v to (output volume of (get volume settings)) + ($delta)',
+      '-e',
+      'if v > 100 then set v to 100',
+      '-e',
+      'if v < 0 then set v to 0',
+      '-e',
+      'set volume output volume v',
     ]);
     return r.exitCode == 0;
   }
@@ -42,7 +46,16 @@ class SystemVolume {
     final sign = up ? '+' : '-';
     // Try PipeWire, then PulseAudio, then ALSA — whichever is installed.
     final attempts = <(String, List<String>)>[
-      ('wpctl', ['set-volume', '-l', '1.0', '@DEFAULT_AUDIO_SINK@', '$stepPercent%$sign']),
+      (
+        'wpctl',
+        [
+          'set-volume',
+          '-l',
+          '1.0',
+          '@DEFAULT_AUDIO_SINK@',
+          '$stepPercent%$sign'
+        ]
+      ),
       ('pactl', ['set-sink-volume', '@DEFAULT_SINK@', '$sign$stepPercent%']),
       ('amixer', ['-q', 'sset', 'Master', '$stepPercent%$sign']),
     ];

--- a/desktop/lib/system_volume.dart
+++ b/desktop/lib/system_volume.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+/// Adjusts the **operating-system** output volume (not the player's own volume),
+/// so the phone remote behaves like a real TV volume rocker. Best-effort and
+/// platform-specific; [step] returns true when a backend handled the change.
+///
+/// - macOS  → AppleScript (`osascript`), clamped to 0–100.
+/// - Linux  → tries PipeWire (`wpctl`), then PulseAudio (`pactl`), then ALSA (`amixer`).
+/// - Windows→ sends the media Volume Up/Down key via `WScript.Shell` (PowerShell).
+class SystemVolume {
+  /// Per-press change, in percent (macOS/Linux). Windows uses the OS key step.
+  static const int stepPercent = 5;
+
+  static bool get isSupported =>
+      Platform.isMacOS || Platform.isLinux || Platform.isWindows;
+
+  static Future<bool> step({required bool up}) async {
+    try {
+      if (Platform.isMacOS) return await _macStep(up);
+      if (Platform.isLinux) return await _linuxStep(up);
+      if (Platform.isWindows) return await _windowsStep(up);
+    } catch (e) {
+      debugPrint('[volume] system volume failed: $e');
+    }
+    return false;
+  }
+
+  static Future<bool> _macStep(bool up) async {
+    final delta = up ? stepPercent : -stepPercent;
+    final r = await Process.run('osascript', [
+      '-e', 'set v to (output volume of (get volume settings)) + ($delta)',
+      '-e', 'if v > 100 then set v to 100',
+      '-e', 'if v < 0 then set v to 0',
+      '-e', 'set volume output volume v',
+    ]);
+    return r.exitCode == 0;
+  }
+
+  static Future<bool> _linuxStep(bool up) async {
+    final sign = up ? '+' : '-';
+    // Try PipeWire, then PulseAudio, then ALSA — whichever is installed.
+    final attempts = <(String, List<String>)>[
+      ('wpctl', ['set-volume', '-l', '1.0', '@DEFAULT_AUDIO_SINK@', '$stepPercent%$sign']),
+      ('pactl', ['set-sink-volume', '@DEFAULT_SINK@', '$sign$stepPercent%']),
+      ('amixer', ['-q', 'sset', 'Master', '$stepPercent%$sign']),
+    ];
+    for (final (bin, args) in attempts) {
+      try {
+        final r = await Process.run(bin, args);
+        if (r.exitCode == 0) return true;
+      } on ProcessException {
+        // Binary not present — try the next backend.
+      }
+    }
+    return false;
+  }
+
+  static Future<bool> _windowsStep(bool up) async {
+    // char 175 = Volume Up media key, 174 = Volume Down.
+    final code = up ? 175 : 174;
+    final r = await Process.run('powershell', [
+      '-NoProfile',
+      '-Command',
+      '(New-Object -ComObject WScript.Shell).SendKeys([char]$code)',
+    ]);
+    return r.exitCode == 0;
+  }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -154,6 +154,12 @@ fun AppNavHost(
     // 1. Inject ViewModels & Singletons
     val connectionViewModel: ConnectionViewModel = koinViewModel()
     val libraryViewModel: LibraryViewModel = koinViewModel()
+    val iptvViewModel: com.playbridge.sender.iptv.IptvViewModel = koinViewModel()
+    val collectionsViewModel: com.playbridge.sender.collection.CollectionsViewModel = koinViewModel()
+    // Centralized "Add to Collection": any screen sets this draft → one shared sheet shows.
+    var addToCollectionDraft by remember { mutableStateOf<com.playbridge.sender.data.collection.CollectionItemDraft?>(null) }
+    val onAddToCollection: (com.playbridge.sender.data.collection.CollectionItemDraft) -> Unit =
+        { addToCollectionDraft = it }
     val connectionCoordinator: ConnectionCoordinator = koinInject()
     val tvQueueCoordinator: com.playbridge.sender.connection.TvQueueCoordinator = koinInject()
     val dlnaQueueCoordinator: com.playbridge.sender.connection.DlnaQueueCoordinator = koinInject()
@@ -545,7 +551,17 @@ fun AppNavHost(
                         onClearHistory = {
                             scope.launch(Dispatchers.IO) { db.commandHistoryDao().clear() }
                         },
-                        onBack = { onScreenChange(lastMainScreen) }
+                        onBack = { onScreenChange(lastMainScreen) },
+                        onAddToCollection = { item ->
+                            onAddToCollection(
+                                com.playbridge.sender.data.collection.CollectionItemDraft(
+                                    title = item.title ?: item.url,
+                                    url = item.url,
+                                    kind = com.playbridge.sender.data.collection.CollectionItemKind.WEB,
+                                    sourceTag = com.playbridge.sender.data.collection.CollectionSource.HISTORY,
+                                )
+                            )
+                        }
                     )
                 }
                  Screen.Tabs -> {
@@ -1270,6 +1286,17 @@ fun AppNavHost(
                         uiState = phoneFilesUiState,
                         onBack = { onScreenChange(Screen.Dashboard) },
                         onOpenAllDevices = { onScreenChange(Screen.Connection) },
+                        onAddToCollection = { media ->
+                            onAddToCollection(
+                                com.playbridge.sender.data.collection.CollectionItemDraft(
+                                    title = media.title,
+                                    url = media.uri.toString(),
+                                    kind = com.playbridge.sender.data.collection.CollectionItemKind.LOCAL,
+                                    mimeType = media.mimeType,
+                                    sourceTag = com.playbridge.sender.data.collection.CollectionSource.PHONE_FILE,
+                                )
+                            )
+                        },
                     )
                 }
                 Screen.DebridLibrary -> {
@@ -1283,7 +1310,54 @@ fun AppNavHost(
                         onShowCastSheet = { video ->
                             onForcedVideosChange(listOf(video))
                             onShowVideoSheetChange(true)
+                        },
+                        onAddToCollection = { title, url ->
+                            onAddToCollection(
+                                com.playbridge.sender.data.collection.CollectionItemDraft(
+                                    title = title,
+                                    url = url,
+                                    kind = com.playbridge.sender.data.collection.CollectionItemKind.WEB,
+                                    sourceTag = com.playbridge.sender.data.collection.CollectionSource.DEBRID,
+                                )
+                            )
                         }
+                    )
+                }
+                Screen.Iptv -> {
+                    BackHandler { onScreenChange(Screen.Dashboard) }
+                    com.playbridge.sender.iptv.IptvScreen(
+                        viewModel = iptvViewModel,
+                        onBack = { onScreenChange(Screen.Dashboard) },
+                        onOpenPlaylist = { id -> onScreenChange(Screen.IptvDetail(id)) },
+                    )
+                }
+                is Screen.IptvDetail -> {
+                    val detail = targetScreen as Screen.IptvDetail
+                    BackHandler { onScreenChange(Screen.Iptv) }
+                    com.playbridge.sender.iptv.IptvDetailScreen(
+                        playlistId = detail.playlistId,
+                        viewModel = iptvViewModel,
+                        connectionViewModel = connectionViewModel,
+                        collectionsViewModel = collectionsViewModel,
+                        onBack = { onScreenChange(Screen.Iptv) },
+                    )
+                }
+                Screen.Collections -> {
+                    BackHandler { onScreenChange(Screen.Dashboard) }
+                    com.playbridge.sender.collection.CollectionsScreen(
+                        viewModel = collectionsViewModel,
+                        onBack = { onScreenChange(Screen.Dashboard) },
+                        onOpenCollection = { id -> onScreenChange(Screen.CollectionDetail(id)) },
+                    )
+                }
+                is Screen.CollectionDetail -> {
+                    val detail = targetScreen as Screen.CollectionDetail
+                    BackHandler { onScreenChange(Screen.Collections) }
+                    com.playbridge.sender.collection.CollectionDetailScreen(
+                        collectionId = detail.collectionId,
+                        viewModel = collectionsViewModel,
+                        connectionViewModel = connectionViewModel,
+                        onBack = { onScreenChange(Screen.Collections) },
                     )
                 }
             }
@@ -1300,7 +1374,11 @@ fun AppNavHost(
             val showNowPlayingBar = targetScreen == Screen.Library ||
                 targetScreen == Screen.PhoneFiles ||
                 targetScreen == Screen.DebridLibrary ||
-                targetScreen is Screen.LibraryDetail
+                targetScreen is Screen.LibraryDetail ||
+                targetScreen == Screen.Iptv ||
+                targetScreen is Screen.IptvDetail ||
+                targetScreen == Screen.Collections ||
+                targetScreen is Screen.CollectionDetail
             if (showNowPlayingBar) {
                 val dlnaActive = activeDlnaTarget != null
                 // A stopped/ended/errored renderer (incl. after Stop) is not "playing", even
@@ -1390,6 +1468,22 @@ fun AppNavHost(
                 )
             }
         }
+    }
+
+    // Shared Add-to-Collection sheet, driven by any screen's onAddToCollection(draft).
+    addToCollectionDraft?.let { draft ->
+        com.playbridge.sender.collection.AddToCollectionSheet(
+            viewModel = collectionsViewModel,
+            draft = draft,
+            onDismiss = { addToCollectionDraft = null },
+            onAdded = { name, added ->
+                Toast.makeText(
+                    context,
+                    if (added) "Added to $name" else "Already in $name",
+                    Toast.LENGTH_SHORT,
+                ).show()
+            },
+        )
     }
 }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
@@ -319,6 +319,12 @@ class BrowserActivity : ComponentActivity() {
             // The screen the Remote was opened from, so Back returns there (e.g. Phone Files,
             // Connection) rather than always falling back to the last main tab.
             var remoteOrigin by remember { mutableStateOf<Screen?>(null) }
+            // Keep the Remote's return target pointed at wherever we actually were last, even
+            // when playback auto-switches into the Remote directly (which bypasses
+            // onScreenChange and would otherwise leave remoteOrigin stale — e.g. stuck on IPTV).
+            LaunchedEffect(currentScreen) {
+                if (currentScreen != Screen.Remote) remoteOrigin = currentScreen
+            }
             // The screen the Dashboard was opened from, so its close (X) returns there.
             var dashboardOrigin by remember { mutableStateOf<Screen?>(null) }
             var isSettingsFromLibrary by remember { mutableStateOf(false) }
@@ -1346,6 +1352,10 @@ class BrowserActivity : ComponentActivity() {
                             Screen.DebridLibrary -> {}
                             Screen.Dashboard -> {}
                             Screen.PhoneFiles -> {}
+                            Screen.Iptv -> {}
+                            is Screen.IptvDetail -> {}
+                            Screen.Collections -> {}
+                            is Screen.CollectionDetail -> {}
                         }
                     },
                         bottomBar = {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/Screen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/Screen.kt
@@ -24,4 +24,8 @@ sealed class Screen {
     data class LibraryDetail(val id: String, val type: String, val source: String? = null) : Screen()
     object Dashboard : Screen()
     object PhoneFiles : Screen()
+    object Iptv : Screen()
+    data class IptvDetail(val playlistId: Long) : Screen()
+    object Collections : Screen()
+    data class CollectionDetail(val collectionId: Long) : Screen()
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/SheetOverlayContainer.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/SheetOverlayContainer.kt
@@ -21,6 +21,7 @@ import com.playbridge.sender.data.library.StremioSubtitleService
 import com.playbridge.sender.library.MagnetParsingSheet
 import playbridge.PlayPayload
 import org.koin.compose.koinInject
+import org.koin.androidx.compose.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -119,9 +120,25 @@ fun SheetOverlayContainer(
 
         // 3. Cast Sheet
         if (showVideoSheet) {
+            val collectionsViewModel: com.playbridge.sender.collection.CollectionsViewModel = koinViewModel()
+            val castSheetContext = LocalContext.current
+            // Set when "Save to Collection" is tapped on a card → shows the collection picker.
+            var saveToCollectionDraft by remember {
+                mutableStateOf<com.playbridge.sender.data.collection.CollectionItemDraft?>(null)
+            }
             CastSheet(
                 videos = detectedVideos,
                 onDismiss = onDismissVideoSheet,
+                onSaveToCollection = { video ->
+                    saveToCollectionDraft = com.playbridge.sender.data.collection.CollectionItemDraft(
+                        title = video.title ?: (try { java.net.URI(video.url).host } catch (e: Exception) { null } ?: video.url),
+                        url = video.url,
+                        kind = com.playbridge.sender.data.collection.CollectionItemKind.WEB,
+                        mimeType = video.contentType,
+                        headers = video.headers ?: emptyMap(),
+                        sourceTag = com.playbridge.sender.data.collection.CollectionSource.BROWSER,
+                    )
+                },
                 onVideoClick = onVideoClick,
                 onQueueVideo = onQueueVideo,
                 onDownload = onDownloadVideo,
@@ -145,6 +162,22 @@ fun SheetOverlayContainer(
                 detectionEnabled = detectVideosEnabled,
                 onEnableDetection = if (!detectVideosEnabled) onToggleVideoDetect else null
             )
+
+            // Collection picker, shown over the cast sheet when saving a detected video.
+            saveToCollectionDraft?.let { draft ->
+                com.playbridge.sender.collection.AddToCollectionSheet(
+                    viewModel = collectionsViewModel,
+                    draft = draft,
+                    onDismiss = { saveToCollectionDraft = null },
+                    onAdded = { name, added ->
+                        Toast.makeText(
+                            castSheetContext,
+                            if (added) "Saved to $name" else "Already in $name",
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                    },
+                )
+            }
         }
 
         // 4. Magnet Parsing Sheet

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheet.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheet.kt
@@ -90,7 +90,9 @@ fun CastSheet(
     onContentClick: (playbridge.PlayPayload) -> Unit = {},
     onQueueContent: (playbridge.PlayPayload) -> Unit = {},
     detectionEnabled: Boolean = true,
-    onEnableDetection: (() -> Unit)? = null
+    onEnableDetection: (() -> Unit)? = null,
+    // When provided, each detected-video card's ⋮ menu gets a "Save to Collection" action.
+    onSaveToCollection: ((DetectedVideo) -> Unit)? = null
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val context = LocalContext.current
@@ -769,7 +771,8 @@ fun CastSheet(
                                     dispatchExternalPlayerForVideo(video)
                                 },
                                 onPreviewClick = { previewVideo = video },
-                                onPlayPhoneClick = { dispatchPhoneForVideo(video) }
+                                onPlayPhoneClick = { dispatchPhoneForVideo(video) },
+                                onSaveToCollection = onSaveToCollection?.let { cb -> { cb(video) } }
                             )
                         }
                     }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheetComponents.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheetComponents.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material.icons.filled.Check
@@ -224,7 +225,8 @@ internal fun VideoItemDetailed(
     onCopyClick: () -> Unit,
     onOpenWithClick: () -> Unit,
     onPreviewClick: () -> Unit,
-    onPlayPhoneClick: () -> Unit
+    onPlayPhoneClick: () -> Unit,
+    onSaveToCollection: (() -> Unit)? = null
 ) {
     val urlInfo = remember(video.url) { parseUrlInfo(video.url) }
     val videoType = remember(video) { getVideoType(video) }
@@ -548,6 +550,21 @@ internal fun VideoItemDetailed(
                             expanded = menuExpanded,
                             onDismissRequest = { menuExpanded = false }
                         ) {
+                            onSaveToCollection?.let { save ->
+                                DropdownMenuItem(
+                                    text = { Text("Save to Collection") },
+                                    leadingIcon = {
+                                        Icon(
+                                            Icons.AutoMirrored.Filled.PlaylistAdd,
+                                            contentDescription = null
+                                        )
+                                    },
+                                    onClick = {
+                                        save()
+                                        menuExpanded = false
+                                    }
+                                )
+                            }
                             DropdownMenuItem(
                                 text = { Text("Open with...") },
                                 leadingIcon = {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/PhoneFilesScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/PhoneFilesScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.Audiotrack
 import androidx.compose.material.icons.filled.Close
@@ -126,6 +127,7 @@ fun PhoneFilesScreen(
     uiState: PhoneFilesUiState,
     onBack: () -> Unit,
     onOpenAllDevices: () -> Unit = {},
+    onAddToCollection: (PhoneMediaItem) -> Unit = {},
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -365,7 +367,13 @@ fun PhoneFilesScreen(
                                     .calculateBottomPadding() + 84.dp
                             ),
                         ) {
-                            items(shown) { media -> PhoneMediaRow(media) { playOrCast(media) } }
+                            items(shown) { media ->
+                                PhoneMediaRow(
+                                    media = media,
+                                    onClick = { playOrCast(media) },
+                                    onAddToCollection = { onAddToCollection(media) },
+                                )
+                            }
                         }
                     }
                 }
@@ -488,12 +496,16 @@ private fun OptionRow(label: String, selected: Boolean, enabled: Boolean = true,
 }
 
 @Composable
-private fun PhoneMediaRow(media: PhoneMediaItem, onClick: () -> Unit) {
+private fun PhoneMediaRow(
+    media: PhoneMediaItem,
+    onClick: () -> Unit,
+    onAddToCollection: () -> Unit = {},
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(start = 16.dp, end = 4.dp, top = 8.dp, bottom = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         MediaThumbnail(media)
@@ -512,6 +524,13 @@ private fun PhoneMediaRow(media: PhoneMediaItem, onClick: () -> Unit) {
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+        }
+        IconButton(onClick = onAddToCollection) {
+            Icon(
+                Icons.AutoMirrored.Filled.PlaylistAdd,
+                contentDescription = "Add to Collection",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.clickable
@@ -42,11 +43,14 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlin.math.abs
 
 /** Live playback status synced from the TV via `status` messages. */
 data class TvPlaybackStatus(
@@ -199,14 +203,16 @@ fun RemoteControlScreen(
                 ) {
                     when (ctx) {
                         RemoteContext.PLAYER -> {
-                            // ── Now Playing: title + live seekbar ──
+                            // ── Now Playing: title only — the seek control lives down in the
+                            //    SeekVolumeBar (swipe ◄► to seek, ▲▼ for volume). ──
                             NowPlayingPanel(
                                 title = mediaTitle,
                                 episodeLabel = episodeLabelFor(currentEpisodeIndex, episodes),
                                 positionMs = positionMs,
                                 durationMs = durationMs,
                                 isLive = isLive,
-                                onSeekTo = onSeekTo
+                                onSeekTo = onSeekTo,
+                                showProgress = false
                             )
 
                             // Native-only: track pickers/settings — hidden for DLNA renderers.
@@ -228,13 +234,17 @@ fun RemoteControlScreen(
                                 modifier = Modifier.weight(1f)
                             )
 
-                            // ── Volume + transport controls ── (volume is native-only for now)
-                            if (!dlnaMode) {
-                                VolumeRow(
-                                    onVolumeUp = { onRemoteKey("volume_up") },
-                                    onVolumeDown = { onRemoteKey("volume_down") }
-                                )
-                            }
+                            // ── Combined seek + volume bar ──
+                            // Swipe left/right to scrub, up/down for volume (volume is native-only).
+                            SeekVolumeBar(
+                                positionMs = positionMs,
+                                durationMs = durationMs,
+                                isLive = isLive,
+                                enableVolume = !dlnaMode,
+                                onSeekTo = onSeekTo,
+                                onVolumeUp = { onRemoteKey("volume_up") },
+                                onVolumeDown = { onRemoteKey("volume_down") }
+                            )
                             // No Back/Home here — Stop already exits playback, so they'd be redundant.
                             MediaControlRow(
                                 isPlaying = playbackState == null || playbackState == "playing" || playbackState == "buffering",
@@ -641,6 +651,139 @@ private fun VolumeRow(
     }
 }
 
+/** Drag-axis lock for the combined seek/volume gesture surface. */
+private enum class DragAxis { HORIZONTAL, VERTICAL }
+
+/**
+ * Combined seek + volume control that sits where the volume rocker used to be (player context).
+ * Swipe **left/right** to scrub the seekbar (absolute seek sent on release); swipe **up/down**
+ * to step the volume. The gesture locks to whichever axis the drag starts on. Seeking needs a
+ * finite duration (disabled for live / unknown-duration streams); volume is gated by
+ * [enableVolume] (native receiver only — DLNA volume isn't wired).
+ */
+@Composable
+private fun SeekVolumeBar(
+    positionMs: Long,
+    durationMs: Long,
+    isLive: Boolean,
+    enableVolume: Boolean,
+    onSeekTo: (Long) -> Unit,
+    onVolumeUp: () -> Unit,
+    onVolumeDown: () -> Unit,
+) {
+    val hasDuration = durationMs > 0L && !isLive
+    val currentPosition by rememberUpdatedState(positionMs)
+
+    var widthPx by remember { mutableStateOf(0f) }
+    var dragging by remember { mutableStateOf(false) }
+    var dragMs by remember { mutableStateOf(0f) }
+    var activeAxis by remember { mutableStateOf<DragAxis?>(null) }
+
+    // Vertical travel required for one volume step.
+    val volumeStepPx = with(LocalDensity.current) { 28.dp.toPx() }
+
+    val displayMs = if (dragging && hasDuration) dragMs else currentPosition.toFloat()
+    val fraction = if (hasDuration && durationMs > 0L)
+        (displayMs / durationMs.toFloat()).coerceIn(0f, 1f) else 0f
+
+    val primary = MaterialTheme.colorScheme.primary
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+            .onSizeChanged { widthPx = it.width.toFloat() }
+            .pointerInput(hasDuration, enableVolume, durationMs) {
+                var axis: DragAxis? = null
+                var volAccum = 0f
+                detectDragGestures(
+                    onDragStart = {
+                        axis = null
+                        volAccum = 0f
+                        dragMs = currentPosition.toFloat()
+                    },
+                    onDrag = { change, drag ->
+                        change.consume()
+                        if (axis == null) {
+                            axis = if (abs(drag.x) >= abs(drag.y)) DragAxis.HORIZONTAL else DragAxis.VERTICAL
+                            activeAxis = axis
+                            if (axis == DragAxis.HORIZONTAL && hasDuration) dragging = true
+                        }
+                        when (axis) {
+                            DragAxis.HORIZONTAL -> if (hasDuration && widthPx > 0f) {
+                                val deltaMs = (drag.x / widthPx) * durationMs.toFloat()
+                                dragMs = (dragMs + deltaMs).coerceIn(0f, durationMs.toFloat())
+                            }
+                            DragAxis.VERTICAL -> if (enableVolume) {
+                                volAccum -= drag.y // swipe up (negative y) raises volume
+                                while (volAccum >= volumeStepPx) { onVolumeUp(); volAccum -= volumeStepPx }
+                                while (volAccum <= -volumeStepPx) { onVolumeDown(); volAccum += volumeStepPx }
+                            }
+                            else -> {}
+                        }
+                    },
+                    onDragEnd = {
+                        if (axis == DragAxis.HORIZONTAL && hasDuration) onSeekTo(dragMs.toLong())
+                        dragging = false
+                        activeAxis = null
+                        axis = null
+                    },
+                    onDragCancel = {
+                        dragging = false
+                        activeAxis = null
+                        axis = null
+                    },
+                )
+            },
+        contentAlignment = Alignment.CenterStart
+    ) {
+        // Progress fill — only meaningful with a finite duration.
+        if (hasDuration) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth(fraction)
+                    .background(primary.copy(alpha = 0.25f))
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = if (hasDuration) formatTime(displayMs.toLong()) else formatTime(currentPosition),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            val centerLabel = when (activeAxis) {
+                DragAxis.VERTICAL -> "Volume"
+                DragAxis.HORIZONTAL -> "Seek"
+                else -> if (enableVolume) "◄ ► seek · ▲ ▼ volume" else "◄ ► seek"
+            }
+            Text(
+                text = centerLabel,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 8.dp)
+            )
+            Text(
+                text = if (isLive) "LIVE" else if (durationMs > 0L) formatTime(durationMs) else "--:--",
+                style = MaterialTheme.typography.labelSmall,
+                color = if (isLive) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
 
 @Composable
 private fun TouchpadArea(
@@ -961,7 +1104,10 @@ private fun NowPlayingPanel(
     positionMs: Long,
     durationMs: Long,
     isLive: Boolean = false,
-    onSeekTo: (Long) -> Unit
+    onSeekTo: (Long) -> Unit,
+    // When false, only the title/episode label show — the seek control is rendered
+    // elsewhere (the SeekVolumeBar in the player context).
+    showProgress: Boolean = true
 ) {
     val hasDuration = durationMs > 0L
     var dragging by remember { mutableStateOf(false) }
@@ -992,34 +1138,36 @@ private fun NowPlayingPanel(
             )
         }
 
-        Slider(
-            value = sliderValue,
-            onValueChange = {
-                dragging = true
-                dragValue = it
-            },
-            onValueChangeFinished = {
-                if (hasDuration) onSeekTo(dragValue.toLong())
-            },
-            valueRange = 0f..(if (hasDuration) durationMs.toFloat() else 1f),
-            enabled = hasDuration,
-            modifier = Modifier.fillMaxWidth()
-        )
+        if (showProgress) {
+            Slider(
+                value = sliderValue,
+                onValueChange = {
+                    dragging = true
+                    dragValue = it
+                },
+                onValueChangeFinished = {
+                    if (hasDuration) onSeekTo(dragValue.toLong())
+                },
+                valueRange = 0f..(if (hasDuration) durationMs.toFloat() else 1f),
+                enabled = hasDuration,
+                modifier = Modifier.fillMaxWidth()
+            )
 
-        Row(modifier = Modifier.fillMaxWidth()) {
-            // Show the real elapsed position even when duration is unknown (DLNA streams that
-            // don't report a total) — sliderValue is clamped to [0,duration] and would pin to 0.
-            Text(
-                text = formatTime(if (dragging) dragValue.toLong() else positionMs),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.weight(1f))
-            Text(
-                text = if (isLive) "LIVE" else if (hasDuration) formatTime(durationMs) else "--:--",
-                style = MaterialTheme.typography.labelSmall,
-                color = if (isLive) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            Row(modifier = Modifier.fillMaxWidth()) {
+                // Show the real elapsed position even when duration is unknown (DLNA streams that
+                // don't report a total) — sliderValue is clamped to [0,duration] and would pin to 0.
+                Text(
+                    text = formatTime(if (dragging) dragValue.toLong() else positionMs),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Text(
+                    text = if (isLive) "LIVE" else if (hasDuration) formatTime(durationMs) else "--:--",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (isLive) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/collection/CollectionDetailScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/collection/CollectionDetailScreen.kt
@@ -1,0 +1,308 @@
+package com.playbridge.sender.collection
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.LiveTv
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.playbridge.sender.connection.ConnectionViewModel
+import com.playbridge.sender.data.collection.CollectionItemEntity
+import com.playbridge.sender.data.collection.CollectionPlayRouter
+import com.playbridge.sender.data.collection.CollectionRoute
+import com.playbridge.sender.data.collection.CollectionSource
+import com.playbridge.sender.data.iptv.decodeHeaders
+import com.playbridge.sender.player.PlayerLauncher
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CollectionDetailScreen(
+    collectionId: Long,
+    viewModel: CollectionsViewModel,
+    connectionViewModel: ConnectionViewModel,
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val snackbar = remember { SnackbarHostState() }
+
+    // Stable per-collection subscription — created once, not rebuilt on every recomposition.
+    val itemsFlow = remember(collectionId) { viewModel.itemsFor(collectionId) }
+    val items by itemsFlow.collectAsState(initial = emptyList())
+    val collection = viewModel.collectionById(collectionId)
+    val title = collection?.name ?: "Collection"
+    var showAddItem by remember { mutableStateOf(false) }
+
+    // Play a single item: cast to the active target, else fall back to the built-in player.
+    fun playItem(item: CollectionItemEntity) {
+        val headers = decodeHeaders(item.headersJson)
+        val casted = when (CollectionPlayRouter.routeOf(item.kind)) {
+            CollectionRoute.LOCAL ->
+                connectionViewModel.castLocalFile(item.url, item.mimeType, item.title)
+            CollectionRoute.WEB ->
+                connectionViewModel.castWebStream(item.url, headers, item.title, item.mimeType)
+        }
+        if (casted) {
+            scope.launch { snackbar.showSnackbar("Casting ${item.title}") }
+        } else {
+            PlayerLauncher.start(
+                context = context,
+                url = item.url,
+                title = item.title,
+                contentType = item.mimeType,
+                headers = headers.ifEmpty { null },
+            )
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbar) },
+        topBar = {
+            TopAppBar(
+                title = { Text(title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showAddItem = true }) {
+                        Icon(Icons.Default.Add, contentDescription = "Add item")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        if (items.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                Text(
+                    "No items yet. Add a URL here, or use \"Add to Collection\" elsewhere.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 32.dp),
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                // Extra bottom padding so the floating now-playing bar doesn't cover the last row.
+                contentPadding = PaddingValues(start = 12.dp, end = 12.dp, top = 8.dp, bottom = 96.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                itemsIndexed(items, key = { _, it -> it.id }) { index, item ->
+                    CollectionItemRow(
+                        item = item,
+                        isFirst = index == 0,
+                        isLast = index == items.lastIndex,
+                        onClick = { playItem(item) },
+                        onRemove = { viewModel.removeItem(item) },
+                        onMoveUp = { viewModel.moveItem(collectionId, item.id, up = true) },
+                        onMoveDown = { viewModel.moveItem(collectionId, item.id, up = false) },
+                    )
+                }
+            }
+        }
+    }
+
+    if (showAddItem) {
+        AddItemDialog(
+            onConfirm = { name, url ->
+                viewModel.addItem(collectionId, manualDraft(name, url)) { added ->
+                    scope.launch {
+                        snackbar.showSnackbar(if (added) "Added" else "Already in this collection")
+                    }
+                }
+                showAddItem = false
+            },
+            onDismiss = { showAddItem = false },
+        )
+    }
+}
+
+@Composable
+private fun CollectionItemRow(
+    item: CollectionItemEntity,
+    isFirst: Boolean,
+    isLast: Boolean,
+    onClick: () -> Unit,
+    onRemove: () -> Unit,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                sourceIcon(item.sourceTag),
+                contentDescription = null,
+                modifier = Modifier.size(22.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(Modifier.size(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                item.title,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                hostOf(item.url),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Icon(
+            Icons.Default.PlayArrow,
+            contentDescription = "Play",
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Box {
+            IconButton(onClick = { menuOpen = true }) {
+                Icon(Icons.Default.MoreVert, contentDescription = "Options")
+            }
+            DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                if (!isFirst) {
+                    DropdownMenuItem(
+                        text = { Text("Move up") },
+                        leadingIcon = { Icon(Icons.Default.ArrowUpward, contentDescription = null) },
+                        onClick = { menuOpen = false; onMoveUp() },
+                    )
+                }
+                if (!isLast) {
+                    DropdownMenuItem(
+                        text = { Text("Move down") },
+                        leadingIcon = { Icon(Icons.Default.ArrowDownward, contentDescription = null) },
+                        onClick = { menuOpen = false; onMoveDown() },
+                    )
+                }
+                DropdownMenuItem(
+                    text = { Text("Remove") },
+                    leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                    onClick = { menuOpen = false; onRemove() },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddItemDialog(
+    onConfirm: (name: String, url: String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var url by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add item") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = url,
+                    onValueChange = { url = it },
+                    label = { Text("Video / stream URL") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name (optional)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = url.isNotBlank(),
+                onClick = { onConfirm(name.trim(), url.trim()) },
+            ) { Text("Add") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+private fun sourceIcon(sourceTag: String?): ImageVector = when (sourceTag) {
+    CollectionSource.IPTV -> Icons.Default.LiveTv
+    CollectionSource.PHONE_FILE -> Icons.Default.Folder
+    CollectionSource.DEBRID -> Icons.Default.Cloud
+    CollectionSource.BROWSER -> Icons.Default.Language
+    CollectionSource.HISTORY -> Icons.Default.History
+    else -> Icons.Default.Link
+}
+
+private fun hostOf(url: String): String = runCatching {
+    android.net.Uri.parse(url).host ?: url
+}.getOrDefault(url)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/collection/CollectionSheets.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/collection/CollectionSheets.kt
@@ -1,0 +1,141 @@
+package com.playbridge.sender.collection
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.playbridge.sender.data.collection.CollectionItemDraft
+import com.playbridge.sender.data.collection.CollectionItemKind
+import com.playbridge.sender.data.collection.CollectionSource
+
+/** Build a manual (typed URL) web item draft. */
+fun manualDraft(name: String, url: String): CollectionItemDraft = CollectionItemDraft(
+    title = name.ifBlank { url },
+    url = url,
+    kind = CollectionItemKind.WEB,
+    sourceTag = CollectionSource.MANUAL,
+)
+
+/**
+ * Reusable "Add to Collection" bottom sheet. Shows existing collections + a "New collection"
+ * row; picking one adds [draft] to it (creating it first if new). Used by entry points across
+ * the app (IPTV, Cast History, Phone Files, …).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddToCollectionSheet(
+    viewModel: CollectionsViewModel,
+    draft: CollectionItemDraft,
+    onDismiss: () -> Unit,
+    onAdded: (collectionName: String, added: Boolean) -> Unit = { _, _ -> },
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val collections by viewModel.collections.collectAsState()
+    var showCreate by remember { mutableStateOf(false) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp)) {
+            Text(
+                "Add to collection",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { showCreate = true }
+                    .padding(vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(Icons.Default.Add, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Spacer(Modifier.size(12.dp))
+                Text("New collection…", style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.primary)
+            }
+
+            LazyColumn(modifier = Modifier.heightIn(max = 360.dp)) {
+                items(collections, key = { it.id }) { collection ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                viewModel.addItem(collection.id, draft) { added ->
+                                    onAdded(collection.name, added)
+                                }
+                                onDismiss()
+                            }
+                            .padding(vertical = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.PlaylistPlay,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(Modifier.size(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                collection.name,
+                                style = MaterialTheme.typography.bodyLarge,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                "${collection.itemCount} item${if (collection.itemCount == 1) "" else "s"}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+        }
+    }
+
+    if (showCreate) {
+        CollectionNameDialog(
+            title = "New collection",
+            initial = "",
+            confirmLabel = "Create & add",
+            onConfirm = { name ->
+                viewModel.createCollection(name) { id ->
+                    viewModel.addItem(id, draft)
+                }
+                showCreate = false
+                onAdded(name, true) // brand-new collection — always added
+                onDismiss()
+            },
+            onDismiss = { showCreate = false },
+        )
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/collection/CollectionsScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/collection/CollectionsScreen.kt
@@ -1,0 +1,282 @@
+package com.playbridge.sender.collection
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.playbridge.sender.data.collection.CollectionEntity
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CollectionsScreen(
+    viewModel: CollectionsViewModel,
+    onBack: () -> Unit,
+    onOpenCollection: (Long) -> Unit,
+) {
+    val collections by viewModel.collections.collectAsState()
+    var showCreate by remember { mutableStateOf(false) }
+    var renameTarget by remember { mutableStateOf<CollectionEntity?>(null) }
+    var deleteTarget by remember { mutableStateOf<CollectionEntity?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Collections") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showCreate = true }) {
+                        Icon(Icons.Default.Add, contentDescription = "New collection")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        if (collections.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.PlaylistPlay,
+                        contentDescription = null,
+                        modifier = Modifier.size(56.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Text("No collections yet", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        "Create a collection, then add videos to it from anywhere.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(20.dp))
+                    Button(onClick = { showCreate = true }) {
+                        Icon(Icons.Default.Add, contentDescription = null)
+                        Spacer(Modifier.size(8.dp))
+                        Text("New collection")
+                    }
+                }
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                // Extra bottom padding so the floating now-playing bar doesn't cover the last card.
+                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 96.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                items(collections, key = { it.id }) { collection ->
+                    CollectionCard(
+                        collection = collection,
+                        onClick = { onOpenCollection(collection.id) },
+                        onRename = { renameTarget = collection },
+                        onDelete = { deleteTarget = collection },
+                    )
+                }
+            }
+        }
+    }
+
+    if (showCreate) {
+        CollectionNameDialog(
+            title = "New collection",
+            initial = "",
+            confirmLabel = "Create",
+            onConfirm = { name ->
+                viewModel.createCollection(name)
+                showCreate = false
+            },
+            onDismiss = { showCreate = false },
+        )
+    }
+
+    renameTarget?.let { target ->
+        CollectionNameDialog(
+            title = "Rename collection",
+            initial = target.name,
+            confirmLabel = "Save",
+            onConfirm = { name ->
+                viewModel.renameCollection(target.id, name)
+                renameTarget = null
+            },
+            onDismiss = { renameTarget = null },
+        )
+    }
+
+    deleteTarget?.let { target ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text("Delete collection?") },
+            text = { Text("\"${target.name}\" and its ${target.itemCount} item(s) will be removed.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteCollection(target.id)
+                    deleteTarget = null
+                }) { Text("Delete", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = { TextButton(onClick = { deleteTarget = null }) { Text("Cancel") } },
+        )
+    }
+}
+
+@Composable
+private fun CollectionCard(
+    collection: CollectionEntity,
+    onClick: () -> Unit,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(start = 16.dp, top = 14.dp, bottom = 14.dp, end = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.AutoMirrored.Filled.PlaylistPlay,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+            Spacer(Modifier.size(14.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    collection.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    "${collection.itemCount} item${if (collection.itemCount == 1) "" else "s"} · updated ${collectionRelativeTime(collection.updatedAt)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Box {
+                IconButton(onClick = { menuOpen = true }) {
+                    Icon(Icons.Default.MoreVert, contentDescription = "Options")
+                }
+                DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                    DropdownMenuItem(
+                        text = { Text("Rename") },
+                        leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
+                        onClick = { menuOpen = false; onRename() },
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Delete") },
+                        leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                        onClick = { menuOpen = false; onDelete() },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun CollectionNameDialog(
+    title: String,
+    initial: String,
+    confirmLabel: String,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf(initial) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Name") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            TextButton(
+                enabled = name.isNotBlank(),
+                onClick = { onConfirm(name.trim()) },
+            ) { Text(confirmLabel) }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+internal fun collectionRelativeTime(epochMs: Long): String {
+    val diff = System.currentTimeMillis() - epochMs
+    if (diff < 0) return "just now"
+    val mins = diff / 60_000
+    val hours = diff / 3_600_000
+    val days = diff / 86_400_000
+    return when {
+        mins < 1 -> "just now"
+        mins < 60 -> "${mins}m ago"
+        hours < 24 -> "${hours}h ago"
+        days < 7 -> "${days}d ago"
+        else -> "${days / 7}w ago"
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/collection/CollectionsViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/collection/CollectionsViewModel.kt
@@ -1,0 +1,53 @@
+package com.playbridge.sender.collection
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.playbridge.sender.data.collection.CollectionEntity
+import com.playbridge.sender.data.collection.CollectionItemDraft
+import com.playbridge.sender.data.collection.CollectionItemEntity
+import com.playbridge.sender.data.collection.CollectionsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class CollectionsViewModel(
+    private val repository: CollectionsRepository,
+) : ViewModel() {
+
+    val collections: StateFlow<List<CollectionEntity>> =
+        repository.observeCollections()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    fun itemsFor(collectionId: Long): Flow<List<CollectionItemEntity>> =
+        repository.observeItems(collectionId)
+
+    fun collectionById(id: Long): CollectionEntity? = collections.value.find { it.id == id }
+
+    fun createCollection(name: String, onCreated: (Long) -> Unit = {}) = viewModelScope.launch {
+        onCreated(repository.createCollection(name))
+    }
+
+    fun renameCollection(id: Long, name: String) = viewModelScope.launch {
+        repository.renameCollection(id, name)
+    }
+
+    fun deleteCollection(id: Long) = viewModelScope.launch { repository.deleteCollection(id) }
+
+    fun addItem(
+        collectionId: Long,
+        draft: CollectionItemDraft,
+        onResult: (added: Boolean) -> Unit = {},
+    ) = viewModelScope.launch {
+        onResult(repository.addItem(collectionId, draft))
+    }
+
+    fun removeItem(item: CollectionItemEntity) = viewModelScope.launch {
+        repository.removeItem(item)
+    }
+
+    fun moveItem(collectionId: Long, itemId: Long, up: Boolean) = viewModelScope.launch {
+        repository.moveItem(collectionId, itemId, up)
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
@@ -288,6 +288,34 @@ class ConnectionViewModel(
         return false
     }
 
+    /**
+     * Cast a web stream (e.g. an IPTV channel) with optional request [headers] to the active
+     * target. Prefers an active DLNA renderer (proxy injects headers); otherwise a connected
+     * native receiver. Returns false if no target is available.
+     */
+    fun castWebStream(
+        url: String,
+        headers: Map<String, String> = emptyMap(),
+        title: String? = null,
+        mime: String? = null,
+    ): Boolean {
+        if (castSessionManager.isDlnaActive) {
+            castSessionManager.playOnDlna(
+                MediaItem(url = url, headers = headers, mimeType = mime, title = title)
+            )
+            return true
+        }
+        if (connectionState.value is WebSocketClient.ConnectionState.Connected) {
+            val cmd = createSingleVideoCommandJson(
+                PlayPayload(url = url, title = title ?: "Channel", headers = headers, content_type = mime),
+            )
+            sendCommandAndRecord(cmd, "play", url, title)
+            castSessionManager.notifyNativePlaybackStarted()
+            return true
+        }
+        return false
+    }
+
     fun disconnect() {
         webSocketClient.disconnect()
         // Also disable auto-connect so it doesn't immediately reconnect

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/collection/CollectionDao.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/collection/CollectionDao.kt
@@ -1,0 +1,64 @@
+package com.playbridge.sender.data.collection
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CollectionDao {
+    @Query("SELECT * FROM collections ORDER BY addedAt DESC")
+    fun observeAll(): Flow<List<CollectionEntity>>
+
+    @Query("SELECT * FROM collections WHERE id = :id")
+    suspend fun getById(id: Long): CollectionEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(item: CollectionEntity): Long
+
+    @Update
+    suspend fun update(item: CollectionEntity)
+
+    @Query("DELETE FROM collections WHERE id = :id")
+    suspend fun deleteById(id: Long)
+
+    @Query("UPDATE collections SET name = :name, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun rename(id: Long, name: String, updatedAt: Long)
+
+    @Query("UPDATE collections SET itemCount = :count, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun markChanged(id: Long, count: Int, updatedAt: Long)
+}
+
+@Dao
+interface CollectionItemDao {
+    @Query("SELECT * FROM collection_items WHERE collectionId = :collectionId ORDER BY orderIndex ASC")
+    fun observeForCollection(collectionId: Long): Flow<List<CollectionItemEntity>>
+
+    @Query("SELECT * FROM collection_items WHERE collectionId = :collectionId ORDER BY orderIndex ASC")
+    suspend fun getForCollection(collectionId: Long): List<CollectionItemEntity>
+
+    @Query("SELECT COUNT(*) FROM collection_items WHERE collectionId = :collectionId")
+    suspend fun countFor(collectionId: Long): Int
+
+    @Query("SELECT COALESCE(MAX(orderIndex), -1) FROM collection_items WHERE collectionId = :collectionId")
+    suspend fun maxOrderIndex(collectionId: Long): Int
+
+    /** A collection is a set keyed by URL — used to skip duplicates on add. */
+    @Query("SELECT * FROM collection_items WHERE collectionId = :collectionId AND url = :url LIMIT 1")
+    suspend fun findByUrl(collectionId: Long, url: String): CollectionItemEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(item: CollectionItemEntity): Long
+
+    @Update
+    suspend fun update(item: CollectionItemEntity)
+
+    @Update
+    suspend fun updateAll(items: List<CollectionItemEntity>)
+
+    @Query("DELETE FROM collection_items WHERE id = :id")
+    suspend fun deleteById(id: Long)
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/collection/CollectionEntities.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/collection/CollectionEntities.kt
@@ -1,0 +1,63 @@
+package com.playbridge.sender.data.collection
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/** Playback kind for a collection item. Stored as the entity's `kind` string. */
+object CollectionItemKind {
+    const val WEB = "WEB"     // http(s) stream (optional headers)
+    const val LOCAL = "LOCAL" // content:// file URI
+}
+
+/** Where an item was curated from (drives the row icon + analytics). */
+object CollectionSource {
+    const val MANUAL = "manual"
+    const val IPTV = "iptv"
+    const val PHONE_FILE = "phone_file"
+    const val DEBRID = "debrid"
+    const val BROWSER = "browser"
+    const val HISTORY = "history"
+}
+
+/**
+ * A user-curated, ordered playlist of concrete playable items ([CollectionItemEntity]).
+ * Distinct from the TMDB watchlist (Library) and from IPTV sources — items here store
+ * everything needed to play directly. See COLLECTIONS_PLAN.md.
+ */
+@Entity(tableName = "collections")
+data class CollectionEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name: String,
+    val addedAt: Long = System.currentTimeMillis(),
+    val updatedAt: Long = System.currentTimeMillis(),
+    val itemCount: Int = 0,
+)
+
+@Entity(
+    tableName = "collection_items",
+    foreignKeys = [
+        ForeignKey(
+            entity = CollectionEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["collectionId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("collectionId")],
+)
+data class CollectionItemEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val collectionId: Long,
+    val title: String,
+    val url: String,
+    val kind: String = CollectionItemKind.WEB,
+    val mimeType: String? = null,
+    /** JSON map of request headers (Referer / User-Agent) for headered web streams. */
+    val headersJson: String? = null,
+    val logo: String? = null,
+    val sourceTag: String? = null,
+    val orderIndex: Int = 0,
+    val addedAt: Long = System.currentTimeMillis(),
+)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/collection/CollectionPlayRouter.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/collection/CollectionPlayRouter.kt
@@ -1,0 +1,13 @@
+package com.playbridge.sender.data.collection
+
+/** Which playback path a collection item takes. */
+enum class CollectionRoute { WEB, LOCAL }
+
+/**
+ * Pure mapping from an item's [CollectionItemEntity.kind] to the playback route. Kept Android-free
+ * so it can be unit-tested; the screen turns the route into the actual cast/local-player call.
+ */
+object CollectionPlayRouter {
+    fun routeOf(kind: String?): CollectionRoute =
+        if (kind == CollectionItemKind.LOCAL) CollectionRoute.LOCAL else CollectionRoute.WEB
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/collection/CollectionsRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/collection/CollectionsRepository.kt
@@ -1,0 +1,89 @@
+package com.playbridge.sender.data.collection
+
+import com.playbridge.sender.data.iptv.encodeHeaders
+
+/** Everything needed to add one playable item to a collection (built at each call site). */
+data class CollectionItemDraft(
+    val title: String,
+    val url: String,
+    val kind: String = CollectionItemKind.WEB,
+    val mimeType: String? = null,
+    val headers: Map<String, String> = emptyMap(),
+    val logo: String? = null,
+    val sourceTag: String? = CollectionSource.MANUAL,
+)
+
+/**
+ * Owns collection storage: create/rename/delete collections and add/remove/reorder their items.
+ * See COLLECTIONS_PLAN.md §7. Koin singleton.
+ */
+class CollectionsRepository(
+    private val collectionDao: CollectionDao,
+    private val itemDao: CollectionItemDao,
+) {
+    fun observeCollections() = collectionDao.observeAll()
+    fun observeItems(collectionId: Long) = itemDao.observeForCollection(collectionId)
+    suspend fun getCollection(id: Long) = collectionDao.getById(id)
+
+    suspend fun createCollection(name: String): Long {
+        val now = System.currentTimeMillis()
+        return collectionDao.insert(CollectionEntity(name = name.trim(), addedAt = now, updatedAt = now))
+    }
+
+    suspend fun renameCollection(id: Long, name: String) =
+        collectionDao.rename(id, name.trim(), System.currentTimeMillis())
+
+    suspend fun deleteCollection(id: Long) = collectionDao.deleteById(id)
+
+    /**
+     * Add [draft] to a collection. A collection is treated as a **set keyed by URL**: if the
+     * same URL is already present, nothing is inserted. Returns true if added, false if it was
+     * already there.
+     */
+    suspend fun addItem(collectionId: Long, draft: CollectionItemDraft): Boolean {
+        val url = draft.url.trim()
+        if (itemDao.findByUrl(collectionId, url) != null) return false
+        val nextIndex = itemDao.maxOrderIndex(collectionId) + 1
+        itemDao.insert(
+            CollectionItemEntity(
+                collectionId = collectionId,
+                title = draft.title.trim().ifBlank { url },
+                url = url,
+                kind = draft.kind,
+                mimeType = draft.mimeType,
+                headersJson = encodeHeaders(draft.headers),
+                logo = draft.logo,
+                sourceTag = draft.sourceTag,
+                orderIndex = nextIndex,
+            ),
+        )
+        touch(collectionId)
+        return true
+    }
+
+    suspend fun removeItem(item: CollectionItemEntity) {
+        itemDao.deleteById(item.id)
+        touch(item.collectionId)
+    }
+
+    /** Move an item one slot up or down by swapping orderIndex with its neighbour. */
+    suspend fun moveItem(collectionId: Long, itemId: Long, up: Boolean) {
+        val items = itemDao.getForCollection(collectionId)
+        val index = items.indexOfFirst { it.id == itemId }
+        if (index < 0) return
+        val swapWith = if (up) index - 1 else index + 1
+        if (swapWith !in items.indices) return
+        val a = items[index]
+        val b = items[swapWith]
+        // Swap their order positions.
+        itemDao.updateAll(
+            listOf(a.copy(orderIndex = b.orderIndex), b.copy(orderIndex = a.orderIndex)),
+        )
+        collectionDao.markChanged(collectionId, items.size, System.currentTimeMillis())
+    }
+
+    private suspend fun touch(collectionId: Long) {
+        val count = itemDao.countFor(collectionId)
+        collectionDao.markChanged(collectionId, count, System.currentTimeMillis())
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/history/DatabaseProvider.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/history/DatabaseProvider.kt
@@ -113,6 +113,69 @@ object DatabaseProvider {
         }
     }
 
+    private val MIGRATION_17_18 = object : Migration(17, 18) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            // IPTV playlists + their cached channels (IPTV_PLAN.md §2).
+            db.execSQL(
+                "CREATE TABLE IF NOT EXISTS `iptv_playlists` (" +
+                    "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                    "`name` TEXT NOT NULL, " +
+                    "`source` TEXT NOT NULL, " +
+                    "`sourceType` TEXT NOT NULL, " +
+                    "`addedAt` INTEGER NOT NULL, " +
+                    "`updatedAt` INTEGER NOT NULL, " +
+                    "`channelCount` INTEGER NOT NULL)"
+            )
+            db.execSQL(
+                "CREATE TABLE IF NOT EXISTS `iptv_channels` (" +
+                    "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                    "`playlistId` INTEGER NOT NULL, " +
+                    "`name` TEXT NOT NULL, " +
+                    "`url` TEXT NOT NULL, " +
+                    "`logo` TEXT, " +
+                    "`groupTitle` TEXT, " +
+                    "`tvgId` TEXT, " +
+                    "`orderIndex` INTEGER NOT NULL, " +
+                    "`headersJson` TEXT, " +
+                    "`probeStatus` TEXT NOT NULL, " +
+                    "`probeLatencyMs` INTEGER, " +
+                    "`probedAt` INTEGER, " +
+                    "FOREIGN KEY(`playlistId`) REFERENCES `iptv_playlists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_iptv_channels_playlistId` ON `iptv_channels` (`playlistId`)")
+        }
+    }
+
+    private val MIGRATION_18_19 = object : Migration(18, 19) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            // User-curated collections + their ordered items (COLLECTIONS_PLAN.md §2).
+            db.execSQL(
+                "CREATE TABLE IF NOT EXISTS `collections` (" +
+                    "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                    "`name` TEXT NOT NULL, " +
+                    "`addedAt` INTEGER NOT NULL, " +
+                    "`updatedAt` INTEGER NOT NULL, " +
+                    "`itemCount` INTEGER NOT NULL)"
+            )
+            db.execSQL(
+                "CREATE TABLE IF NOT EXISTS `collection_items` (" +
+                    "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                    "`collectionId` INTEGER NOT NULL, " +
+                    "`title` TEXT NOT NULL, " +
+                    "`url` TEXT NOT NULL, " +
+                    "`kind` TEXT NOT NULL, " +
+                    "`mimeType` TEXT, " +
+                    "`headersJson` TEXT, " +
+                    "`logo` TEXT, " +
+                    "`sourceTag` TEXT, " +
+                    "`orderIndex` INTEGER NOT NULL, " +
+                    "`addedAt` INTEGER NOT NULL, " +
+                    "FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_collection_items_collectionId` ON `collection_items` (`collectionId`)")
+        }
+    }
+
     @Volatile
     private var INSTANCE: HistoryDatabase? = null
 
@@ -123,7 +186,7 @@ object DatabaseProvider {
                 HistoryDatabase::class.java,
                 "history_database"
             )
-            .addMigrations(MIGRATION_4_5, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17)
+            .addMigrations(MIGRATION_4_5, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19)
             .fallbackToDestructiveMigration()
             .build()
             INSTANCE = instance

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/history/HistoryDatabase.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/history/HistoryDatabase.kt
@@ -2,6 +2,14 @@ package com.playbridge.sender.data.history
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import com.playbridge.sender.data.collection.CollectionDao
+import com.playbridge.sender.data.collection.CollectionEntity
+import com.playbridge.sender.data.collection.CollectionItemDao
+import com.playbridge.sender.data.collection.CollectionItemEntity
+import com.playbridge.sender.data.iptv.IptvChannelDao
+import com.playbridge.sender.data.iptv.IptvChannelEntity
+import com.playbridge.sender.data.iptv.IptvPlaylistDao
+import com.playbridge.sender.data.iptv.IptvPlaylistEntity
 import com.playbridge.sender.data.library.AddonDao
 import com.playbridge.sender.data.library.InstalledAddonEntity
 import com.playbridge.sender.data.library.PlaybackResumeDao
@@ -10,8 +18,8 @@ import com.playbridge.sender.data.library.WatchlistDao
 import com.playbridge.sender.data.library.WatchlistEntity
 
 @Database(
-    entities = [HistoryEntity::class, BookmarkEntity::class, TabEntity::class, InstalledAddonEntity::class, CommandHistoryEntity::class, WatchlistEntity::class, SearchHistoryEntity::class, PlaybackResumeEntity::class],
-    version = 17
+    entities = [HistoryEntity::class, BookmarkEntity::class, TabEntity::class, InstalledAddonEntity::class, CommandHistoryEntity::class, WatchlistEntity::class, SearchHistoryEntity::class, PlaybackResumeEntity::class, IptvPlaylistEntity::class, IptvChannelEntity::class, CollectionEntity::class, CollectionItemEntity::class],
+    version = 19
 )
 abstract class HistoryDatabase : RoomDatabase() {
     abstract fun historyDao(): HistoryDao
@@ -22,4 +30,8 @@ abstract class HistoryDatabase : RoomDatabase() {
     abstract fun watchlistDao(): WatchlistDao
     abstract fun searchHistoryDao(): SearchHistoryDao
     abstract fun playbackResumeDao(): PlaybackResumeDao
+    abstract fun iptvPlaylistDao(): IptvPlaylistDao
+    abstract fun iptvChannelDao(): IptvChannelDao
+    abstract fun collectionDao(): CollectionDao
+    abstract fun collectionItemDao(): CollectionItemDao
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvDao.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvDao.kt
@@ -1,0 +1,62 @@
+package com.playbridge.sender.data.iptv
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface IptvPlaylistDao {
+    @Query("SELECT * FROM iptv_playlists ORDER BY addedAt DESC")
+    fun observeAll(): Flow<List<IptvPlaylistEntity>>
+
+    @Query("SELECT * FROM iptv_playlists WHERE id = :id")
+    suspend fun getById(id: Long): IptvPlaylistEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(item: IptvPlaylistEntity): Long
+
+    @Update
+    suspend fun update(item: IptvPlaylistEntity)
+
+    @Delete
+    suspend fun delete(item: IptvPlaylistEntity)
+
+    @Query("DELETE FROM iptv_playlists WHERE id = :id")
+    suspend fun deleteById(id: Long)
+
+    @Query("UPDATE iptv_playlists SET updatedAt = :updatedAt, channelCount = :count WHERE id = :id")
+    suspend fun markRefreshed(id: Long, updatedAt: Long, count: Int)
+}
+
+@Dao
+interface IptvChannelDao {
+    @Query("SELECT * FROM iptv_channels WHERE playlistId = :playlistId ORDER BY orderIndex ASC")
+    fun observeForPlaylist(playlistId: Long): Flow<List<IptvChannelEntity>>
+
+    @Query("SELECT * FROM iptv_channels WHERE playlistId = :playlistId ORDER BY orderIndex ASC")
+    suspend fun getForPlaylist(playlistId: Long): List<IptvChannelEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(items: List<IptvChannelEntity>)
+
+    @Query("DELETE FROM iptv_channels WHERE playlistId = :playlistId")
+    suspend fun deleteForPlaylist(playlistId: Long)
+
+    @Query(
+        "UPDATE iptv_channels SET probeStatus = :status, probeLatencyMs = :latencyMs, " +
+            "probedAt = :probedAt WHERE id = :id",
+    )
+    suspend fun updateProbe(id: Long, status: String, latencyMs: Int?, probedAt: Long)
+
+    /** Atomically replace the cached channels for a playlist. */
+    @Transaction
+    suspend fun replaceForPlaylist(playlistId: Long, items: List<IptvChannelEntity>) {
+        deleteForPlaylist(playlistId)
+        insertAll(items)
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvEntities.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvEntities.kt
@@ -1,0 +1,69 @@
+package com.playbridge.sender.data.iptv
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/** Source kind for an IPTV playlist. Stored as the entity's `sourceType` string. */
+object IptvSourceType {
+    const val URL = "URL"
+    const val FILE = "FILE"
+}
+
+/** Result of a channel reachability probe. Stored as the entity's `probeStatus` string. */
+object IptvProbeStatus {
+    const val UNKNOWN = "UNKNOWN"
+    const val ACTIVE = "ACTIVE"
+    const val DEAD = "DEAD"
+}
+
+/**
+ * A user-added IPTV (M3U/M3U8) playlist. The actual channels are cached separately in
+ * [IptvChannelEntity] so reopening the playlist is instant; "Update" re-parses [source].
+ *
+ * [source] is either an `http(s)://` URL (when [sourceType] == [IptvSourceType.URL]) or a
+ * persisted `content://` document URI (when [sourceType] == [IptvSourceType.FILE]).
+ */
+@Entity(tableName = "iptv_playlists")
+data class IptvPlaylistEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name: String,
+    val source: String,
+    val sourceType: String,
+    val addedAt: Long = System.currentTimeMillis(),
+    val updatedAt: Long = System.currentTimeMillis(),
+    val channelCount: Int = 0,
+)
+
+/**
+ * A single cached channel belonging to a playlist. Populated by the M3U parser; the probe
+ * columns are filled in lazily by the reachability probe (see IptvRepository.probe).
+ */
+@Entity(
+    tableName = "iptv_channels",
+    foreignKeys = [
+        ForeignKey(
+            entity = IptvPlaylistEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["playlistId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("playlistId")],
+)
+data class IptvChannelEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val playlistId: Long,
+    val name: String,
+    val url: String,
+    val logo: String? = null,
+    val groupTitle: String? = null,
+    val tvgId: String? = null,
+    val orderIndex: Int = 0,
+    /** JSON map of request headers (Referer / User-Agent) extracted from the playlist. */
+    val headersJson: String? = null,
+    val probeStatus: String = IptvProbeStatus.UNKNOWN,
+    val probeLatencyMs: Int? = null,
+    val probedAt: Long? = null,
+)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvRepository.kt
@@ -1,0 +1,181 @@
+package com.playbridge.sender.data.iptv
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import com.playbridge.shared.player.IptvChannel
+import com.playbridge.shared.player.M3uParser
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+
+/**
+ * Owns IPTV playlist storage: add/edit/delete, (re)parse + cache channels, and probe
+ * channel reachability. See IPTV_PLAN.md §4 / §6. Koin singleton.
+ */
+class IptvRepository(
+    private val context: Context,
+    private val playlistDao: IptvPlaylistDao,
+    private val channelDao: IptvChannelDao,
+    httpClient: OkHttpClient,
+) {
+    companion object {
+        private const val TAG = "IptvRepository"
+        private const val PROBE_CONCURRENCY = 8
+        private const val PROBE_TIMEOUT_SEC = 6L
+        /** Don't re-probe channels checked more recently than this unless forced. */
+        const val PROBE_FRESHNESS_MS = 30 * 60 * 1000L
+    }
+
+    // Short-timeout client dedicated to probes so a stalled channel can't hang the pool.
+    private val probeClient: OkHttpClient = httpClient.newBuilder()
+        .connectTimeout(PROBE_TIMEOUT_SEC, TimeUnit.SECONDS)
+        .readTimeout(PROBE_TIMEOUT_SEC, TimeUnit.SECONDS)
+        .build()
+
+    fun observePlaylists() = playlistDao.observeAll()
+    fun observeChannels(playlistId: Long) = channelDao.observeForPlaylist(playlistId)
+
+    /** Add a playlist and immediately parse + cache its channels. Returns the new id. */
+    suspend fun addPlaylist(name: String, source: String, sourceType: String): Long {
+        val now = System.currentTimeMillis()
+        val id = playlistDao.insert(
+            IptvPlaylistEntity(
+                name = name.trim(),
+                source = source.trim(),
+                sourceType = sourceType,
+                addedAt = now,
+                updatedAt = now,
+                channelCount = 0,
+            ),
+        )
+        runCatching { refresh(id) }
+            .onFailure { Log.w(TAG, "Initial parse failed for playlist $id", it) }
+        return id
+    }
+
+    suspend fun editPlaylist(id: Long, name: String, source: String, sourceType: String) {
+        val existing = playlistDao.getById(id) ?: return
+        val sourceChanged = existing.source != source.trim() || existing.sourceType != sourceType
+        playlistDao.update(
+            existing.copy(name = name.trim(), source = source.trim(), sourceType = sourceType),
+        )
+        if (sourceChanged) runCatching { refresh(id) }
+    }
+
+    suspend fun deletePlaylist(playlist: IptvPlaylistEntity) = playlistDao.delete(playlist)
+
+    /** Re-read the source, re-parse, and atomically replace cached channels. */
+    suspend fun refresh(id: Long) {
+        val playlist = playlistDao.getById(id) ?: return
+        val channels = parseSource(playlist) ?: emptyList()
+        val entities = channels.map { it.toEntity(id) }
+        channelDao.replaceForPlaylist(id, entities)
+        playlistDao.markRefreshed(id, System.currentTimeMillis(), entities.size)
+    }
+
+    private suspend fun parseSource(playlist: IptvPlaylistEntity): List<IptvChannel>? =
+        when (playlist.sourceType) {
+            IptvSourceType.URL -> M3uParser.fetchChannels(playlist.source, null)
+            IptvSourceType.FILE -> withContext(Dispatchers.IO) {
+                runCatching {
+                    context.contentResolver.openInputStream(Uri.parse(playlist.source))
+                        ?.bufferedReader()?.use { it.readText() }
+                }.getOrNull()?.let { M3uParser.parseM3uText(it) }
+            }
+            else -> null
+        }
+
+    /**
+     * Probe each channel's URL for reachability and record status + latency. Bounded
+     * concurrency; cancellable; skips channels probed within [PROBE_FRESHNESS_MS] unless
+     * [force]. [onProgress] receives (done, total).
+     */
+    suspend fun probe(
+        playlistId: Long,
+        force: Boolean = false,
+        onProgress: (done: Int, total: Int) -> Unit = { _, _ -> },
+    ) {
+        val all = channelDao.getForPlaylist(playlistId)
+        val now = System.currentTimeMillis()
+        val toProbe = if (force) all else all.filter {
+            it.probedAt == null || now - it.probedAt > PROBE_FRESHNESS_MS
+        }
+        val total = toProbe.size
+        if (total == 0) {
+            onProgress(0, 0)
+            return
+        }
+        val semaphore = Semaphore(PROBE_CONCURRENCY)
+        var done = 0
+        coroutineScope {
+            toProbe.forEach { channel ->
+                launch {
+                    semaphore.withPermit {
+                        val result = probeOne(channel)
+                        channelDao.updateProbe(
+                            channel.id, result.first, result.second, System.currentTimeMillis(),
+                        )
+                    }
+                    synchronized(semaphore) { done++; onProgress(done, total) }
+                }
+            }
+        }
+    }
+
+    /** @return (status, latencyMs?) for one channel. */
+    private suspend fun probeOne(channel: IptvChannelEntity): Pair<String, Int?> =
+        withContext(Dispatchers.IO) {
+            val headers = decodeHeaders(channel.headersJson)
+            val builder = Request.Builder()
+                .url(channel.url)
+                .header("Range", "bytes=0-0")
+            headers.forEach { (k, v) -> builder.header(k, v) }
+            val start = System.currentTimeMillis()
+            try {
+                probeClient.newCall(builder.get().build()).execute().use { resp ->
+                    val latency = (System.currentTimeMillis() - start).toInt()
+                    // 2xx and 206 (partial) are good; 3xx are auto-followed.
+                    if (resp.isSuccessful || resp.code == 206) {
+                        IptvProbeStatus.ACTIVE to latency
+                    } else {
+                        IptvProbeStatus.DEAD to null
+                    }
+                }
+            } catch (e: Exception) {
+                IptvProbeStatus.DEAD to null
+            }
+        }
+}
+
+private fun IptvChannel.toEntity(playlistId: Long) = IptvChannelEntity(
+    playlistId = playlistId,
+    name = name,
+    url = url,
+    logo = logo,
+    groupTitle = groupTitle,
+    tvgId = tvgId,
+    orderIndex = order,
+    headersJson = encodeHeaders(headers),
+)
+
+private val headerSerializer = MapSerializer(String.serializer(), String.serializer())
+
+internal fun encodeHeaders(headers: Map<String, String>): String? {
+    if (headers.isEmpty()) return null
+    return Json.encodeToString(headerSerializer, headers)
+}
+
+internal fun decodeHeaders(json: String?): Map<String, String> {
+    if (json.isNullOrBlank()) return emptyMap()
+    return runCatching { Json.decodeFromString(headerSerializer, json) }.getOrDefault(emptyMap())
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvSortRules.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvSortRules.kt
@@ -1,0 +1,50 @@
+package com.playbridge.sender.data.iptv
+
+/** How the playlist list is ordered. Persisted in settings. */
+enum class IptvPlaylistSort { ADDED_DATE, NAME }
+
+/** Pure, unit-tested ordering rules for IPTV playlists and channels. */
+object IptvSortRules {
+
+    /** Sort playlists by the chosen key + direction. */
+    fun sortPlaylists(
+        playlists: List<IptvPlaylistEntity>,
+        sort: IptvPlaylistSort,
+        ascending: Boolean,
+    ): List<IptvPlaylistEntity> {
+        val base = when (sort) {
+            IptvPlaylistSort.ADDED_DATE -> playlists.sortedBy { it.addedAt }
+            IptvPlaylistSort.NAME -> playlists.sortedBy { it.name.lowercase() }
+        }
+        return if (ascending) base else base.reversed()
+    }
+
+    /**
+     * Rank a channel for "active first" ordering: lower sorts earlier.
+     * ACTIVE (0) → UNKNOWN (1) → DEAD (2). Within ACTIVE, faster probes win.
+     */
+    fun channelRank(channel: IptvChannelEntity): Int = when (channel.probeStatus) {
+        IptvProbeStatus.ACTIVE -> 0
+        IptvProbeStatus.DEAD -> 2
+        else -> 1
+    }
+
+    /**
+     * Order channels so live (ACTIVE) ones float to the top, faster first; DEAD sink to the
+     * bottom; original order is preserved as the final tiebreak. When [activeFirst] is false,
+     * channels keep their original playlist order.
+     */
+    fun sortChannels(
+        channels: List<IptvChannelEntity>,
+        activeFirst: Boolean,
+    ): List<IptvChannelEntity> {
+        if (!activeFirst) return channels.sortedBy { it.orderIndex }
+        return channels.sortedWith(
+            compareBy(
+                { channelRank(it) },
+                { it.probeLatencyMs ?: Int.MAX_VALUE },
+                { it.orderIndex },
+            ),
+        )
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/settings/SettingsRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/settings/SettingsRepository.kt
@@ -29,6 +29,9 @@ class SettingsRepository(
         val BLOCK_POPUPS = booleanPreferencesKey("block_popups")
         val POPUP_WHITELIST = stringSetPreferencesKey("popup_whitelist")
         val POPUP_BLACKLIST = stringSetPreferencesKey("popup_blacklist")
+        val IPTV_SORT = stringPreferencesKey("iptv_sort")           // "ADDED_DATE" | "NAME"
+        val IPTV_SORT_ASCENDING = booleanPreferencesKey("iptv_sort_ascending")
+        val IPTV_ACTIVE_FIRST = booleanPreferencesKey("iptv_active_first")
     }
 
     // 2. Flow definitions for reactive Compose collectors
@@ -49,6 +52,11 @@ class SettingsRepository(
     val blockPopups: Flow<Boolean> = dataStore.data.catch { handleException(it) }.map { it[Keys.BLOCK_POPUPS] ?: true }
     val popupWhitelist: Flow<Set<String>> = dataStore.data.catch { handleException(it) }.map { it[Keys.POPUP_WHITELIST] ?: emptySet() }
     val popupBlacklist: Flow<Set<String>> = dataStore.data.catch { handleException(it) }.map { it[Keys.POPUP_BLACKLIST] ?: emptySet() }
+    /** IPTV playlist sort key: "ADDED_DATE" (default) or "NAME". */
+    val iptvSort: Flow<String> = dataStore.data.catch { handleException(it) }.map { it[Keys.IPTV_SORT] ?: "ADDED_DATE" }
+    val iptvSortAscending: Flow<Boolean> = dataStore.data.catch { handleException(it) }.map { it[Keys.IPTV_SORT_ASCENDING] ?: false }
+    /** When exploring a playlist, float probe-confirmed live channels to the top. */
+    val iptvActiveFirst: Flow<Boolean> = dataStore.data.catch { handleException(it) }.map { it[Keys.IPTV_ACTIVE_FIRST] ?: true }
 
     // 3. Mutator methods
     suspend fun setAutoSwitchToRemote(value: Boolean) = write { it[Keys.AUTO_SWITCH_TO_REMOTE] = value }
@@ -63,6 +71,9 @@ class SettingsRepository(
     suspend fun setTrackWatchProgress(value: Boolean) = write { it[Keys.TRACK_WATCH_PROGRESS] = value }
     suspend fun setAutoAddToWatching(value: Boolean) = write { it[Keys.AUTO_ADD_TO_WATCHING] = value }
     suspend fun setBlockPopups(value: Boolean) = write { it[Keys.BLOCK_POPUPS] = value }
+    suspend fun setIptvSort(value: String) = write { it[Keys.IPTV_SORT] = value }
+    suspend fun setIptvSortAscending(value: Boolean) = write { it[Keys.IPTV_SORT_ASCENDING] = value }
+    suspend fun setIptvActiveFirst(value: Boolean) = write { it[Keys.IPTV_ACTIVE_FIRST] = value }
     
     suspend fun addPopupWhitelist(host: String) = write { prefs ->
         val current = prefs[Keys.POPUP_WHITELIST] ?: emptySet()

--- a/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
@@ -47,6 +47,10 @@ val appModule = module {
     single { get<HistoryDatabase>().playbackResumeDao() }
     single { get<HistoryDatabase>().commandHistoryDao() }
     single { get<HistoryDatabase>().tabDao() }
+    single { get<HistoryDatabase>().iptvPlaylistDao() }
+    single { get<HistoryDatabase>().iptvChannelDao() }
+    single { get<HistoryDatabase>().collectionDao() }
+    single { get<HistoryDatabase>().collectionItemDao() }
 
     // 3. Core Repositories & Services
     single {
@@ -72,6 +76,20 @@ val appModule = module {
         DebridRepository(
             context = androidContext(),
             client = get()
+        )
+    }
+    single {
+        com.playbridge.sender.data.iptv.IptvRepository(
+            context = androidContext(),
+            playlistDao = get(),
+            channelDao = get(),
+            httpClient = get()
+        )
+    }
+    single {
+        com.playbridge.sender.data.collection.CollectionsRepository(
+            collectionDao = get(),
+            itemDao = get()
         )
     }
 
@@ -154,6 +172,20 @@ val appModule = module {
             tmdb = get(),
             database = get(),
             addonRepository = get()
+        )
+    }
+
+    viewModel {
+        com.playbridge.sender.iptv.IptvViewModel(
+            application = androidApplication(),
+            repository = get(),
+            settings = get()
+        )
+    }
+
+    viewModel {
+        com.playbridge.sender.collection.CollectionsViewModel(
+            repository = get()
         )
     }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/history/CommandHistoryScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/history/CommandHistoryScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.ui.res.painterResource
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.OpenInBrowser
@@ -32,7 +33,8 @@ fun CastHistoryScreen(
     onItemClick: (CommandHistoryEntity) -> Unit,
     onDelete: (CommandHistoryEntity) -> Unit,
     onClearHistory: () -> Unit,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onAddToCollection: (CommandHistoryEntity) -> Unit = {}
 ) {
     Scaffold(
         topBar = {
@@ -88,7 +90,8 @@ fun CastHistoryScreen(
                     CastHistoryItem(
                         item = item,
                         onClick = { onItemClick(item) },
-                        onDelete = { onDelete(item) }
+                        onDelete = { onDelete(item) },
+                        onAddToCollection = { onAddToCollection(item) }
                     )
                     Spacer(modifier = Modifier.height(12.dp))
                 }
@@ -101,7 +104,8 @@ fun CastHistoryScreen(
 fun CastHistoryItem(
     item: CommandHistoryEntity,
     onClick: () -> Unit,
-    onDelete: () -> Unit
+    onDelete: () -> Unit,
+    onAddToCollection: () -> Unit = {}
 ) {
     val dateFormat = SimpleDateFormat("MMM d, h:mm a", Locale.getDefault())
     val icon = if (item.commandType.lowercase() == "play") Icons.Default.PlayArrow else Icons.Default.OpenInBrowser
@@ -133,12 +137,21 @@ fun CastHistoryItem(
             Icon(icon, contentDescription = null)
         },
         trailingContent = {
-            IconButton(onClick = onDelete) {
-                Icon(
-                    Icons.Default.Delete,
-                    contentDescription = "Delete",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+            Row {
+                IconButton(onClick = onAddToCollection) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.PlaylistAdd,
+                        contentDescription = "Add to Collection",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        Icons.Default.Delete,
+                        contentDescription = "Delete",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         },
         modifier = Modifier.clickable(onClick = onClick)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvDetailScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvDetailScreen.kt
@@ -1,0 +1,358 @@
+package com.playbridge.sender.iptv
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.LiveTv
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.NetworkCheck
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import com.playbridge.sender.collection.AddToCollectionSheet
+import com.playbridge.sender.collection.CollectionsViewModel
+import com.playbridge.sender.connection.ConnectionViewModel
+import com.playbridge.sender.data.collection.CollectionItemDraft
+import com.playbridge.sender.data.collection.CollectionItemKind
+import com.playbridge.sender.data.collection.CollectionSource
+import com.playbridge.sender.data.iptv.IptvChannelEntity
+import com.playbridge.sender.data.iptv.IptvProbeStatus
+import com.playbridge.sender.data.iptv.IptvSortRules
+import com.playbridge.sender.data.iptv.decodeHeaders
+import com.playbridge.sender.player.PlayerLauncher
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun IptvDetailScreen(
+    playlistId: Long,
+    viewModel: IptvViewModel,
+    connectionViewModel: ConnectionViewModel,
+    collectionsViewModel: CollectionsViewModel,
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val snackbar = remember { SnackbarHostState() }
+
+    val channels by viewModel.channelsFor(playlistId).collectAsState(initial = emptyList())
+    val activeFirst by viewModel.activeFirst.collectAsState()
+    val probeProgress by viewModel.probeProgress.collectAsState()
+    val updatingId by viewModel.updatingPlaylistId.collectAsState()
+
+    val playlist = viewModel.playlistById(playlistId)
+    val title = playlist?.name ?: "Channels"
+    val updating = updatingId == playlistId
+    val probing = probeProgress?.let { it.playlistId == playlistId && it.isRunning } == true
+
+    var query by remember { mutableStateOf("") }
+    var searchActive by remember { mutableStateOf(false) }
+    var selectedGroup by remember { mutableStateOf<String?>(null) } // null = All
+    var menuOpen by remember { mutableStateOf(false) }
+    var addToCollection by remember { mutableStateOf<IptvChannelEntity?>(null) }
+
+    val groups = remember(channels) {
+        channels.mapNotNull { it.groupTitle?.takeIf { g -> g.isNotBlank() } }.distinct().sorted()
+    }
+
+    val visible = remember(channels, query, selectedGroup, activeFirst) {
+        val byGroup = if (selectedGroup == null) channels else channels.filter { it.groupTitle == selectedGroup }
+        val byQuery = if (query.isBlank()) byGroup
+        else byGroup.filter { it.name.contains(query, ignoreCase = true) }
+        IptvSortRules.sortChannels(byQuery, activeFirst)
+    }
+
+    fun castChannel(channel: IptvChannelEntity) {
+        val headers = decodeHeaders(channel.headersJson)
+        // Cast to the active TV/DLNA target if one is connected; otherwise play in the
+        // built-in player on this device (same fallback as Phone Files).
+        val casted = connectionViewModel.castWebStream(
+            url = channel.url,
+            headers = headers,
+            title = channel.name,
+        )
+        if (casted) {
+            scope.launch { snackbar.showSnackbar("Casting ${channel.name}") }
+        } else {
+            PlayerLauncher.start(
+                context = context,
+                url = channel.url,
+                title = channel.name,
+                headers = headers,
+            )
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbar) },
+        topBar = {
+            TopAppBar(
+                title = {
+                    if (searchActive) {
+                        TextField(
+                            value = query,
+                            onValueChange = { query = it },
+                            placeholder = { Text("Search channels") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = TextFieldDefaults.colors(
+                                focusedContainerColor = Color.Transparent,
+                                unfocusedContainerColor = Color.Transparent,
+                            ),
+                        )
+                    } else {
+                        Text(title, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        if (searchActive) { searchActive = false; query = "" } else onBack()
+                    }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { searchActive = !searchActive; if (!searchActive) query = "" }) {
+                        Icon(Icons.Default.Search, contentDescription = "Search")
+                    }
+                    IconButton(onClick = { viewModel.refresh(playlistId) }, enabled = !updating) {
+                        if (updating) {
+                            CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                        } else {
+                            Icon(Icons.Default.Refresh, contentDescription = "Update")
+                        }
+                    }
+                    Box {
+                        IconButton(onClick = { menuOpen = true }) {
+                            Icon(Icons.Default.MoreVert, contentDescription = "More")
+                        }
+                        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                            DropdownMenuItem(
+                                text = { Text(if (probing) "Checking channels…" else "Check channels") },
+                                leadingIcon = { Icon(Icons.Default.NetworkCheck, contentDescription = null) },
+                                enabled = !probing,
+                                onClick = { menuOpen = false; viewModel.probe(playlistId) },
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Live channels first") },
+                                leadingIcon = {
+                                    if (activeFirst) Icon(Icons.Default.Check, contentDescription = null)
+                                    else Spacer(Modifier.size(24.dp))
+                                },
+                                onClick = { menuOpen = false; viewModel.setActiveFirst(!activeFirst) },
+                            )
+                        }
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            probeProgress?.takeIf { it.playlistId == playlistId && it.total > 0 }?.let { p ->
+                Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp)) {
+                    Text(
+                        "Checking channels ${p.done}/${p.total}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(2.dp))
+                    LinearProgressIndicator(
+                        progress = { if (p.total == 0) 0f else p.done.toFloat() / p.total },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+
+            if (groups.isNotEmpty()) {
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    item {
+                        FilterChip(
+                            selected = selectedGroup == null,
+                            onClick = { selectedGroup = null },
+                            label = { Text("All") },
+                        )
+                    }
+                    items(groups) { group ->
+                        FilterChip(
+                            selected = selectedGroup == group,
+                            onClick = { selectedGroup = group },
+                            label = { Text(group) },
+                        )
+                    }
+                }
+            }
+
+            if (channels.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(
+                        if (updating) "Loading channels…" else "No channels. Tap Update to fetch.",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    // Extra bottom padding so the floating now-playing bar doesn't cover the last row.
+                    contentPadding = PaddingValues(start = 12.dp, end = 12.dp, top = 8.dp, bottom = 96.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    items(visible, key = { it.id }) { channel ->
+                        ChannelRow(
+                            channel = channel,
+                            onClick = { castChannel(channel) },
+                            onAddToCollection = { addToCollection = channel },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    addToCollection?.let { channel ->
+        AddToCollectionSheet(
+            viewModel = collectionsViewModel,
+            draft = CollectionItemDraft(
+                title = channel.name,
+                url = channel.url,
+                kind = CollectionItemKind.WEB,
+                mimeType = null,
+                headers = decodeHeaders(channel.headersJson),
+                logo = channel.logo,
+                sourceTag = CollectionSource.IPTV,
+            ),
+            onDismiss = { addToCollection = null },
+            onAdded = { name, added ->
+                scope.launch {
+                    snackbar.showSnackbar(if (added) "Added to $name" else "Already in $name")
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun ChannelRow(
+    channel: IptvChannelEntity,
+    onClick: () -> Unit,
+    onAddToCollection: () -> Unit,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                Icons.Default.LiveTv,
+                contentDescription = null,
+                modifier = Modifier.size(22.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(Modifier.size(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                channel.name,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            channel.groupTitle?.takeIf { it.isNotBlank() }?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        ProbeDot(channel.probeStatus)
+        Box {
+            IconButton(onClick = { menuOpen = true }) {
+                Icon(Icons.Default.MoreVert, contentDescription = "Options")
+            }
+            DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                DropdownMenuItem(
+                    text = { Text("Add to Collection") },
+                    leadingIcon = { Icon(Icons.AutoMirrored.Filled.PlaylistAdd, contentDescription = null) },
+                    onClick = { menuOpen = false; onAddToCollection() },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProbeDot(status: String) {
+    val color = when (status) {
+        IptvProbeStatus.ACTIVE -> Color(0xFF4CAF50)
+        IptvProbeStatus.DEAD -> Color(0xFFE53935)
+        else -> Color(0xFFBDBDBD)
+    }
+    if (status == IptvProbeStatus.UNKNOWN) return
+    Box(modifier = Modifier.size(8.dp).clip(CircleShape).background(color))
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvScreen.kt
@@ -1,0 +1,419 @@
+package com.playbridge.sender.iptv
+
+import android.content.Intent
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Sort
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.LiveTv
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.UploadFile
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import com.playbridge.sender.data.iptv.IptvPlaylistEntity
+import com.playbridge.sender.data.iptv.IptvPlaylistSort
+import com.playbridge.sender.data.iptv.IptvSourceType
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun IptvScreen(
+    viewModel: IptvViewModel,
+    onBack: () -> Unit,
+    onOpenPlaylist: (Long) -> Unit,
+) {
+    val playlists by viewModel.playlists.collectAsState()
+    var showAddSheet by remember { mutableStateOf(false) }
+    var editTarget by remember { mutableStateOf<IptvPlaylistEntity?>(null) }
+    var showSortSheet by remember { mutableStateOf(false) }
+    var deleteTarget by remember { mutableStateOf<IptvPlaylistEntity?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("IPTV") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showSortSheet = true }) {
+                        Icon(Icons.AutoMirrored.Filled.Sort, contentDescription = "Sort")
+                    }
+                    IconButton(onClick = { editTarget = null; showAddSheet = true }) {
+                        Icon(Icons.Default.Add, contentDescription = "Add playlist")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        if (playlists.isEmpty()) {
+            EmptyIptv(
+                modifier = Modifier.padding(padding),
+                onAdd = { editTarget = null; showAddSheet = true },
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                // Extra bottom padding so the floating now-playing bar doesn't cover the last card.
+                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 96.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                items(playlists, key = { it.id }) { playlist ->
+                    PlaylistCard(
+                        playlist = playlist,
+                        onClick = { onOpenPlaylist(playlist.id) },
+                        onEdit = { editTarget = playlist; showAddSheet = true },
+                        onDelete = { deleteTarget = playlist },
+                    )
+                }
+            }
+        }
+    }
+
+    if (showAddSheet) {
+        IptvAddEditSheet(
+            existing = editTarget,
+            onDismiss = { showAddSheet = false },
+            onSaveUrl = { name, url ->
+                val target = editTarget
+                if (target == null) viewModel.addUrlPlaylist(name, url)
+                else viewModel.editPlaylist(target.id, name, url, IptvSourceType.URL)
+                showAddSheet = false
+            },
+            onSaveFile = { name, uri ->
+                val target = editTarget
+                if (target == null) viewModel.addFilePlaylist(name, uri)
+                else viewModel.editPlaylist(target.id, name, uri, IptvSourceType.FILE)
+                showAddSheet = false
+            },
+        )
+    }
+
+    if (showSortSheet) {
+        IptvSortSheet(
+            viewModel = viewModel,
+            onDismiss = { showSortSheet = false },
+        )
+    }
+
+    deleteTarget?.let { target ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text("Remove playlist?") },
+            text = { Text("\"${target.name}\" and its cached channels will be removed.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deletePlaylist(target)
+                    deleteTarget = null
+                }) { Text("Remove", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteTarget = null }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun EmptyIptv(modifier: Modifier = Modifier, onAdd: () -> Unit) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                Icons.Default.LiveTv,
+                contentDescription = null,
+                modifier = Modifier.size(56.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(12.dp))
+            Text("No IPTV playlists yet", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Add an M3U URL or file to get started.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(20.dp))
+            Button(onClick = onAdd) {
+                Icon(Icons.Default.Add, contentDescription = null)
+                Spacer(Modifier.size(8.dp))
+                Text("Add IPTV playlist")
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlaylistCard(
+    playlist: IptvPlaylistEntity,
+    onClick: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(start = 16.dp, top = 14.dp, bottom = 14.dp, end = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Default.LiveTv,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+            Spacer(Modifier.size(14.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    playlist.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    "${playlist.channelCount} channels · updated ${relativeTime(playlist.updatedAt)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Box {
+                IconButton(onClick = { menuOpen = true }) {
+                    Icon(Icons.Default.MoreVert, contentDescription = "Options")
+                }
+                DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                    DropdownMenuItem(
+                        text = { Text("Edit") },
+                        leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
+                        onClick = { menuOpen = false; onEdit() },
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Remove") },
+                        leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                        onClick = { menuOpen = false; onDelete() },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun IptvAddEditSheet(
+    existing: IptvPlaylistEntity?,
+    onDismiss: () -> Unit,
+    onSaveUrl: (name: String, url: String) -> Unit,
+    onSaveFile: (name: String, uri: String) -> Unit,
+) {
+    val context = LocalContext.current
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var name by remember { mutableStateOf(existing?.name ?: "") }
+    var url by remember {
+        mutableStateOf(if (existing?.sourceType == IptvSourceType.URL) existing.source else "")
+    }
+    var fileUri by remember {
+        mutableStateOf(if (existing?.sourceType == IptvSourceType.FILE) existing.source else null)
+    }
+    var fileName by remember { mutableStateOf<String?>(null) }
+
+    val filePicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri: Uri? ->
+        if (uri != null) {
+            runCatching {
+                context.contentResolver.takePersistableUriPermission(
+                    uri, Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
+            }
+            fileUri = uri.toString()
+            fileName = queryDisplayName(context, uri) ?: uri.lastPathSegment
+            url = "" // file source supersedes URL
+        }
+    }
+
+    val canSave = name.isNotBlank() && (url.isNotBlank() || fileUri != null)
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp)) {
+            Text(
+                if (existing == null) "Add IPTV playlist" else "Edit playlist",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.height(16.dp))
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Name") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = url,
+                onValueChange = { url = it; if (it.isNotBlank()) { fileUri = null; fileName = null } },
+                label = { Text("IPTV address (M3U URL)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(8.dp))
+            Text("or", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = { filePicker.launch(arrayOf("audio/x-mpegurl", "application/x-mpegurl", "audio/mpegurl", "*/*")) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(Icons.Default.UploadFile, contentDescription = null)
+                Spacer(Modifier.size(8.dp))
+                Text(fileName ?: (fileUri?.let { "File selected" }) ?: "Select an M3U file")
+            }
+            Spacer(Modifier.height(20.dp))
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onDismiss) { Text("Cancel") }
+                Spacer(Modifier.size(8.dp))
+                Button(
+                    enabled = canSave,
+                    onClick = {
+                        val fu = fileUri
+                        if (url.isNotBlank()) onSaveUrl(name.trim(), url.trim())
+                        else if (fu != null) onSaveFile(name.trim(), fu)
+                    },
+                ) { Text("Save") }
+            }
+            Spacer(Modifier.height(12.dp))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun IptvSortSheet(
+    viewModel: IptvViewModel,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState()
+    val sortKey by viewModel.sortKey.collectAsState()
+    val ascending by viewModel.sortAscending.collectAsState()
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp)) {
+            Text("Sort by", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Spacer(Modifier.height(4.dp))
+            RadioRow("Added date", sortKey == IptvPlaylistSort.ADDED_DATE.name) {
+                viewModel.setSort(IptvPlaylistSort.ADDED_DATE.name)
+            }
+            RadioRow("Name", sortKey == IptvPlaylistSort.NAME.name) {
+                viewModel.setSort(IptvPlaylistSort.NAME.name)
+            }
+            Spacer(Modifier.height(12.dp))
+            Text("Order", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Spacer(Modifier.height(4.dp))
+            RadioRow("Ascending", ascending) { viewModel.setSortAscending(true) }
+            RadioRow("Descending", !ascending) { viewModel.setSortAscending(false) }
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun RadioRow(label: String, selected: Boolean, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(selected = selected, onClick = onClick)
+        Spacer(Modifier.size(8.dp))
+        Text(label, style = MaterialTheme.typography.bodyLarge)
+    }
+}
+
+internal fun queryDisplayName(context: android.content.Context, uri: Uri): String? = runCatching {
+    context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+        ?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val idx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (idx >= 0) cursor.getString(idx) else null
+            } else null
+        }
+}.getOrNull()
+
+internal fun relativeTime(epochMs: Long): String {
+    val diff = System.currentTimeMillis() - epochMs
+    if (diff < 0) return "just now"
+    val mins = diff / 60_000
+    val hours = diff / 3_600_000
+    val days = diff / 86_400_000
+    return when {
+        mins < 1 -> "just now"
+        mins < 60 -> "${mins}m ago"
+        hours < 24 -> "${hours}h ago"
+        days < 7 -> "${days}d ago"
+        else -> "${days / 7}w ago"
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvViewModel.kt
@@ -1,0 +1,95 @@
+package com.playbridge.sender.iptv
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.playbridge.sender.data.iptv.IptvChannelEntity
+import com.playbridge.sender.data.iptv.IptvPlaylistEntity
+import com.playbridge.sender.data.iptv.IptvPlaylistSort
+import com.playbridge.sender.data.iptv.IptvRepository
+import com.playbridge.sender.data.iptv.IptvSortRules
+import com.playbridge.sender.data.iptv.IptvSourceType
+import com.playbridge.sender.data.settings.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/** Live probe progress for the currently-explored playlist. */
+data class ProbeProgress(val playlistId: Long, val done: Int, val total: Int) {
+    val isRunning: Boolean get() = done < total
+}
+
+class IptvViewModel(
+    application: Application,
+    private val repository: IptvRepository,
+    private val settings: SettingsRepository,
+) : AndroidViewModel(application) {
+
+    /** Playlists sorted by the user's chosen key + direction. */
+    val playlists: StateFlow<List<IptvPlaylistEntity>> =
+        combine(
+            repository.observePlaylists(),
+            settings.iptvSort,
+            settings.iptvSortAscending,
+        ) { list, sortKey, ascending ->
+            val sort = runCatching { IptvPlaylistSort.valueOf(sortKey) }
+                .getOrDefault(IptvPlaylistSort.ADDED_DATE)
+            IptvSortRules.sortPlaylists(list, sort, ascending)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val sortKey: StateFlow<String> =
+        settings.iptvSort.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "ADDED_DATE")
+    val sortAscending: StateFlow<Boolean> =
+        settings.iptvSortAscending.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+    val activeFirst: StateFlow<Boolean> =
+        settings.iptvActiveFirst.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+
+    private val _updatingPlaylistId = MutableStateFlow<Long?>(null)
+    val updatingPlaylistId: StateFlow<Long?> = _updatingPlaylistId.asStateFlow()
+
+    private val _probeProgress = MutableStateFlow<ProbeProgress?>(null)
+    val probeProgress: StateFlow<ProbeProgress?> = _probeProgress.asStateFlow()
+
+    /** Raw cached channels for a playlist (screen applies search + active-first ordering). */
+    fun channelsFor(playlistId: Long): Flow<List<IptvChannelEntity>> =
+        repository.observeChannels(playlistId)
+
+    fun playlistById(id: Long): IptvPlaylistEntity? = playlists.value.find { it.id == id }
+
+    fun addUrlPlaylist(name: String, url: String) = viewModelScope.launch {
+        repository.addPlaylist(name, url, IptvSourceType.URL)
+    }
+
+    fun addFilePlaylist(name: String, uri: String) = viewModelScope.launch {
+        repository.addPlaylist(name, uri, IptvSourceType.FILE)
+    }
+
+    fun editPlaylist(id: Long, name: String, source: String, sourceType: String) =
+        viewModelScope.launch { repository.editPlaylist(id, name, source, sourceType) }
+
+    fun deletePlaylist(playlist: IptvPlaylistEntity) =
+        viewModelScope.launch { repository.deletePlaylist(playlist) }
+
+    fun refresh(id: Long) = viewModelScope.launch {
+        _updatingPlaylistId.value = id
+        runCatching { repository.refresh(id) }
+        _updatingPlaylistId.value = null
+    }
+
+    fun probe(playlistId: Long, force: Boolean = false) = viewModelScope.launch {
+        _probeProgress.value = ProbeProgress(playlistId, 0, 0)
+        repository.probe(playlistId, force) { done, total ->
+            _probeProgress.value = ProbeProgress(playlistId, done, total)
+        }
+        _probeProgress.value = null
+    }
+
+    fun setSort(key: String) = viewModelScope.launch { settings.setIptvSort(key) }
+    fun setSortAscending(value: Boolean) = viewModelScope.launch { settings.setIptvSortAscending(value) }
+    fun setActiveFirst(value: Boolean) = viewModelScope.launch { settings.setIptvActiveFirst(value) }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/library/DebridLibraryScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/library/DebridLibraryScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -39,7 +40,8 @@ private const val TAG_LIBRARY = "DebridLibraryScreen"
 fun DebridLibraryScreen(
     onMenuClick: () -> Unit,
     onCopyUrl: (String) -> Unit,
-    onShowCastSheet: (DetectedVideo) -> Unit
+    onShowCastSheet: (DetectedVideo) -> Unit,
+    onAddToCollection: (title: String, url: String) -> Unit = { _, _ -> }
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -757,6 +759,29 @@ fun DebridLibraryScreen(
                                                 }
                                             }) {
                                                 Icon(Icons.Default.Tv, "Play on TV", tint = MaterialTheme.colorScheme.primary)
+                                            }
+                                            IconButton(onClick = {
+                                                scope.launch {
+                                                    try {
+                                                        Toast.makeText(context, "Resolving link...", Toast.LENGTH_SHORT).show()
+                                                        val provider = repository.getActiveProvider() ?: return@launch
+                                                        val configName = repository.getConfiguredProviderName()
+                                                        val link = when (configName) {
+                                                            DebridRepository.PROVIDER_PREMIUMIZE -> file.id
+                                                            DebridRepository.PROVIDER_TORBOX -> "${torrentDetails!!.id}:${file.id}"
+                                                            else -> if (file.link.isNotEmpty()) file.link else file.id
+                                                        }
+                                                        val unrestricted = provider.unrestrictLink(link)
+                                                        onAddToCollection(
+                                                            file.path.substringAfterLast('/'),
+                                                            unrestricted.downloadUrl,
+                                                        )
+                                                    } catch (e: Exception) {
+                                                        unrestrictionError = e.message ?: "Unknown error"
+                                                    }
+                                                }
+                                            }) {
+                                                Icon(Icons.AutoMirrored.Filled.PlaylistAdd, "Add to Collection", tint = MaterialTheme.colorScheme.primary)
                                             }
                                         }
                                     }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/ui/DashboardScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/ui/DashboardScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.LibraryBooks
+import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -345,6 +346,20 @@ fun DashboardScreen(
                     subtitle = "Cloud torrents",
                     screen = Screen.DebridLibrary,
                     gradientColors = listOf(Color(0xFF00838F), Color(0xFF00ACC1))
+                ),
+                DashboardItem(
+                    icon = Icons.Default.LiveTv,
+                    title = "IPTV",
+                    subtitle = "Live channels",
+                    screen = Screen.Iptv,
+                    gradientColors = listOf(Color(0xFF00695C), Color(0xFF00897B))
+                ),
+                DashboardItem(
+                    icon = Icons.AutoMirrored.Filled.PlaylistPlay,
+                    title = "Collections",
+                    subtitle = "Your playlists",
+                    screen = Screen.Collections,
+                    gradientColors = listOf(Color(0xFFAD1457), Color(0xFFD81B60))
                 ),
                 DashboardItem(
                     icon = Icons.Default.History,

--- a/mobile/android/app/src/test/java/com/playbridge/sender/data/collection/CollectionPlayRouterTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/data/collection/CollectionPlayRouterTest.kt
@@ -1,0 +1,23 @@
+package com.playbridge.sender.data.collection
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CollectionPlayRouterTest {
+
+    @Test
+    fun localKindRoutesToLocal() {
+        assertEquals(CollectionRoute.LOCAL, CollectionPlayRouter.routeOf(CollectionItemKind.LOCAL))
+    }
+
+    @Test
+    fun webKindRoutesToWeb() {
+        assertEquals(CollectionRoute.WEB, CollectionPlayRouter.routeOf(CollectionItemKind.WEB))
+    }
+
+    @Test
+    fun unknownOrNullDefaultsToWeb() {
+        assertEquals(CollectionRoute.WEB, CollectionPlayRouter.routeOf(null))
+        assertEquals(CollectionRoute.WEB, CollectionPlayRouter.routeOf("something_else"))
+    }
+}

--- a/mobile/android/app/src/test/java/com/playbridge/sender/data/iptv/IptvSortRulesTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/data/iptv/IptvSortRulesTest.kt
@@ -1,0 +1,83 @@
+package com.playbridge.sender.data.iptv
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class IptvSortRulesTest {
+
+    private fun playlist(id: Long, name: String, addedAt: Long) =
+        IptvPlaylistEntity(id = id, name = name, source = "s", sourceType = IptvSourceType.URL, addedAt = addedAt, updatedAt = addedAt)
+
+    private fun channel(
+        id: Long,
+        order: Int,
+        status: String = IptvProbeStatus.UNKNOWN,
+        latency: Int? = null,
+    ) = IptvChannelEntity(
+        id = id, playlistId = 1, name = "ch$id", url = "u$id",
+        orderIndex = order, probeStatus = status, probeLatencyMs = latency,
+    )
+
+    // ── Playlist sorting ────────────────────────────────────────────────────
+
+    @Test
+    fun sortPlaylistsByAddedDateDescending() {
+        val list = listOf(
+            playlist(1, "B", 100),
+            playlist(2, "A", 300),
+            playlist(3, "C", 200),
+        )
+        val result = IptvSortRules.sortPlaylists(list, IptvPlaylistSort.ADDED_DATE, ascending = false)
+        assertEquals(listOf(2L, 3L, 1L), result.map { it.id })
+    }
+
+    @Test
+    fun sortPlaylistsByNameAscendingCaseInsensitive() {
+        val list = listOf(
+            playlist(1, "banana", 1),
+            playlist(2, "Apple", 2),
+            playlist(3, "cherry", 3),
+        )
+        val result = IptvSortRules.sortPlaylists(list, IptvPlaylistSort.NAME, ascending = true)
+        assertEquals(listOf(2L, 1L, 3L), result.map { it.id })
+    }
+
+    // ── Channel sorting ─────────────────────────────────────────────────────
+
+    @Test
+    fun activeFirstFloatsLiveChannelsUpAndDeadDown() {
+        val channels = listOf(
+            channel(1, order = 0, status = IptvProbeStatus.DEAD),
+            channel(2, order = 1, status = IptvProbeStatus.ACTIVE, latency = 200),
+            channel(3, order = 2, status = IptvProbeStatus.UNKNOWN),
+            channel(4, order = 3, status = IptvProbeStatus.ACTIVE, latency = 50),
+        )
+        val result = IptvSortRules.sortChannels(channels, activeFirst = true)
+        // ACTIVE (faster first) → UNKNOWN → DEAD
+        assertEquals(listOf(4L, 2L, 3L, 1L), result.map { it.id })
+    }
+
+    @Test
+    fun activeFirstDisabledKeepsOriginalOrder() {
+        val channels = listOf(
+            channel(3, order = 2, status = IptvProbeStatus.ACTIVE, latency = 10),
+            channel(1, order = 0, status = IptvProbeStatus.DEAD),
+            channel(2, order = 1, status = IptvProbeStatus.UNKNOWN),
+        )
+        val result = IptvSortRules.sortChannels(channels, activeFirst = false)
+        assertEquals(listOf(1L, 2L, 3L), result.map { it.id })
+    }
+
+    @Test
+    fun headerRoundTrip() {
+        val headers = mapOf("User-Agent" to "Agent/1.0", "Referer" to "http://ref")
+        val encoded = encodeHeaders(headers)
+        assertEquals(headers, decodeHeaders(encoded))
+    }
+
+    @Test
+    fun emptyHeadersEncodeToNull() {
+        assertEquals(null, encodeHeaders(emptyMap()))
+        assertEquals(emptyMap<String, String>(), decodeHeaders(null))
+    }
+}

--- a/shared/src/commonMain/kotlin/com/playbridge/shared/player/M3uParser.kt
+++ b/shared/src/commonMain/kotlin/com/playbridge/shared/player/M3uParser.kt
@@ -7,6 +7,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.Url
 import io.ktor.http.fullPath
 import io.ktor.http.isSuccess
@@ -23,11 +24,159 @@ data class HlsVariant(
     val codecs: String?
 )
 
+/**
+ * A single channel parsed from an IPTV-style M3U playlist, retaining the metadata the
+ * casting path needs ([headers]) and the UI uses ([logo]/[groupTitle]). Convert to a
+ * [PlayPayload] via [toPlayPayload] when casting.
+ */
+data class IptvChannel(
+    val name: String,
+    val url: String,
+    val logo: String? = null,
+    val groupTitle: String? = null,
+    val tvgId: String? = null,
+    val order: Int = 0,
+    val headers: Map<String, String> = emptyMap(),
+) {
+    fun toPlayPayload(): PlayPayload = PlayPayload(
+        url = url,
+        title = name,
+        content_type = null,
+        detected_by = "iptv_m3u",
+        headers = headers,
+    )
+}
+
 object M3uParser {
     private val http: HttpClient = SharedHttpClient.client
     private val REGEX_RESOLUTION = Regex("""RESOLUTION=(\d+x\d+)""")
     private val REGEX_BANDWIDTH = Regex("""BANDWIDTH=(\d+)""")
     private val REGEX_CODECS = Regex("""CODECS="([^"]+)"""")
+    private val REGEX_TVG_ID = Regex("""tvg-id="([^"]*)"""")
+    private val REGEX_TVG_LOGO = Regex("""tvg-logo="([^"]*)"""")
+    private val REGEX_TVG_NAME = Regex("""tvg-name="([^"]*)"""")
+    private val REGEX_GROUP_TITLE = Regex("""group-title="([^"]*)"""")
+
+    /**
+     * Pure parser for an IPTV M3U document already in memory (so a local file's contents can
+     * reuse the exact same logic as a fetched URL). Captures tvg-logo/group-title/tvg-id and
+     * per-channel #EXTVLCOPT headers, merged over [baseHeaders]. Returns null if the text is
+     * not an IPTV playlist (e.g. a single-stream HLS manifest).
+     */
+    fun parseM3uText(
+        text: String,
+        baseUrl: String? = null,
+        baseHeaders: Map<String, String> = emptyMap(),
+    ): List<IptvChannel>? {
+        val lines = text.lineSequence().iterator()
+        if (!lines.hasNext()) return null
+
+        val channels = mutableListOf<IptvChannel>()
+        var isFirstLine = true
+        var isIptv = false
+
+        var currentTitle: String? = null
+        var currentLogo: String? = null
+        var currentGroup: String? = null
+        var currentTvgId: String? = null
+        var pendingGroup: String? = null // from a standalone #EXTGRP line
+        val currentHeaders = baseHeaders.toMutableMap()
+
+        fun resetCurrent() {
+            currentTitle = null
+            currentLogo = null
+            currentGroup = null
+            currentTvgId = null
+            currentHeaders.clear()
+            currentHeaders.putAll(baseHeaders)
+        }
+
+        while (lines.hasNext()) {
+            val trimmed = lines.next().trim()
+
+            if (isFirstLine) {
+                isFirstLine = false
+                if (!trimmed.startsWith("#EXTM3U")) return null
+                continue
+            }
+            if (trimmed.isEmpty()) continue
+
+            // A real HLS manifest, not an IPTV channel list — bail so it plays directly.
+            if (trimmed.startsWith("#EXT-X-STREAM-INF") || trimmed.startsWith("#EXT-X-TARGETDURATION")) {
+                return null
+            }
+
+            when {
+                trimmed.startsWith("#EXTINF:") -> {
+                    isIptv = true
+                    currentTvgId = REGEX_TVG_ID.find(trimmed)?.groupValues?.get(1)?.ifBlank { null }
+                    currentLogo = REGEX_TVG_LOGO.find(trimmed)?.groupValues?.get(1)?.ifBlank { null }
+                    currentGroup = REGEX_GROUP_TITLE.find(trimmed)?.groupValues?.get(1)?.ifBlank { null }
+                        ?: pendingGroup
+                    val commaIndex = trimmed.indexOf(',')
+                    currentTitle = if (commaIndex != -1 && commaIndex + 1 < trimmed.length) {
+                        trimmed.substring(commaIndex + 1).trim().ifBlank { null }
+                    } else null
+                    if (currentTitle == null) {
+                        currentTitle = REGEX_TVG_NAME.find(trimmed)?.groupValues?.get(1)?.ifBlank { null }
+                    }
+                }
+                trimmed.startsWith("#EXTGRP:") -> {
+                    pendingGroup = trimmed.substringAfter(':').trim().ifBlank { null }
+                    if (currentGroup == null) currentGroup = pendingGroup
+                }
+                trimmed.startsWith("#EXTVLCOPT:") -> {
+                    val opt = trimmed.substringAfter(':').trim()
+                    val key = opt.substringBefore('=', "").trim().lowercase()
+                    val value = opt.substringAfter('=', "").trim()
+                    if (value.isNotEmpty()) when (key) {
+                        "http-user-agent" -> currentHeaders["User-Agent"] = value
+                        "http-referrer" -> currentHeaders["Referer"] = value
+                        "http-origin" -> currentHeaders["Origin"] = value
+                    }
+                }
+                trimmed.startsWith("#") -> { /* ignore other tags */ }
+                else -> {
+                    val streamUrl = if (baseUrl != null) resolveUrl(baseUrl, trimmed) else trimmed
+                    channels.add(
+                        IptvChannel(
+                            name = currentTitle ?: "Channel ${channels.size + 1}",
+                            url = streamUrl,
+                            logo = currentLogo,
+                            groupTitle = currentGroup,
+                            tvgId = currentTvgId,
+                            order = channels.size,
+                            headers = currentHeaders.toMap(),
+                        )
+                    )
+                    resetCurrent()
+                }
+            }
+        }
+
+        return if (isIptv && channels.isNotEmpty()) channels else null
+    }
+
+    /** Fetch [url] and parse it into [IptvChannel]s (URL-sourced playlists). */
+    suspend fun fetchChannels(url: String, inputHeaders: Map<String, String>?): List<IptvChannel>? =
+        withContext(Dispatchers.Default) {
+            try {
+                val response: HttpResponse = http.get(url) {
+                    inputHeaders?.forEach { (k, v) -> headers.append(k, v) }
+                }
+                if (!response.status.isSuccess()) {
+                    logger.w(TAG, "Failed to fetch IPTV playlist: HTTP ${response.status.value}")
+                    return@withContext null
+                }
+                val body = response.bodyAsText()
+                parseM3uText(body, baseUrl = url, baseHeaders = inputHeaders ?: emptyMap())
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.e(TAG, "Error fetching IPTV playlist", e)
+                null
+            }
+        }
 
     suspend fun parseMasterPlaylist(url: String, inputHeaders: Map<String, String>?): List<HlsVariant>? = withContext(Dispatchers.Default) {
         try {

--- a/shared/src/commonMain/kotlin/com/playbridge/shared/player/M3uParser.kt
+++ b/shared/src/commonMain/kotlin/com/playbridge/shared/player/M3uParser.kt
@@ -309,20 +309,19 @@ object M3uParser {
     }
 
     private fun resolveUrl(baseUrl: String, relativeUrl: String): String {
+        if (relativeUrl.contains("://")) {
+            return relativeUrl
+        }
         return try {
             val base = Url(baseUrl)
-            val relative = Url(relativeUrl)
-            if (relative.protocol.name == "http" || relative.protocol.name == "https") {
-                relativeUrl
+            if (relativeUrl.startsWith("//")) {
+                "${base.protocol.name}:$relativeUrl"
+            } else if (relativeUrl.startsWith("/")) {
+                "${base.protocol.name}://${base.hostWithPort}${relativeUrl}"
             } else {
-                // Manual resolution for relative paths since Ktor Url doesn't have a simple 'resolve'
-                if (relativeUrl.startsWith("/")) {
-                    "${base.protocol.name}://${base.hostWithPort}${relativeUrl}"
-                } else {
-                    val lastSlash = base.fullPath.lastIndexOf('/')
-                    val path = if (lastSlash != -1) base.fullPath.substring(0, lastSlash + 1) else "/"
-                    "${base.protocol.name}://${base.hostWithPort}${path}${relativeUrl}"
-                }
+                val lastSlash = base.fullPath.lastIndexOf('/')
+                val path = if (lastSlash != -1) base.fullPath.substring(0, lastSlash + 1) else "/"
+                "${base.protocol.name}://${base.hostWithPort}${path}${relativeUrl}"
             }
         } catch (e: Exception) {
             relativeUrl

--- a/shared/src/commonTest/kotlin/com/playbridge/shared/player/M3uParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/playbridge/shared/player/M3uParserTest.kt
@@ -1,0 +1,132 @@
+package com.playbridge.shared.player
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class M3uParserTest {
+
+    @Test
+    fun parsesChannelsWithAttributes() {
+        val text = """
+            #EXTM3U
+            #EXTINF:-1 tvg-id="cnn.us" tvg-logo="http://logo/cnn.png" group-title="News",CNN
+            http://example.com/cnn.m3u8
+            #EXTINF:-1 tvg-logo="http://logo/espn.png" group-title="Sports",ESPN
+            http://example.com/espn.m3u8
+        """.trimIndent()
+
+        val channels = M3uParser.parseM3uText(text)
+        assertEquals(2, channels?.size)
+        val cnn = channels!![0]
+        assertEquals("CNN", cnn.name)
+        assertEquals("News", cnn.groupTitle)
+        assertEquals("cnn.us", cnn.tvgId)
+        assertEquals("http://logo/cnn.png", cnn.logo)
+        assertEquals("http://example.com/cnn.m3u8", cnn.url)
+        assertEquals(0, cnn.order)
+        assertEquals("Sports", channels[1].groupTitle)
+        assertEquals(1, channels[1].order)
+    }
+
+    @Test
+    fun capturesPerChannelHeaders() {
+        val text = """
+            #EXTM3U
+            #EXTINF:-1,Channel One
+            #EXTVLCOPT:http-user-agent=MyAgent/1.0
+            #EXTVLCOPT:http-referrer=http://ref.example
+            http://example.com/one
+        """.trimIndent()
+
+        val channels = M3uParser.parseM3uText(text, baseHeaders = mapOf("Cookie" to "abc"))
+        val ch = channels!!.single()
+        assertEquals("MyAgent/1.0", ch.headers["User-Agent"])
+        assertEquals("http://ref.example", ch.headers["Referer"])
+        assertEquals("abc", ch.headers["Cookie"]) // base header preserved
+    }
+
+    @Test
+    fun headersDoNotLeakAcrossChannels() {
+        val text = """
+            #EXTM3U
+            #EXTINF:-1,One
+            #EXTVLCOPT:http-user-agent=Agent1
+            http://example.com/one
+            #EXTINF:-1,Two
+            http://example.com/two
+        """.trimIndent()
+
+        val channels = M3uParser.parseM3uText(text)!!
+        assertEquals("Agent1", channels[0].headers["User-Agent"])
+        assertNull(channels[1].headers["User-Agent"])
+    }
+
+    @Test
+    fun extGrpSetsGroupForFollowingChannels() {
+        val text = """
+            #EXTM3U
+            #EXTGRP:Movies
+            #EXTINF:-1,Movie Channel
+            http://example.com/movie
+        """.trimIndent()
+
+        val channels = M3uParser.parseM3uText(text)!!
+        assertEquals("Movies", channels.single().groupTitle)
+    }
+
+    @Test
+    fun resolvesRelativeUrlsAgainstBase() {
+        val text = """
+            #EXTM3U
+            #EXTINF:-1,Relative
+            stream/chan.m3u8
+        """.trimIndent()
+
+        val channels = M3uParser.parseM3uText(text, baseUrl = "http://host.tv/lists/playlist.m3u")!!
+        assertEquals("http://host.tv/lists/stream/chan.m3u8", channels.single().url)
+    }
+
+    @Test
+    fun returnsNullForHlsManifest() {
+        val text = """
+            #EXTM3U
+            #EXT-X-STREAM-INF:BANDWIDTH=1280000,RESOLUTION=1280x720
+            chunk.m3u8
+        """.trimIndent()
+
+        assertNull(M3uParser.parseM3uText(text))
+    }
+
+    @Test
+    fun returnsNullForNonM3u() {
+        assertNull(M3uParser.parseM3uText("just some text\nnot a playlist"))
+    }
+
+    @Test
+    fun fallsBackToTvgNameWhenNoTitle() {
+        val text = """
+            #EXTM3U
+            #EXTINF:-1 tvg-name="Fallback Name" group-title="X",
+            http://example.com/x
+        """.trimIndent()
+
+        val ch = M3uParser.parseM3uText(text)!!.single()
+        assertEquals("Fallback Name", ch.name)
+    }
+
+    @Test
+    fun toPlayPayloadCarriesHeadersAndTitle() {
+        val ch = IptvChannel(
+            name = "CNN",
+            url = "http://example.com/cnn",
+            headers = mapOf("User-Agent" to "A"),
+        )
+        val payload = ch.toPlayPayload()
+        assertEquals("CNN", payload.title)
+        assertEquals("http://example.com/cnn", payload.url)
+        assertEquals("A", payload.headers["User-Agent"])
+        assertTrue(payload.detected_by == "iptv_m3u")
+    }
+}


### PR DESCRIPTION
- IPTV: dashboard tile, playlist manager (add via URL/file), channel explorer
  with categories/search, cached channels + refresh, URL probing (active-first),
  cast or play-in-app. Shared M3uParser captures tvg-logo/group-title/headers.
- Collections: dashboard tile, create/rename/delete, per-item play (cast or
  built-in player), reorder, dedupe by URL. 'Add to Collection' from IPTV,
  Cast History, Phone Files, Debrid, and the browser cast sheet's per-video menu.
- Remote: combined seek/volume bar (swipe horizontally to seek, vertically for
  volume); fixed Back-from-Remote returning to a stale screen.
- Desktop: handle the 'remote' command; volume keys now drive the host OS volume
  (macOS osascript / Linux wpctl|pactl|amixer / Windows SendKeys), player-volume fallback.
- Room DB v17 -> v19 (iptv_playlists, iptv_channels, collections, collection_items).
- UI: bottom padding so the now-playing bar no longer overlaps the last list row.
