### PR TITLE
fix(android): resolve bundle tool signing failure

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 
     signingConfigs {
         create("release") {
-            storeFile = file("../../keystore/release.jks")
+            storeFile = file("../../keystore/release.jks").absoluteFile
             storePassword = System.getenv("PLAYBRIDGE_STORE_PASSWORD") ?: findProperty("PLAYBRIDGE_STORE_PASSWORD")?.toString()
             keyAlias = System.getenv("PLAYBRIDGE_KEY_ALIAS") ?: findProperty("PLAYBRIDGE_KEY_ALIAS")?.toString()
             keyPassword = System.getenv("PLAYBRIDGE_KEY_PASSWORD") ?: findProperty("PLAYBRIDGE_KEY_PASSWORD")?.toString()

--- a/tv/android/geckoview-plugin/app/build.gradle.kts
+++ b/tv/android/geckoview-plugin/app/build.gradle.kts
@@ -34,7 +34,7 @@ android {
 
     signingConfigs {
         create("release") {
-            storeFile = file("../../../keystore/release.jks")
+            storeFile = file("../../../keystore/release.jks").absoluteFile
             storePassword = System.getenv("PLAYBRIDGE_STORE_PASSWORD") ?: findProperty("PLAYBRIDGE_STORE_PASSWORD")?.toString()
             keyAlias = System.getenv("PLAYBRIDGE_KEY_ALIAS") ?: findProperty("PLAYBRIDGE_KEY_ALIAS")?.toString()
             keyPassword = System.getenv("PLAYBRIDGE_KEY_PASSWORD") ?: findProperty("PLAYBRIDGE_KEY_PASSWORD")?.toString()

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -44,7 +44,7 @@ android {
 
     signingConfigs {
         create("release") {
-            storeFile = file("../../../keystore/release.jks")
+            storeFile = file("../../../keystore/release.jks").absoluteFile
             storePassword = System.getenv("PLAYBRIDGE_STORE_PASSWORD") ?: findProperty("PLAYBRIDGE_STORE_PASSWORD")?.toString()
             keyAlias = System.getenv("PLAYBRIDGE_KEY_ALIAS") ?: findProperty("PLAYBRIDGE_KEY_ALIAS")?.toString()
             keyPassword = System.getenv("PLAYBRIDGE_KEY_PASSWORD") ?: findProperty("PLAYBRIDGE_KEY_PASSWORD")?.toString()


### PR DESCRIPTION
Converts the storeFile relative paths to absoluteFile in build.gradle.kts configurations to ensure bundletool successfully resolves and reads the keystore file during AAB signing.