### PR TITLE
Fix IPv6 connection, add TV subtitles, and optimize remote UI

### DIFF
--- a/desktop/lib/tv_sender_client.dart
+++ b/desktop/lib/tv_sender_client.dart
@@ -126,7 +126,10 @@ class TvSenderClient {
     _setState(SenderConnectionState.connecting);
 
     final resolvedWssPort = wssPort ?? (port + 1);
-    final uri = Uri.parse('wss://$host:$resolvedWssPort/');
+    final formattedHost = host.contains(':') && !host.startsWith('[')
+        ? '[${host.replaceFirst('%', '%25')}]'
+        : host;
+    final uri = Uri.parse('wss://$formattedHost:$resolvedWssPort/');
 
     final customClient = HttpClient()
       ..badCertificateCallback = (X509Certificate cert, String h, int p) {

--- a/desktop/play_payload.json
+++ b/desktop/play_payload.json
@@ -1,0 +1,158 @@
+{
+  "item": {
+    "url": "https://comet.feels.legal/eyJtYXhSZXN1bHRzUGVyUmVzb2x1dGlvbiI6MCwibWF4U2l6ZSI6MCwiY2FjaGVkT25seSI6ZmFsc2UsInJlbW92ZVRyYXNoIjpmYWxzZSwicmVzdWx0Rm9ybWF0IjpbImFsbCJdLCJkZWJyaWRTZXJ2aWNlcyI6W3sic2VydmljZSI6InRvcmJveCIsImFwaUtleSI6IjI2ODBhNjA2LTU3MjItNDdjNS05ZjY2LWM5MjE1NDI4YTcwZSJ9LHsic2VydmljZSI6InJlYWxkZWJyaWQiLCJhcGlLZXkiOiJHTklWUklGV1pNTVdDRlUyM1QzTUNMT0NVT01RRUJZNE1CVDY0UUpKWTJCUUpNNFhYUTNRIn1dLCJlbmFibGVUb3JyZW50IjpmYWxzZSwic2NyYXBlRGVicmlkQWNjb3VudFRvcnJlbnRzIjpmYWxzZSwiZGVicmlkU3RyZWFtUHJveHlQYXNzd29yZCI6IiIsImxhbmd1YWdlcyI6eyJyZXF1aXJlZCI6W10sImV4Y2x1ZGUiOltdLCJwcmVmZXJyZWQiOltdfSwicmVzb2x1dGlvbnMiOnt9LCJvcHRpb25zIjp7InJlbW92ZV9yYW5rc191bmRlciI6LTEwMDAwMDAwMDAwLCJhbGxvd19lbmdsaXNoX2luX2xhbmd1YWdlcyI6ZmFsc2UsInJlbW92ZV91bmtub3duX2xhbmd1YWdlcyI6ZmFsc2V9fQ==/playback/917ed044cbe0edae06d7755524ef884c71a8b8f4/0/1/6/1?torrent_name=Il.Trono.di.Spade.S06E01.La.Donna.Rossa.ITA.ENG.1080p.AC3.H265-BlackEgg.mkv&name=Game%20of%20Thrones&media_id=tt0944947",
+    "title": "Game of Thrones S6E1 - The Red Woman",
+    "content_type": "series",
+    "subtitles": [
+      {
+        "url": "https://opensubtitles.stremio.homes/sub.vtt/?lang_code=en&sub_id=6588069",
+        "label": "English · BLURAY 720p"
+      },
+      {
+        "url": "https://opensubtitles.stremio.homes/sub.vtt/?lang_code=en&sub_id=10744088",
+        "label": "English · WEB 1080p"
+      },
+      {
+        "url": "https://opensubtitles.stremio.homes/sub.vtt/?lang_code=en&sub_id=6117616",
+        "label": "English · WEB"
+      },
+      {
+        "url": "https://opensubtitles.stremio.homes/sub.vtt/?lang_code=en&sub_id=6116503",
+        "label": "English · WEB 1080p"
+      },
+      {
+        "url": "https://opensubtitles.stremio.homes/sub.vtt/?lang_code=en&sub_id=9739098",
+        "label": "English · DVD"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954695130?senc=cp1250",
+        "label": "CZE"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954694299",
+        "label": "CZE"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954694455?senc=cp1250",
+        "label": "CZE"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954695083?senc=cp1250",
+        "label": "CZE"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954694793",
+        "label": "POB"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954694795",
+        "label": "POB"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954695394",
+        "label": "POB"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954695026",
+        "label": "POB"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954695580",
+        "label": "POB"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1955002293",
+        "label": "Portuguese"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954695282",
+        "label": "Portuguese"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954694577",
+        "label": "Portuguese"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954694762",
+        "label": "Portuguese"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954695314",
+        "label": "Portuguese"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954693913",
+        "label": "Italian"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954695428",
+        "label": "Italian"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954694242",
+        "label": "Italian"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954694253",
+        "label": "Italian"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954695210",
+        "label": "Italian"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954695095?senc=cp1250",
+        "label": "HUN"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954695059?senc=cp1250",
+        "label": "HUN"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954695154?senc=cp1250",
+        "label": "HUN"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954693878?senc=cp1250",
+        "label": "RON"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954693858?senc=cp1250",
+        "label": "RON"
+      },
+      {
+        "url": "https://subs5.strem.io/en/download/subencoding-stremio-utf8/src-api/file/1954695075?senc=cp1250",
+        "label": "RON"
+      }
+    ],
+    "detected_by": "library",
+    "player_mode": "exo",
+    "preferred_audio_language": "en",
+    "preferred_subtitle_language": "en",
+    "default_video_quality": "1080p",
+    "max_bitrate_cap_mbps": 0.0,
+    "visual_metadata": {
+      "title": "Game of Thrones",
+      "year": 2011,
+      "rating": 9.2,
+      "runtime": "1h20min",
+      "overview": "Seven noble families fight for control of the mythical land of Westeros. Friction between the houses leads to full-scale war. All while a very ancient evil awakens in the farthest north. Amidst the war, a neglected military order of misfits, the Night's Watch, is all that stands between the realms of men and icy horrors beyond.",
+      "genres": ["Sci-Fi & Fantasy", "Drama", "Action & Adventure"],
+      "cast": [
+        "Peter Dinklage", "Kit Harington", "Nikolaj Coster-Waldau", "Lena Headey",
+        "Emilia Clarke", "Liam Cunningham", "Maisie Williams", "Isaac Hempstead Wright",
+        "Sophie Turner", "John Bradley", "Rory McCann", "Joe Dempsie",
+        "Gwendoline Christie", "Jacob Anderson"
+      ],
+      "backdrop_url": "https://images.metahub.space/background/medium/tt0944947/img",
+      "poster_url": "https://images.metahub.space/poster/medium/tt0944947/img",
+      "logo_url": "https://images.metahub.space/logo/medium/tt0944947/img",
+      "season": 5,
+      "episode": 1,
+      "episode_title": "The Red Woman",
+      "imdb_id": "tt0944947",
+      "tmdb_id": 1399
+    },
+    "binge_group": "aiostreams.viren070.com|1080p|BlackEgg"
+  }
+}

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -378,7 +378,10 @@ function connectWebSocket(ip, pin) {
     updateWsStatus('connecting');
     
     try {
-        wsConnection = new WebSocket(`ws://${ip}:${playbridgePort}`);
+        const formattedIp = ip.includes(':') && !ip.startsWith('[')
+            ? `[${ip.replace('%', '%25')}]`
+            : ip;
+        wsConnection = new WebSocket(`ws://${formattedIp}:${playbridgePort}`);
         
         wsConnection.onopen = () => {
             console.log('[VideoDetector BG] WS Connected to PlayBridge TV');

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -918,6 +918,8 @@ fun AppNavHost(
                                 // connection setup so they can be bundled into the play command without
                                 // delaying it.
                                 val subsDeferred = async {
+                                    val sendSubtitles = runCatching { settingsRepository.sendSubtitlesToTv.first() }.getOrDefault(true)
+                                    if (!sendSubtitles) return@async emptyList<String>()
                                     subtitleService.getAllSubtitleUrls(
                                         payload.visual_metadata?.imdb_id,
                                         payload.visual_metadata?.season,
@@ -987,6 +989,8 @@ fun AppNavHost(
                             scope.launch {
                                 // Fetch the start episode's subtitles in parallel with connecting.
                                 val startSubsDeferred = async {
+                                    val sendSubtitles = runCatching { settingsRepository.sendSubtitlesToTv.first() }.getOrDefault(true)
+                                    if (!sendSubtitles) return@async emptyList<String>()
                                     subtitleService.getAllSubtitleUrls(
                                         current.visual_metadata?.imdb_id,
                                         current.visual_metadata?.season,
@@ -1150,6 +1154,8 @@ fun AppNavHost(
                                 val startItem = playlist.items.getOrNull(playlist.start_index)
                                 val startVm = startItem?.visual_metadata
                                 val startSubsDeferred = async {
+                                    val sendSubtitles = runCatching { settingsRepository.sendSubtitlesToTv.first() }.getOrDefault(true)
+                                    if (!sendSubtitles) return@async emptyList<String>()
                                     subtitleService.getAllSubtitleUrls(
                                         startVm?.imdb_id, startVm?.season, startVm?.episode, preferredSubLang,
                                         videoRelease = subtitleService.filenameFromUrl(startItem?.url)
@@ -1420,26 +1426,6 @@ fun AppNavHost(
                     primaryText = primaryText,
                     secondaryText = secondaryText,
                     leadingIcon = leadingIcon,
-                    showPlayPause = playing,
-                    isPlaying = if (dlnaActive) {
-                        dlnaStatus?.state == PlaybackState.PLAYING
-                    } else {
-                        tvPlayback?.state == "playing"
-                    },
-                    onPlayPause = {
-                        if (dlnaActive) {
-                            if (dlnaStatus?.state == PlaybackState.PLAYING) {
-                                connectionViewModel.dlnaPause()
-                            } else {
-                                connectionViewModel.dlnaPlay()
-                            }
-                        } else {
-                            val cmd = if (tvPlayback?.state == "playing") "pause" else "play"
-                            connectionViewModel.webSocketClient.send(
-                                com.playbridge.shared.protocol.createControlCommandJson(cmd)
-                            )
-                        }
-                    },
                     onClick = {
                         if (playing) {
                             if (!dlnaActive) {
@@ -1452,6 +1438,10 @@ fun AppNavHost(
                             // Idle → choose / switch the cast destination.
                             showDevicePicker = true
                         }
+                    },
+                    showTvIcon = playing,
+                    onTvIconClick = {
+                        showDevicePicker = true
                     },
                     // Poster-matched accent on the library detail screen (the old FAB's
                     // dynamic styling); FAB-like primaryContainer elsewhere.

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/DevicePicker.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/DevicePicker.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import android.content.Context
 import com.playbridge.sender.connection.ConnectionViewModel
 import com.playbridge.sender.connection.WebSocketClient
 import com.playbridge.sender.model.TvDevice
@@ -208,6 +210,8 @@ fun DeviceConnectionSheet(
     onPickedThisDevice: (() -> Unit)? = null,
     onPickedDevice: ((TvDevice) -> Unit)? = null
 ) {
+    val context = LocalContext.current
+    val browserPrefs = remember { context.getSharedPreferences("browser_prefs", Context.MODE_PRIVATE) }
     val viewModel: ConnectionViewModel = koinViewModel()
     val discovered by viewModel.discoveredDevices.collectAsState()
     val history by viewModel.deviceHistory.collectAsState(initial = emptyList())
@@ -281,6 +285,7 @@ fun DeviceConnectionSheet(
                     selected = onPhone,
                     onClick = {
                         viewModel.disconnect()
+                        browserPrefs.edit().putBoolean("watch_on_tv", false).apply()
                         onPickedThisDevice?.invoke()
                         onDismiss()
                     }
@@ -346,6 +351,7 @@ fun DeviceConnectionSheet(
                                     device.connectDevice.uuid
                                 )
                             }
+                            browserPrefs.edit().putBoolean("watch_on_tv", true).apply()
                             onPickedDevice?.invoke(device.connectDevice)
                             onDismiss()
                         },

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/NowPlayingBar.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/NowPlayingBar.kt
@@ -9,8 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Tv
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -29,11 +28,10 @@ import androidx.compose.ui.unit.dp
 /**
  * Persistent cast mini-bar shown across the main screens. It has two visual modes:
  *
- *  - **Playing** ([showPlayPause] = true): a cast session is active with media loaded —
- *    shows the title + "on <device>" and a play/pause button; tapping opens the Remote.
- *  - **Idle** ([showPlayPause] = false): no media is playing — shows the current cast
- *    destination (a connected TV/renderer, or "This Device" when nothing is connected) and
- *    tapping opens the device picker. No play/pause button.
+ *  - **Playing**: a cast session is active with media loaded — shows the title + "on <device>";
+ *    tapping opens the Remote. Shows a TV icon button on the right to open the connection sheet.
+ *  - **Idle**: no media is playing — shows the current cast destination (a connected TV/renderer,
+ *    or "This Device" when nothing is connected) and tapping opens the device picker.
  *
  * The bar is intentionally "dumb": the host computes [primaryText]/[secondaryText]/[leadingIcon]
  * and the mode flags from the live connection state.
@@ -47,10 +45,9 @@ fun NowPlayingBar(
     primaryText: String,
     secondaryText: String?,
     leadingIcon: ImageVector,
-    showPlayPause: Boolean,
-    isPlaying: Boolean,
-    onPlayPause: () -> Unit,
     onClick: () -> Unit,
+    showTvIcon: Boolean = false,
+    onTvIconClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     accentColor: Color? = null,
 ) {
@@ -100,11 +97,11 @@ fun NowPlayingBar(
                     )
                 }
             }
-            if (showPlayPause) {
-                IconButton(onClick = onPlayPause) {
+            if (showTvIcon && onTvIconClick != null) {
+                IconButton(onClick = onTvIconClick) {
                     Icon(
-                        imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                        contentDescription = if (isPlaying) "Pause" else "Play",
+                        imageVector = Icons.Default.Tv,
+                        contentDescription = "Connection Sheet",
                         tint = content,
                     )
                 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -1,4 +1,9 @@
 package com.playbridge.sender.cast
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.ui.platform.LocalContext
+import android.net.Uri
 import com.playbridge.sender.library.*
 import com.playbridge.sender.browser.*
 import com.playbridge.sender.connection.WebSocketClient
@@ -29,6 +34,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
+import androidx.compose.material.icons.automirrored.filled.VolumeDown
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.foundation.text.KeyboardActions
@@ -43,6 +49,8 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
@@ -50,6 +58,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.ui.graphics.Brush
 import kotlin.math.abs
 
 /** Live playback status synced from the TV via `status` messages. */
@@ -64,7 +77,8 @@ data class TvPlaybackStatus(
 data class MediaTrack(
     val id: String,
     val name: String,
-    val selected: Boolean
+    val selected: Boolean,
+    val type: String? = null
 )
 
 /** TV player settings synced via `player_settings` messages. */
@@ -143,6 +157,7 @@ fun RemoteControlScreen(
 ) {
     var showSettingsSheet by remember { mutableStateOf(false) }
     var showAddSubtitle by remember { mutableStateOf(false) }
+    var showSubtitlesSheet by remember { mutableStateOf(false) }
     // Input mode for the non-player (browser) hero area. Defaults to the touchpad.
     var inputMode by remember { mutableStateOf(RemoteInputMode.TOUCHPAD) }
     // When idle (e.g. right after Stop), the calm empty state can reveal the input surface on demand.
@@ -221,7 +236,7 @@ fun RemoteControlScreen(
                                     audioTracks = audioTracks,
                                     subtitleTracks = subtitleTracks,
                                     onSelectAudio = onSelectAudio,
-                                    onSelectSubtitle = onSelectSubtitle,
+                                    onSubtitlesClick = { showSubtitlesSheet = true },
                                     onMore = { showSettingsSheet = true }
                                 )
                             }
@@ -316,6 +331,13 @@ fun RemoteControlScreen(
                 showSettingsSheet = false
             },
             onDismiss = { showAddSubtitle = false }
+        )
+    }
+    if (showSubtitlesSheet) {
+        SubtitlesBottomSheet(
+            tracks = subtitleTracks,
+            onSelect = onSelectSubtitle,
+            onDismiss = { showSubtitlesSheet = false }
         )
     }
 }
@@ -678,6 +700,9 @@ private fun SeekVolumeBar(
     var dragging by remember { mutableStateOf(false) }
     var dragMs by remember { mutableStateOf(0f) }
     var activeAxis by remember { mutableStateOf<DragAxis?>(null) }
+    var volumeDirection by remember { mutableStateOf<String?>(null) } // "up" or "down"
+    var touchDownTime by remember { mutableStateOf(0L) }
+    var isAggressive by remember { mutableStateOf(false) }
 
     // Vertical travel required for one volume step.
     val volumeStepPx = with(LocalDensity.current) { 28.dp.toPx() }
@@ -687,21 +712,38 @@ private fun SeekVolumeBar(
         (displayMs / durationMs.toFloat()).coerceIn(0f, 1f) else 0f
 
     val primary = MaterialTheme.colorScheme.primary
+
+    // Vertical offset to center the popups vertically on the screen (above the seekbar)
+    val popupOffset = with(LocalDensity.current) {
+        IntOffset(0, -180.dp.roundToPx())
+    }
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(56.dp)
-            .clip(RoundedCornerShape(16.dp))
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+            .height(76.dp)
+            .clip(RoundedCornerShape(24.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.15f))
+            .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.12f)), RoundedCornerShape(24.dp))
             .onSizeChanged { widthPx = it.width.toFloat() }
+            .pointerInput(Unit) {
+                awaitEachGesture {
+                    awaitFirstDown(requireUnconsumed = false)
+                    touchDownTime = System.currentTimeMillis()
+                }
+            }
             .pointerInput(hasDuration, enableVolume, durationMs) {
                 var axis: DragAxis? = null
                 var volAccum = 0f
                 detectDragGestures(
                     onDragStart = {
+                        val dragStartTime = System.currentTimeMillis()
+                        isAggressive = (dragStartTime - touchDownTime) >= 400L
+
                         axis = null
                         volAccum = 0f
                         dragMs = currentPosition.toFloat()
+                        volumeDirection = null
                     },
                     onDrag = { change, drag ->
                         change.consume()
@@ -712,13 +754,30 @@ private fun SeekVolumeBar(
                         }
                         when (axis) {
                             DragAxis.HORIZONTAL -> if (hasDuration && widthPx > 0f) {
-                                val deltaMs = (drag.x / widthPx) * durationMs.toFloat()
+                                val rangeMs = if (isAggressive) {
+                                    durationMs.toFloat()
+                                } else {
+                                    (durationMs / 10L).coerceIn(120_000L, 600_000L).toFloat()
+                                }
+                                val deltaMs = (drag.x / widthPx) * rangeMs
                                 dragMs = (dragMs + deltaMs).coerceIn(0f, durationMs.toFloat())
                             }
                             DragAxis.VERTICAL -> if (enableVolume) {
+                                if (volumeDirection == null) {
+                                    volumeDirection = if (drag.y < 0) "up" else "down"
+                                }
                                 volAccum -= drag.y // swipe up (negative y) raises volume
-                                while (volAccum >= volumeStepPx) { onVolumeUp(); volAccum -= volumeStepPx }
-                                while (volAccum <= -volumeStepPx) { onVolumeDown(); volAccum += volumeStepPx }
+                                val stepPx = if (isAggressive) volumeStepPx / 2.5f else volumeStepPx
+                                while (volAccum >= stepPx) {
+                                    onVolumeUp()
+                                    volAccum -= stepPx
+                                    volumeDirection = "up"
+                                }
+                                while (volAccum <= -stepPx) {
+                                    onVolumeDown()
+                                    volAccum += stepPx
+                                    volumeDirection = "down"
+                                }
                             }
                             else -> {}
                         }
@@ -728,58 +787,268 @@ private fun SeekVolumeBar(
                         dragging = false
                         activeAxis = null
                         axis = null
+                        volumeDirection = null
+                        isAggressive = false
                     },
                     onDragCancel = {
                         dragging = false
                         activeAxis = null
                         axis = null
+                        volumeDirection = null
+                        isAggressive = false
                     },
                 )
             },
         contentAlignment = Alignment.CenterStart
     ) {
-        // Progress fill — only meaningful with a finite duration.
-        if (hasDuration) {
+        // --- Redesigned UX: Visual axis guides and guides in background ---
+        // Horizontal guide line
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(Color.White.copy(alpha = 0.08f))
+                .align(Alignment.Center)
+        )
+        // Vertical guide line
+        if (enableVolume) {
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
-                    .fillMaxWidth(fraction)
-                    .background(primary.copy(alpha = 0.25f))
+                    .width(1.dp)
+                    .background(Color.White.copy(alpha = 0.08f))
+                    .align(Alignment.Center)
             )
         }
 
-        Row(
+        // --- Arrow Indicators to suggest directions ---
+        // Left Seek arrow
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+            contentDescription = null,
+            tint = if (activeAxis == DragAxis.HORIZONTAL) primary else Color.White.copy(alpha = 0.3f),
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .padding(start = 8.dp)
+                .size(24.dp)
+        )
+        // Right Seek arrow
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = if (activeAxis == DragAxis.HORIZONTAL) primary else Color.White.copy(alpha = 0.3f),
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(end = 8.dp)
+                .size(24.dp)
+        )
+        // Top Volume arrow
+        if (enableVolume) {
+            Icon(
+                imageVector = Icons.Filled.KeyboardArrowUp,
+                contentDescription = null,
+                tint = if (activeAxis == DragAxis.VERTICAL) primary else Color.White.copy(alpha = 0.3f),
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = 2.dp)
+                    .size(14.dp)
+            )
+        }
+        // Bottom Volume arrow
+        if (enableVolume) {
+            Icon(
+                imageVector = Icons.Filled.KeyboardArrowDown,
+                contentDescription = null,
+                tint = if (activeAxis == DragAxis.VERTICAL) primary else Color.White.copy(alpha = 0.3f),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 2.dp)
+                    .size(14.dp)
+            )
+        }
+
+        // --- Content Column containing labels and progress bar ---
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 14.dp),
-            verticalAlignment = Alignment.CenterVertically
+                .padding(horizontal = 36.dp).padding(top = 18.dp, bottom = 18.dp),
+            verticalArrangement = Arrangement.SpaceBetween,
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text(
-                text = if (hasDuration) formatTime(displayMs.toLong()) else formatTime(currentPosition),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            val centerLabel = when (activeAxis) {
-                DragAxis.VERTICAL -> "Volume"
-                DragAxis.HORIZONTAL -> "Seek"
-                else -> if (enableVolume) "◄ ► seek · ▲ ▼ volume" else "◄ ► seek"
+            // Top Status Label Row: seek text on left half, volume text on right half
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier.weight(1f),
+                    contentAlignment = Alignment.Center
+                ) {
+                    val seekLabel = if (activeAxis == DragAxis.HORIZONTAL) {
+                        if (isAggressive) "Fast Seeking ◄►" else "Seeking ◄►"
+                    } else "Swipe ◄► Seek"
+                    Text(
+                        text = seekLabel,
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = if (activeAxis == DragAxis.HORIZONTAL) primary else Color.White.copy(alpha = 0.6f)
+                    )
+                }
+                if (enableVolume) {
+                    Box(
+                        modifier = Modifier.weight(1f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        val volumeLabel = if (activeAxis == DragAxis.VERTICAL) {
+                            if (isAggressive) "Fast Volume ▲▼" else "Adjusting Volume ▲▼"
+                        } else "Swipe ▲▼ Volume"
+                        Text(
+                            text = volumeLabel,
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = if (activeAxis == DragAxis.VERTICAL) primary else Color.White.copy(alpha = 0.6f)
+                        )
+                    }
+                }
             }
-            Text(
-                text = centerLabel,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(horizontal = 8.dp)
+
+            // Center Progress Bar
+            if (hasDuration) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(6.dp)
+                        .clip(RoundedCornerShape(3.dp))
+                        .background(Color.White.copy(alpha = 0.12f))
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .fillMaxWidth(fraction)
+                            .background(
+                                Brush.horizontalGradient(
+                                    colors = listOf(primary, primary.copy(alpha = 0.7f))
+                                )
+                            )
+                    )
+                }
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(Color.White.copy(alpha = 0.12f))
+                )
+            }
+
+            // Bottom Time Row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = if (hasDuration) formatTime(displayMs.toLong()) else formatTime(currentPosition),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.White.copy(alpha = 0.5f)
+                )
+                Text(
+                    text = if (isLive) "LIVE" else if (durationMs > 0L) formatTime(durationMs) else "--:--",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.White.copy(alpha = 0.5f)
+                )
+            }
+        }
+    }
+
+    // --- Seek HUD Overlay popup ---
+    if (dragging && activeAxis == DragAxis.HORIZONTAL && hasDuration) {
+        val deltaMs = dragMs.toLong() - currentPosition
+        Popup(
+            alignment = Alignment.Center,
+            offset = popupOffset,
+            properties = PopupProperties(
+                focusable = false,
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false
             )
-            Text(
-                text = if (isLive) "LIVE" else if (durationMs > 0L) formatTime(durationMs) else "--:--",
-                style = MaterialTheme.typography.labelSmall,
-                color = if (isLive) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
+        ) {
+            Surface(
+                color = Color.Black.copy(alpha = 0.75f),
+                shape = RoundedCornerShape(18.dp),
+                border = BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = if (isAggressive) "Fast Seek" else "Seek",
+                        color = primary,
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        "${formatTime(dragMs.toLong())} / ${formatTime(durationMs)}",
+                        color = Color.White,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    val sign = if (deltaMs >= 0) "+" else "-"
+                    Text(
+                        "$sign${formatTime(abs(deltaMs))}",
+                        color = Color.White.copy(alpha = 0.8f),
+                        style = MaterialTheme.typography.labelMedium
+                    )
+                }
+            }
+        }
+    }
+
+    // --- Volume HUD Overlay popup ---
+    if (activeAxis == DragAxis.VERTICAL && enableVolume) {
+        Popup(
+            alignment = Alignment.Center,
+            offset = popupOffset,
+            properties = PopupProperties(
+                focusable = false,
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false
             )
+        ) {
+            Surface(
+                color = Color.Black.copy(alpha = 0.75f),
+                shape = RoundedCornerShape(18.dp),
+                border = BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    val volumeIcon = when (volumeDirection) {
+                        "down" -> Icons.AutoMirrored.Filled.VolumeDown
+                        else -> Icons.AutoMirrored.Filled.VolumeUp
+                    }
+                    Icon(
+                        imageVector = volumeIcon,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(28.dp)
+                    )
+                    val volumeLabel = when (volumeDirection) {
+                        "up" -> if (isAggressive) "Volume Up (Fast) ▲" else "Volume Up ▲"
+                        "down" -> if (isAggressive) "Volume Down (Fast) ▼" else "Volume Down ▼"
+                        else -> if (isAggressive) "Volume (Fast)" else "Volume"
+                    }
+                    Text(
+                        volumeLabel,
+                        color = Color.White,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
         }
     }
 }
@@ -1245,7 +1514,7 @@ private fun TrackChipsRow(
     audioTracks: List<MediaTrack>,
     subtitleTracks: List<MediaTrack>,
     onSelectAudio: (String) -> Unit,
-    onSelectSubtitle: (String) -> Unit,
+    onSubtitlesClick: () -> Unit,
     onMore: () -> Unit
 ) {
     Row(
@@ -1263,13 +1532,40 @@ private fun TrackChipsRow(
             )
         }
         if (subtitleTracks.isNotEmpty()) {
-            TrackChip(
-                icon = Icons.Default.Subtitles,
-                label = "Subs",
-                tracks = subtitleTracks,
-                onSelect = onSelectSubtitle,
-                modifier = Modifier.weight(1f)
-            )
+            val selectedName = subtitleTracks.firstOrNull { it.selected }?.name ?: "—"
+            Surface(
+                onClick = onSubtitlesClick,
+                shape = RoundedCornerShape(20.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+                modifier = Modifier.weight(1f).height(40.dp)
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    Icon(
+                        Icons.Default.Subtitles,
+                        contentDescription = "Subtitles",
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = "Subs: $selectedName",
+                        style = MaterialTheme.typography.labelLarge,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Icon(
+                        Icons.Default.ArrowDropDown,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
         }
         if (audioTracks.isEmpty() && subtitleTracks.isEmpty()) {
             Spacer(modifier = Modifier.weight(1f))
@@ -1506,12 +1802,60 @@ private fun AddSubtitleDialog(
     var searching by remember { mutableStateOf(false) }
     var searched by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
+    val filePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        if (uri != null) {
+            val fileName = runCatching {
+                val cursor = context.contentResolver.query(uri, null, null, null, null)
+                cursor?.use { c ->
+                    val nameIndex = c.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+                    if (nameIndex != -1 && c.moveToFirst()) c.getString(nameIndex) else null
+                }
+            }.getOrNull() ?: uri.lastPathSegment ?: "subtitle.srt"
+
+            val extension = fileName.substringAfterLast('.', "").lowercase()
+            val supportedExtensions = setOf("srt", "vtt", "ass", "ssa", "sub")
+            if (extension !in supportedExtensions) {
+                android.widget.Toast.makeText(context, "Only subtitle files (.srt, .vtt, .ass) are supported", android.widget.Toast.LENGTH_SHORT).show()
+                return@rememberLauncherForActivityResult
+            }
+
+            val mime = when {
+                fileName.endsWith(".vtt", ignoreCase = true) -> "text/vtt"
+                else -> "application/x-subrip"
+            }
+
+            val proxyServer = com.playbridge.sender.cast.dlna.DlnaProxyHolder.proxy(context)
+            val proxyUrl = proxyServer.publishLocal(uri, mime)
+            val urlWithFragment = "$proxyUrl#${java.net.URLEncoder.encode(fileName, "UTF-8")}"
+            onAddUrl(urlWithFragment)
+        }
+    }
 
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("Add subtitle") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(
+                    onClick = { filePickerLauncher.launch("*/*") },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.filledTonalButtonColors()
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.UploadFile,
+                        contentDescription = "Upload local file",
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Choose Local Subtitle File")
+                }
+
+                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
                 OutlinedTextField(
                     value = url,
                     onValueChange = { url = it },
@@ -1568,3 +1912,240 @@ private fun AddSubtitleDialog(
         dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }
     )
 }
+
+
+private const val OFF_KEY = "__off__"
+private const val EMBEDDED_KEY = "__embedded__"
+private const val REMOTE_KEY = "__remote__"
+private const val EXTERNAL_KEY = "__external__"
+
+private data class SubGroup(
+    val key: String,
+    val label: String,
+    val tracks: List<MediaTrack>,
+    val hasSelected: Boolean
+)
+
+private data class SubInfo(val langKey: String, val langDisplay: String, val optionLabel: String)
+
+// Mapping from language token to display name
+private val LANG_TOKENS: Map<String, String> = buildMap {
+    fun add(display: String, vararg tokens: String) { tokens.forEach { put(it, display) } }
+    add("English", "english", "en", "eng")
+    add("Spanish", "spanish", "es", "spa", "esp")
+    add("French", "french", "fr", "fre", "fra")
+    add("German", "german", "de", "ger", "deu")
+    add("Italian", "italian", "it", "ita")
+    add("Japanese", "japanese", "ja", "jpn")
+    add("Korean", "korean", "ko", "kor")
+    add("Chinese", "chinese", "zh", "chi", "zho")
+    add("Russian", "russian", "ru", "rus")
+    add("Portuguese", "portuguese", "pt", "por")
+    add("Portuguese (BR)", "portuguese (br)", "pob", "pt-br", "ptbr")
+    add("Arabic", "arabic", "ar", "ara")
+    add("Hindi", "hindi", "hi", "hin")
+    add("Dutch", "dutch", "nl", "dut", "nld")
+    add("Swedish", "swedish", "sv", "swe")
+    add("Turkish", "turkish", "tr", "tur")
+    add("Polish", "polish", "pl", "pol")
+    add("Romanian", "romanian", "ro", "ron", "rum")
+    add("Greek", "greek", "el", "ell", "gre")
+    add("Czech", "czech", "cs", "cze", "ces")
+    add("Danish", "danish", "da", "dan")
+    add("Hungarian", "hungarian", "hu", "hun")
+    add("Bulgarian", "bulgarian", "bg", "bul")
+    add("Slovenian", "slovenian", "sl", "slv")
+    add("Indonesian", "indonesian", "id", "ind")
+    add("Hebrew", "hebrew", "he", "heb")
+    add("Finnish", "finish", "fi", "fin")
+    add("Serbian", "serbian", "sr", "srp")
+    add("Croatian", "croatian", "hr", "hrv")
+    add("Norwegian", "norwegian", "no", "nor")
+    add("Ukrainian", "ukrainian", "uk", "ukr")
+    add("Thai", "thai", "th", "tha")
+    add("Vietnamese", "vietnamese", "vi", "vie")
+    add("Persian", "persian", "farsi", "fa", "per", "fas")
+}
+
+private fun languageOf(segment: String): String? = LANG_TOKENS[segment.trim().lowercase()]
+
+private fun classifySub(t: MediaTrack): SubInfo {
+    if (t.id == "off" || t.id == "none") {
+        return SubInfo(OFF_KEY, "Off", "Off")
+    }
+
+    val isExternal = t.type == "external_sub" || t.id.startsWith("external_") || t.id.contains("://")
+    if (!isExternal) {
+        return SubInfo(EMBEDDED_KEY, "Embedded", t.name)
+    }
+
+    if (!t.name.contains("OpenSubtitles #")) {
+        return SubInfo(REMOTE_KEY, "Phone Remote", t.name.ifBlank { "Remote Subtitle" })
+    }
+
+    val segs = t.name.split(" · ", " • ").map { it.trim() }.filter { it.isNotEmpty() }
+    val lang = segs.firstNotNullOfOrNull { languageOf(it) }
+    return if (lang != null) {
+        val rest = segs.filter { languageOf(it) == null }.joinToString(" • ")
+        val opt = rest.ifBlank { "Add-on" }
+        SubInfo(lang.lowercase(), lang, opt)
+    } else {
+        SubInfo(EXTERNAL_KEY, "External", t.name.ifBlank { "Subtitle" })
+    }
+}
+
+private fun groupSubtitleTracks(tracks: List<MediaTrack>): List<SubGroup> {
+    val off = tracks.firstOrNull { it.id == "off" || it.id == "none" }
+    val byLang = LinkedHashMap<String, Pair<String, MutableList<MediaTrack>>>()
+    
+    tracks.filter { it.id != "off" && it.id != "none" }.forEach { t ->
+        val info = classifySub(t)
+        byLang.getOrPut(info.langKey) { info.langDisplay to mutableListOf() }.second.add(t)
+    }
+    
+    val groups = mutableListOf<SubGroup>()
+    if (off != null) {
+        groups.add(SubGroup(OFF_KEY, "Off", listOf(off), off.selected))
+    }
+
+    byLang[EMBEDDED_KEY]?.let { (display, list) ->
+        groups.add(SubGroup(EMBEDDED_KEY, display, list, list.any { it.selected }))
+    }
+
+    byLang[REMOTE_KEY]?.let { (display, list) ->
+        groups.add(SubGroup(REMOTE_KEY, display, list, list.any { it.selected }))
+    }
+
+    byLang.filterKeys { it != EMBEDDED_KEY && it != REMOTE_KEY && it != EXTERNAL_KEY }.forEach { (k, v) ->
+        groups.add(SubGroup(k, v.first, v.second, v.second.any { it.selected }))
+    }
+
+    byLang[EXTERNAL_KEY]?.let { (display, list) ->
+        groups.add(SubGroup(EXTERNAL_KEY, display, list, list.any { it.selected }))
+    }
+
+    return groups
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SubtitlesBottomSheet(
+    tracks: List<MediaTrack>,
+    onSelect: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val groups = remember(tracks) { groupSubtitleTracks(tracks) }
+    
+    // Find the group that contains the currently selected track, or fallback to the first non-Off group, or the first group
+    val initialGroupKey = remember(groups) {
+        groups.firstOrNull { g -> g.tracks.any { it.selected } && g.key != OFF_KEY }?.key
+            ?: groups.firstOrNull { it.key != OFF_KEY }?.key
+            ?: groups.firstOrNull()?.key
+    }
+    var selectedGroupKey by remember(groups) { mutableStateOf(initialGroupKey) }
+    val currentGroup = groups.firstOrNull { it.key == selectedGroupKey }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        containerColor = MaterialTheme.colorScheme.surface,
+        dragHandle = { BottomSheetDefaults.DragHandle() }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 24.dp)
+        ) {
+            Text(
+                text = "Subtitles",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Categories horizontal chips row
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                groups.forEach { group ->
+                    val isSelected = selectedGroupKey == group.key
+                    FilterChip(
+                        selected = isSelected,
+                        onClick = { selectedGroupKey = group.key },
+                        label = {
+                            val countSuffix = if (group.key != OFF_KEY && group.tracks.isNotEmpty()) " (${group.tracks.size})" else ""
+                            Text(group.label + countSuffix)
+                        },
+                        leadingIcon = if (group.hasSelected) {
+                            {
+                                Icon(
+                                    imageVector = Icons.Default.Check,
+                                    contentDescription = "Active selection",
+                                    modifier = Modifier.size(16.dp)
+                                )
+                            }
+                        } else null,
+                        shape = RoundedCornerShape(20.dp)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (currentGroup != null) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth().heightIn(max = 360.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    items(currentGroup.tracks, key = { it.id }) { track ->
+                        val isSelected = track.selected
+                        val displayLabel = if (currentGroup.key == OFF_KEY) "Off" else classifySub(track).optionLabel
+                        
+                        Surface(
+                            onClick = {
+                                onSelect(track.id)
+                                onDismiss()
+                            },
+                            shape = RoundedCornerShape(12.dp),
+                            color = if (isSelected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+                            border = if (isSelected) BorderStroke(1.dp, MaterialTheme.colorScheme.primary) else null,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(
+                                    text = displayLabel,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                                    color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
+                                )
+                                if (isSelected) {
+                                    Icon(
+                                        imageVector = Icons.Default.Check,
+                                        contentDescription = "Selected",
+                                        tint = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.size(20.dp)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/StreamingSettingsScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/StreamingSettingsScreen.kt
@@ -66,6 +66,7 @@ fun StreamingSettingsScreen(onBack: () -> Unit) {
 
     val preferredSubLang by settingsRepository.preferredSubtitleLang.collectAsState(initial = "")
     var subExpanded by remember { mutableStateOf(false) }
+    val sendSubtitlesToTv by settingsRepository.sendSubtitlesToTv.collectAsState(initial = true)
 
     var minSizeText by remember {
         mutableStateOf(browserPrefs.getString("auto_stream_min_gb", "") ?: "")
@@ -441,6 +442,23 @@ fun StreamingSettingsScreen(onBack: () -> Unit) {
                     }
                 }
             }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            ListItem(
+                headlineContent = { Text("Send Subtitles to TV") },
+                supportingContent = { Text("Fetch and send addon subtitles automatically when casting from the library") },
+                trailingContent = {
+                    Switch(
+                        checked = sendSubtitlesToTv,
+                        onCheckedChange = { checked ->
+                            scope.launch { settingsRepository.setSendSubtitlesToTv(checked) }
+                        }
+                    )
+                },
+                modifier = Modifier.clickable {
+                    scope.launch { settingsRepository.setSendSubtitlesToTv(!sendSubtitlesToTv) }
+                }
+            )
         }
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionCoordinator.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionCoordinator.kt
@@ -96,7 +96,8 @@ class ConnectionCoordinator(
                                                 MediaTrack(
                                                     id = o.optString("id"),
                                                     name = o.optString("name", "Track ${i + 1}"),
-                                                    selected = o.optBoolean("selected", false)
+                                                    selected = o.optBoolean("selected", false),
+                                                    type = if (o.has("type")) o.optString("type") else null
                                                 )
                                             )
                                         }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/TvQueueCoordinator.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/TvQueueCoordinator.kt
@@ -185,6 +185,8 @@ class TvQueueCoordinator(
 
     /** Preferred-language addon subtitles for an episode (from its template's visual_metadata). */
     private suspend fun fetchSubtitlesFor(tmpl: playbridge.PlayPayload, resolvedUrl: String?): List<String> {
+        val sendSubtitles = runCatching { settingsRepository.sendSubtitlesToTv.first() }.getOrDefault(true)
+        if (!sendSubtitles) return emptyList()
         val pref = runCatching { settingsRepository.preferredSubtitleLang.first() }.getOrDefault("")
         val vm = tmpl.visual_metadata
         return subtitleService.getAllSubtitleUrls(

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
@@ -29,6 +29,7 @@ private const val TAG = "WebSocketClient"
 class WebSocketClient {
     
     private val client = OkHttpClient.Builder()
+        .dns(LinkLocalDns())
         .pingInterval(15, TimeUnit.SECONDS)
         .connectTimeout(10, TimeUnit.SECONDS)
         .readTimeout(0, TimeUnit.MILLISECONDS)
@@ -148,7 +149,8 @@ class WebSocketClient {
         val conn = targetConnection
         val wssPort = conn?.wssPort ?: (port + 1)
         isSecure = true
-        val url = "wss://$ip:$wssPort/"
+        val formattedHost = LinkLocalDns.encodeIpv6ToHost(ip)
+        val url = "wss://$formattedHost:$wssPort/"
         val httpClient = buildPinningClient(conn?.pin)
         Log.i(TAG, "Connecting to $url")
 
@@ -419,5 +421,50 @@ class WebSocketClient {
         disconnect()
         scope.cancel()
         client.dispatcher.executorService.shutdown()
+    }
+}
+
+internal class LinkLocalDns : Dns {
+    override fun lookup(hostname: String): List<java.net.InetAddress> {
+        if (hostname.endsWith(".local-ipv6")) {
+            try {
+                val decodedIp = decodeHostToIpv6String(hostname)
+                return listOf(java.net.InetAddress.getByName(decodedIp))
+            } catch (e: Exception) {
+                // fallback to default resolution
+            }
+        }
+        return Dns.SYSTEM.lookup(hostname)
+    }
+
+    companion object {
+        fun encodeIpv6ToHost(ip: String): String {
+            if (!ip.contains(":")) return ip
+            val cleanIp = ip.removePrefix("[").removeSuffix("]")
+            val rawIp = cleanIp.substringBefore("%")
+            val scope = cleanIp.substringAfter("%", "")
+            return try {
+                val addr = java.net.InetAddress.getByName(rawIp)
+                val hexBytes = addr.address.joinToString("") { "%02x".format(it) }
+                if (scope.isNotEmpty()) "$hexBytes-$scope.local-ipv6" else "$hexBytes.local-ipv6"
+            } catch (e: Exception) {
+                cleanIp // fallback
+            }
+        }
+
+        fun decodeHostToIpv6String(hostname: String): String {
+            if (!hostname.endsWith(".local-ipv6")) return hostname
+            val parts = hostname.removeSuffix(".local-ipv6")
+            val hexPart = parts.substringBefore("-")
+            if (hexPart.length != 32) return hostname
+            val scopePart = parts.substringAfter("-", "")
+            val ipStringBuilder = StringBuilder()
+            for (i in 0 until 8) {
+                if (i > 0) ipStringBuilder.append(":")
+                ipStringBuilder.append(hexPart.substring(i * 4, i * 4 + 4))
+            }
+            val ipStr = ipStringBuilder.toString()
+            return if (scopePart.isNotEmpty() && scopePart != parts) "$ipStr%$scopePart" else ipStr
+        }
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/settings/SettingsRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/settings/SettingsRepository.kt
@@ -32,6 +32,7 @@ class SettingsRepository(
         val IPTV_SORT = stringPreferencesKey("iptv_sort")           // "ADDED_DATE" | "NAME"
         val IPTV_SORT_ASCENDING = booleanPreferencesKey("iptv_sort_ascending")
         val IPTV_ACTIVE_FIRST = booleanPreferencesKey("iptv_active_first")
+        val SEND_SUBTITLES_TO_TV = booleanPreferencesKey("send_subtitles_to_tv")
     }
 
     // 2. Flow definitions for reactive Compose collectors
@@ -57,6 +58,7 @@ class SettingsRepository(
     val iptvSortAscending: Flow<Boolean> = dataStore.data.catch { handleException(it) }.map { it[Keys.IPTV_SORT_ASCENDING] ?: false }
     /** When exploring a playlist, float probe-confirmed live channels to the top. */
     val iptvActiveFirst: Flow<Boolean> = dataStore.data.catch { handleException(it) }.map { it[Keys.IPTV_ACTIVE_FIRST] ?: true }
+    val sendSubtitlesToTv: Flow<Boolean> = dataStore.data.catch { handleException(it) }.map { it[Keys.SEND_SUBTITLES_TO_TV] ?: true }
 
     // 3. Mutator methods
     suspend fun setAutoSwitchToRemote(value: Boolean) = write { it[Keys.AUTO_SWITCH_TO_REMOTE] = value }
@@ -74,6 +76,7 @@ class SettingsRepository(
     suspend fun setIptvSort(value: String) = write { it[Keys.IPTV_SORT] = value }
     suspend fun setIptvSortAscending(value: Boolean) = write { it[Keys.IPTV_SORT_ASCENDING] = value }
     suspend fun setIptvActiveFirst(value: Boolean) = write { it[Keys.IPTV_ACTIVE_FIRST] = value }
+    suspend fun setSendSubtitlesToTv(value: Boolean) = write { it[Keys.SEND_SUBTITLES_TO_TV] = value }
     
     suspend fun addPopupWhitelist(host: String) = write { prefs ->
         val current = prefs[Keys.POPUP_WHITELIST] ?: emptySet()

--- a/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryDetailScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryDetailScreen.kt
@@ -174,6 +174,13 @@ fun LibraryDetailScreen(
         )
     }
 
+    // Reactively update watchOnTv mode when TV connection status changes live
+    LaunchedEffect(isTvConnected) {
+        if (isTvConnected) {
+            watchOnTv = true
+        }
+    }
+
     // Player mode (mirrors CastSheet; persisted to browser_prefs/tv_player_mode)
     val settingsRepository: com.playbridge.sender.data.settings.SettingsRepository = org.koin.compose.koinInject()
     val tmdbRepository: com.playbridge.sender.data.library.TmdbRepository = org.koin.compose.koinInject()
@@ -348,7 +355,7 @@ fun LibraryDetailScreen(
             logo_url = displayLogo,
             imdb_id = currentImdbId,
             tmdb_id = currentTmdbId?.toString(),
-            season = if (isSeries) selectedSeason else null,
+            season = if (isSeries) (episode?.season ?: selectedSeason) else null,
             episode = if (isSeries) episode?.episode else null,
             episode_title = if (isSeries) episode?.title else null
         )

--- a/mobile/android/app/src/test/java/com/playbridge/sender/ExampleUnitTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/ExampleUnitTest.kt
@@ -1,8 +1,9 @@
 package com.playbridge.sender
 
 import org.junit.Test
-
 import org.junit.Assert.*
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import com.playbridge.sender.connection.LinkLocalDns
 
 /**
  * Example local unit test, which will execute on the development machine (host).
@@ -13,5 +14,25 @@ class ExampleUnitTest {
     @Test
     fun addition_isCorrect() {
         assertEquals(4, 2 + 2)
+    }
+
+    @Test
+    fun testLinkLocalDnsFormatting() {
+        val rawIp = "fe80::d704:283a:2eca:e313%lo0"
+        
+        // Encode IP into a safe hostname
+        val hostname = LinkLocalDns.encodeIpv6ToHost(rawIp)
+        assertEquals("fe80000000000000d704283a2ecae313-lo0.local-ipv6", hostname)
+        
+        val url = "https://$hostname:8766/"
+        
+        // OkHttp HttpUrl should parse this perfectly
+        val httpUrl = url.toHttpUrl()
+        assertEquals(hostname, httpUrl.host)
+        
+        // Decode hostname back to IPv6 string
+        val decoded = LinkLocalDns.decodeHostToIpv6String(hostname)
+        val expectedNormalizedIp = "fe80:0000:0000:0000:d704:283a:2eca:e313%lo0"
+        assertEquals(expectedNormalizedIp, decoded)
     }
 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
@@ -135,6 +135,7 @@ class ExoPlayerActivity : PlayerActivity() {
             displayTitle?.takeIf { it.isNotBlank() }?.let {
                 android.widget.Toast.makeText(this@ExoPlayerActivity, it, android.widget.Toast.LENGTH_SHORT).show()
             }
+            controlsViewModel.setPrePlay(item.visual_metadata, showCountdown = false)
             playVideo(
                 url = item.url,
                 title = displayTitle,
@@ -297,7 +298,7 @@ class ExoPlayerActivity : PlayerActivity() {
                         onPrePlayStartNow = {
                             launchJob?.cancel()
                             controlsViewModel.setPrePlayLaunching(true)
-                            controlsViewModel.setPrePlay(null)
+                            controlsViewModel.setPrePlay(null, clearOnlineSubs = false)
                         },
                         onPrePlayBack = {
                             launchJob?.cancel()
@@ -336,7 +337,7 @@ class ExoPlayerActivity : PlayerActivity() {
                         },
                         onToggleAudioBoost = { controlsViewModel.toggleAudioBoost() },
                         onAdjustSubtitleDelay = { controlsViewModel.adjustSubtitleDelay(it) },
-                        onPreloadSubtitles = { controlsViewModel.preloadSubtitleCues(it) }
+                        onPreloadSubtitles = { controlsViewModel.preloadSubtitleCues(it) },
                     )
                 }
             }
@@ -780,7 +781,7 @@ class ExoPlayerActivity : PlayerActivity() {
                         triggerPrePlayCountdown(controlsViewModel) {
                             FileLogger.i(TAG, "Countdown finished - starting playback")
                             engine?.getExoPlayer()?.playWhenReady = true
-                            controlsViewModel.setPrePlay(null)
+                            controlsViewModel.setPrePlay(null, clearOnlineSubs = false)
                         }
                     } else {
                         engine?.getExoPlayer()?.playWhenReady = true
@@ -1568,7 +1569,8 @@ class ExoPlayerActivity : PlayerActivity() {
         controlsViewModel.updateTracks(
             audio = mapTracks(androidx.media3.common.C.TRACK_TYPE_AUDIO, "audio"),
             subtitles = buildSubtitleTracks(tracks, params),
-            video = mapTracks(androidx.media3.common.C.TRACK_TYPE_VIDEO, "video")
+            video = mapTracks(androidx.media3.common.C.TRACK_TYPE_VIDEO, "video"),
+            currentSubtitleUrl = currentSubtitleUrl
         )
         controlsViewModel.setPlaybackSpeed(player.playbackParameters.speed)
         
@@ -1622,5 +1624,12 @@ class ExoPlayerActivity : PlayerActivity() {
         format.language?.let { if (it.isNotEmpty()) items.add(it.uppercase()) }
         if (format.bitrate != androidx.media3.common.Format.NO_VALUE) items.add("${format.bitrate / 1000} kbps")
         return if (items.isEmpty()) format.id ?: "Unknown" else items.joinToString(" • ")
+    }
+
+    override fun addExternalSubtitle(url: String) {
+        if (url !in subtitleUrls) {
+            subtitleUrls = subtitleUrls + url
+        }
+        applyUnifiedTrackSelection("external_sub", url)
     }
 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/InputHandler.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/InputHandler.kt
@@ -116,8 +116,8 @@ class InputHandler(
             val upEvent = KeyEvent(KeyEvent.ACTION_UP, keyCode)
 
             activity.runOnUiThread {
-                activity.dispatchKeyEvent(downEvent)
-                activity.dispatchKeyEvent(upEvent)
+                (activity as android.app.Activity).dispatchKeyEvent(downEvent)
+                (activity as android.app.Activity).dispatchKeyEvent(upEvent)
             }
         }
     }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/InputHandler.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/InputHandler.kt
@@ -14,7 +14,7 @@ private const val TAG = "InputHandler"
  * phone remote key simulation, and physical TV remote D-pad events.
  */
 class InputHandler(
-    private val activity: Activity,
+    private val activity: PlayerActivity,
     private val audioManager: AudioManager,
     private val engine: PlayerEngineAdapter,
     private val controls: PlayerControlsViewModel,
@@ -53,7 +53,7 @@ class InputHandler(
                 }
                 command.startsWith("add_subtitle:") -> {
                     val url = command.removePrefix("add_subtitle:")
-                    if (url.isNotBlank()) controls.loadExternalSubtitle(url)
+                    if (url.isNotBlank()) activity.addExternalSubtitle(url)
                     return
                 }
                 command == "audio_boost" -> {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
@@ -156,6 +156,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
                     Toast.makeText(this@MpvPlayerActivity, it, Toast.LENGTH_SHORT).show()
                     controlsViewModel.setTitle(it)
                 }
+                controlsViewModel.setPrePlay(item.visual_metadata, showCountdown = false)
                 controlsViewModel.hideControls()
             }
             stopPlayback()
@@ -282,7 +283,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
                         onPrePlayStartNow = {
                             launchJob?.cancel()
                             controlsViewModel.setPrePlayLaunching(true)
-                            controlsViewModel.setPrePlay(null)
+                            controlsViewModel.setPrePlay(null, clearOnlineSubs = false)
                         },
                         onPrePlayBack = {
                             launchJob?.cancel()
@@ -313,7 +314,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
                         },
                         onToggleAudioBoost = { controlsViewModel.toggleAudioBoost() },
                         onAdjustSubtitleDelay = { controlsViewModel.adjustSubtitleDelay(it) },
-                        onPreloadSubtitles = { controlsViewModel.preloadSubtitleCues(it) }
+                        onPreloadSubtitles = { controlsViewModel.preloadSubtitleCues(it) },
                     )
                 }
             }
@@ -621,7 +622,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
                         triggerPrePlayCountdown(controlsViewModel) {
                             FileLogger.i(TAG, "Countdown finished - starting playback")
                             engine?.play()
-                            controlsViewModel.setPrePlay(null)
+                            controlsViewModel.setPrePlay(null, clearOnlineSubs = false)
                         }
                     }
 
@@ -1089,7 +1090,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
         val noSubSelected = allTracks.none { it.type == "sub" && it.isSelected } && currentSubtitleUrl == null
         val offSub = UnifiedTrack("none", "Off", noSubSelected, "sub")
         
-        controlsViewModel.updateTracks(audio, listOf(offSub) + embeddedSubs + externalSubs, video)
+        controlsViewModel.updateTracks(audio, listOf(offSub) + embeddedSubs + externalSubs, video, currentSubtitleUrl)
         controlsViewModel.setPlaybackSpeed(currentPlaybackSpeed)
     }
 
@@ -1192,5 +1193,12 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
                 if (dest.exists() && dest.length() == 0L) dest.delete()
             }
         }
+    }
+
+    override fun addExternalSubtitle(url: String) {
+        if (url !in subtitleUrls) {
+            subtitleUrls = subtitleUrls + url
+        }
+        applyMpvTrackSelection("external_sub", url)
     }
 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerActivity.kt
@@ -182,6 +182,7 @@ abstract class PlayerActivity : ComponentActivity() {
                         put("id", t.id)
                         put("name", t.name)
                         put("selected", t.isSelected)
+                        put("type", t.type)
                     })
                 }
             }
@@ -419,19 +420,19 @@ abstract class PlayerActivity : ComponentActivity() {
     }
 
     protected fun handlePrePlayMetadata(intent: Intent?, controlsViewModel: PlayerControlsViewModel) {
-        if (intent?.getBooleanExtra(ServerService.EXTRA_SKIP_PREPLAY, false) == true) {
-            FileLogger.d("PlayerActivity", "Skipping pre-play metadata per EXTRA_SKIP_PREPLAY")
-            controlsViewModel.setPrePlay(null)
-            return
-        }
+        val skipPreplay = intent?.getBooleanExtra(ServerService.EXTRA_SKIP_PREPLAY, false) == true
         val visualMetadataBytes = intent?.getByteArrayExtra(ServerService.EXTRA_VISUAL_METADATA)
         if (visualMetadataBytes != null) {
             try {
                 val metadata = playbridge.VisualMetadata.ADAPTER.decode(visualMetadataBytes)
-                FileLogger.i("PlayerActivity", "Received pre-play metadata: ${metadata.title}")
-                controlsViewModel.setPrePlay(metadata)
-                controlsViewModel.setPrePlayLaunching(true)
-                controlsViewModel.setPrePlayCountdown(-1) // -1 signifies "Connecting..."
+                FileLogger.i("PlayerActivity", "Received visual metadata (skipPreplay=$skipPreplay): ${metadata.title}")
+                if (skipPreplay) {
+                    controlsViewModel.setPrePlay(metadata, showCountdown = false)
+                } else {
+                    controlsViewModel.setPrePlay(metadata)
+                    controlsViewModel.setPrePlayLaunching(true)
+                    controlsViewModel.setPrePlayCountdown(-1) // -1 signifies "Connecting..."
+                }
             } catch (e: Exception) {
                 FileLogger.e("PlayerActivity", "Failed to parse visual metadata", e)
                 controlsViewModel.setPrePlay(null)
@@ -495,7 +496,6 @@ abstract class PlayerActivity : ComponentActivity() {
 
         // Remove EXTRA_CONTENT_PAYLOAD so we don't re-resolve streams
         newIntent.removeExtra(ServerService.EXTRA_CONTENT_PAYLOAD)
-        newIntent.removeExtra(ServerService.EXTRA_VISUAL_METADATA)
         newIntent.putExtra(ServerService.EXTRA_SKIP_PREPLAY, true)
 
 
@@ -530,6 +530,15 @@ abstract class PlayerActivity : ComponentActivity() {
             PlaylistStore.currentPlaylist = queueItems
             newIntent.putExtra(ServerService.EXTRA_IS_PLAYLIST, true)
             newIntent.putExtra(ServerService.EXTRA_PLAYLIST_INDEX, queueIndex)
+
+            // Carry the current item's visual metadata across the switch.
+            val currentItem = queueItems.getOrNull(queueIndex)
+            val currentVisualMetadata = currentItem?.visual_metadata
+            if (currentVisualMetadata != null) {
+                newIntent.putExtra(ServerService.EXTRA_VISUAL_METADATA, currentVisualMetadata.encode())
+            } else {
+                newIntent.removeExtra(ServerService.EXTRA_VISUAL_METADATA)
+            }
         } else {
             newIntent.removeExtra(ServerService.EXTRA_IS_PLAYLIST)
             newIntent.removeExtra(ServerService.EXTRA_PLAYLIST_INDEX)
@@ -544,6 +553,9 @@ abstract class PlayerActivity : ComponentActivity() {
         startActivity(newIntent)
         finish()
     }
+
+    abstract fun addExternalSubtitle(url: String)
+
     companion object {
         @Volatile
         private var current: java.lang.ref.WeakReference<PlayerActivity>? = null

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/SubtitleFetcher.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/SubtitleFetcher.kt
@@ -1,0 +1,57 @@
+package com.playbridge.player.player
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+
+object SubtitleFetcher {
+    private const val TAG = "SubtitleFetcher"
+    private val client = OkHttpClient()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @kotlinx.serialization.Serializable
+    data class StremioSubtitle(
+        val id: String = "",
+        val url: String = "",
+        val SubEncoding: String? = null,
+        val lang: String = ""
+    )
+
+    @kotlinx.serialization.Serializable
+    data class StremioSubtitleResponse(
+        val subtitles: List<StremioSubtitle> = emptyList()
+    )
+
+    suspend fun fetchSubtitles(imdbId: String, season: Int?, episode: Int?): List<StremioSubtitle> = withContext(Dispatchers.IO) {
+        val url = if (season != null && episode != null) {
+            "https://opensubtitles-v3.strem.io/subtitles/series/$imdbId:$season:$episode.json"
+        } else {
+            "https://opensubtitles-v3.strem.io/subtitles/movie/$imdbId.json"
+        }
+
+        Log.i(TAG, "Fetching subtitles from: $url")
+        val request = Request.Builder()
+            .url(url)
+            .header("User-Agent", "Mozilla/5.0")
+            .build()
+
+        try {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    Log.w(TAG, "Failed to fetch subtitles: HTTP ${response.code}")
+                    return@withContext emptyList()
+                }
+                val bodyText = response.body?.string() ?: return@withContext emptyList()
+                val parsed = json.decodeFromString<StremioSubtitleResponse>(bodyText)
+                parsed.subtitles
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error fetching subtitles from stremio proxy", e)
+            emptyList()
+        }
+    }
+}

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
@@ -326,6 +326,11 @@ class ServerService : Service() {
     }
 
     private fun handleMessage(msg: IncomingMessage) {
+        val isDebug = (applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0
+        if (isDebug && msg !is IncomingMessage.Mouse) {
+            logDebugLong(TAG, "Command received: $msg")
+        }
+
         if (msg !is IncomingMessage.Mouse) {
             FileLogger.i(TAG, "=== MESSAGE RECEIVED ===")
             FileLogger.i(TAG, "Message type: ${msg.javaClass.simpleName}")
@@ -715,6 +720,16 @@ class ServerService : Service() {
         // Cancel scope after stopping server
         scope.cancel()
         super.onDestroy()
+    }
+
+    private fun logDebugLong(tag: String, message: String) {
+        val maxLogSize = 2000
+        var i = 0
+        while (i < message.length) {
+            val end = minOf(i + maxLogSize, message.length)
+            Log.d(tag, message.substring(i, end))
+            i += maxLogSize
+        }
     }
 
     companion object {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsOverlay.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsOverlay.kt
@@ -92,7 +92,8 @@ fun PlayerControlsOverlay(
                         onPreloadLanguage = onPreloadSubtitles,
                         onTrackSelected = onTrackSelected,
                         onAdjustDelay = onAdjustSubtitleDelay,
-                        onDismiss = onOverlayDismiss
+                        onDismiss = onOverlayDismiss,
+                        activeMetadata = state.activeMetadata,
                     )
                 }
 

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsState.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsState.kt
@@ -38,6 +38,7 @@ data class PlayerControlsState(
     val hasPlaylist: Boolean = false,
     val engineType: String = "",
     val prePlayMetadata: playbridge.VisualMetadata? = null,
+    val activeMetadata: playbridge.VisualMetadata? = null,
     val prePlayCountdown: Int = 0,
     val isPrePlayLaunching: Boolean = false,
     
@@ -62,5 +63,5 @@ data class PlayerControlsState(
     val currentSubtitleText: String? = null,
     // Bumped whenever a subtitle preview finishes loading, so the overlay re-reads the
     // SubtitleCueLoader cache. The cues themselves live in the loader, not in state.
-    val subtitleCuesVersion: Int = 0
+    val subtitleCuesVersion: Int = 0,
 )

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsViewModel.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import android.util.Log
 import com.playbridge.player.player.SubtitleManager
 import com.playbridge.player.player.SubtitleCueLoader
 
@@ -21,6 +20,8 @@ class PlayerControlsViewModel : ViewModel() {
     private var progressUpdateJob: Job? = null
     private var engine: PlayerEngineAdapter? = null
     private var subtitleManager: SubtitleManager? = null
+    private var onlineSubtitleJob: Job? = null
+    private var cachedOnlineTracks: List<UnifiedTrack> = emptyList()
 
     /** Request headers for fetching subtitle files (set by the activity when media loads). */
     var subtitleRequestHeaders: Map<String, String>? = null
@@ -150,8 +151,52 @@ class PlayerControlsViewModel : ViewModel() {
         _controlsState.update { it.copy(isBuffering = isBuffering) }
     }
     
-    fun setPrePlay(metadata: playbridge.VisualMetadata?) {
-        _controlsState.update { it.copy(prePlayMetadata = metadata) }
+    fun setPrePlay(
+        metadata: playbridge.VisualMetadata?,
+        clearOnlineSubs: Boolean = true,
+        showCountdown: Boolean = true
+    ) {
+        if (clearOnlineSubs) {
+            onlineSubtitleJob?.cancel()
+            cachedOnlineTracks = emptyList()
+        }
+
+        _controlsState.update { state ->
+            val nextActiveMetadata = metadata ?: if (!clearOnlineSubs) state.activeMetadata else null
+            state.copy(
+                activeMetadata = nextActiveMetadata,
+                prePlayMetadata = if (metadata != null && showCountdown) metadata else null
+            )
+        }
+
+        val imdbId = metadata?.imdb_id?.takeIf { it.isNotBlank() }
+        if (imdbId != null) {
+            onlineSubtitleJob = viewModelScope.launch {
+                try {
+                    val results = com.playbridge.player.player.SubtitleFetcher.fetchSubtitles(
+                        imdbId = imdbId,
+                        season = metadata.season,
+                        episode = metadata.episode
+                    )
+                    val fetchedTracks = results.map { sub ->
+                        val name = "${sub.lang} · OpenSubtitles #${sub.id}"
+                        val urlWithFragment = "${sub.url}#${java.net.URLEncoder.encode(name, "UTF-8")}"
+                        UnifiedTrack(
+                            id = urlWithFragment,
+                            name = name,
+                            isSelected = false,
+                            type = "external_sub"
+                        )
+                    }
+                    cachedOnlineTracks = fetchedTracks
+                    _controlsState.update { s ->
+                        val existingIds = s.subtitleTracks.map { it.id }.toSet()
+                        val newTracks = fetchedTracks.filter { it.id !in existingIds }
+                        s.copy(subtitleTracks = s.subtitleTracks + newTracks)
+                    }
+                } catch (_: Exception) { }
+            }
+        }
     }
     
     fun setPrePlayCountdown(seconds: Int) {
@@ -283,11 +328,29 @@ class PlayerControlsViewModel : ViewModel() {
         resetAutoHideTimer()
     }
 
-    fun updateTracks(audio: List<UnifiedTrack>, subtitles: List<UnifiedTrack>, video: List<UnifiedTrack>) {
-        _controlsState.update { 
-            it.copy(
+    fun updateTracks(
+        audio: List<UnifiedTrack>,
+        subtitles: List<UnifiedTrack>,
+        video: List<UnifiedTrack>,
+        currentSubtitleUrl: String? = null
+    ) {
+        _controlsState.update { state ->
+            val mergedSubs = subtitles.toMutableList()
+            
+            // Re-apply selection states to the cached online tracks. An online track is selected
+            // if it matches the current active external subtitle URL.
+            val selectedSubId = currentSubtitleUrl ?: subtitles.firstOrNull { it.isSelected }?.id
+            val onlineTracks = cachedOnlineTracks.map { track ->
+                track.copy(isSelected = track.id == selectedSubId)
+            }
+            
+            // Append any online tracks that aren't already present in the list
+            val existingIds = mergedSubs.map { it.id }.toSet()
+            val newOnlineTracks = onlineTracks.filter { it.id !in existingIds }
+            
+            state.copy(
                 audioTracks = audio,
-                subtitleTracks = subtitles,
+                subtitleTracks = mergedSubs + newOnlineTracks,
                 videoTracks = video
             )
         }
@@ -322,6 +385,8 @@ class PlayerControlsViewModel : ViewModel() {
         autoHideJob?.cancel()
         progressUpdateJob?.cancel()
         commitSeekJob?.cancel()
+        onlineSubtitleJob?.cancel()
+        cachedOnlineTracks = emptyList()
         engine = null
     }
 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/SubtitleSelectionOverlay.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/SubtitleSelectionOverlay.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -41,6 +42,8 @@ import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
 
 private const val OFF_KEY = "__off__"
+private const val EMBEDDED_KEY = "__embedded__"
+private const val REMOTE_KEY = "__remote__"
 private const val EXTERNAL_KEY = "__external__"
 
 private data class SubLangGroup(
@@ -99,6 +102,14 @@ private data class SubInfo(val langKey: String, val langDisplay: String, val opt
 
 /** Decide a subtitle's language group + option label. No recognizable language → External. */
 private fun classify(t: UnifiedTrack): SubInfo {
+    if (t.type == "sub" && t.id != "off" && t.id != "none") {
+        return SubInfo(EMBEDDED_KEY, "Embedded", t.name)
+    }
+
+    if (t.type == "external_sub" && !t.name.contains("OpenSubtitles #")) {
+        return SubInfo(REMOTE_KEY, "Phone Remote", t.name.ifBlank { "Remote Subtitle" })
+    }
+
     val segs = t.name.split(" · ", " • ").map { it.trim() }.filter { it.isNotEmpty() }
     val lang = segs.firstNotNullOfOrNull { languageOf(it) }
     return if (lang != null) {
@@ -117,16 +128,27 @@ private fun sourceLabel(t: UnifiedTrack): String =
     if (t.type == "external_sub") "EXTERNAL" else "EMBEDDED"
 
 private fun groupSubtitleTracks(tracks: List<UnifiedTrack>): List<SubLangGroup> {
-    val off = tracks.firstOrNull { it.id == "off" }
+    val off = tracks.firstOrNull { it.id == "off" || it.id == "none" }
     val byLang = LinkedHashMap<String, Pair<String, MutableList<UnifiedTrack>>>()
-    tracks.filter { it.id != "off" }.forEach { t ->
+    tracks.filter { it.id != "off" && it.id != "none" }.forEach { t ->
         val info = classify(t)
         byLang.getOrPut(info.langKey) { info.langDisplay to mutableListOf() }.second.add(t)
     }
     val groups = mutableListOf<SubLangGroup>()
     if (off != null) groups.add(SubLangGroup(OFF_KEY, "Off", listOf(off), off.isSelected))
-    // Real languages first (encounter order), the External bucket last.
-    byLang.filterKeys { it != EXTERNAL_KEY }.forEach { (k, v) ->
+
+    // Put "Embedded" group first after "Off" if it exists
+    byLang[EMBEDDED_KEY]?.let { (display, list) ->
+        groups.add(SubLangGroup(EMBEDDED_KEY, display, list, list.any { it.isSelected }))
+    }
+
+    // Put "Phone Remote" group next if it exists
+    byLang[REMOTE_KEY]?.let { (display, list) ->
+        groups.add(SubLangGroup(REMOTE_KEY, display, list, list.any { it.isSelected }))
+    }
+
+    // Real languages first (encounter order)
+    byLang.filterKeys { it != EMBEDDED_KEY && it != REMOTE_KEY && it != EXTERNAL_KEY }.forEach { (k, v) ->
         groups.add(SubLangGroup(k, v.first, v.second, v.second.any { it.isSelected }))
     }
     byLang[EXTERNAL_KEY]?.let { (display, list) ->
@@ -150,6 +172,7 @@ fun SubtitleSelectionOverlay(
     onTrackSelected: (UnifiedTrack) -> Unit,
     onAdjustDelay: (Long) -> Unit,
     onDismiss: () -> Unit,
+    activeMetadata: playbridge.VisualMetadata? = null,
 ) {
     BackHandler { onDismiss() }
 
@@ -169,13 +192,6 @@ fun SubtitleSelectionOverlay(
     val initialFocus = remember { FocusRequester() }
     LaunchedEffect(Unit) { runCatching { initialFocus.requestFocus() } }
 
-    // Fetch previews only for the selected language's external subs (lazy, cached).
-    LaunchedEffect(selectedLangKey, groups) {
-        currentGroup?.takeIf { it.key != OFF_KEY }?.let { g ->
-            onPreloadLanguage(g.tracks.filter { it.type == "external_sub" }.map { it.id })
-        }
-    }
-
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -187,12 +203,34 @@ fun SubtitleSelectionOverlay(
                 .padding(start = 48.dp, end = 48.dp, top = 40.dp, bottom = 56.dp),
             verticalArrangement = Arrangement.Top
         ) {
+            val searchInfo = activeMetadata?.let { meta ->
+                val imdbId = meta.imdb_id?.takeIf { it.isNotBlank() }
+                if (imdbId != null) {
+                    val s = meta.season
+                    val e = meta.episode
+                    if (s != null && s > 0 && e != null && e > 0) {
+                        "Source: https://opensubtitles-v3.strem.io/subtitles/series/$imdbId:$s:$e.json"
+                    } else {
+                        "Source: https://opensubtitles-v3.strem.io/subtitles/movie/$imdbId.json"
+                    }
+                } else null
+            }
+
             Text(
                 text = "Subtitles",
                 style = MaterialTheme.typography.headlineMedium,
                 color = Color.White,
-                modifier = Modifier.padding(bottom = 14.dp)
+                modifier = Modifier.padding(bottom = if (searchInfo != null) 4.dp else 14.dp)
             )
+
+            if (searchInfo != null) {
+                Text(
+                    text = searchInfo,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.White.copy(alpha = 0.5f),
+                    modifier = Modifier.padding(bottom = 14.dp)
+                )
+            }
 
             Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                 // ---- Language rail ----
@@ -226,35 +264,44 @@ fun SubtitleSelectionOverlay(
 
                 // ---- Options rail ----
                 RailColumn(title = "Subtitles", width = 380.dp) {
-                    if (currentGroup == null || currentGroup.key == OFF_KEY) {
-                        EmptyRailCard("Subtitles off")
-                    } else {
-                        LazyColumn(
-                            verticalArrangement = Arrangement.spacedBy(6.dp),
-                            modifier = Modifier.heightIn(max = 460.dp)
-                        ) {
-                            items(currentGroup.tracks, key = { it.id }) { t ->
-                                val isExternal = t.type == "external_sub"
-                                // Re-windows when the offset (subtitleDelayMs) or cache version changes.
-                                val preview = remember(t.id, cuesVersion, subtitleDelayMs) {
-                                    if (!isExternal) null
-                                    else SubtitleCueLoader.cached(t.id)
-                                        ?.let { SubtitleCueLoader.preview(it, frozenPos + subtitleDelayMs) }
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(10.dp),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        if (currentGroup == null || currentGroup.key == OFF_KEY) {
+                            EmptyRailCard("Subtitles off")
+                        } else {
+                            LazyColumn(
+                                verticalArrangement = Arrangement.spacedBy(6.dp),
+                                modifier = Modifier.heightIn(max = 380.dp)
+                            ) {
+                                items(currentGroup.tracks, key = { it.id }) { t ->
+                                    val isExternal = t.type == "external_sub"
+                                    // Re-windows when the offset (subtitleDelayMs) or cache version changes.
+                                    val preview = remember(t.id, cuesVersion, subtitleDelayMs) {
+                                        if (!isExternal) null
+                                        else SubtitleCueLoader.cached(t.id)
+                                            ?.let { SubtitleCueLoader.preview(it, frozenPos + subtitleDelayMs) }
+                                    }
+                                    val loading = isExternal && SubtitleCueLoader.cached(t.id) == null
+                                    SubCard(
+                                        title = optionLabel(t),
+                                        meta = null,
+                                        source = sourceLabel(t),
+                                        trailingCount = null,
+                                        checked = t.isSelected,
+                                        highlighted = t.isSelected,
+                                        previewLines = preview,
+                                        loading = loading,
+                                        focusRequester = null,
+                                        onFocused = {
+                                            if (isExternal) {
+                                                onPreloadLanguage(listOf(t.id))
+                                            }
+                                        },
+                                        onClick = { onTrackSelected(t) }
+                                    )
                                 }
-                                val loading = isExternal && SubtitleCueLoader.cached(t.id) == null
-                                SubCard(
-                                    title = optionLabel(t),
-                                    meta = null,
-                                    source = sourceLabel(t),
-                                    trailingCount = null,
-                                    checked = t.isSelected,
-                                    highlighted = t.isSelected,
-                                    previewLines = preview,
-                                    loading = loading,
-                                    focusRequester = null,
-                                    onFocused = {},
-                                    onClick = { onTrackSelected(t) }
-                                )
                             }
                         }
                     }
@@ -298,6 +345,7 @@ private fun SubCard(
     previewLines: List<String>? = null,
     loading: Boolean = false,
 ) {
+    var isFocused by remember { mutableStateOf(false) }
     Surface(
         onClick = onClick,
         scale = ClickableSurfaceDefaults.scale(focusedScale = 1.02f),
@@ -310,7 +358,10 @@ private fun SubCard(
         modifier = Modifier
             .fillMaxWidth()
             .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
-            .onFocusChanged { if (it.isFocused) onFocused() }
+            .onFocusChanged {
+                isFocused = it.isFocused
+                if (it.isFocused) onFocused()
+            }
     ) {
         Row(
             modifier = Modifier
@@ -329,7 +380,7 @@ private fun SubCard(
                 }
                 // Preview mode (subtitle options): show the cue lines at the current scene
                 // instead of a filename, so you can eyeball which one is in sync.
-                val showPreview = loading || previewLines != null
+                val showPreview = isFocused && (loading || previewLines != null)
                 if (showPreview) {
                     when {
                         loading -> Text(
@@ -450,3 +501,6 @@ private fun SyncRow(label: String, minus: String, plus: String, step: Long, onAd
         ) { Text(plus, style = MaterialTheme.typography.labelSmall) }
     }
 }
+
+
+


### PR DESCRIPTION
# PlayBridge: IPv6 Stability, TV Addon Subtitles, and Remote Control UI Enhancements

This Pull Request addresses critical connection stability issues, introduces dynamic online subtitle support for the TV app, and optimizes the remote control UI.

## 🛠 Key Changes

### 1. 🌐 IPv6 Link-Local Connection Stability
- **`LinkLocalDns` Resolver**: Registers a custom DNS interceptor in the Android companion's OkHttp client. This converts raw, scope-indexed IPv6 addresses (e.g. `fe80::1%eth0`) into RFC-compliant hostnames ending with `.local-ipv6` to prevent `IllegalArgumentException` crashes in OkHttp URL parsing, and decodes them back to raw scoped `InetAddress` objects during lookup.
- **Safety Fixes**: Includes length validation checks (`hexPart.length == 32`) and wraps decoding within a try-catch block inside DNS lookup to prevent crashes on malformed hostnames.
- **Client Bracket Wrapping**: Wrapped IPv6 addresses in brackets `[...]` in the Flutter Desktop client and Chrome Extension background worker to ensure exception-free URI parsing.
- **Unit Testing**: Added test coverage in `ExampleUnitTest.kt` to validate the DNS host encoding and decoding algorithm.

### 2. 🎬 TV App: Dynamic OpenSubtitles Addon Subtitles
- **`SubtitleFetcher`**: Added a new helper module to fetch online subtitles from the OpenSubtitles Stremio addon proxy API using the active IMDb ID (supporting seasons/episodes for series).
- **Resilient Serialization**: Configured the JSON serializer with default fallback values for response properties to ensure the app doesn't crash on incomplete API responses.
- **On-Demand Loading & Preview**: Optimized the TV's subtitle selection list to only cache/preload subtitle cues once an external track card gains focus. Includes an inline cue preview of active subtitles.
- **Dynamic Injection**: Added support in both `ExoPlayerActivity` and `MpvPlayerActivity` to inject external subtitle URLs on-the-fly.

### 3. 📱 Companion App (Phone): Subtitle Sheet & UI Updates
- **"Send Subtitles to TV" Toggle**: Introduced a preference switch in the Streaming Settings screen (backed by Jetpack DataStore) to completely skip subtitle resolution when casting if the user wants to conserve bandwidth.
- **Categorized Subtitle Sheet**: Added a bottom overlay sheet in `RemoteControlScreen.kt` that filters available subtitles using horizontal categorization chips.
- **Now Playing Bar**: Replaced the play/pause button with a TV icon button when actively casting to route users directly to the connection sheet.
- **Library Syncing**: Automatically triggers TV casting mode when the companion app connects to a TV; fixed the season parameter key when casting series episodes.