### PR TITLE
chore: uprev desktop to 0.3.1+15, phone to 0.2.8, tv-player to 0.2.9

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.1+15] — 2026-06-17
+
+### Added
+- **Host OS Volume Control**: Remote volume commands from the phone now drive the host system's OS volume (via `osascript` on macOS, `wpctl`/`pactl`/`amixer` on Linux, and `SendKeys` on Windows), falling back to in-app player volume. (#39)
+- Support for handling remote seek and volume control websocket commands. (#39)
+
+### Changed
+- Hide the **Now Playing** sidebar tab when no media is casting. (#38)
+
 ## [0.3.0+14] — 2026-06-16
 
 ### Added

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: playbridge_desktop
 description: "PlayBridge desktop receiver — accepts cast commands from the phone and plays via libmpv."
 publish_to: 'none'
-version: 0.3.0+14
+version: 0.3.1+15
 
 environment:
   sdk: ^3.6.0

--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.8] — 2026-06-17 (versionCode 208)
+
+### Added
+- **IPTV Integration**: Dashboard tile, playlist manager (URL/file upload), category-grouped channel explorer with search, active-first URL probing, and in-app playback or casting. (#39)
+- **Collections**: Dashboard tile, custom collections (create, rename, delete, reorder, deduplicate), and quick "Add to Collection" actions from IPTV, Phone Files, Debrid, Cast History, and the browser cast sheet. (#39)
+- **Remote Control Redesign**: Combined seek and volume gesture bar (horizontal swipe to seek, vertical swipe for volume). (#39)
+- Upgraded local Room Database (v17 -> v19) to store playlists, channels, and collection schemas. (#39)
+
+### Changed
+- Improved UI bottom padding to prevent the Now Playing bar from overlapping the bottom list items. (#39)
+
+### Fixed
+- Fixed back navigation from the Remote screen returning to a stale/outdated screen. (#39)
+- Resolved relative URL resolution failures in the shared M3U parser. (#39)
+
 ## [0.2.7] — 2026-06-15 (versionCode 207)
 
 ### Added

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 207
-        versionName = "0.2.7"
+        versionCode = 208
+        versionName = "0.2.8"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,14 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [0.2.9] — 2026-06-17 (versionCode 209)
+
+### Changed
+- Settings: Updated "Allow insecure connections (ws)" toggle description to warn users about security implications of unencrypted websocket connections. (#36)
+
+### Removed
+- ContentSniffer: Removed unused legacy `getUnsafeOkHttpClient` helper. (#36)
+
 ## Player [0.2.8] — 2026-06-15 (versionCode 208)
 
 ### Added

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 208
-        versionName = "0.2.8"
+        versionCode = 209
+        versionName = "0.2.9"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
Uprevs the desktop, phone, and tv-player projects to reflect recent changes, and updates their respective changelogs.