### PR TITLE
feat(tv-player): add support to skip intro, recap, and outro using IntroDB

### DIFF
--- a/shared/src/androidMain/kotlin/com/playbridge/shared/player/MpvPlayerEngine.kt
+++ b/shared/src/androidMain/kotlin/com/playbridge/shared/player/MpvPlayerEngine.kt
@@ -105,7 +105,7 @@ class MpvPlayerEngine(private val context: Context) : PlaybackEngine, MPVLib.Eve
 
             // Register properties to observe
             MPVLib.observeProperty("pause",               3) // Boolean
-            MPVLib.observeProperty("time-pos",            4) // Long (seconds)
+            MPVLib.observeProperty("time-pos",            5) // Double (seconds)
             MPVLib.observeProperty("duration",            4) // Long (seconds)
             MPVLib.observeProperty("height",              4) // Long (px)
             MPVLib.observeProperty("video-bitrate",       4) // Long (bits/s)
@@ -198,7 +198,6 @@ class MpvPlayerEngine(private val context: Context) : PlaybackEngine, MPVLib.Eve
 
     override fun eventProperty(property: String, value: Long) {
         when (property) {
-            "time-pos" -> _position.value = value * 1000
             "duration" -> _duration.value = value * 1000
             "height" -> _videoHeight.value = value
             "video-bitrate" -> _videoBitrate.value = value
@@ -299,7 +298,7 @@ class MpvPlayerEngine(private val context: Context) : PlaybackEngine, MPVLib.Eve
     override fun seek(positionMs: Long) {
         logger.d(TAG, "seek($positionMs)")
         if (!mpvInitialized) return
-        MPVLib.command("seek", (positionMs / 1000.0).toString(), "absolute+keyframes")
+        MPVLib.command("seek", (positionMs / 1000.0).toString(), "absolute")
     }
 
     override fun setRate(rate: Float) {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
@@ -135,7 +135,7 @@ class ExoPlayerActivity : PlayerActivity() {
             displayTitle?.takeIf { it.isNotBlank() }?.let {
                 android.widget.Toast.makeText(this@ExoPlayerActivity, it, android.widget.Toast.LENGTH_SHORT).show()
             }
-            controlsViewModel.setPrePlay(item.visual_metadata, showCountdown = false)
+            controlsViewModel.setPrePlay(item.visual_metadata, context = this@ExoPlayerActivity, showCountdown = false)
             playVideo(
                 url = item.url,
                 title = displayTitle,
@@ -295,6 +295,8 @@ class ExoPlayerActivity : PlayerActivity() {
                         onLoop = { setLooping(!isLooping) },
                         onSwitchPlayer = { controlsViewModel.showSwitchPlayer() },
                         onSeek = { controlsViewModel.handleScrubbing(it) },
+                        onSkipSegment = { controlsViewModel.skipCurrentSegment() },
+                        onSkipButtonFocusChanged = { controlsViewModel.setSkipButtonFocused(it) },
                         onPrePlayStartNow = {
                             launchJob?.cancel()
                             controlsViewModel.setPrePlayLaunching(true)
@@ -427,7 +429,7 @@ class ExoPlayerActivity : PlayerActivity() {
             isExternalOverlayVisible = { controlsViewModel.controlsState.value.prePlayMetadata != null || controlsViewModel.controlsState.value.activeOverlay != ActiveOverlay.NONE }
         )
         
-        controlsViewModel.setEngine(engineAdapter, "exo")
+        controlsViewModel.setEngine(engineAdapter, "exo", this)
 
         // Register broadcast receiver for control commands
         val filter = IntentFilter().apply {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/InputHandler.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/InputHandler.kt
@@ -223,6 +223,24 @@ class InputHandler(
             }
         }
 
+        // --- Skip Button Handling when controls are hidden ---
+        if (!state.isVisible && !isExtVisible && state.activeSkipSegment != null) {
+            if (state.isSkipButtonFocused) {
+                if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER) {
+                    return false
+                }
+                if (keyCode == KeyEvent.KEYCODE_DPAD_UP || keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
+                    keyCode == KeyEvent.KEYCODE_DPAD_LEFT || keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+                    return false
+                }
+            } else {
+                if (keyCode == KeyEvent.KEYCODE_DPAD_UP || keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
+                    keyCode == KeyEvent.KEYCODE_DPAD_LEFT || keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+                    return false
+                }
+            }
+        }
+
         // --- Normal mode (no overlay) ---
         return when (keyCode) {
             KeyEvent.KEYCODE_DPAD_CENTER, KeyEvent.KEYCODE_ENTER -> {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
@@ -144,7 +144,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
             Toast.makeText(this, "Seek failed (network error)", Toast.LENGTH_SHORT).show()
             // Seek back to the pre-seek position (known-good). Using positionMs here would
             // re-seek to the stuck target because MPV reports the target as time-pos mid-seek.
-            MPVLib.command("seek", (preSeePositionMs / 1000.0).toString(), "absolute+keyframes")
+            MPVLib.command("seek", (preSeePositionMs / 1000.0).toString(), "absolute")
         }
     }
 
@@ -416,7 +416,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
         // Format IDs: MPV_FORMAT_STRING=1, MPV_FORMAT_FLAG=3, MPV_FORMAT_INT64=4, MPV_FORMAT_DOUBLE=5
         MPVLib.addObserver(this)
         MPVLib.observeProperty("pause",               3) // Boolean
-        MPVLib.observeProperty("time-pos",            4) // Long (seconds)
+        MPVLib.observeProperty("time-pos",            5) // Double (seconds)
         MPVLib.observeProperty("duration",            4) // Long (seconds)
         MPVLib.observeProperty("height",              4) // Long (px)
         MPVLib.observeProperty("video-bitrate",       4) // Long (bits/s)
@@ -540,9 +540,6 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
 
     override fun eventProperty(property: String, value: Long) {
         when (property) {
-            "time-pos" -> {
-                positionMs = value * 1000
-            }
             "duration" -> {
                 durationMs = value * 1000
             }
@@ -576,6 +573,9 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
 
     override fun eventProperty(property: String, value: Double) {
         when (property) {
+            "time-pos" -> {
+                positionMs = (value * 1000).toLong()
+            }
             "demuxer-cache-time" -> {
                 bufferAheadMs = (value * 1000).toLong()
             }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
@@ -156,7 +156,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
                     Toast.makeText(this@MpvPlayerActivity, it, Toast.LENGTH_SHORT).show()
                     controlsViewModel.setTitle(it)
                 }
-                controlsViewModel.setPrePlay(item.visual_metadata, showCountdown = false)
+                controlsViewModel.setPrePlay(item.visual_metadata, context = this@MpvPlayerActivity, showCountdown = false)
                 controlsViewModel.hideControls()
             }
             stopPlayback()
@@ -280,6 +280,8 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
                         onLoop = { setLooping(!isLooping) },
                         onSwitchPlayer = { controlsViewModel.showSwitchPlayer() },
                         onSeek = { controlsViewModel.handleScrubbing(it) },
+                        onSkipSegment = { controlsViewModel.skipCurrentSegment() },
+                        onSkipButtonFocusChanged = { controlsViewModel.setSkipButtonFocused(it) },
                         onPrePlayStartNow = {
                             launchJob?.cancel()
                             controlsViewModel.setPrePlayLaunching(true)
@@ -407,7 +409,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
             isExternalOverlayVisible = { controlsViewModel.controlsState.value.prePlayMetadata != null || controlsViewModel.controlsState.value.activeOverlay != ActiveOverlay.NONE }
         )
 
-        controlsViewModel.setEngine(engineAdapter, "mpv")
+        controlsViewModel.setEngine(engineAdapter, "mpv", this)
 
         // Register MPV observer NOW — after controlsManager is initialized — so that
         // property-change callbacks can safely reference controlsManager without crashing.

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerActivity.kt
@@ -427,9 +427,9 @@ abstract class PlayerActivity : ComponentActivity() {
                 val metadata = playbridge.VisualMetadata.ADAPTER.decode(visualMetadataBytes)
                 FileLogger.i("PlayerActivity", "Received visual metadata (skipPreplay=$skipPreplay): ${metadata.title}")
                 if (skipPreplay) {
-                    controlsViewModel.setPrePlay(metadata, showCountdown = false)
+                    controlsViewModel.setPrePlay(metadata, context = this, showCountdown = false)
                 } else {
-                    controlsViewModel.setPrePlay(metadata)
+                    controlsViewModel.setPrePlay(metadata, context = this)
                     controlsViewModel.setPrePlayLaunching(true)
                     controlsViewModel.setPrePlayCountdown(-1) // -1 signifies "Connecting..."
                 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/SkipSegment.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/SkipSegment.kt
@@ -1,0 +1,7 @@
+package com.playbridge.player.player
+
+data class SkipSegment(
+    val type: String, // "intro", "recap", "outro"
+    val startMs: Long,
+    val endMs: Long
+)

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/SkipSegmentFetcher.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/SkipSegmentFetcher.kt
@@ -1,0 +1,73 @@
+package com.playbridge.player.player
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+
+object SkipSegmentFetcher {
+    private const val TAG = "SkipSegmentFetcher"
+    private val client = OkHttpClient()
+
+    suspend fun fetchSegments(
+        context: Context,
+        imdbId: String,
+        season: Int,
+        episode: Int
+    ): List<SkipSegment> = withContext(Dispatchers.IO) {
+        val prefs = context.getSharedPreferences("browser_prefs", Context.MODE_PRIVATE)
+        val baseUrl = prefs.getString("introdb_api_url", "https://api.introdb.app")?.trim()?.removeSuffix("/") ?: "https://api.introdb.app"
+        val apiKey = prefs.getString("introdb_api_key", "") ?: ""
+
+        val url = "$baseUrl/segments?imdb_id=$imdbId&season=$season&episode=$episode"
+        Log.i(TAG, "Fetching skip segments from: $url")
+
+        val requestBuilder = Request.Builder()
+            .url(url)
+            .header("User-Agent", "PlayBridgeTV/1.0")
+
+        if (apiKey.isNotBlank()) {
+            if (apiKey.startsWith("ey")) {
+                requestBuilder.header("Authorization", "Bearer $apiKey")
+            } else {
+                requestBuilder.header("x-api-key", apiKey)
+                requestBuilder.header("Authorization", "Bearer $apiKey")
+            }
+        }
+
+        try {
+            client.newCall(requestBuilder.build()).execute().use { response ->
+                if (!response.isSuccessful) {
+                    Log.w(TAG, "Failed to fetch skip segments: HTTP ${response.code}")
+                    return@withContext emptyList()
+                }
+                val bodyText = response.body?.string() ?: return@withContext emptyList()
+                val json = JSONObject(bodyText)
+                val segments = mutableListOf<SkipSegment>()
+
+                val types = listOf("intro", "recap", "outro")
+                for (type in types) {
+                    if (json.has(type) && !json.isNull(type)) {
+                        val segObj = json.getJSONObject(type)
+                        val startMs = segObj.optLong("start_ms", -1L).takeIf { it != -1L }
+                            ?: (segObj.optDouble("start_sec", -1.0).takeIf { it != -1.0 }?.let { (it * 1000).toLong() })
+                        val endMs = segObj.optLong("end_ms", -1L).takeIf { it != -1L }
+                            ?: (segObj.optDouble("end_sec", -1.0).takeIf { it != -1.0 }?.let { (it * 1000).toLong() })
+
+                        if (startMs != null && endMs != null) {
+                            segments.add(SkipSegment(type, startMs, endMs))
+                        }
+                    }
+                }
+                Log.i(TAG, "Successfully fetched ${segments.size} segments: $segments")
+                segments
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error fetching skip segments", e)
+            emptyList()
+        }
+    }
+}

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/SettingsScreen.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/SettingsScreen.kt
@@ -65,6 +65,15 @@ fun SettingsScreen(
     var isGeckoInstalled by remember { mutableStateOf(false) }
     var showGeckoDialog by remember { mutableStateOf(false) }
 
+    // Skip segments states
+    var introDbApiKey by remember { mutableStateOf(prefs.getString("introdb_api_key", "") ?: "") }
+    var introDbApiUrl by remember { mutableStateOf(prefs.getString("introdb_api_url", "https://api.introdb.app") ?: "https://api.introdb.app") }
+    var autoSkipIntro by remember { mutableStateOf(prefs.getBoolean("auto_skip_intro", false)) }
+    var autoSkipRecap by remember { mutableStateOf(prefs.getBoolean("auto_skip_recap", false)) }
+    var autoSkipOutro by remember { mutableStateOf(prefs.getBoolean("auto_skip_outro", false)) }
+    var showApiKeyDialog by remember { mutableStateOf(false) }
+    var showApiUrlDialog by remember { mutableStateOf(false) }
+
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
         val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
@@ -217,6 +226,56 @@ fun SettingsScreen(
                                 onCheckedChange = {
                                     hideSoftKeyboard = it
                                     prefs.edit().putBoolean("hide_soft_keyboard", it).apply()
+                                }
+                            )
+                        }
+                    }
+
+                    SettingsCategory.INTEGRATIONS -> {
+                        item {
+                            SettingClickableItem(
+                                label = "IntroDB API Key",
+                                description = if (introDbApiKey.isEmpty()) "Not Configured" else "••••••••",
+                                onClick = { showApiKeyDialog = true }
+                            )
+                        }
+                        item {
+                            SettingClickableItem(
+                                label = "IntroDB API URL",
+                                description = introDbApiUrl,
+                                onClick = { showApiUrlDialog = true }
+                            )
+                        }
+                        item {
+                            SettingToggleItem(
+                                label = "Auto-Skip Intro",
+                                description = "Automatically skip show intros.",
+                                checked = autoSkipIntro,
+                                onCheckedChange = {
+                                    autoSkipIntro = it
+                                    prefs.edit().putBoolean("auto_skip_intro", it).apply()
+                                }
+                            )
+                        }
+                        item {
+                            SettingToggleItem(
+                                label = "Auto-Skip Recap",
+                                description = "Automatically skip show recaps.",
+                                checked = autoSkipRecap,
+                                onCheckedChange = {
+                                    autoSkipRecap = it
+                                    prefs.edit().putBoolean("auto_skip_recap", it).apply()
+                                }
+                            )
+                        }
+                        item {
+                            SettingToggleItem(
+                                label = "Auto-Skip Outro",
+                                description = "Automatically skip show outros/credits.",
+                                checked = autoSkipOutro,
+                                onCheckedChange = {
+                                    autoSkipOutro = it
+                                    prefs.edit().putBoolean("auto_skip_outro", it).apply()
                                 }
                             )
                         }
@@ -391,12 +450,112 @@ fun SettingsScreen(
             }
         }
     }
+
+    if (showApiKeyDialog) {
+        var tempKey by remember { mutableStateOf(introDbApiKey) }
+        androidx.compose.ui.window.Dialog(onDismissRequest = { showApiKeyDialog = false }) {
+            Surface(
+                shape = MaterialTheme.shapes.medium,
+                modifier = Modifier.width(400.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(32.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Text("IntroDB API Key", style = MaterialTheme.typography.headlineSmall)
+                    Text(
+                        "Enter your IntroDB API key or Clerk token. Leave empty if using the public API.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    androidx.compose.foundation.text.BasicTextField(
+                        value = tempKey,
+                        onValueChange = { tempKey = it },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(MaterialTheme.colorScheme.surfaceVariant, MaterialTheme.shapes.small)
+                            .padding(16.dp),
+                        textStyle = androidx.compose.ui.text.TextStyle(color = MaterialTheme.colorScheme.onSurface, fontSize = 16.sp)
+                    )
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Button(onClick = { showApiKeyDialog = false }, modifier = Modifier.padding(end = 8.dp)) {
+                            Text("Cancel")
+                        }
+                        Button(onClick = {
+                            introDbApiKey = tempKey.trim()
+                            prefs.edit().putString("introdb_api_key", introDbApiKey).apply()
+                            showApiKeyDialog = false
+                        }) {
+                            Text("Save")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showApiUrlDialog) {
+        var tempUrl by remember { mutableStateOf(introDbApiUrl) }
+        androidx.compose.ui.window.Dialog(onDismissRequest = { showApiUrlDialog = false }) {
+            Surface(
+                shape = MaterialTheme.shapes.medium,
+                modifier = Modifier.width(400.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(32.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Text("IntroDB API URL", style = MaterialTheme.typography.headlineSmall)
+                    Text(
+                        "Set custom API url for skip segments. Default is https://api.introdb.app",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    androidx.compose.foundation.text.BasicTextField(
+                        value = tempUrl,
+                        onValueChange = { tempUrl = it },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(MaterialTheme.colorScheme.surfaceVariant, MaterialTheme.shapes.small)
+                            .padding(16.dp),
+                        textStyle = androidx.compose.ui.text.TextStyle(color = MaterialTheme.colorScheme.onSurface, fontSize = 16.sp)
+                    )
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Button(onClick = { showApiUrlDialog = false }, modifier = Modifier.padding(end = 8.dp)) {
+                            Text("Cancel")
+                        }
+                        Button(onClick = {
+                            val finalUrl = tempUrl.trim().ifEmpty { "https://api.introdb.app" }
+                            introDbApiUrl = finalUrl
+                            prefs.edit().putString("introdb_api_url", finalUrl).apply()
+                            showApiUrlDialog = false
+                        }) {
+                            Text("Save")
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 enum class SettingsCategory(val label: String, val icon: ImageVector) {
     PLAYER("Player", Icons.Default.PlayArrow),
     BROWSER("Browser", Icons.Default.Search),
     NETWORK("Network", Icons.Default.Settings),
+    INTEGRATIONS("Integrations", Icons.Default.Build),
     APPEARANCE("Appearance", Icons.Default.Add),
     ABOUT("About", Icons.Default.Info)
 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsOverlay.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsOverlay.kt
@@ -4,12 +4,20 @@ import androidx.compose.animation.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.LaunchedEffect
+import androidx.tv.material3.Surface
+import androidx.tv.material3.ClickableSurfaceDefaults
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.Border
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import androidx.compose.ui.unit.sp
@@ -44,6 +52,8 @@ fun PlayerControlsOverlay(
     onToggleAudioBoost: () -> Unit = {},
     onAdjustSubtitleDelay: (Long) -> Unit = {},
     onPreloadSubtitles: (List<String>) -> Unit = {},
+    onSkipSegment: () -> Unit = {},
+    onSkipButtonFocusChanged: (Boolean) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -224,6 +234,62 @@ fun PlayerControlsOverlay(
                 text = state.currentSubtitleText,
                 modifier = Modifier.align(Alignment.BottomCenter)
             )
+        }
+
+        // Skip Segment Button (Netflix style)
+        state.activeSkipSegment?.let { segment ->
+            val focusRequester = remember { FocusRequester() }
+            
+            // Request focus when the button becomes visible
+            LaunchedEffect(segment) {
+                focusRequester.requestFocus()
+            }
+            
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(end = 48.dp, bottom = 120.dp), // floats above seekbar / controls
+                contentAlignment = Alignment.BottomEnd
+            ) {
+                Surface(
+                    onClick = { onSkipSegment() },
+                    modifier = Modifier
+                        .focusRequester(focusRequester)
+                        .onFocusChanged { focusState ->
+                            onSkipButtonFocusChanged(focusState.isFocused)
+                        }
+                        .width(140.dp)
+                        .height(40.dp),
+                    scale = ClickableSurfaceDefaults.scale(focusedScale = 1.05f),
+                    colors = ClickableSurfaceDefaults.colors(
+                        containerColor = Color.Black.copy(alpha = 0.55f),
+                        focusedContainerColor = Color.Black.copy(alpha = 0.8f)
+                    ),
+                    shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(6.dp)),
+                    border = ClickableSurfaceDefaults.border(
+                        border = Border(
+                            border = androidx.compose.foundation.BorderStroke(1.dp, Color.White.copy(alpha = 0.25f))
+                        ),
+                        focusedBorder = Border(
+                            border = androidx.compose.foundation.BorderStroke(1.5.dp, Color.White)
+                        )
+                    )
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Skip ${segment.type.replaceFirstChar { it.uppercase() }}",
+                            style = androidx.compose.ui.text.TextStyle(
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Medium,
+                                color = Color.White
+                            )
+                        )
+                    }
+                }
+            }
         }
 
         // PrePlay Overlay — TOP layer, deliberately last: it must cover the

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsState.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsState.kt
@@ -64,4 +64,7 @@ data class PlayerControlsState(
     // Bumped whenever a subtitle preview finishes loading, so the overlay re-reads the
     // SubtitleCueLoader cache. The cues themselves live in the loader, not in state.
     val subtitleCuesVersion: Int = 0,
+    val skipSegments: List<com.playbridge.player.player.SkipSegment> = emptyList(),
+    val activeSkipSegment: com.playbridge.player.player.SkipSegment? = null,
+    val isSkipButtonFocused: Boolean = false,
 )

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsViewModel.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import com.playbridge.player.player.SubtitleManager
 import com.playbridge.player.player.SubtitleCueLoader
+import com.playbridge.player.player.SkipSegment
 
 class PlayerControlsViewModel : ViewModel() {
     private val _controlsState = MutableStateFlow(PlayerControlsState())
@@ -22,6 +23,7 @@ class PlayerControlsViewModel : ViewModel() {
     private var subtitleManager: SubtitleManager? = null
     private var onlineSubtitleJob: Job? = null
     private var cachedOnlineTracks: List<UnifiedTrack> = emptyList()
+    private var lastSkippedSegment: SkipSegment? = null
 
     /** Request headers for fetching subtitle files (set by the activity when media loads). */
     var subtitleRequestHeaders: Map<String, String>? = null
@@ -41,8 +43,11 @@ class PlayerControlsViewModel : ViewModel() {
         }
     }
 
-    fun setEngine(playerEngine: PlayerEngineAdapter, engineType: String) {
+    private var contextRef: java.lang.ref.WeakReference<android.content.Context>? = null
+
+    fun setEngine(playerEngine: PlayerEngineAdapter, engineType: String, context: android.content.Context) {
         this.engine = playerEngine
+        this.contextRef = java.lang.ref.WeakReference(context.applicationContext)
         _controlsState.update { it.copy(engineType = engineType) }
         startProgressUpdates()
     }
@@ -151,8 +156,11 @@ class PlayerControlsViewModel : ViewModel() {
         _controlsState.update { it.copy(isBuffering = isBuffering) }
     }
     
+    private var skipSegmentsJob: kotlinx.coroutines.Job? = null
+
     fun setPrePlay(
         metadata: playbridge.VisualMetadata?,
+        context: android.content.Context? = null,
         clearOnlineSubs: Boolean = true,
         showCountdown: Boolean = true
     ) {
@@ -160,12 +168,18 @@ class PlayerControlsViewModel : ViewModel() {
             onlineSubtitleJob?.cancel()
             cachedOnlineTracks = emptyList()
         }
+        skipSegmentsJob?.cancel()
+        lastSkippedSegment = null
 
         _controlsState.update { state ->
             val nextActiveMetadata = metadata ?: if (!clearOnlineSubs) state.activeMetadata else null
+            val nextSkipSegments = if (metadata != null) emptyList() else if (!clearOnlineSubs) state.skipSegments else emptyList()
+            val nextActiveSkipSegment = if (metadata != null) null else if (!clearOnlineSubs) state.activeSkipSegment else null
             state.copy(
                 activeMetadata = nextActiveMetadata,
-                prePlayMetadata = if (metadata != null && showCountdown) metadata else null
+                prePlayMetadata = if (metadata != null && showCountdown) metadata else null,
+                skipSegments = nextSkipSegments,
+                activeSkipSegment = nextActiveSkipSegment
             )
         }
 
@@ -195,6 +209,23 @@ class PlayerControlsViewModel : ViewModel() {
                         s.copy(subtitleTracks = s.subtitleTracks + newTracks)
                     }
                 } catch (_: Exception) { }
+            }
+        }
+
+        val season = metadata?.season
+        val episode = metadata?.episode
+        if (imdbId != null && context != null && season != null && episode != null) {
+            val appCtx = context.applicationContext
+            skipSegmentsJob = viewModelScope.launch {
+                try {
+                    val segments = com.playbridge.player.player.SkipSegmentFetcher.fetchSegments(
+                        appCtx, imdbId, season, episode
+                    )
+                    com.playbridge.player.logging.FileLogger.i("PlayerControlsViewModel", "Set skipSegments in state: $segments")
+                    _controlsState.update { it.copy(skipSegments = segments) }
+                } catch (e: Exception) {
+                    com.playbridge.player.logging.FileLogger.e("PlayerControlsViewModel", "Error fetching skip segments: ${e.message}")
+                }
             }
         }
     }
@@ -239,20 +270,69 @@ class PlayerControlsViewModel : ViewModel() {
             resetAutoHideTimer()
         }
     }
-
     private fun startProgressUpdates() {
         progressUpdateJob?.cancel()
         progressUpdateJob = viewModelScope.launch {
             while (true) {
                 engine?.let {
+                    val currentPos = if (isScrubbing) _controlsState.value.currentPosition else it.currentPosition
+                    val duration = it.duration
+                    
+                    val activeSegment = _controlsState.value.skipSegments.firstOrNull { segment ->
+                        currentPos >= segment.startMs && currentPos <= segment.endMs && segment != lastSkippedSegment
+                    }
+                    
+                    lastSkippedSegment?.let { skipped ->
+                        if (currentPos < skipped.startMs || currentPos > skipped.endMs) {
+                            lastSkippedSegment = null
+                        }
+                    }
+                    
+                    com.playbridge.player.logging.FileLogger.d("PlayerControlsViewModel", "Progress: currentPos=$currentPos, segmentsCount=${_controlsState.value.skipSegments.size}, active=$activeSegment")
+                    
+                    val context = contextRef?.get()
+                    var isAutoSkipTriggered = false
+                    if (activeSegment != null && context != null && lastSkippedSegment != activeSegment) {
+                        val prefs = context.getSharedPreferences("browser_prefs", android.content.Context.MODE_PRIVATE)
+                        val shouldAutoSkip = when (activeSegment.type) {
+                            "intro" -> prefs.getBoolean("auto_skip_intro", false)
+                            "recap" -> prefs.getBoolean("auto_skip_recap", false)
+                            "outro" -> prefs.getBoolean("auto_skip_outro", false)
+                            else -> false
+                        }
+                        if (shouldAutoSkip) {
+                            lastSkippedSegment = activeSegment
+                            isAutoSkipTriggered = true
+                            engine?.seekTo(activeSegment.endMs + 1000)
+                            viewModelScope.launch(kotlinx.coroutines.Dispatchers.Main) {
+                                android.widget.Toast.makeText(context, "Auto-skipped ${activeSegment.type}", android.widget.Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                    }
+
+                    val uiActiveSegment = if (isAutoSkipTriggered) null else {
+                        val isAutoSkipEnabled = if (context != null && activeSegment != null) {
+                            val prefs = context.getSharedPreferences("browser_prefs", android.content.Context.MODE_PRIVATE)
+                            when (activeSegment.type) {
+                                "intro" -> prefs.getBoolean("auto_skip_intro", false)
+                                "recap" -> prefs.getBoolean("auto_skip_recap", false)
+                                "outro" -> prefs.getBoolean("auto_skip_outro", false)
+                                else -> false
+                            }
+                        } else false
+                        
+                        if (isAutoSkipEnabled) null else activeSegment
+                    }
+
                     _controlsState.update { s ->
                         s.copy(
                             currentPosition = if (isScrubbing) s.currentPosition else it.currentPosition,
-                            duration = it.duration,
+                            duration = duration,
                             bufferedPosition = it.bufferedPosition,
                             isPlaying = it.isPlaying,
                             streamInfo = it.streamInfo,
-                            hdrFormat = it.hdrFormat
+                            hdrFormat = it.hdrFormat,
+                            activeSkipSegment = uiActiveSegment
                         )
                     }
                 }
@@ -379,6 +459,18 @@ class PlayerControlsViewModel : ViewModel() {
     fun clearSubtitle() {
         subtitleManager?.disable()
         _controlsState.update { it.copy(currentSubtitleText = null) }
+    }
+
+    fun skipCurrentSegment() {
+        val segment = _controlsState.value.activeSkipSegment ?: return
+        lastSkippedSegment = segment
+        engine?.seekTo(segment.endMs + 1000)
+        _controlsState.update { it.copy(activeSkipSegment = null) }
+        resetAutoHideTimer()
+    }
+
+    fun setSkipButtonFocused(focused: Boolean) {
+        _controlsState.update { it.copy(isSkipButtonFocused = focused) }
     }
 
     fun detach() {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsViewModel.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsViewModel.kt
@@ -288,8 +288,6 @@ class PlayerControlsViewModel : ViewModel() {
                         }
                     }
                     
-                    com.playbridge.player.logging.FileLogger.d("PlayerControlsViewModel", "Progress: currentPos=$currentPos, segmentsCount=${_controlsState.value.skipSegments.size}, active=$activeSegment")
-                    
                     val context = contextRef?.get()
                     var isAutoSkipTriggered = false
                     if (activeSegment != null && context != null && lastSkippedSegment != activeSegment) {
@@ -324,6 +322,10 @@ class PlayerControlsViewModel : ViewModel() {
                         if (isAutoSkipEnabled) null else activeSegment
                     }
 
+                    if (_controlsState.value.activeSkipSegment != uiActiveSegment) {
+                        com.playbridge.player.logging.FileLogger.d("PlayerControlsViewModel", "Active segment changed: old=${_controlsState.value.activeSkipSegment}, new=$uiActiveSegment")
+                    }
+
                     _controlsState.update { s ->
                         s.copy(
                             currentPosition = if (isScrubbing) s.currentPosition else it.currentPosition,
@@ -336,7 +338,7 @@ class PlayerControlsViewModel : ViewModel() {
                         )
                     }
                 }
-                delay(1000)
+                delay(250)
             }
         }
     }


### PR DESCRIPTION
# Android TV: Support for Skipping Intros, Recaps, and Outros

This PR implements support for automatically or manually skipping intros, recaps, and outros in the Android TV player using the **IntroDB** API.

## Key Features

1. **Segments Fetching & Data Layer**
   - Fetches episode segment boundaries asynchronously from `api.introdb.app/segments` using the media's IMDb ID, season, and episode.
   - Supports self-hosted API URLs and custom private API keys configured in settings.

2. **Settings Configurations**
   - Added an **Integrations** category to Settings.
   - Toggles to configure **Auto-Skip Intro**, **Auto-Skip Recap**, and **Auto-Skip Outro**.
   - Input dialogs to set the custom API URL and API Key.

3. **Sleek UX UI Button**
   - Displays a glassmorphic, non-distracting manual "Skip" button on the bottom-right of the player controls overlay when inside a segment (and auto-skip is disabled).
   - The button is fully focusable via TV D-pad navigation, auto-focuses when it appears, and triggers the skip on remote Center/Enter keys.

4. **Auto-Skipping & Feedback**
   - If auto-skip is enabled for a category, it skips the segment instantly and shows a toast confirmation (e.g., *"Auto-skipped intro"*).

5. **Clamping & Outro Visibility Fix**
   - Solved the issue where seeking to `endMs + 1000` near the end of a video (clamped by the player to the final frame) keeps the skip button visible. Added tracking for `lastSkippedSegment` to hide the button immediately upon skipping, resetting it if the user manually navigates out of the segment or loads new media.

6. **MPV Performance & Seek Accuracy Fixes**
   - Changed MPV's `time-pos` property observation from format `4` (Long) to `5` (Double) to enable millisecond-precision position updates.
   - Changed progress tracking loop interval from `1000ms` to `250ms` in `PlayerControlsViewModel` to avoid latency/delays when segments start/end.
   - Restricted progress logs to only fire on segment transitions to prevent log spam.
   - Switched MPV seeking from `absolute+keyframes` to exact `absolute` seeks so that skipping a segment lands precisely past the boundary, preventing keyframe alignment from snapping the player back into the skipped segment.