### PR TITLE
chore: uprev versions and update changelogs

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.0+17] — 2026-06-22
+
+### Added
+- **Logs Screen**: Added an in-app Logs viewer screen and log store to track app operations and assist in debugging. (#55)
+
+### Changed
+- Overhauled the Remote Control UI, volume handlers, and Now Playing card. (#55)
+
 ## [0.4.0+16] — 2026-06-21
 
 ### Added

--- a/desktop/lib/logging/log_store.dart
+++ b/desktop/lib/logging/log_store.dart
@@ -123,8 +123,8 @@ class LogStore {
           .whereType<File>()
           .where((f) => _isLogFile(f))
           .toList()
-        ..sort((a, b) =>
-            a.statSync().modified.compareTo(b.statSync().modified));
+        ..sort(
+            (a, b) => a.statSync().modified.compareTo(b.statSync().modified));
       return files.map((f) => f.readAsStringSync()).join('\n');
     } catch (_) {
       return '';
@@ -204,7 +204,6 @@ class LogStore {
         : lower.contains('warn')
             ? LogLevel.warn
             : LogLevel.debug;
-    return LogEntry(
-        time: DateTime.now(), level: level, tag: tag, message: msg);
+    return LogEntry(time: DateTime.now(), level: level, tag: tag, message: msg);
   }
 }

--- a/desktop/lib/logs_screen.dart
+++ b/desktop/lib/logs_screen.dart
@@ -114,7 +114,8 @@ class _LogsScreenState extends State<LogsScreen> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(Icons.description_outlined, size: 40, color: Colors.white38),
+            const Icon(Icons.description_outlined,
+                size: 40, color: Colors.white38),
             const SizedBox(height: 16),
             const Text(
               'Logging is disabled. No logs are being saved.',
@@ -221,7 +222,9 @@ class _LogsScreenState extends State<LogsScreen> {
 Color _dotColor(LogLevel level) => switch (level) {
       LogLevel.error => const Color(0xFFFF5A5A),
       LogLevel.warn => const Color(0xFFFFA726),
-      LogLevel.info || LogLevel.debug || LogLevel.verbose =>
+      LogLevel.info ||
+      LogLevel.debug ||
+      LogLevel.verbose =>
         const Color(0xFF7AA2F7),
       LogLevel.unknown => const Color(0xFF8A8A8A),
     };
@@ -317,7 +320,8 @@ class _LogDetailScreen extends StatelessWidget {
               ),
             ],
           ),
-          _ValueBox(child: SelectableText(
+          _ValueBox(
+              child: SelectableText(
             entry.message,
             style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
           )),

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: playbridge_desktop
 description: "PlayBridge desktop receiver — accepts cast commands from the phone and plays via libmpv."
 publish_to: 'none'
-version: 0.4.0+16
+version: 0.5.0+17
 
 environment:
   sdk: ^3.6.0

--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.0] — 2026-06-22 (versionCode 210)
+
+### Added
+- **Diagnostics Logs Viewer**: Added diagnostics logs screen with real-time logcat reader and email/share attachments. (#54)
+- **Crash Logger**: Automatically captures and stores uncaught exceptions locally for diagnostic analysis. (#54)
+
+### Changed
+- **Tabs Screen UI**: Refactored the web browser tabs screen interface and navigation logic for improved tab lifecycle. (#56)
+- **Player Control Overlays**: Enhanced player control overlay states and TV connection logic. (#56)
+
+### Fixed
+- Fixed keystore path signing failure by converting `storeFile` to an absolute path. (#53)
+
 ## [0.3.0] — 2026-06-21 (versionCode 209)
 
 ### Added

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 209
-        versionName = "0.3.0"
+        versionCode = 210
+        versionName = "0.4.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,20 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [0.4.0] — 2026-06-22 (versionCode 211)
+
+### Added
+- **Diagnostics Logger**: Support for in-app diagnostics logs and `FileLogger` writing to disk. (#54)
+- **Diagnostics Setting**: Added toggle to enable/disable file logging in Settings. (#54)
+
+### Changed
+- Improved player activity and playback coordinator state management. (#56)
+
+## GeckoView Plugin [0.2.7] — 2026-06-22 (versionCode 207)
+
+### Fixed
+- Fixed keystore path signing failure by converting `storeFile` to an absolute path. (#53)
+
 ## Player [0.3.0] — 2026-06-21 (versionCode 210)
 
 ### Added

--- a/tv/android/geckoview-plugin/app/build.gradle.kts
+++ b/tv/android/geckoview-plugin/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "com.playbridge.geckoview.plugin"
         minSdk = 26
         targetSdk = 36
-        versionCode = 206
-        versionName = "0.2.6"
+        versionCode = 207
+        versionName = "0.2.7"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 210
-        versionName = "0.3.0"
+        versionCode = 211
+        versionName = "0.4.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
Bumps versions and updates changelogs for modified projects (Android TV Player, Android TV GeckoView Plugin, Desktop, and Android Phone) to cover recent diagnostics logging, crash logger, and UI updates.