### PR TITLE
feat: implement WebView video controls and remote control mode redesign

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -800,6 +800,9 @@ fun AppNavHost(
                         onMouseScroll = { dx, dy ->
                             connectionViewModel.webSocketClient.sendMouseCommand("scroll", dx, dy)
                         },
+                        onPinchZoom = { factor ->
+                            connectionViewModel.webSocketClient.sendMouseCommand("zoom", factor, 0f)
+                        },
                         onMouseDown = {
                             connectionViewModel.webSocketClient.sendMouseCommand("down", 0f, 0f)
                         },

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
@@ -833,16 +833,8 @@ class BrowserActivity : ComponentActivity() {
                     if (dlnaTarget != null) {
                         val video = detectedVideos.filter { !it.isSubtitle }
                             .sortedWith(
-                                compareByDescending<DetectedVideo> { v ->
-                                    val hasMaster = v.url.contains("master", ignoreCase = true)
-                                    val base = when {
-                                        v.hlsPlaylist?.videoQualities?.isNotEmpty() == true -> 5
-                                        v.isPlayable == true && (v.url.contains(".m3u8", ignoreCase = true) || v.url.contains(".mpd", ignoreCase = true)) -> 4
-                                        v.isPlayable == false -> 1
-                                        else -> 2
-                                    }
-                                    if (hasMaster) base + 1 else base
-                                }.thenByDescending { it.timestamp }
+                                compareByDescending<DetectedVideo> { it.castScore() }
+                                    .thenByDescending { it.timestamp }
                             )
                             .firstOrNull()
                         if (video == null) {
@@ -923,16 +915,8 @@ class BrowserActivity : ComponentActivity() {
                     // 2. Check detected videos
                     val playable = detectedVideos.filter { !it.isSubtitle }
                         .sortedWith(
-                            compareByDescending<DetectedVideo> { video ->
-                                val hasMaster = video.url.contains("master", ignoreCase = true)
-                                val base = when {
-                                    video.hlsPlaylist?.videoQualities?.isNotEmpty() == true -> 5
-                                    video.isPlayable == true && (video.url.contains(".m3u8", ignoreCase = true) || video.url.contains(".mpd", ignoreCase = true)) -> 4
-                                    video.isPlayable == false -> 1
-                                    else -> 2
-                                }
-                                if (hasMaster) base + 1 else base
-                            }.thenByDescending { it.timestamp }
+                            compareByDescending<DetectedVideo> { it.castScore() }
+                                .thenByDescending { it.timestamp }
                         )
 
                     if (playable.isNotEmpty()) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheet.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheet.kt
@@ -101,21 +101,8 @@ fun CastSheet(
     val playableVideos = remember(videos) {
         videos.filter { !it.isSubtitle }
               .sortedWith(
-                  compareByDescending<DetectedVideo> { video ->
-                      val hasMaster = video.url.contains("master", ignoreCase = true)
-                      val base = when {
-                          // Score 5: HLS with multiple variants (Master Playlist)
-                          video.hlsPlaylist?.videoQualities?.isNotEmpty() == true -> 5
-                          // Score 4: Playable stream (HLS/DASH)
-                          video.isPlayable == true && (video.url.contains(".m3u8", ignoreCase = true) || video.url.contains(".mpd", ignoreCase = true)) -> 4
-                          // Score 1: Verified unplayable (dead link, 403, etc)
-                          video.isPlayable == false -> 1
-                          // Score 2: Normal video — unchecked or confirmed playable both rank equally,
-                          // so timestamp (thenByDescending below) determines order: newest first.
-                          else -> 2
-                      }
-                      if (hasMaster) base + 1 else base
-                  }.thenByDescending { it.timestamp }
+                  compareByDescending<DetectedVideo> { it.castScore() }
+                      .thenByDescending { it.timestamp }
               )
     }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -162,14 +162,21 @@ fun RemoteControlScreen(
     var showSettingsSheet by remember { mutableStateOf(false) }
     var showAddSubtitle by remember { mutableStateOf(false) }
     var showSubtitlesSheet by remember { mutableStateOf(false) }
-    // Input mode for the non-player (browser) hero area. Defaults to the touchpad.
-    var inputMode by remember { mutableStateOf(RemoteInputMode.TOUCHPAD) }
-    // When idle (e.g. right after Stop), the calm empty state can reveal the input surface on demand.
-    var idleShowingInput by remember { mutableStateOf(false) }
-
     val remoteContext = remoteContextOf(activeContext)
-    // Leaving idle (TV started playing or opened the browser) collapses the on-demand input surface.
-    LaunchedEffect(remoteContext) { if (remoteContext != RemoteContext.IDLE) idleShowingInput = false }
+    // The interaction surface is chosen via the mode chip (Context / D-Pad / Touchpad /
+    // Keyboard) and remembered separately per context: player defaults to Context (its
+    // scrubber + controls), browser to Touchpad. Picking a mode sticks for that context.
+    var modeByContext by remember {
+        mutableStateOf(
+            mapOf(
+                RemoteContext.PLAYER to RemoteMode.CONTEXT,
+                RemoteContext.BROWSER to RemoteMode.TOUCHPAD,
+                RemoteContext.IDLE to RemoteMode.CONTEXT
+            )
+        )
+    }
+    val selectedMode = modeByContext[remoteContext] ?: RemoteMode.CONTEXT
+    fun selectMode(mode: RemoteMode) { modeByContext = modeByContext + (remoteContext to mode) }
 
     Scaffold(
         topBar = {
@@ -179,6 +186,9 @@ fun RemoteControlScreen(
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
                     }
+                },
+                actions = {
+                    RemoteModeChip(selected = selectedMode, onSelect = { selectMode(it) })
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = Color.Transparent
@@ -206,7 +216,7 @@ fun RemoteControlScreen(
             Spacer(modifier = Modifier.height(12.dp))
 
             AnimatedContent(
-                targetState = remoteContext,
+                targetState = selectedMode to remoteContext,
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth(),
@@ -214,99 +224,113 @@ fun RemoteControlScreen(
                     fadeIn(animationSpec = tween(220)) togetherWith fadeOut(animationSpec = tween(220))
                 },
                 label = "RemoteBody"
-            ) { ctx ->
+            ) { (mode, ctx) ->
                 Column(
                     modifier = Modifier.fillMaxSize(),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    when (ctx) {
-                        RemoteContext.PLAYER -> {
-                            // ── Now Playing: title only — the seek control lives down in the
-                            //    SeekVolumeBar (swipe ◄► to seek, ▲▼ for volume). ──
-                            NowPlayingPanel(
-                                title = mediaTitle,
-                                episodeLabel = null,
-                                positionMs = positionMs,
-                                durationMs = durationMs,
-                                isLive = isLive,
-                                onSeekTo = onSeekTo,
-                                showProgress = false
-                            )
+                    when (mode) {
+                        // Adaptive view: player controls, browser now-playing, or idle.
+                        RemoteMode.CONTEXT -> when (ctx) {
+                            RemoteContext.PLAYER -> {
+                                // ── Now Playing: title only — the seek control lives down in the
+                                //    SeekVolumeBar (swipe ◄► to seek, ▲▼ for volume). ──
+                                NowPlayingPanel(
+                                    title = mediaTitle,
+                                    episodeLabel = null,
+                                    positionMs = positionMs,
+                                    durationMs = durationMs,
+                                    isLive = isLive,
+                                    onSeekTo = onSeekTo,
+                                    showProgress = false
+                                )
 
-                            // Native-only: track pickers/settings — hidden for DLNA renderers.
-                            if (!dlnaMode) {
-                                TrackChipsRow(
-                                    audioTracks = audioTracks,
-                                    subtitleTracks = subtitleTracks,
-                                    onSelectAudio = onSelectAudio,
-                                    onSubtitlesClick = { showSubtitlesSheet = true },
-                                    onMore = { showSettingsSheet = true }
+                                // Native-only: track pickers/settings — hidden for DLNA renderers.
+                                if (!dlnaMode) {
+                                    TrackChipsRow(
+                                        audioTracks = audioTracks,
+                                        subtitleTracks = subtitleTracks,
+                                        onSelectAudio = onSelectAudio,
+                                        onSubtitlesClick = { showSubtitlesSheet = true },
+                                        onMore = { showSettingsSheet = true }
+                                    )
+                                }
+
+                                // ── Episode list (fills available space) ──
+                                EpisodesList(
+                                    episodes = episodes,
+                                    currentIndex = currentEpisodeIndex,
+                                    onJumpToEpisode = onJumpToEpisode,
+                                    modifier = Modifier.weight(1f)
+                                )
+
+                                // ── Combined seek + volume bar ──
+                                // Swipe left/right to scrub, up/down for volume (volume native-only).
+                                SeekVolumeBar(
+                                    positionMs = positionMs,
+                                    durationMs = durationMs,
+                                    isLive = isLive,
+                                    enableVolume = !dlnaMode,
+                                    onSeekTo = onSeekTo,
+                                    onVolumeUp = { onRemoteKey("volume_up") },
+                                    onVolumeDown = { onRemoteKey("volume_down") }
+                                )
+                                MediaControlRow(
+                                    isPlaying = playbackState == null || playbackState == "playing" || playbackState == "buffering",
+                                    onPlayerControl = onPlayerControl,
+                                    showLoop = !dlnaMode,
+                                    showSeek = !isLive
                                 )
                             }
 
-                            // ── Episode list (fills available space) ──
-                            EpisodesList(
-                                episodes = episodes,
-                                currentIndex = currentEpisodeIndex,
-                                onJumpToEpisode = onJumpToEpisode,
-                                modifier = Modifier.weight(1f)
-                            )
-
-                            // ── Combined seek + volume bar ──
-                            // Swipe left/right to scrub, up/down for volume (volume is native-only).
-                            SeekVolumeBar(
+                            RemoteContext.BROWSER -> BrowserContextView(
+                                playbackState = playbackState,
                                 positionMs = positionMs,
                                 durationMs = durationMs,
-                                isLive = isLive,
-                                enableVolume = !dlnaMode,
-                                onSeekTo = onSeekTo,
-                                onVolumeUp = { onRemoteKey("volume_up") },
-                                onVolumeDown = { onRemoteKey("volume_down") }
+                                mediaTitle = mediaTitle,
+                                onBrowserControl = onBrowserControl,
+                                onRemoteKey = onRemoteKey
                             )
-                            // No Back/Home here — Stop already exits playback, so they'd be redundant.
-                            MediaControlRow(
-                                isPlaying = playbackState == null || playbackState == "playing" || playbackState == "buffering",
-                                onPlayerControl = onPlayerControl,
-                                showLoop = !dlnaMode,
-                                showSeek = !isLive
+
+                            RemoteContext.IDLE -> IdleEmptyState(
+                                tvName = tvName,
+                                onShowControls = { selectMode(RemoteMode.TOUCHPAD) },
+                                modifier = Modifier.weight(1f)
                             )
                         }
 
-                        RemoteContext.BROWSER -> BrowserInputSurface(
-                            inputMode = inputMode,
-                            onSelectMode = { inputMode = it },
-                            onRemoteKey = onRemoteKey,
-                            onMouseMove = onMouseMove,
-                            onMouseClick = onMouseClick,
-                            onMouseScroll = onMouseScroll,
-                            onMouseDown = onMouseDown,
-                            onMouseUp = onMouseUp,
-                            onBrowserControl = onBrowserControl
-                        )
-
-                        RemoteContext.IDLE -> {
-                            if (idleShowingInput) {
-                                BrowserInputSurface(
-                                    inputMode = inputMode,
-                                    onSelectMode = { inputMode = it },
-                                    onRemoteKey = onRemoteKey,
+                        // Explicit input surfaces — work in any context (the TV routes by
+                        // its own context). The surface fills the space, with the current
+                        // context's bottom controls kept below it for quick access.
+                        RemoteMode.DPAD -> {
+                            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                                DpadArea(onRemoteKey = onRemoteKey)
+                            }
+                            ModeBottomBar(
+                                ctx = ctx, dlnaMode = dlnaMode, isLive = isLive,
+                                playbackState = playbackState, onRemoteKey = onRemoteKey,
+                                onBrowserControl = onBrowserControl, onPlayerControl = onPlayerControl
+                            )
+                        }
+                        RemoteMode.TOUCHPAD -> {
+                            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                                TouchpadArea(
                                     onMouseMove = onMouseMove,
                                     onMouseClick = onMouseClick,
                                     onMouseScroll = onMouseScroll,
                                     onMouseDown = onMouseDown,
-                                    onMouseUp = onMouseUp,
-                                    onBrowserControl = onBrowserControl
-                                )
-                            } else {
-                                // Calm "nothing playing" state — Stop lands here instead of dumping
-                                // the user straight onto a touchpad.
-                                IdleEmptyState(
-                                    tvName = tvName,
-                                    onShowControls = { idleShowingInput = true },
-                                    modifier = Modifier.weight(1f)
+                                    onMouseUp = onMouseUp
                                 )
                             }
+                            ModeBottomBar(
+                                ctx = ctx, dlnaMode = dlnaMode, isLive = isLive,
+                                playbackState = playbackState, onRemoteKey = onRemoteKey,
+                                onBrowserControl = onBrowserControl, onPlayerControl = onPlayerControl
+                            )
+                        }
+                        RemoteMode.KEYBOARD -> Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                            KeyboardArea(onRemoteKey = onRemoteKey)
                         }
                     }
                 }
@@ -347,11 +371,41 @@ fun RemoteControlScreen(
 }
 
 
-/** Which input surface the non-player ("browser") remote shows. */
-private enum class RemoteInputMode { TOUCHPAD, DPAD, KEYBOARD }
+/**
+ * The interaction surface the user picks from the mode chip. CONTEXT is the adaptive
+ * view (player controls / browser now-playing); the others are explicit input surfaces
+ * that work regardless of the TV's context (the TV routes the keys/mouse by context).
+ */
+private enum class RemoteMode(val label: String) {
+    CONTEXT("Context"), DPAD("D-Pad"), TOUCHPAD("Touchpad"), KEYBOARD("Keyboard")
+}
 
 /** Which TV surface the remote is controlling, derived from the TV's reported context. */
 private enum class RemoteContext { PLAYER, BROWSER, IDLE }
+
+/** Dropdown chip in the app bar that selects the interaction mode. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RemoteModeChip(selected: RemoteMode, onSelect: (RemoteMode) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    Box(modifier = Modifier.padding(end = 8.dp)) {
+        AssistChip(
+            onClick = { expanded = true },
+            label = { Text(selected.label) },
+            trailingIcon = {
+                Icon(Icons.Default.ArrowDropDown, contentDescription = "Change mode")
+            }
+        )
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            RemoteMode.entries.forEach { mode ->
+                DropdownMenuItem(
+                    text = { Text(mode.label) },
+                    onClick = { onSelect(mode); expanded = false }
+                )
+            }
+        }
+    }
+}
 
 private fun remoteContextOf(active: String): RemoteContext = when (active) {
     "player" -> RemoteContext.PLAYER
@@ -441,47 +495,88 @@ private fun ProtocolBadge(text: String, accent: Color) {
 }
 
 /**
- * The browser/input hero shared by the **browser** context and the on-demand reveal from the
- * **idle** empty state: the Touchpad/D-Pad/Keyboard switcher + hero, volume, and browser controls.
+ * The browser CONTEXT view: a now-playing strip (title + scrubber + play/pause) when the
+ * WebView reports a controllable video, then volume and the browser controls. The raw input
+ * surfaces (touchpad/d-pad/keyboard) are now separate modes chosen from the mode chip.
  */
 @Composable
-private fun ColumnScope.BrowserInputSurface(
-    inputMode: RemoteInputMode,
-    onSelectMode: (RemoteInputMode) -> Unit,
-    onRemoteKey: (String) -> Unit,
-    onMouseMove: (dx: Float, dy: Float) -> Unit,
-    onMouseClick: () -> Unit,
-    onMouseScroll: (dx: Float, dy: Float) -> Unit,
-    onMouseDown: () -> Unit,
-    onMouseUp: () -> Unit,
-    onBrowserControl: (String) -> Unit
+private fun ColumnScope.BrowserContextView(
+    playbackState: String?,
+    positionMs: Long,
+    durationMs: Long,
+    mediaTitle: String?,
+    onBrowserControl: (String) -> Unit,
+    onRemoteKey: (String) -> Unit
 ) {
-    // ── Input mode switcher: Touchpad / D-Pad / Keyboard ──
-    InputModeSwitcher(mode = inputMode, onSelect = onSelectMode)
-
-    // ── Hero Area (fills available space) ──
-    Box(modifier = Modifier.weight(1f)) {
-        when (inputMode) {
-            RemoteInputMode.TOUCHPAD -> TouchpadArea(
-                onMouseMove = onMouseMove,
-                onMouseClick = onMouseClick,
-                onMouseScroll = onMouseScroll,
-                onMouseDown = onMouseDown,
-                onMouseUp = onMouseUp
+    val videoActive = playbackState == "playing" || playbackState == "paused" ||
+        playbackState == "buffering"
+    if (videoActive) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 4.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            NowPlayingPanel(
+                title = mediaTitle,
+                episodeLabel = null,
+                positionMs = positionMs,
+                durationMs = durationMs,
+                onSeekTo = { ms -> onBrowserControl("seek_to:$ms") }
             )
-            RemoteInputMode.DPAD -> DpadArea(onRemoteKey = onRemoteKey)
-            RemoteInputMode.KEYBOARD -> KeyboardArea(onRemoteKey = onRemoteKey)
+            IconButton(onClick = { onBrowserControl("toggle_play") }) {
+                Icon(
+                    imageVector = if (playbackState == "playing") Icons.Default.Pause
+                                  else Icons.Default.PlayArrow,
+                    contentDescription = "Play/Pause",
+                    tint = MaterialTheme.colorScheme.onSurface
+                )
+            }
         }
     }
 
-    // ── Volume (sits where Back/Home used to be) ──
+    // Push the controls to the bottom; the top stays calm when nothing's playing.
+    Spacer(modifier = Modifier.weight(1f))
+
     VolumeRow(
         onVolumeUp = { onRemoteKey("volume_up") },
         onVolumeDown = { onRemoteKey("volume_down") }
     )
 
-    // ── Browser Controls: Back · Refresh · Ad Block · Fullscreen · Home ──
+    // ── Browser Controls: Back · Refresh · Ad Block · Fullscreen · iFrame · Home ──
     BrowserContextRow(onBrowserControl = onBrowserControl, onRemoteKey = onRemoteKey)
+}
+
+/**
+ * Context-appropriate bottom controls kept beneath the D-Pad / Touchpad surfaces:
+ * browser nav + volume in browser context, media transport in player context.
+ */
+@Composable
+private fun ColumnScope.ModeBottomBar(
+    ctx: RemoteContext,
+    dlnaMode: Boolean,
+    isLive: Boolean,
+    playbackState: String?,
+    onRemoteKey: (String) -> Unit,
+    onBrowserControl: (String) -> Unit,
+    onPlayerControl: (String) -> Unit
+) {
+    when (ctx) {
+        RemoteContext.BROWSER -> {
+            VolumeRow(
+                onVolumeUp = { onRemoteKey("volume_up") },
+                onVolumeDown = { onRemoteKey("volume_down") }
+            )
+            BrowserContextRow(onBrowserControl = onBrowserControl, onRemoteKey = onRemoteKey)
+        }
+        RemoteContext.PLAYER -> MediaControlRow(
+            isPlaying = playbackState == null || playbackState == "playing" || playbackState == "buffering",
+            onPlayerControl = onPlayerControl,
+            showLoop = !dlnaMode,
+            showSeek = !isLive
+        )
+        RemoteContext.IDLE -> { /* nothing to control */ }
+    }
 }
 
 /**
@@ -521,73 +616,6 @@ private fun IdleEmptyState(
             Icon(Icons.Default.TouchApp, contentDescription = null, modifier = Modifier.size(18.dp))
             Spacer(modifier = Modifier.width(8.dp))
             Text("Show touchpad & controls")
-        }
-    }
-}
-
-@Composable
-private fun InputModeSwitcher(mode: RemoteInputMode, onSelect: (RemoteInputMode) -> Unit) {
-    val shape = RoundedCornerShape(20.dp)
-    Row(
-        modifier = Modifier
-            .clip(shape)
-            .background(MaterialTheme.colorScheme.surfaceVariant)
-            .padding(4.dp),
-        horizontalArrangement = Arrangement.Center
-    ) {
-        PillOption(
-            label = "Touchpad",
-            icon = Icons.Default.TouchApp,
-            selected = mode == RemoteInputMode.TOUCHPAD,
-            onClick = { onSelect(RemoteInputMode.TOUCHPAD) }
-        )
-        PillOption(
-            label = "D-Pad",
-            icon = Icons.Default.Gamepad,
-            selected = mode == RemoteInputMode.DPAD,
-            onClick = { onSelect(RemoteInputMode.DPAD) }
-        )
-        PillOption(
-            label = "Keyboard",
-            icon = Icons.Default.Keyboard,
-            selected = mode == RemoteInputMode.KEYBOARD,
-            onClick = { onSelect(RemoteInputMode.KEYBOARD) }
-        )
-    }
-}
-
-@Composable
-private fun PillOption(
-    label: String,
-    icon: ImageVector,
-    selected: Boolean,
-    onClick: () -> Unit
-) {
-    val bg by animateColorAsState(
-        if (selected) MaterialTheme.colorScheme.primary
-        else Color.Transparent,
-        label = "pillBg"
-    )
-    val fg by animateColorAsState(
-        if (selected) MaterialTheme.colorScheme.onPrimary
-        else MaterialTheme.colorScheme.onSurfaceVariant,
-        label = "pillFg"
-    )
-
-    Surface(
-        onClick = onClick,
-        shape = RoundedCornerShape(20.dp),
-        color = bg,
-        contentColor = fg,
-        modifier = Modifier.height(40.dp)
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 14.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp)
-        ) {
-            Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp))
-            Text(label, style = MaterialTheme.typography.labelMedium, maxLines = 1)
         }
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -1322,6 +1322,7 @@ private fun BrowserContextRow(
     onRemoteKey: (String) -> Unit
 ) {
     var isVideoMaximized by remember { mutableStateOf(false) }
+    var iframeMode by remember { mutableStateOf(false) }
 
     Row(
         modifier = Modifier
@@ -1361,6 +1362,19 @@ private fun BrowserContextRow(
             onClick = {
                 onBrowserControl(if (isVideoMaximized) "restore_video" else "maximize_video")
                 isVideoMaximized = !isVideoMaximized
+            }
+        )
+        // iFrame — switch D-pad video control to videos inside iframes (embeds).
+        // Most sites need the default (main) target; flip this for embedded players.
+        LabeledIconButton(
+            icon = Icons.Default.Layers,
+            label = if (iframeMode) "Main" else "iFrame",
+            tint = if (iframeMode) MaterialTheme.colorScheme.primary
+                   else MaterialTheme.colorScheme.onSurfaceVariant,
+            onClick = {
+                val next = !iframeMode
+                onBrowserControl(if (next) "video_target_iframe" else "video_target_main")
+                iframeMode = next
             }
         )
         // Home — exits the browser

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
@@ -545,7 +546,7 @@ private fun ColumnScope.BrowserContextView(
         onVolumeDown = { onRemoteKey("volume_down") }
     )
 
-    // ── Browser Controls: Back · Refresh · Ad Block · Fullscreen · Source · Home ──
+    // ── Browser Controls: Back · Refresh · Ad Block · Fullscreen · Source · Unmute · Home ──
     BrowserContextRow(onBrowserControl = onBrowserControl, onRemoteKey = onRemoteKey)
 }
 
@@ -1376,6 +1377,7 @@ private fun BrowserContextRow(
     onRemoteKey: (String) -> Unit
 ) {
     var isVideoMaximized by remember { mutableStateOf(false) }
+    var showMoreSheet by remember { mutableStateOf(false) }
 
     Row(
         modifier = Modifier
@@ -1386,12 +1388,19 @@ private fun BrowserContextRow(
         horizontalArrangement = Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        // Back — goes back one page
+        // Back — goes back one page (exits when no history left)
         LabeledIconButton(
             icon = Icons.AutoMirrored.Filled.ArrowBack,
             label = "Back",
             tint = MaterialTheme.colorScheme.onSurface,
             onClick = { onRemoteKey("back") }
+        )
+        // Forward — goes forward one page
+        LabeledIconButton(
+            icon = Icons.AutoMirrored.Filled.ArrowForward,
+            label = "Forward",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            onClick = { onBrowserControl("forward") }
         )
         // Refresh
         LabeledIconButton(
@@ -1399,13 +1408,6 @@ private fun BrowserContextRow(
             label = "Refresh",
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
             onClick = { onBrowserControl("refresh") }
-        )
-        // Ad Blocker
-        LabeledIconButton(
-            icon = Icons.Default.Shield,
-            label = "Ad Block",
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            onClick = { onBrowserControl("toggle_ublock") }
         )
         // Maximize / Restore Video
         LabeledIconButton(
@@ -1417,15 +1419,6 @@ private fun BrowserContextRow(
                 isVideoMaximized = !isVideoMaximized
             }
         )
-        // Source — manual override for the D-pad's video target. The TV auto-follows the
-        // largest on-screen video (main page or any embedded iframe); tap to cycle to the
-        // next one when auto-selection picks the wrong player. Momentary, not a mode.
-        LabeledIconButton(
-            icon = Icons.Default.Layers,
-            label = "Source",
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            onClick = { onBrowserControl("video_target_cycle") }
-        )
         // Home — exits the browser
         LabeledIconButton(
             icon = Icons.Default.Home,
@@ -1433,6 +1426,70 @@ private fun BrowserContextRow(
             tint = MaterialTheme.colorScheme.onSurface,
             onClick = { onRemoteKey("home") }
         )
+        // More — overflow sheet for the less-frequent page/video controls
+        LabeledIconButton(
+            icon = Icons.Default.MoreHoriz,
+            label = "More",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            onClick = { showMoreSheet = true }
+        )
+    }
+
+    if (showMoreSheet) {
+        BrowserMoreSheet(
+            onBrowserControl = onBrowserControl,
+            onDismiss = { showMoreSheet = false }
+        )
+    }
+}
+
+/**
+ * Overflow sheet for the browser controls that don't earn a spot in the main row:
+ * ad-blocker toggle, the D-pad video "source" override, and manual unmute.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BrowserMoreSheet(
+    onBrowserControl: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Text(
+            "More controls",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(start = 24.dp, bottom = 4.dp)
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Ad Block — toggle uBlock on the TV browser
+            LabeledIconButton(
+                icon = Icons.Default.Shield,
+                label = "Ad Block",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                onClick = { onBrowserControl("toggle_ublock"); onDismiss() }
+            )
+            // Source — cycle the D-pad's video target when auto-selection picks the wrong
+            // player (the TV auto-follows the largest on-screen video by default).
+            LabeledIconButton(
+                icon = Icons.Default.Layers,
+                label = "Source",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                onClick = { onBrowserControl("video_target_cycle"); onDismiss() }
+            )
+            // Unmute — manual fallback for muted players the TV didn't auto-unmute.
+            LabeledIconButton(
+                icon = Icons.AutoMirrored.Filled.VolumeUp,
+                label = "Unmute",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                onClick = { onBrowserControl("video_unmute"); onDismiss() }
+            )
+        }
+        Spacer(Modifier.height(16.dp))
     }
 }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -545,7 +545,7 @@ private fun ColumnScope.BrowserContextView(
         onVolumeDown = { onRemoteKey("volume_down") }
     )
 
-    // ── Browser Controls: Back · Refresh · Ad Block · Fullscreen · iFrame · Home ──
+    // ── Browser Controls: Back · Refresh · Ad Block · Fullscreen · Source · Home ──
     BrowserContextRow(onBrowserControl = onBrowserControl, onRemoteKey = onRemoteKey)
 }
 
@@ -1376,7 +1376,6 @@ private fun BrowserContextRow(
     onRemoteKey: (String) -> Unit
 ) {
     var isVideoMaximized by remember { mutableStateOf(false) }
-    var iframeMode by remember { mutableStateOf(false) }
 
     Row(
         modifier = Modifier
@@ -1418,18 +1417,14 @@ private fun BrowserContextRow(
                 isVideoMaximized = !isVideoMaximized
             }
         )
-        // iFrame — switch D-pad video control to videos inside iframes (embeds).
-        // Most sites need the default (main) target; flip this for embedded players.
+        // Source — manual override for the D-pad's video target. The TV auto-follows the
+        // largest on-screen video (main page or any embedded iframe); tap to cycle to the
+        // next one when auto-selection picks the wrong player. Momentary, not a mode.
         LabeledIconButton(
             icon = Icons.Default.Layers,
-            label = if (iframeMode) "Main" else "iFrame",
-            tint = if (iframeMode) MaterialTheme.colorScheme.primary
-                   else MaterialTheme.colorScheme.onSurfaceVariant,
-            onClick = {
-                val next = !iframeMode
-                onBrowserControl(if (next) "video_target_iframe" else "video_target_main")
-                iframeMode = next
-            }
+            label = "Source",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            onClick = { onBrowserControl("video_target_cycle") }
         )
         // Home — exits the browser
         LabeledIconButton(

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -128,6 +128,7 @@ fun RemoteControlScreen(
     onMouseMove: (dx: Float, dy: Float) -> Unit,
     onMouseClick: () -> Unit,
     onMouseScroll: (dx: Float, dy: Float) -> Unit,
+    onPinchZoom: (factor: Float) -> Unit = {},
     onMouseDown: () -> Unit = {},
     onMouseUp: () -> Unit = {},
     onBrowserControl: (String) -> Unit = {},
@@ -319,6 +320,7 @@ fun RemoteControlScreen(
                                     onMouseMove = onMouseMove,
                                     onMouseClick = onMouseClick,
                                     onMouseScroll = onMouseScroll,
+                                    onPinchZoom = onPinchZoom,
                                     onMouseDown = onMouseDown,
                                     onMouseUp = onMouseUp
                                 )
@@ -1123,6 +1125,7 @@ private fun TouchpadArea(
     onMouseMove: (dx: Float, dy: Float) -> Unit,
     onMouseClick: () -> Unit,
     onMouseScroll: (dx: Float, dy: Float) -> Unit,
+    onPinchZoom: (factor: Float) -> Unit = {},
     onMouseDown: () -> Unit = {},
     onMouseUp: () -> Unit = {}
 ) {
@@ -1147,11 +1150,34 @@ private fun TouchpadArea(
 
                         if (pointerCount >= 2) {
                             isScrolling = true
-                            val change = event.changes.firstOrNull { it.pressed }
-                            if (change != null && change.previousPressed) {
-                                val delta = change.position - change.previousPosition
-                                onMouseScroll(delta.x, delta.y * 2f)
-                                change.consume()
+                            // Two fingers = scroll OR pinch-zoom. Decide per-frame by
+                            // whether the fingers' separation changed more than their
+                            // shared (centroid) translation: distance-dominant → zoom,
+                            // translation-dominant → scroll.
+                            val pressed = event.changes.filter { it.pressed }
+                            val a = pressed.getOrNull(0)
+                            val b = pressed.getOrNull(1)
+                            if (a != null && b != null &&
+                                a.previousPressed && b.previousPressed
+                            ) {
+                                val curDist = (a.position - b.position).getDistance()
+                                val prevDist =
+                                    (a.previousPosition - b.previousPosition).getDistance()
+                                val panX = ((a.position.x + b.position.x) -
+                                    (a.previousPosition.x + b.previousPosition.x)) / 2f
+                                val panY = ((a.position.y + b.position.y) -
+                                    (a.previousPosition.y + b.previousPosition.y)) / 2f
+                                val distDelta = curDist - prevDist
+                                if (prevDist > 0f &&
+                                    kotlin.math.abs(distDelta) > kotlin.math.abs(panY) &&
+                                    kotlin.math.abs(distDelta) > kotlin.math.abs(panX)
+                                ) {
+                                    onPinchZoom(curDist / prevDist)
+                                } else {
+                                    onMouseScroll(panX, panY * 2f)
+                                }
+                                a.consume()
+                                b.consume()
                             }
                         } else if (pointerCount == 1 && !isScrolling) {
                             val change = event.changes.first()
@@ -1208,7 +1234,7 @@ private fun TouchpadArea(
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
-                "1 finger: move  •  2 fingers: scroll  •  Tap: click  •  Long-press+drag: drag",
+                "1 finger: move  •  2 fingers: scroll  •  Pinch: zoom  •  Tap: click  •  Long-press+drag: drag",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
                 textAlign = TextAlign.Center

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/VideoDetector.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/VideoDetector.kt
@@ -62,6 +62,47 @@ data class DetectedVideo(
 }
 
 /**
+ * Ranking score for ordering and auto-picking detected videos (higher = better).
+ * Adaptive streams (HLS **and** DASH) outrank progressive files, and streams whose
+ * variant list has already been parsed outrank ones that haven't. DASH is treated at
+ * full parity with HLS here — its variants live in [DetectedVideo.qualities] (there is
+ * no dash equivalent of [DetectedVideo.hlsPlaylist]), so checking only `hlsPlaylist`
+ * used to bury DASH manifests below plain video files.
+ *
+ * Crucially, a stream that merely *looks* adaptive (by `.mpd`/`.m3u8` URL or
+ * content-type) is ranked as adaptive **immediately** — variant parsing and the
+ * playability probe both run asynchronously, so if scoring waited on `qualities` /
+ * `isPlayable` the stream would sit at the bottom on first open and only jump up once
+ * the sheet was dismissed and reopened (by which point the async work had finished).
+ * We only demote below progressive video when the probe has *verified* it unplayable.
+ *
+ * Kept in one place so the cast sheet and the quick-cast / DLNA auto-pick paths can
+ * never diverge.
+ */
+fun DetectedVideo.castScore(): Int {
+    val isDash = url.contains(".mpd", ignoreCase = true) ||
+                 contentType?.contains("dash", ignoreCase = true) == true
+    val isHlsUrl = url.contains(".m3u8", ignoreCase = true) ||
+                   contentType?.contains("mpegurl", ignoreCase = true) == true
+    val looksAdaptive = isDash || isHlsUrl
+    val base = when {
+        // Score 1: verified unplayable (dead link, 403, etc) — lowest, even if it looked adaptive.
+        isPlayable == false -> 1
+        // Score 5: adaptive stream with parsed variants (HLS master playlist or DASH manifest).
+        hlsPlaylist?.videoQualities?.isNotEmpty() == true -> 5
+        isDash && qualities.isNotEmpty() -> 5
+        // Score 4: looks like an adaptive stream (HLS/DASH) by URL or content-type. Ranked high
+        // up front, before the async variant/playability check resolves, so it never starts at
+        // the bottom on the first open.
+        looksAdaptive -> 4
+        // Score 2: normal video — unchecked or confirmed-playable rank equally; timestamp breaks ties.
+        else -> 2
+    }
+    // Master playlists (multi-variant entry points) edge out same-tier single renditions.
+    return if (url.contains("master", ignoreCase = true)) base + 1 else base
+}
+
+/**
  * Data class representing an active subtitle period
  */
 data class Cue(val startTime: Long, val endTime: Long, val text: String) : Comparable<Cue> {
@@ -485,6 +526,10 @@ object VideoDetector {
                     video.qualitiesChecked = true
                     if (qualities.isNotEmpty()) video.isPlayable = true
                     Log.d(TAG, "Fetched ${qualities.size} DASH qualities for ${video.url}")
+                    // Bump the version so the cast sheet re-derives and re-ranks live — the
+                    // HLS path below does this, but DASH was returning early without it, so a
+                    // parsed DASH stream only moved up after the sheet was reopened.
+                    withContext(Dispatchers.Main) { notifyVideoUpdated() }
                     return@withContext qualities
                 }
 

--- a/shared/src/androidMain/kotlin/com/playbridge/shared/player/ExoPlayerEngine.kt
+++ b/shared/src/androidMain/kotlin/com/playbridge/shared/player/ExoPlayerEngine.kt
@@ -13,6 +13,7 @@ import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.dash.DashMediaSource
 import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
@@ -193,20 +194,38 @@ class ExoPlayerEngine(private val context: Context) : PlaybackEngine {
                     (payload.content_type == MimeTypes.APPLICATION_M3U8) ||
                     (payload.content_type.isNullOrEmpty() && (payload.url.contains(".m3u8") || payload.url.contains(".jpg")))
 
-        logger.i(TAG, "Content detection: isHls=$isHls (detectedBy=${payload.detected_by}, contentType=${payload.content_type})")
+        // DASH gets the same explicit treatment as HLS. DefaultMediaSourceFactory can
+        // only infer DASH from a `.mpd` URL extension; manifests served from query-style
+        // URLs with no extension would otherwise fall through to the progressive
+        // extractor and fail. Detect via content-type or `.mpd` in the URL and force
+        // the DASH source + MIME. (HLS is checked first so it always wins a tie.)
+        val isDash = !isHls && (
+                    (payload.content_type == MimeTypes.APPLICATION_MPD) ||
+                    (payload.content_type?.contains("dash", ignoreCase = true) == true) ||
+                    (payload.url.substringBefore('?').contains(".mpd", ignoreCase = true)))
 
-        val mediaSourceFactory = if (isHls) {
-            logger.i(TAG, "Using HlsMediaSource.Factory")
-            HlsMediaSource.Factory(httpDataSourceFactory)
-                .setAllowChunklessPreparation(true)
-                .setLoadErrorHandlingPolicy(CustomLoadErrorHandlingPolicy())
-        } else {
-            logger.i(TAG, "Using DefaultMediaSourceFactory")
-            val extractorsFactory = androidx.media3.extractor.DefaultExtractorsFactory()
-                .setConstantBitrateSeekingEnabled(true)
-                .setTsExtractorFlags(androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory.FLAG_ENABLE_HDMV_DTS_AUDIO_STREAMS)
-            DefaultMediaSourceFactory(httpDataSourceFactory, extractorsFactory)
-                .setLoadErrorHandlingPolicy(CustomLoadErrorHandlingPolicy())
+        logger.i(TAG, "Content detection: isHls=$isHls, isDash=$isDash (detectedBy=${payload.detected_by}, contentType=${payload.content_type})")
+
+        val mediaSourceFactory = when {
+            isHls -> {
+                logger.i(TAG, "Using HlsMediaSource.Factory")
+                HlsMediaSource.Factory(httpDataSourceFactory)
+                    .setAllowChunklessPreparation(true)
+                    .setLoadErrorHandlingPolicy(CustomLoadErrorHandlingPolicy())
+            }
+            isDash -> {
+                logger.i(TAG, "Using DashMediaSource.Factory")
+                DashMediaSource.Factory(httpDataSourceFactory)
+                    .setLoadErrorHandlingPolicy(CustomLoadErrorHandlingPolicy())
+            }
+            else -> {
+                logger.i(TAG, "Using DefaultMediaSourceFactory")
+                val extractorsFactory = androidx.media3.extractor.DefaultExtractorsFactory()
+                    .setConstantBitrateSeekingEnabled(true)
+                    .setTsExtractorFlags(androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory.FLAG_ENABLE_HDMV_DTS_AUDIO_STREAMS)
+                DefaultMediaSourceFactory(httpDataSourceFactory, extractorsFactory)
+                    .setLoadErrorHandlingPolicy(CustomLoadErrorHandlingPolicy())
+            }
         }
 
         val builder = MediaItem.Builder().setUri(finalUrl)
@@ -215,6 +234,8 @@ class ExoPlayerEngine(private val context: Context) : PlaybackEngine {
         }
         if (isHls) {
             builder.setMimeType(MimeTypes.APPLICATION_M3U8)
+        } else if (isDash) {
+            builder.setMimeType(MimeTypes.APPLICATION_MPD)
         } else if (!payload.content_type.isNullOrEmpty()) {
             builder.setMimeType(payload.content_type)
         }

--- a/shared/src/commonMain/kotlin/com/playbridge/shared/protocol/BinaryProtocol.kt
+++ b/shared/src/commonMain/kotlin/com/playbridge/shared/protocol/BinaryProtocol.kt
@@ -4,8 +4,8 @@ package com.playbridge.shared.protocol
  * Compact binary representations for high-frequency events (Mouse).
  *
  * Packet Structure (9 bytes):
- * [0] - Type (0=Move, 1=Click, 2=Scroll, 3=Down, 4=Up)
- * [1-4] - Float DX (Big Endian)
+ * [0] - Type (0=Move, 1=Click, 2=Scroll, 3=Down, 4=Up, 5=Zoom)
+ * [1-4] - Float DX (Big Endian)  // for Zoom: relative scale factor (dy unused)
  * [5-8] - Float DY (Big Endian)
  */
 object MousePacket {
@@ -14,6 +14,7 @@ object MousePacket {
     const val SCROLL: Byte = 2
     const val DOWN: Byte = 3
     const val UP: Byte = 4
+    const val ZOOM: Byte = 5
 
     fun pack(event: String, dx: Float, dy: Float): ByteArray {
         val type = when (event) {
@@ -22,6 +23,7 @@ object MousePacket {
             "scroll" -> SCROLL
             "down" -> DOWN
             "up" -> UP
+            "zoom" -> ZOOM
             else -> MOVE
         }
         val result = ByteArray(9)
@@ -56,6 +58,7 @@ object MousePacket {
             SCROLL -> "scroll"
             DOWN -> "down"
             UP -> "up"
+            ZOOM -> "zoom"
             else -> "move"
         }
 

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -106,6 +106,10 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation("androidx.dynamicanimation:dynamicanimation:1.0.0")
 
+    // AndroidX WebKit — addDocumentStartJavaScript + WebMessageListener, so the video
+    // controller can be injected into (and message) cross-origin iframes too.
+    implementation("androidx.webkit:webkit:1.12.1")
+
     // Ktor WebSocket Server (plaintext ws:// — loopback + opt-in external)
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.cio)

--- a/tv/android/player/app/src/main/assets/pb-video-control.js
+++ b/tv/android/player/app/src/main/assets/pb-video-control.js
@@ -87,6 +87,10 @@
     toggle: function () {
       var v = find();
       if (!v) return 'none';
+      // NOTE: we intentionally do NOT touch v.muted here. Unmuting autoplay-muted video
+      // requires a trusted user gesture, which this injected call doesn't carry — setting
+      // muted=false silently fails on YouTube and can even block an unmuted play(). Unmute
+      // is handled natively via a real synthesized tap (see BrowserActivity video_unmute).
       if (v.paused) { v.play(); } else { v.pause(); }
       return v.paused ? 'paused' : 'playing';
     },
@@ -114,6 +118,19 @@
       v.muted = false;
       v.volume = clamp(v.volume + (Number(delta) || 0), 0, 1);
       return String(v.volume);
+    },
+    unmute: function () {
+      var v = find();
+      if (!v) return 'none';
+      // Runs right after native's real tap, inside the user-activation window that tap
+      // grants — so muted=false sticks here even on sites without a "tap to unmute".
+      v.muted = false;
+      if (v.volume === 0) v.volume = 1;
+      // The preceding tap may have toggled playback off on a player that has no unmute
+      // affordance (e.g. a muted background video). Resume so unmuting never leaves it
+      // paused — the symptom on sites whose videos don't start muted.
+      if (v.paused) { try { v.play(); } catch (e) {} }
+      return v.muted ? 'muted' : 'unmuted';
     },
     setRate: function (r) {
       var v = find();
@@ -143,6 +160,7 @@
       case 'seek': return { kind: 'seek', value: api.seek(parts[1]) };
       case 'seekto': return { kind: 'seek', value: api.seekTo(parts[1]) };
       case 'vol': return { kind: 'vol', value: api.volume(parts[1]) };
+      case 'unmute': return { kind: 'vol', value: api.unmute() };
       case 'rate': return { kind: 'rate', value: api.setRate(parts[1]) };
       case 'state': return { kind: 'state', value: api.state() };
       default: return { kind: 'none', value: 'none' };
@@ -199,7 +217,10 @@
       state: !v ? 'idle' : (v.paused ? 'paused' : 'playing'),
       position: v ? Math.round((v.currentTime || 0) * 1000) : 0,
       duration: (v && isFinite(v.duration)) ? Math.round(v.duration * 1000) : 0,
-      title: (document.title || '')
+      title: (document.title || ''),
+      // Lets native auto-unmute on fullscreen only when actually muted (so it never
+      // pauses an already-audible video). Extra field; older phone parsers ignore it.
+      muted: !!(v && v.muted)
     });
   }
 

--- a/tv/android/player/app/src/main/assets/pb-video-control.js
+++ b/tv/android/player/app/src/main/assets/pb-video-control.js
@@ -96,6 +96,13 @@
       }
       return v.currentTime + ',' + (isFinite(v.duration) ? v.duration : 0);
     },
+    seekTo: function (seconds) {
+      var v = find();
+      if (!v) return 'none';
+      var t = Number(seconds) || 0;
+      v.currentTime = isFinite(v.duration) && v.duration > 0 ? clamp(t, 0, v.duration) : Math.max(0, t);
+      return v.currentTime + ',' + (isFinite(v.duration) ? v.duration : 0);
+    },
     volume: function (delta) {
       var v = find();
       if (!v) return 'none';
@@ -129,6 +136,7 @@
     switch (op) {
       case 'toggle': return { kind: 'toggle', value: api.toggle() };
       case 'seek': return { kind: 'seek', value: api.seek(parts[1]) };
+      case 'seekto': return { kind: 'seek', value: api.seekTo(parts[1]) };
       case 'vol': return { kind: 'vol', value: api.volume(parts[1]) };
       case 'rate': return { kind: 'rate', value: api.setRate(parts[1]) };
       case 'state': return { kind: 'state', value: api.state() };
@@ -170,6 +178,33 @@
     };
   }
 
+  // ── Status push (drives the phone's now-playing scrubber) ─────────────────
+  // Same shape the native player emits, so the phone parses it unchanged.
+  function sendStatus(json) {
+    if (IS_MAIN) {
+      if (window.PBVideoNative && window.PBVideoNative.onStatus) {
+        try { window.PBVideoNative.onStatus(json); } catch (e) { /* unbound */ }
+      }
+    } else if (channel) {
+      channel.postMessage(json);
+    }
+  }
+
+  function activeStatusJson() {
+    var v = find();
+    return JSON.stringify({
+      type: 'status',
+      state: !v ? 'idle' : (v.paused ? 'paused' : 'playing'),
+      position: v ? Math.round((v.currentTime || 0) * 1000) : 0,
+      duration: (v && isFinite(v.duration)) ? Math.round(v.duration * 1000) : 0,
+      title: (document.title || '')
+    });
+  }
+
+  function idleStatusJson() {
+    return JSON.stringify({ type: 'status', state: 'idle', position: 0, duration: 0 });
+  }
+
   // ── Activation monitor ────────────────────────────────────────────────────
   var lastActive = null, lastScore = -1, lastPlaying = null;
   function report() {
@@ -182,11 +217,18 @@
     // so native's cross-frame "which frame wins" pick stays current.
     if (active !== lastActive || playing !== lastPlaying ||
         (active && Math.abs(score - lastScore) > score * 0.2)) {
+      var becameInactive = (lastActive === true && !active);
       lastActive = active; lastScore = score; lastPlaying = playing;
       reportActive(active, score, playing);
+      // Push status immediately on change; one idle status when the video goes away
+      // so the phone clears its scrubber.
+      if (active) sendStatus(activeStatusJson());
+      else if (becameInactive) sendStatus(idleStatusJson());
     }
   }
 
+  // Periodic status while active, for the live scrubber.
+  setInterval(function () { if (lastActive) sendStatus(activeStatusJson()); }, 1000);
   setInterval(report, 600);
   document.addEventListener('play', report, true);
   document.addEventListener('pause', report, true);

--- a/tv/android/player/app/src/main/assets/pb-video-control.js
+++ b/tv/android/player/app/src/main/assets/pb-video-control.js
@@ -3,14 +3,19 @@
  *
  * Injected at document start into EVERY frame (main + cross-origin iframes) via
  * WebViewCompat.addDocumentStartJavaScript, so it can reach videos that the main
- * frame's JS can't (same-origin policy). Each frame talks to native over its own
- * WebMessageListener channel: window.pbVideoChannel.
+ * frame's JS can't (same-origin policy). Each frame — INCLUDING the main frame —
+ * talks to native over its own WebMessageListener channel: window.pbVideoChannel.
  *
- * Transport is auto-detected:
- *   - window.pbVideoChannel present  -> per-frame message channel (multi-frame mode)
- *   - else window.PBVideoNative      -> legacy main-frame fallback (evaluateJavascript
- *                                       drives __pbvc directly; PBVideoNative.setActive
- *                                       reports activation)
+ * Transport is auto-detected by channel presence (NOT by frame type):
+ *   - window.pbVideoChannel present  -> per-frame message channel. Used for the main
+ *                                       frame and every iframe alike, so there is a
+ *                                       single unified pathway. Native picks which
+ *                                       frame the D-pad drives via the per-frame score.
+ *   - else window.PBVideoNative      -> legacy fallback for WebViews lacking the
+ *                                       DOCUMENT_START_SCRIPT / WEB_MESSAGE_LISTENER
+ *                                       features (main frame only; evaluateJavascript
+ *                                       drives __pbvc, PBVideoNative.setActive reports
+ *                                       activation).
  *
  * Native -> frame commands (channel, string): "toggle" | "seek,<s>" | "vol,<d>" |
  *   "rate,<r>" | "state". Frame -> native messages (channel, JSON):
@@ -144,33 +149,31 @@
     }
   }
 
-  // ── Transport: split by frame type ────────────────────────────────────────
-  // MAIN FRAME  -> the proven path: native reports activation via PBVideoNative and
-  //               drives __pbvc directly through evaluateJavascript. No channel.
-  // IFRAME      -> the message channel (window.pbVideoChannel), the only way native
-  //               can reach a cross-origin iframe's video.
-  // This keeps the two solutions independent: main-frame control is untouched by the
-  // iframe work, and vice-versa.
-  var IS_MAIN = true;
-  try { IS_MAIN = (window.top === window.self); } catch (e) { IS_MAIN = true; }
+  // ── Transport: one pathway, chosen by channel presence ────────────────────
+  // CHANNEL (preferred): window.pbVideoChannel, injected by native into EVERY frame
+  //   incl. the main one. All frames report activation/score/status and receive
+  //   commands the same way; native decides which frame the D-pad drives.
+  // LEGACY (fallback): only when no channel exists (old WebView without the webkit
+  //   features) — native reports activation via PBVideoNative and drives __pbvc
+  //   through evaluateJavascript on the main frame.
+  function useChannel() { return !!window.pbVideoChannel; }
 
   var channel = null;
 
   function reportActive(active, score, playing) {
-    if (IS_MAIN) {
-      if (window.PBVideoNative && window.PBVideoNative.setActive) {
-        try { window.PBVideoNative.setActive(active); } catch (e) { /* unbound */ }
-      }
-    } else if (channel) {
-      channel.postMessage(JSON.stringify({
+    if (useChannel()) {
+      bindChannel();
+      if (channel) channel.postMessage(JSON.stringify({
         type: 'active', active: active, score: score, playing: playing
       }));
+    } else if (window.PBVideoNative && window.PBVideoNative.setActive) {
+      try { window.PBVideoNative.setActive(active); } catch (e) { /* unbound */ }
     }
   }
 
-  // Iframes only: bind the channel so native can post commands and read results.
+  // Bind the channel (any frame) so native can post commands and read results.
   function bindChannel() {
-    if (IS_MAIN || channel || !window.pbVideoChannel) return;
+    if (channel || !window.pbVideoChannel) return;
     channel = window.pbVideoChannel;
     channel.onmessage = function (e) {
       var res = execute(e.data);
@@ -181,12 +184,11 @@
   // ── Status push (drives the phone's now-playing scrubber) ─────────────────
   // Same shape the native player emits, so the phone parses it unchanged.
   function sendStatus(json) {
-    if (IS_MAIN) {
-      if (window.PBVideoNative && window.PBVideoNative.onStatus) {
-        try { window.PBVideoNative.onStatus(json); } catch (e) { /* unbound */ }
-      }
-    } else if (channel) {
-      channel.postMessage(json);
+    if (useChannel()) {
+      bindChannel();
+      if (channel) channel.postMessage(json);
+    } else if (window.PBVideoNative && window.PBVideoNative.onStatus) {
+      try { window.PBVideoNative.onStatus(json); } catch (e) { /* unbound */ }
     }
   }
 

--- a/tv/android/player/app/src/main/assets/pb-video-control.js
+++ b/tv/android/player/app/src/main/assets/pb-video-control.js
@@ -1,21 +1,23 @@
 /*
  * PlayBridge WebView video controller.
  *
- * Injected on every page load by SystemWebViewEngine. Exposes window.__pbvc so the
- * native side (BrowserActivity) can drive the active <video> from the phone D-pad.
+ * Injected at document start into EVERY frame (main + cross-origin iframes) via
+ * WebViewCompat.addDocumentStartJavaScript, so it can reach videos that the main
+ * frame's JS can't (same-origin policy). Each frame talks to native over its own
+ * WebMessageListener channel: window.pbVideoChannel.
  *
- * Feedback is rendered NATIVELY by BrowserActivity (an Android overlay over the
- * WebView), not in the DOM: in fullscreen the WebView composites the video surface
- * on top of page HTML, so a DOM overlay would be hidden behind the video. Each
- * command therefore returns a compact result string for the evaluateJavascript
- * callback so native can show the right feedback:
+ * Transport is auto-detected:
+ *   - window.pbVideoChannel present  -> per-frame message channel (multi-frame mode)
+ *   - else window.PBVideoNative      -> legacy main-frame fallback (evaluateJavascript
+ *                                       drives __pbvc directly; PBVideoNative.setActive
+ *                                       reports activation)
  *
- *   toggle()        -> "playing" | "paused" | "none"
- *   seek(delta)     -> "<currentTime>,<duration>" (seconds) | "none"
- *   volume(delta)   -> "<volume 0..1>" | "none"
- *   setRate(r)      -> "<rate>" | "none"
- *   getRate()       -> "<rate>" | "none"
- *   state()         -> JSON {hasVideo,paused,currentTime,duration,volume,rate}
+ * Native -> frame commands (channel, string): "toggle" | "seek,<s>" | "vol,<d>" |
+ *   "rate,<r>" | "state". Frame -> native messages (channel, JSON):
+ *   {type:"active",active,cov} on change, and {type:"result",kind,value} per command.
+ *
+ * Feedback is rendered NATIVELY by BrowserActivity (a DOM overlay would be hidden
+ * behind the video surface in fullscreen), so this script renders no UI.
  */
 (function () {
   'use strict';
@@ -24,16 +26,10 @@
 
   var clamp = function (v, lo, hi) { return Math.max(lo, Math.min(hi, v)); };
 
-  // ── Video discovery (shadow-DOM aware) ────────────────────────────────────
-  // Walk the main document plus any open shadow roots. Cross-origin iframes are
-  // unreachable (separate JS context) and are silently skipped.
+  // ── Video discovery (shadow-DOM aware, this frame only) ───────────────────
   function collectVideos(root, out) {
     var vids;
-    try {
-      vids = root.querySelectorAll('video');
-    } catch (e) {
-      return;
-    }
+    try { vids = root.querySelectorAll('video'); } catch (e) { return; }
     for (var i = 0; i < vids.length; i++) out.push(vids[i]);
     var all = root.querySelectorAll('*');
     for (var j = 0; j < all.length; j++) {
@@ -41,7 +37,7 @@
     }
   }
 
-  // Fraction of the viewport that a video's visible rect covers (0..1).
+  // Fraction of THIS frame's viewport that a video's visible rect covers (0..1).
   function coverage(v) {
     var r = v.getBoundingClientRect();
     if (r.width <= 0 || r.height <= 0) return 0;
@@ -52,8 +48,6 @@
     return (ix * iy) / (vw * vh);
   }
 
-  // The video the user is most plausibly watching: the one covering the most of
-  // the viewport. Looked up fresh each call so SPA navigation needs no re-inject.
   function bestVideo() {
     var out = [];
     collectVideos(document, out);
@@ -65,18 +59,26 @@
     return { v: best, cov: bestCov };
   }
 
-  function find() {
-    return bestVideo().v;
-  }
+  function find() { return bestVideo().v; }
 
-  // A video is "control-active" when it dominates the screen — covers most of the
-  // viewport — whether playing or paused. This is the activation signal for the
-  // D-pad, since sites like m.youtube.com expand the player in-page rather than
-  // entering HTML5 fullscreen (so native onShowCustomView never fires).
+  // A video is "control-active" when it dominates this frame's viewport, whether
+  // playing or paused — the activation signal for the D-pad. Covers m.youtube.com's
+  // in-page expand (no HTML5 fullscreen) and cross-origin iframe players alike.
   var COVERAGE_THRESHOLD = 0.6;
 
-  // ── Public API ────────────────────────────────────────────────────────────
-  window.__pbvc = {
+  // Absolute on-screen area of the dominating video in CSS px². Comparable ACROSS
+  // frames (unlike coverage, which is relative to each frame's own viewport), so
+  // native can pick the genuinely largest video among main frame + all iframes.
+  // This alone defeats tiny ad iframes (small area => loses), so there's no minimum
+  // gate — keeping the gate off avoids suppressing legitimately small embeds.
+  function videoScore(cov) {
+    var vw = window.innerWidth || document.documentElement.clientWidth || 1;
+    var vh = window.innerHeight || document.documentElement.clientHeight || 1;
+    return cov * vw * vh;
+  }
+
+  // ── Direct API (also used by the legacy evaluateJavascript fallback) ───────
+  var api = {
     toggle: function () {
       var v = find();
       if (!v) return 'none';
@@ -92,60 +94,100 @@
       } else {
         v.currentTime = Math.max(0, v.currentTime + d);
       }
-      var dur = isFinite(v.duration) ? v.duration : 0;
-      return v.currentTime + ',' + dur;
+      return v.currentTime + ',' + (isFinite(v.duration) ? v.duration : 0);
     },
     volume: function (delta) {
       var v = find();
       if (!v) return 'none';
-      var d = Number(delta) || 0;
       v.muted = false;
-      v.volume = clamp(v.volume + d, 0, 1);
+      v.volume = clamp(v.volume + (Number(delta) || 0), 0, 1);
       return String(v.volume);
     },
     setRate: function (r) {
       var v = find();
       if (!v) return 'none';
-      var rate = clamp(Number(r) || 1, 0.0625, 16);
-      v.playbackRate = rate;
+      v.playbackRate = clamp(Number(r) || 1, 0.0625, 16);
       return String(v.playbackRate);
     },
-    getRate: function () {
-      var v = find();
-      return v ? String(v.playbackRate) : 'none';
-    },
+    getRate: function () { var v = find(); return v ? String(v.playbackRate) : 'none'; },
     state: function () {
       var v = find();
       if (!v) return JSON.stringify({ hasVideo: false });
       return JSON.stringify({
-        hasVideo: true,
-        paused: !!v.paused,
-        currentTime: v.currentTime || 0,
-        duration: isFinite(v.duration) ? v.duration : 0,
-        volume: v.volume,
-        rate: v.playbackRate
+        hasVideo: true, paused: !!v.paused, currentTime: v.currentTime || 0,
+        duration: isFinite(v.duration) ? v.duration : 0, volume: v.volume, rate: v.playbackRate
       });
     }
   };
+  window.__pbvc = api;
 
-  // ── Activation monitor ────────────────────────────────────────────────────
-  // Tell native (PBVideoNative.setActive) whenever a screen-dominating video
-  // appears/disappears, so BrowserActivity can route the D-pad to playback
-  // control without depending on the HTML5 fullscreen API. Reports only on change.
-  var lastActive = null;
-  function report() {
-    var active = bestVideo().cov >= COVERAGE_THRESHOLD;
-    if (active !== lastActive) {
-      lastActive = active;
-      try {
-        if (window.PBVideoNative && window.PBVideoNative.setActive) {
-          window.PBVideoNative.setActive(active);
-        }
-      } catch (e) { /* interface not bound */ }
+  // ── Command execution (shared by channel + fallback) ──────────────────────
+  // Returns {kind, value} so native can render the right overlay.
+  function execute(cmd) {
+    var parts = String(cmd).split(',');
+    var op = parts[0];
+    switch (op) {
+      case 'toggle': return { kind: 'toggle', value: api.toggle() };
+      case 'seek': return { kind: 'seek', value: api.seek(parts[1]) };
+      case 'vol': return { kind: 'vol', value: api.volume(parts[1]) };
+      case 'rate': return { kind: 'rate', value: api.setRate(parts[1]) };
+      case 'state': return { kind: 'state', value: api.state() };
+      default: return { kind: 'none', value: 'none' };
     }
   }
+
+  // ── Transport: split by frame type ────────────────────────────────────────
+  // MAIN FRAME  -> the proven path: native reports activation via PBVideoNative and
+  //               drives __pbvc directly through evaluateJavascript. No channel.
+  // IFRAME      -> the message channel (window.pbVideoChannel), the only way native
+  //               can reach a cross-origin iframe's video.
+  // This keeps the two solutions independent: main-frame control is untouched by the
+  // iframe work, and vice-versa.
+  var IS_MAIN = true;
+  try { IS_MAIN = (window.top === window.self); } catch (e) { IS_MAIN = true; }
+
+  var channel = null;
+
+  function reportActive(active, score, playing) {
+    if (IS_MAIN) {
+      if (window.PBVideoNative && window.PBVideoNative.setActive) {
+        try { window.PBVideoNative.setActive(active); } catch (e) { /* unbound */ }
+      }
+    } else if (channel) {
+      channel.postMessage(JSON.stringify({
+        type: 'active', active: active, score: score, playing: playing
+      }));
+    }
+  }
+
+  // Iframes only: bind the channel so native can post commands and read results.
+  function bindChannel() {
+    if (IS_MAIN || channel || !window.pbVideoChannel) return;
+    channel = window.pbVideoChannel;
+    channel.onmessage = function (e) {
+      var res = execute(e.data);
+      channel.postMessage(JSON.stringify({ type: 'result', kind: res.kind, value: res.value }));
+    };
+  }
+
+  // ── Activation monitor ────────────────────────────────────────────────────
+  var lastActive = null, lastScore = -1, lastPlaying = null;
+  function report() {
+    bindChannel();
+    var b = bestVideo();
+    var score = videoScore(b.cov);
+    var active = b.cov >= COVERAGE_THRESHOLD;
+    var playing = active && b.v && !b.v.paused;
+    // Re-send when active/playing flips, or score shifts notably (resize/maximize),
+    // so native's cross-frame "which frame wins" pick stays current.
+    if (active !== lastActive || playing !== lastPlaying ||
+        (active && Math.abs(score - lastScore) > score * 0.2)) {
+      lastActive = active; lastScore = score; lastPlaying = playing;
+      reportActive(active, score, playing);
+    }
+  }
+
   setInterval(report, 600);
-  // capture=true so we still see play/pause from videos inside shadow roots
   document.addEventListener('play', report, true);
   document.addEventListener('pause', report, true);
   document.addEventListener('loadedmetadata', report, true);

--- a/tv/android/player/app/src/main/assets/pb-video-control.js
+++ b/tv/android/player/app/src/main/assets/pb-video-control.js
@@ -1,0 +1,156 @@
+/*
+ * PlayBridge WebView video controller.
+ *
+ * Injected on every page load by SystemWebViewEngine. Exposes window.__pbvc so the
+ * native side (BrowserActivity) can drive the active <video> from the phone D-pad.
+ *
+ * Feedback is rendered NATIVELY by BrowserActivity (an Android overlay over the
+ * WebView), not in the DOM: in fullscreen the WebView composites the video surface
+ * on top of page HTML, so a DOM overlay would be hidden behind the video. Each
+ * command therefore returns a compact result string for the evaluateJavascript
+ * callback so native can show the right feedback:
+ *
+ *   toggle()        -> "playing" | "paused" | "none"
+ *   seek(delta)     -> "<currentTime>,<duration>" (seconds) | "none"
+ *   volume(delta)   -> "<volume 0..1>" | "none"
+ *   setRate(r)      -> "<rate>" | "none"
+ *   getRate()       -> "<rate>" | "none"
+ *   state()         -> JSON {hasVideo,paused,currentTime,duration,volume,rate}
+ */
+(function () {
+  'use strict';
+  if (window.__pbvcInjected) return;
+  window.__pbvcInjected = true;
+
+  var clamp = function (v, lo, hi) { return Math.max(lo, Math.min(hi, v)); };
+
+  // ── Video discovery (shadow-DOM aware) ────────────────────────────────────
+  // Walk the main document plus any open shadow roots. Cross-origin iframes are
+  // unreachable (separate JS context) and are silently skipped.
+  function collectVideos(root, out) {
+    var vids;
+    try {
+      vids = root.querySelectorAll('video');
+    } catch (e) {
+      return;
+    }
+    for (var i = 0; i < vids.length; i++) out.push(vids[i]);
+    var all = root.querySelectorAll('*');
+    for (var j = 0; j < all.length; j++) {
+      if (all[j].shadowRoot) collectVideos(all[j].shadowRoot, out);
+    }
+  }
+
+  // Fraction of the viewport that a video's visible rect covers (0..1).
+  function coverage(v) {
+    var r = v.getBoundingClientRect();
+    if (r.width <= 0 || r.height <= 0) return 0;
+    var vw = window.innerWidth || document.documentElement.clientWidth || 1;
+    var vh = window.innerHeight || document.documentElement.clientHeight || 1;
+    var ix = Math.max(0, Math.min(r.right, vw) - Math.max(r.left, 0));
+    var iy = Math.max(0, Math.min(r.bottom, vh) - Math.max(r.top, 0));
+    return (ix * iy) / (vw * vh);
+  }
+
+  // The video the user is most plausibly watching: the one covering the most of
+  // the viewport. Looked up fresh each call so SPA navigation needs no re-inject.
+  function bestVideo() {
+    var out = [];
+    collectVideos(document, out);
+    var best = null, bestCov = 0;
+    for (var i = 0; i < out.length; i++) {
+      var c = coverage(out[i]);
+      if (c > bestCov) { bestCov = c; best = out[i]; }
+    }
+    return { v: best, cov: bestCov };
+  }
+
+  function find() {
+    return bestVideo().v;
+  }
+
+  // A video is "control-active" when it dominates the screen — covers most of the
+  // viewport — whether playing or paused. This is the activation signal for the
+  // D-pad, since sites like m.youtube.com expand the player in-page rather than
+  // entering HTML5 fullscreen (so native onShowCustomView never fires).
+  var COVERAGE_THRESHOLD = 0.6;
+
+  // ── Public API ────────────────────────────────────────────────────────────
+  window.__pbvc = {
+    toggle: function () {
+      var v = find();
+      if (!v) return 'none';
+      if (v.paused) { v.play(); } else { v.pause(); }
+      return v.paused ? 'paused' : 'playing';
+    },
+    seek: function (delta) {
+      var v = find();
+      if (!v) return 'none';
+      var d = Number(delta) || 0;
+      if (isFinite(v.duration) && v.duration > 0) {
+        v.currentTime = clamp(v.currentTime + d, 0, v.duration);
+      } else {
+        v.currentTime = Math.max(0, v.currentTime + d);
+      }
+      var dur = isFinite(v.duration) ? v.duration : 0;
+      return v.currentTime + ',' + dur;
+    },
+    volume: function (delta) {
+      var v = find();
+      if (!v) return 'none';
+      var d = Number(delta) || 0;
+      v.muted = false;
+      v.volume = clamp(v.volume + d, 0, 1);
+      return String(v.volume);
+    },
+    setRate: function (r) {
+      var v = find();
+      if (!v) return 'none';
+      var rate = clamp(Number(r) || 1, 0.0625, 16);
+      v.playbackRate = rate;
+      return String(v.playbackRate);
+    },
+    getRate: function () {
+      var v = find();
+      return v ? String(v.playbackRate) : 'none';
+    },
+    state: function () {
+      var v = find();
+      if (!v) return JSON.stringify({ hasVideo: false });
+      return JSON.stringify({
+        hasVideo: true,
+        paused: !!v.paused,
+        currentTime: v.currentTime || 0,
+        duration: isFinite(v.duration) ? v.duration : 0,
+        volume: v.volume,
+        rate: v.playbackRate
+      });
+    }
+  };
+
+  // ── Activation monitor ────────────────────────────────────────────────────
+  // Tell native (PBVideoNative.setActive) whenever a screen-dominating video
+  // appears/disappears, so BrowserActivity can route the D-pad to playback
+  // control without depending on the HTML5 fullscreen API. Reports only on change.
+  var lastActive = null;
+  function report() {
+    var active = bestVideo().cov >= COVERAGE_THRESHOLD;
+    if (active !== lastActive) {
+      lastActive = active;
+      try {
+        if (window.PBVideoNative && window.PBVideoNative.setActive) {
+          window.PBVideoNative.setActive(active);
+        }
+      } catch (e) { /* interface not bound */ }
+    }
+  }
+  setInterval(report, 600);
+  // capture=true so we still see play/pause from videos inside shadow roots
+  document.addEventListener('play', report, true);
+  document.addEventListener('pause', report, true);
+  document.addEventListener('loadedmetadata', report, true);
+  window.addEventListener('resize', report, true);
+  document.addEventListener('fullscreenchange', report, true);
+  document.addEventListener('webkitfullscreenchange', report, true);
+  report();
+})();

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
@@ -828,6 +828,14 @@ class BrowserActivity : ComponentActivity() {
         cursorHideHandler.postDelayed(cursorHideRunnable, cursorHideDelayMs)
     }
 
+    override fun onResume() {
+        super.onResume()
+        // Claim the server context for the browser whenever we're foregrounded — so a
+        // context_query reports "browser" regardless of how this activity was launched,
+        // and we reclaim it after returning from a player launched on top of us.
+        com.playbridge.player.server.ServerService.notifyContextBrowser()
+    }
+
     override fun onStop() {
         super.onStop()
         if (!isFinishing && !isChangingConfigurations) {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
@@ -244,6 +244,12 @@ class BrowserActivity : ComponentActivity() {
         // cross-origin iframe frames, delivered asynchronously over the message channel).
         engine?.onVideoResult = { kind, value -> renderVideoResult(kind, value) }
 
+        // Forward the controller's playback status to the phone (drives its scrubber).
+        // Same "status" message the native player emits, so the phone parses it as-is.
+        engine?.onVideoStatus = { json ->
+            com.playbridge.player.server.ServerService.broadcastStatus(json)
+        }
+
         // Add engine view at index 0 (behind cursor)
         contentContainer?.addView(engine?.getView(), 0)
     }
@@ -721,6 +727,14 @@ class BrowserActivity : ComponentActivity() {
 
     private fun handleBrowserControlCommand(action: String?) {
         Log.d(TAG, "Browser control: $action")
+        // Absolute seek from the phone scrubber (value in ms) — prefix, so handled
+        // before the exact-match when below.
+        if (action != null && action.startsWith("seek_to:")) {
+            action.removePrefix("seek_to:").toLongOrNull()?.let { ms ->
+                engine?.videoSeekTo(ms / 1000.0)
+            }
+            return
+        }
         when (action) {
             "video_target_iframe" -> {
                 engine?.setVideoTarget(true)
@@ -730,6 +744,7 @@ class BrowserActivity : ComponentActivity() {
                 engine?.setVideoTarget(false)
                 showVideoFeedback("Controls: main video")
             }
+            "toggle_play" -> engine?.videoToggle()
             "refresh" -> engine?.reload()
             "maximize_video" -> {
                 val js = "(function(){" +

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
@@ -743,13 +743,11 @@ class BrowserActivity : ComponentActivity() {
             return
         }
         when (action) {
-            "video_target_iframe" -> {
-                engine?.setVideoTarget(true)
-                showVideoFeedback("Controls: iFrame video")
-            }
-            "video_target_main" -> {
-                engine?.setVideoTarget(false)
-                showVideoFeedback("Controls: main video")
+            "video_target_cycle" -> {
+                // Manual override: pin the D-pad to the next on-screen video (main or
+                // any iframe). Auto-selection resumes when that frame goes inactive.
+                engine?.cycleVideoTarget()
+                showVideoFeedback("Switched video source")
             }
             "toggle_play" -> engine?.videoToggle()
             "refresh" -> engine?.reload()

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
@@ -481,7 +481,14 @@ class BrowserActivity : ComponentActivity() {
                 cursorView?.animateClick()
             }
             "scroll" -> {
-                engine?.scrollBy(dx, dy)
+                // Scroll the element under the cursor, not just the page — this is what
+                // makes inner overflow regions (and horizontal carousels) respond.
+                showCursorAndResetTimer()
+                engine?.wheelScrollAt(cursorX, cursorY, dx, dy)
+            }
+            "zoom" -> {
+                // Pinch-zoom from the phone touchpad; dx carries the relative scale factor.
+                engine?.zoomBy(dx)
             }
             "down" -> {
                 // Start a click-drag: send ACTION_DOWN and remember the time

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
@@ -250,6 +250,10 @@ class BrowserActivity : ComponentActivity() {
             com.playbridge.player.server.ServerService.broadcastStatus(json)
         }
 
+        // Auto-unmute: when a muted video becomes the active control target (in-page
+        // expand or native fullscreen), dispatch a real tap to restore audio.
+        engine?.onRequestUnmuteTap = { autoUnmuteActiveVideo() }
+
         // Add engine view at index 0 (behind cursor)
         contentContainer?.addView(engine?.getView(), 0)
     }
@@ -416,6 +420,27 @@ class BrowserActivity : ComponentActivity() {
             systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         }
         window.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    }
+
+    /**
+     * Dispatch a real centre tap to unmute the active video — the trusted user gesture
+     * that injected JS can't supply. Driven by the engine's [SystemWebViewEngine.onRequestUnmuteTap]
+     * (fired when a muted video becomes active), so it works for native fullscreen AND
+     * YouTube's in-page expand alike. The video dominates the screen when control is
+     * active, so a centre tap lands on it (and on YouTube takes its "tap to unmute").
+     */
+    private fun autoUnmuteActiveVideo() {
+        runOnUiThread {
+            if (engine?.isActiveVideoMuted() != true) return@runOnUiThread
+            val dm = resources.displayMetrics
+            Log.d(TAG, "auto-unmute: dispatching real centre tap")
+            simulateClickOnActiveView(dm.widthPixels / 2f, dm.heightPixels / 2f)
+            // After the tap establishes activation, a JS unmute covers generic players
+            // that lack YouTube's tap-to-unmute affordance — and resumes playback if the
+            // tap paused it. Delay lets the tap's effect register before that check.
+            cursorHideHandler.postDelayed({ engine?.videoUnmute() }, 150)
+            showVideoFeedback("🔊")
+        }
     }
 
     private fun exitFullscreen() {
@@ -750,6 +775,17 @@ class BrowserActivity : ComponentActivity() {
                 showVideoFeedback("Switched video source")
             }
             "toggle_play" -> engine?.videoToggle()
+            "video_unmute" -> {
+                // Same guarded path as auto-unmute: only taps when the video is actually
+                // muted, so it never pauses an already-audible video. Unmuting needs a
+                // *trusted* gesture (a real tap) that injected JS can't supply.
+                when (engine?.isActiveVideoMuted()) {
+                    true -> autoUnmuteActiveVideo()
+                    false -> showVideoFeedback("Audio is on")
+                    null -> showVideoFeedback("No active video")
+                }
+            }
+            "forward" -> engine?.goForward()
             "refresh" -> engine?.reload()
             "maximize_video" -> {
                 val js = "(function(){" +
@@ -865,6 +901,7 @@ class BrowserActivity : ComponentActivity() {
 
     override fun onDestroy() {
         cursorHideHandler.removeCallbacks(cursorHideRunnable)
+        videoOverlayHideHandler.removeCallbacks(videoOverlayHideRunnable)
         unregisterReceiver(commandReceiver)
         scope.cancel()
         engine?.destroy()

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
@@ -240,6 +240,10 @@ class BrowserActivity : ComponentActivity() {
             onDownloadStarted = { id, name -> showDownloadPopup(id, name) }
         )
 
+        // Render native feedback for video-control command results (incl. those from
+        // cross-origin iframe frames, delivered asynchronously over the message channel).
+        engine?.onVideoResult = { kind, value -> renderVideoResult(kind, value) }
+
         // Add engine view at index 0 (behind cursor)
         contentContainer?.addView(engine?.getView(), 0)
     }
@@ -538,10 +542,6 @@ class BrowserActivity : ComponentActivity() {
         }
     }
 
-    /** Strip the JSON quoting evaluateJavascript wraps around returned strings. */
-    private fun jsStr(raw: String?): String =
-        raw?.takeIf { it != "null" }?.trim()?.removeSurrounding("\"") ?: ""
-
     private fun fmtTime(totalSec: Double): String {
         if (!totalSec.isFinite() || totalSec < 0) return "0:00"
         val s = totalSec.toInt()
@@ -555,25 +555,33 @@ class BrowserActivity : ComponentActivity() {
         return "█".repeat(filled) + "░".repeat(slots - filled)
     }
 
-    private fun onToggleResult(raw: String?) {
-        when (jsStr(raw)) {
-            "playing" -> showVideoFeedback("▶")   // ▶
-            "paused" -> showVideoFeedback("❙❙") // ❚❚
+    /**
+     * Render native feedback for a command result reported by the engine
+     * ([SystemWebViewEngine.onVideoResult]). value is already unquoted.
+     */
+    private fun renderVideoResult(kind: String, value: String) {
+        when (kind) {
+            "toggle" -> when (value) {
+                "playing" -> showVideoFeedback("▶")
+                "paused" -> showVideoFeedback("❙❙")
+            }
+            "seek" -> {
+                val parts = value.split(",")
+                if (parts.size != 2) return
+                val t = parts[0].toDoubleOrNull() ?: return
+                val d = parts[1].toDoubleOrNull() ?: 0.0
+                val frac = if (d > 0) t / d else 0.0
+                showVideoFeedback("${fmtTime(t)}   /   ${fmtTime(d)}\n${progressBar(frac)}")
+            }
+            "vol" -> {
+                val vol = value.toDoubleOrNull() ?: return
+                showVideoFeedback("🔊  ${Math.round(vol * 100)}%\n${progressBar(vol)}")
+            }
+            "rate" -> {
+                val r = value.toDoubleOrNull() ?: return
+                showVideoFeedback("${r.toString().removeSuffix(".0")}×")
+            }
         }
-    }
-
-    private fun onSeekResult(raw: String?) {
-        val parts = jsStr(raw).split(",")
-        if (parts.size != 2) return
-        val t = parts[0].toDoubleOrNull() ?: return
-        val d = parts[1].toDoubleOrNull() ?: 0.0
-        val frac = if (d > 0) t / d else 0.0
-        showVideoFeedback("${fmtTime(t)}   /   ${fmtTime(d)}\n${progressBar(frac)}")
-    }
-
-    private fun onVolumeResult(raw: String?) {
-        val vol = jsStr(raw).toDoubleOrNull() ?: return
-        showVideoFeedback("🔊  ${Math.round(vol * 100)}%\n${progressBar(vol)}")
     }
 
     private fun handleRemoteCommand(key: String?) {
@@ -589,11 +597,11 @@ class BrowserActivity : ComponentActivity() {
                 // In fullscreen the D-pad drives the playing <video> via the injected
                 // controller (window.__pbvc); feedback is rendered natively over the
                 // WebView. Site chrome (e.g. YouTube) is pointer-driven and won't show.
-                "dpad_center" -> engine?.videoToggle(::onToggleResult)
-                "dpad_left" -> engine?.videoSeek(-SEEK_STEP_SECONDS, ::onSeekResult)
-                "dpad_right" -> engine?.videoSeek(SEEK_STEP_SECONDS, ::onSeekResult)
-                "dpad_up" -> engine?.videoVolume(VOLUME_STEP, ::onVolumeResult)
-                "dpad_down" -> engine?.videoVolume(-VOLUME_STEP, ::onVolumeResult)
+                "dpad_center" -> engine?.videoToggle()
+                "dpad_left" -> engine?.videoSeek(-SEEK_STEP_SECONDS)
+                "dpad_right" -> engine?.videoSeek(SEEK_STEP_SECONDS)
+                "dpad_up" -> engine?.videoVolume(VOLUME_STEP)
+                "dpad_down" -> engine?.videoVolume(-VOLUME_STEP)
             }
             return
         }
@@ -604,11 +612,11 @@ class BrowserActivity : ComponentActivity() {
         // The phone touchpad still drives the cursor via ACTION_MOUSE.
         if (engine?.isVideoControlActive() == true) {
             when (key) {
-                "dpad_center" -> { engine?.videoToggle(::onToggleResult); return }
-                "dpad_left" -> { engine?.videoSeek(-SEEK_STEP_SECONDS, ::onSeekResult); return }
-                "dpad_right" -> { engine?.videoSeek(SEEK_STEP_SECONDS, ::onSeekResult); return }
-                "dpad_up" -> { engine?.videoVolume(VOLUME_STEP, ::onVolumeResult); return }
-                "dpad_down" -> { engine?.videoVolume(-VOLUME_STEP, ::onVolumeResult); return }
+                "dpad_center" -> { engine?.videoToggle(); return }
+                "dpad_left" -> { engine?.videoSeek(-SEEK_STEP_SECONDS); return }
+                "dpad_right" -> { engine?.videoSeek(SEEK_STEP_SECONDS); return }
+                "dpad_up" -> { engine?.videoVolume(VOLUME_STEP); return }
+                "dpad_down" -> { engine?.videoVolume(-VOLUME_STEP); return }
             }
         }
 
@@ -714,6 +722,14 @@ class BrowserActivity : ComponentActivity() {
     private fun handleBrowserControlCommand(action: String?) {
         Log.d(TAG, "Browser control: $action")
         when (action) {
+            "video_target_iframe" -> {
+                engine?.setVideoTarget(true)
+                showVideoFeedback("Controls: iFrame video")
+            }
+            "video_target_main" -> {
+                engine?.setVideoTarget(false)
+                showVideoFeedback("Controls: main video")
+            }
             "refresh" -> engine?.reload()
             "maximize_video" -> {
                 val js = "(function(){" +

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
@@ -46,6 +46,10 @@ class BrowserActivity : ComponentActivity() {
         const val EXTRA_MOUSE_DY = "mouse_dy"
         const val EXTRA_REMOTE_KEY = "remote_key"
         const val EXTRA_BROWSER_ACTION = "browser_action"
+
+        // Fullscreen video-control D-pad steps
+        private const val SEEK_STEP_SECONDS = 10
+        private const val VOLUME_STEP = 0.1
     }
 
     private var engine: SystemWebViewEngine? = null
@@ -77,6 +81,12 @@ class BrowserActivity : ComponentActivity() {
     private var fullscreenCallback: WebChromeClient.CustomViewCallback? = null
     private var fullscreenContainer: FrameLayout? = null
     private var contentContainer: FrameLayout? = null
+
+    // Native video-control feedback overlay (rendered over the WebView, because a DOM
+    // overlay is hidden behind the video surface in fullscreen).
+    private var videoOverlayView: android.widget.TextView? = null
+    private val videoOverlayHideHandler = Handler(Looper.getMainLooper())
+    private val videoOverlayHideRunnable = Runnable { videoOverlayView?.visibility = View.GONE }
 
     private val commandReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -489,6 +499,83 @@ class BrowserActivity : ComponentActivity() {
         }
     }
 
+    // ── Native video-control feedback overlay ────────────────────────────────
+
+    private fun showVideoFeedback(text: String) {
+        runOnUiThread {
+            val density = resources.displayMetrics.density
+            fun dp(v: Int) = (v * density).toInt()
+            var ov = videoOverlayView
+            if (ov == null) {
+                ov = android.widget.TextView(this).apply {
+                    setTextColor(Color.WHITE)
+                    textSize = 24f
+                    typeface = android.graphics.Typeface.DEFAULT_BOLD
+                    gravity = android.view.Gravity.CENTER
+                    setLineSpacing(dp(4).toFloat(), 1f)
+                    setPadding(dp(30), dp(22), dp(30), dp(22))
+                    background = android.graphics.drawable.GradientDrawable().apply {
+                        cornerRadius = dp(18).toFloat()
+                        setColor(Color.parseColor("#D2141618"))
+                    }
+                    elevation = dp(48).toFloat()
+                    visibility = View.GONE
+                }
+                rootContainer.addView(
+                    ov,
+                    FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.WRAP_CONTENT,
+                        FrameLayout.LayoutParams.WRAP_CONTENT
+                    ).apply { gravity = android.view.Gravity.CENTER }
+                )
+                videoOverlayView = ov
+            }
+            ov.text = text
+            ov.visibility = View.VISIBLE
+            ov.bringToFront()
+            videoOverlayHideHandler.removeCallbacks(videoOverlayHideRunnable)
+            videoOverlayHideHandler.postDelayed(videoOverlayHideRunnable, 1500)
+        }
+    }
+
+    /** Strip the JSON quoting evaluateJavascript wraps around returned strings. */
+    private fun jsStr(raw: String?): String =
+        raw?.takeIf { it != "null" }?.trim()?.removeSurrounding("\"") ?: ""
+
+    private fun fmtTime(totalSec: Double): String {
+        if (!totalSec.isFinite() || totalSec < 0) return "0:00"
+        val s = totalSec.toInt()
+        val h = s / 3600; val m = (s % 3600) / 60; val sec = s % 60
+        return if (h > 0) String.format("%d:%02d:%02d", h, m, sec)
+        else String.format("%d:%02d", m, sec)
+    }
+
+    private fun progressBar(frac: Double, slots: Int = 16): String {
+        val filled = Math.round(frac.coerceIn(0.0, 1.0) * slots).toInt()
+        return "█".repeat(filled) + "░".repeat(slots - filled)
+    }
+
+    private fun onToggleResult(raw: String?) {
+        when (jsStr(raw)) {
+            "playing" -> showVideoFeedback("▶")   // ▶
+            "paused" -> showVideoFeedback("❙❙") // ❚❚
+        }
+    }
+
+    private fun onSeekResult(raw: String?) {
+        val parts = jsStr(raw).split(",")
+        if (parts.size != 2) return
+        val t = parts[0].toDoubleOrNull() ?: return
+        val d = parts[1].toDoubleOrNull() ?: 0.0
+        val frac = if (d > 0) t / d else 0.0
+        showVideoFeedback("${fmtTime(t)}   /   ${fmtTime(d)}\n${progressBar(frac)}")
+    }
+
+    private fun onVolumeResult(raw: String?) {
+        val vol = jsStr(raw).toDoubleOrNull() ?: return
+        showVideoFeedback("🔊  ${Math.round(vol * 100)}%\n${progressBar(vol)}")
+    }
+
     private fun handleRemoteCommand(key: String?) {
         Log.d(TAG, "Remote command: $key")
 
@@ -499,26 +586,30 @@ class BrowserActivity : ComponentActivity() {
                         exitFullscreen()
                     }
                 }
-                "dpad_center" -> {
-                    showCursorAndResetTimer()
-                    simulateClickOnActiveView(cursorX, cursorY)
-                    cursorView?.animateClick()
-                }
-                "dpad_up", "dpad_down", "dpad_left", "dpad_right" -> {
-                    // Allow cursor movement during fullscreen
-                    showCursorAndResetTimer()
-                    val cursorStep = 15f
-                    val displayMetrics = resources.displayMetrics
-                    when (key) {
-                        "dpad_up" -> cursorY = (cursorY - cursorStep).coerceAtLeast(0f)
-                        "dpad_down" -> cursorY = (cursorY + cursorStep).coerceAtMost(displayMetrics.heightPixels.toFloat())
-                        "dpad_left" -> cursorX = (cursorX - cursorStep).coerceAtLeast(0f)
-                        "dpad_right" -> cursorX = (cursorX + cursorStep).coerceAtMost(displayMetrics.widthPixels.toFloat())
-                    }
-                    cursorView?.updatePosition(cursorX, cursorY)
-                }
+                // In fullscreen the D-pad drives the playing <video> via the injected
+                // controller (window.__pbvc); feedback is rendered natively over the
+                // WebView. Site chrome (e.g. YouTube) is pointer-driven and won't show.
+                "dpad_center" -> engine?.videoToggle(::onToggleResult)
+                "dpad_left" -> engine?.videoSeek(-SEEK_STEP_SECONDS, ::onSeekResult)
+                "dpad_right" -> engine?.videoSeek(SEEK_STEP_SECONDS, ::onSeekResult)
+                "dpad_up" -> engine?.videoVolume(VOLUME_STEP, ::onVolumeResult)
+                "dpad_down" -> engine?.videoVolume(-VOLUME_STEP, ::onVolumeResult)
             }
             return
+        }
+
+        // Not in native (HTML5) fullscreen, but a screen-dominating video is on
+        // screen (e.g. m.youtube.com's in-page expand). Intercept the playback keys
+        // for video control; let everything else (back, etc.) navigate normally.
+        // The phone touchpad still drives the cursor via ACTION_MOUSE.
+        if (engine?.isVideoControlActive() == true) {
+            when (key) {
+                "dpad_center" -> { engine?.videoToggle(::onToggleResult); return }
+                "dpad_left" -> { engine?.videoSeek(-SEEK_STEP_SECONDS, ::onSeekResult); return }
+                "dpad_right" -> { engine?.videoSeek(SEEK_STEP_SECONDS, ::onSeekResult); return }
+                "dpad_up" -> { engine?.videoVolume(VOLUME_STEP, ::onVolumeResult); return }
+                "dpad_down" -> { engine?.videoVolume(-VOLUME_STEP, ::onVolumeResult); return }
+            }
         }
 
         // Keyboard input streamed from the phone (browser keyboard mode).

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
@@ -101,6 +101,9 @@ class SystemWebViewEngine(
     /** Callback for command results: (kind in {toggle,seek,vol,rate}, value). */
     var onVideoResult: ((String, String) -> Unit)? = null
 
+    /** Periodic playback status (a `{"type":"status",…}` JSON string) for the phone scrubber. */
+    var onVideoStatus: ((String) -> Unit)? = null
+
     // Iframe videos currently reporting a screen-dominating video, keyed by their
     // reply proxy, with the absolute on-screen video area used to pick the largest.
     // (The main frame never reports here — it uses PBVideoNative.)
@@ -129,6 +132,7 @@ class SystemWebViewEngine(
 
     fun videoToggle() = sendVideoCommand("toggle")
     fun videoSeek(deltaSeconds: Int) = sendVideoCommand("seek,$deltaSeconds")
+    fun videoSeekTo(seconds: Double) = sendVideoCommand("seekto,$seconds")
     fun videoVolume(delta: Double) = sendVideoCommand("vol,$delta")
     fun videoSetRate(rate: Double) = sendVideoCommand("rate,$rate")
 
@@ -146,6 +150,7 @@ class SystemWebViewEngine(
         when (cmd.substringBefore(',')) {
             "toggle" -> { kind = "toggle"; js = "(window.__pbvc&&window.__pbvc.toggle())||'none'" }
             "seek" -> { kind = "seek"; js = "(window.__pbvc&&window.__pbvc.seek($arg))||'none'" }
+            "seekto" -> { kind = "seek"; js = "(window.__pbvc&&window.__pbvc.seekTo($arg))||'none'" }
             "vol" -> { kind = "vol"; js = "(window.__pbvc&&window.__pbvc.volume($arg))||'none'" }
             "rate" -> { kind = "rate"; js = "(window.__pbvc&&window.__pbvc.setRate($arg))||'none'" }
             else -> return
@@ -180,6 +185,11 @@ class SystemWebViewEngine(
                     val value = o.optString("value")
                     if (kind != "none" && value != "none") onVideoResult?.invoke(kind, value)
                 }
+                "status" -> {
+                    // Forward only when iframes are the active target, so we don't push
+                    // an iframe's status while the main frame is being controlled.
+                    if (preferIframe) onVideoStatus?.invoke(data)
+                }
             }
         } catch (e: Exception) {
             Log.w(TAG, "Bad frame message: $data", e)
@@ -191,6 +201,12 @@ class SystemWebViewEngine(
         @android.webkit.JavascriptInterface
         fun setActive(active: Boolean) {
             videoControlActiveFallback = active
+        }
+
+        @android.webkit.JavascriptInterface
+        fun onStatus(json: String) {
+            // Main-frame status; forward only when the main frame is the active target.
+            if (!preferIframe) onVideoStatus?.invoke(json)
         }
     }
 

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
@@ -78,6 +78,12 @@ class SystemWebViewEngine(
 
     fun canGoBack(): Boolean = canGoBack
 
+    fun goForward() {
+        if (webView.canGoForward()) {
+            webView.goForward()
+        }
+    }
+
     fun evaluateJavascript(script: String, callback: ((String?) -> Unit)? = null) {
         webView.evaluateJavascript(script, callback)
     }
@@ -119,6 +125,27 @@ class SystemWebViewEngine(
     private var stickyProxy: JavaScriptReplyProxy? = null
     private var overrideProxy: JavaScriptReplyProxy? = null
 
+    /**
+     * Drop all video-control state. Called on top-level navigation, where the previous
+     * document's frames (and their reply proxies) are destroyed without a final
+     * active:false report — leaving them here would strand the D-pad on a dead frame.
+     */
+    private fun resetVideoControlState() {
+        val hadFrames = activeFrames.isNotEmpty() || videoControlActiveFallback
+        activeFrames.clear()
+        stickyProxy = null
+        overrideProxy = null
+        videoControlActiveFallback = false
+        activeVideoMuted = null
+        autoUnmuteDone = false
+        // The destroyed frames can't send their own final idle status, so the phone's
+        // now-playing strip/scrubber would stay frozen on the old video. Push one idle
+        // status here so the phone clears it on navigation.
+        if (hadFrames) {
+            onVideoStatus?.invoke("""{"type":"status","state":"idle","position":0,"duration":0}""")
+        }
+    }
+
     /** Manual override: pin the D-pad to the next active frame in round-robin order. */
     fun cycleVideoTarget() {
         if (activeFrames.isEmpty()) { overrideProxy = null; return }
@@ -136,11 +163,49 @@ class SystemWebViewEngine(
     fun isVideoControlActive(): Boolean =
         if (multiFrame) activeFrames.isNotEmpty() else videoControlActiveFallback
 
+    // Last-known muted state of the active/target video, parsed from its status pushes.
+    // null = unknown.
+    @Volatile
+    private var activeVideoMuted: Boolean? = null
+
+    /** null = unknown; true/false = last reported muted state of the controlled video. */
+    fun isActiveVideoMuted(): Boolean? = activeVideoMuted
+
+    // Fired (once per active session) when the controlled video is found to be muted, so
+    // native can dispatch a REAL tap — the trusted user gesture that actually unmutes
+    // (injected JS can't). Driven by status, so it works for BOTH native HTML5 fullscreen
+    // AND YouTube-style in-page expand (which never fires onShowCustomView).
+    var onRequestUnmuteTap: (() -> Unit)? = null
+    @Volatile
+    private var autoUnmuteDone = false
+
+    private fun trackMutedFromStatus(json: String) {
+        try {
+            val o = org.json.JSONObject(json)
+            val before = activeVideoMuted
+            if (o.has("muted")) activeVideoMuted = o.optBoolean("muted")
+            val state = o.optString("state")
+            if (state == "idle") { activeVideoMuted = null; autoUnmuteDone = false }
+            if (activeVideoMuted != before) Log.d(TAG, "activeVideoMuted: $before -> $activeVideoMuted")
+            // Auto-unmute ONLY a muted *and actively playing* video — that's the real
+            // autoplay-muted case where a tap is consumed by the "tap to unmute" affordance
+            // instead of toggling playback. Tapping a paused or already-audible video would
+            // just pause/unpause it. Once per session (reset on idle/navigation).
+            if (activeVideoMuted == true && state == "playing" && !autoUnmuteDone) {
+                autoUnmuteDone = true
+                Log.d(TAG, "auto-unmute: muted+playing video active, requesting native tap")
+                onRequestUnmuteTap?.invoke()
+            }
+        } catch (_: Exception) { /* ignore non-status JSON */ }
+    }
+
     /**
      * Which frame the D-pad drives. A manual pin wins while its frame stays active;
-     * otherwise auto-pick: prefer frames whose video is actually playing, then the
-     * largest on-screen area, but keep the incumbent unless a challenger beats it by a
-     * clear margin (hysteresis) so the target doesn't thrash between near-equal frames.
+     * otherwise auto-pick by **on-screen size first** (the big player the user is looking
+     * at), using "playing" only to break ties between comparably-sized frames. Size-first
+     * is deliberate: a tiny autoplaying ad or background clip must NOT steal control from
+     * a large player that happens to be paused (the common iframe-embed case). Hysteresis
+     * keeps the incumbent unless a challenger is clearly bigger or newly starts playing.
      */
     private fun currentProxy(): JavaScriptReplyProxy? {
         if (activeFrames.isEmpty()) { stickyProxy = null; overrideProxy = null; return null }
@@ -152,18 +217,27 @@ class SystemWebViewEngine(
     }
 
     private fun pickBestProxy(incumbent: JavaScriptReplyProxy?): JavaScriptReplyProxy? {
-        val playing = activeFrames.entries.filter { it.value.playing }
-        val pool = if (playing.isNotEmpty()) playing else activeFrames.entries.toList()
-        val top = pool.maxByOrNull { it.value.score } ?: return incumbent
-        if (incumbent != null) {
+        // Largest on-screen video wins by default.
+        val largest = activeFrames.entries.maxByOrNull { it.value.score } ?: return incumbent
+        // Only let a *playing* frame override the largest one if it's comparably big
+        // (≥60% of the top score). This favours real playback without letting a small
+        // playing ad outrank a large paused player.
+        val best = if (!largest.value.playing) {
+            activeFrames.entries
+                .filter { it.value.playing && it.value.score >= largest.value.score * 0.6 }
+                .maxByOrNull { it.value.score } ?: largest
+        } else largest
+        if (incumbent != null && best.key !== incumbent) {
             val inc = activeFrames[incumbent]
-            // Keep the incumbent if it's still in the candidate pool and the challenger
-            // isn't at least 25% larger — avoids bouncing between similar-sized videos.
-            if (inc != null && pool.any { it.key === incumbent } && top.value.score < inc.score * 1.25) {
+            // Keep the incumbent unless the challenger is clearly bigger (≥25%) or it has
+            // started playing while the incumbent hasn't — avoids thrashing on near-ties.
+            val clearlyBigger = inc != null && best.value.score >= inc.score * 1.25
+            val newlyPlaying = inc != null && best.value.playing && !inc.playing
+            if (inc != null && !clearlyBigger && !newlyPlaying) {
                 return incumbent
             }
         }
-        return top.key
+        return best.key
     }
 
     fun videoToggle() = sendVideoCommand("toggle")
@@ -171,12 +245,23 @@ class SystemWebViewEngine(
     fun videoSeekTo(seconds: Double) = sendVideoCommand("seekto,$seconds")
     fun videoVolume(delta: Double) = sendVideoCommand("vol,$delta")
     fun videoSetRate(rate: Double) = sendVideoCommand("rate,$rate")
+    /** JS unmute — only reliable after native has established a user gesture (a real tap). */
+    fun videoUnmute() = sendVideoCommand("unmute")
 
     private fun sendVideoCommand(cmd: String) {
         if (multiFrame) {
             // Unified channel pathway: post to the current target frame (main or iframe);
             // result comes back asynchronously via the message listener -> onVideoResult.
-            currentProxy()?.postMessage(cmd)
+            // Guarded: a frame can be torn down between its last report and this post.
+            val proxy = currentProxy() ?: return
+            try {
+                proxy.postMessage(cmd)
+            } catch (e: Exception) {
+                Log.w(TAG, "postMessage to a stale frame proxy failed; dropping it", e)
+                activeFrames.remove(proxy)
+                if (proxy === overrideProxy) overrideProxy = null
+                if (proxy === stickyProxy) stickyProxy = null
+            }
             return
         }
         // LEGACY fallback (no channel support): evaluateJavascript on the main frame.
@@ -229,7 +314,10 @@ class SystemWebViewEngine(
                 "status" -> {
                     // Forward only the current target frame's status, so a background
                     // frame can't push its scrubber state over the one being controlled.
-                    if (proxy === currentProxy()) onVideoStatus?.invoke(data)
+                    if (proxy === currentProxy()) {
+                        trackMutedFromStatus(data)
+                        onVideoStatus?.invoke(data)
+                    }
                 }
             }
         } catch (e: Exception) {
@@ -251,6 +339,7 @@ class SystemWebViewEngine(
         @android.webkit.JavascriptInterface
         fun onStatus(json: String) {
             // Legacy path is main-frame only, so there's no other target to guard against.
+            trackMutedFromStatus(json)
             onVideoStatus?.invoke(json)
         }
     }
@@ -532,11 +621,14 @@ class SystemWebViewEngine(
             // Enable third-party cookies (required for many iframe embeds)
             android.webkit.CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
 
-            // Video controller transports — the two solutions run side by side:
-            //  • MAIN frame: PBVideoNative interface (activation) + evaluateJavascript
-            //    (commands). Always available; the proven default path.
-            //  • IFRAMES: a per-frame message channel, added only when the WebView
-            //    supports it. The injected script picks its transport by frame type.
+            // Video controller transport — ONE unified pathway, chosen by the script via
+            // channel presence (not frame type):
+            //  • CHANNEL (preferred): a per-frame WebMessageListener (pbVideoChannel),
+            //    added when the WebView supports it. Every frame — main + iframes alike —
+            //    reports activation/score/status and receives commands over it.
+            //  • LEGACY (fallback): on older WebViews without the features, the script
+            //    falls back to the PBVideoNative interface + evaluateJavascript on the
+            //    main frame only. PBVideoNative is registered solely for that path.
             addJavascriptInterface(VideoControlBridge(), "PBVideoNative")
             if (multiFrame && videoControlScript.isNotEmpty()) {
                 WebViewCompat.addWebMessageListener(
@@ -642,6 +734,11 @@ class SystemWebViewEngine(
 
         override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
             super.onPageStarted(view, url, favicon)
+            // A new top-level document tears down all previous frames, but their reply
+            // proxies never send a final active:false — so without this the old frames
+            // linger in activeFrames, isVideoControlActive() stays stuck true, and the
+            // D-pad keeps trying to control a phantom video on the new page. Reset here.
+            resetVideoControlState()
         }
 
         override fun onPageFinished(view: WebView?, url: String?) {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
@@ -79,6 +79,47 @@ class SystemWebViewEngine(
         webView.evaluateJavascript(script, callback)
     }
 
+    // ── Injected video controller bridge (pb-video-control.js) ────────────────
+    // All commands target the active <video> via window.__pbvc. Each returns a
+    // compact result string (via [callback]) so BrowserActivity can render NATIVE
+    // feedback — a DOM overlay would be hidden behind the video surface in
+    // fullscreen. Calls are no-ops (callback "none") if no video is present.
+
+    fun videoToggle(callback: ((String?) -> Unit)? = null) =
+        webView.evaluateJavascript("(window.__pbvc&&window.__pbvc.toggle())||'none'", callback)
+
+    fun videoSeek(deltaSeconds: Int, callback: ((String?) -> Unit)? = null) =
+        webView.evaluateJavascript("(window.__pbvc&&window.__pbvc.seek($deltaSeconds))||'none'", callback)
+
+    fun videoVolume(delta: Double, callback: ((String?) -> Unit)? = null) =
+        webView.evaluateJavascript("(window.__pbvc&&window.__pbvc.volume($delta))||'none'", callback)
+
+    fun videoSetRate(rate: Double, callback: ((String?) -> Unit)? = null) =
+        webView.evaluateJavascript("(window.__pbvc&&window.__pbvc.setRate($rate))||'none'", callback)
+
+    /** Returns the controller's JSON state via [callback], e.g. {"hasVideo":true,...}. */
+    fun queryVideoState(callback: (String?) -> Unit) =
+        webView.evaluateJavascript("(window.__pbvc&&window.__pbvc.state())||'{\"hasVideo\":false}'", callback)
+
+    /**
+     * True when a screen-dominating <video> is present, as reported by the injected
+     * controller's monitor. Drives D-pad playback control without relying on the HTML5
+     * fullscreen API (sites like m.youtube.com expand the player in-page instead).
+     * Set from the JS bridge thread — volatile so the main thread sees updates.
+     */
+    @Volatile
+    private var videoControlActive = false
+
+    fun isVideoControlActive(): Boolean = videoControlActive
+
+    /** JS-exposed bridge object; the injected script calls PBVideoNative.setActive(bool). */
+    private inner class VideoControlBridge {
+        @android.webkit.JavascriptInterface
+        fun setActive(active: Boolean) {
+            videoControlActive = active
+        }
+    }
+
     fun destroy() {
         webView.destroy()
     }
@@ -225,6 +266,19 @@ class SystemWebViewEngine(
         })();
     """.trimIndent()
 
+    /**
+     * The injected video controller (assets/pb-video-control.js). Read once; re-injected
+     * on every page load. Idempotent — the script self-guards via window.__pbvcInjected.
+     */
+    private val videoControlScript: String by lazy {
+        try {
+            context.assets.open("pb-video-control.js").bufferedReader().use { it.readText() }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to load pb-video-control.js", e)
+            ""
+        }
+    }
+
     private fun setupWebView() {
         webView.apply {
             isFocusable = true
@@ -286,6 +340,9 @@ class SystemWebViewEngine(
 
             // Enable third-party cookies (required for many iframe embeds)
             android.webkit.CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+
+            // Bridge for the injected video controller to report activation state.
+            addJavascriptInterface(VideoControlBridge(), "PBVideoNative")
 
             // Handle Downloads via Android DownloadManager
             setDownloadListener { url, userAgent, contentDisposition, mimeType, contentLength ->
@@ -390,6 +447,12 @@ class SystemWebViewEngine(
             // Inject anti-popup script once the new document's JS context is ready.
             // The __pbAdblockInjected guard prevents double-injection on soft navigations.
             view?.evaluateJavascript(antiPopupScript, null)
+
+            // Inject the video controller (window.__pbvc) for phone D-pad playback control.
+            // Self-guards via window.__pbvcInjected, so re-injection on soft navs is harmless.
+            if (videoControlScript.isNotEmpty()) {
+                view?.evaluateJavascript(videoControlScript, null)
+            }
 
             // Inject cosmetic filters (element hiding CSS)
             val cosmeticCss = adBlocker.getCosmeticFilterCss()

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
@@ -16,6 +16,9 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
+import androidx.webkit.JavaScriptReplyProxy
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
 import java.io.ByteArrayInputStream
 
 @SuppressLint("SetJavaScriptEnabled")
@@ -52,9 +55,9 @@ class SystemWebViewEngine(
     private var scrollAccumulatorX = 0f
     private var scrollAccumulatorY = 0f
 
-    init {
-        setupWebView()
-    }
+    // NOTE: setupWebView() is invoked from an init block at the BOTTOM of the class,
+    // after all property initializers (e.g. the videoControlScript lazy delegate),
+    // because setupWebView() reads them. An init block here would run too early.
 
     fun getView(): View = webView
 
@@ -80,43 +83,114 @@ class SystemWebViewEngine(
     }
 
     // ── Injected video controller bridge (pb-video-control.js) ────────────────
-    // All commands target the active <video> via window.__pbvc. Each returns a
-    // compact result string (via [callback]) so BrowserActivity can render NATIVE
-    // feedback — a DOM overlay would be hidden behind the video surface in
-    // fullscreen. Calls are no-ops (callback "none") if no video is present.
-
-    fun videoToggle(callback: ((String?) -> Unit)? = null) =
-        webView.evaluateJavascript("(window.__pbvc&&window.__pbvc.toggle())||'none'", callback)
-
-    fun videoSeek(deltaSeconds: Int, callback: ((String?) -> Unit)? = null) =
-        webView.evaluateJavascript("(window.__pbvc&&window.__pbvc.seek($deltaSeconds))||'none'", callback)
-
-    fun videoVolume(delta: Double, callback: ((String?) -> Unit)? = null) =
-        webView.evaluateJavascript("(window.__pbvc&&window.__pbvc.volume($delta))||'none'", callback)
-
-    fun videoSetRate(rate: Double, callback: ((String?) -> Unit)? = null) =
-        webView.evaluateJavascript("(window.__pbvc&&window.__pbvc.setRate($rate))||'none'", callback)
-
-    /** Returns the controller's JSON state via [callback], e.g. {"hasVideo":true,...}. */
-    fun queryVideoState(callback: (String?) -> Unit) =
-        webView.evaluateJavascript("(window.__pbvc&&window.__pbvc.state())||'{\"hasVideo\":false}'", callback)
+    // Commands target the active <video> via the injected controller. In multi-frame
+    // mode they're posted to the owning frame's WebMessageListener channel (reaches
+    // cross-origin iframes); results come back asynchronously and are delivered to
+    // [onVideoResult] as (kind, value). BrowserActivity renders NATIVE feedback from
+    // that — a DOM overlay would be hidden behind the video surface in fullscreen.
 
     /**
-     * True when a screen-dominating <video> is present, as reported by the injected
-     * controller's monitor. Drives D-pad playback control without relying on the HTML5
-     * fullscreen API (sites like m.youtube.com expand the player in-page instead).
-     * Set from the JS bridge thread — volatile so the main thread sees updates.
+     * True when addDocumentStartJavaScript + WebMessageListener are available.
+     * A computed getter (not a lazy/backed val) so it's safe to read from
+     * setupWebView(), which runs from the init block before field initializers.
      */
+    private val multiFrame: Boolean
+        get() = WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT) &&
+            WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
+
+    /** Callback for command results: (kind in {toggle,seek,vol,rate}, value). */
+    var onVideoResult: ((String, String) -> Unit)? = null
+
+    // Iframe videos currently reporting a screen-dominating video, keyed by their
+    // reply proxy, with the absolute on-screen video area used to pick the largest.
+    // (The main frame never reports here — it uses PBVideoNative.)
+    private data class FrameVideo(val score: Double)
+    private val activeFrames = LinkedHashMap<JavaScriptReplyProxy, FrameVideo>()
+
+    // Which solution the D-pad uses. Default = MAIN frame (the proven
+    // evaluateJavascript + PBVideoNative path; works on the vast majority of sites).
+    // The remote's "iFrame" toggle flips to the channel-based iframe solution. The
+    // two are fully independent so neither can regress the other.
+    private var preferIframe = false
+
+    fun setVideoTarget(iframe: Boolean) { preferIframe = iframe }
+
+    // Main-frame activation flag, set via the PBVideoNative bridge.
     @Volatile
-    private var videoControlActive = false
+    private var videoControlActiveFallback = false
 
-    fun isVideoControlActive(): Boolean = videoControlActive
+    fun isVideoControlActive(): Boolean =
+        if (preferIframe) (multiFrame && activeFrames.isNotEmpty())
+        else videoControlActiveFallback
 
-    /** JS-exposed bridge object; the injected script calls PBVideoNative.setActive(bool). */
+    // Iframe command target: the largest iframe video (absolute on-screen area).
+    private fun currentProxy(): JavaScriptReplyProxy? =
+        activeFrames.maxByOrNull { it.value.score }?.key
+
+    fun videoToggle() = sendVideoCommand("toggle")
+    fun videoSeek(deltaSeconds: Int) = sendVideoCommand("seek,$deltaSeconds")
+    fun videoVolume(delta: Double) = sendVideoCommand("vol,$delta")
+    fun videoSetRate(rate: Double) = sendVideoCommand("rate,$rate")
+
+    private fun sendVideoCommand(cmd: String) {
+        if (preferIframe) {
+            // Iframe solution: post to the owning frame's channel; result comes back
+            // asynchronously via the message listener -> onVideoResult.
+            currentProxy()?.postMessage(cmd)
+            return
+        }
+        // Main-frame solution (proven): evaluateJavascript and map the return value.
+        val arg = cmd.substringAfter(',', "")
+        val kind: String
+        val js: String
+        when (cmd.substringBefore(',')) {
+            "toggle" -> { kind = "toggle"; js = "(window.__pbvc&&window.__pbvc.toggle())||'none'" }
+            "seek" -> { kind = "seek"; js = "(window.__pbvc&&window.__pbvc.seek($arg))||'none'" }
+            "vol" -> { kind = "vol"; js = "(window.__pbvc&&window.__pbvc.volume($arg))||'none'" }
+            "rate" -> { kind = "rate"; js = "(window.__pbvc&&window.__pbvc.setRate($arg))||'none'" }
+            else -> return
+        }
+        webView.evaluateJavascript(js) { raw ->
+            val value = raw?.trim()?.removeSurrounding("\"") ?: "none"
+            if (value != "none") onVideoResult?.invoke(kind, value)
+        }
+    }
+
+    /** Parse an iframe -> native message (activation change or command result). */
+    private fun handleFrameMessage(
+        data: String,
+        proxy: JavaScriptReplyProxy,
+        isMainFrame: Boolean
+    ) {
+        // The channel is the iframe-only solution; ignore any main-frame report
+        // (the main frame uses the PBVideoNative + evaluateJavascript path).
+        if (isMainFrame) return
+        try {
+            val o = org.json.JSONObject(data)
+            when (o.optString("type")) {
+                "active" -> {
+                    if (o.optBoolean("active")) {
+                        activeFrames[proxy] = FrameVideo(score = o.optDouble("score", 0.0))
+                    } else {
+                        activeFrames.remove(proxy)
+                    }
+                }
+                "result" -> {
+                    val kind = o.optString("kind")
+                    val value = o.optString("value")
+                    if (kind != "none" && value != "none") onVideoResult?.invoke(kind, value)
+                }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Bad frame message: $data", e)
+        }
+    }
+
+    /** JS-exposed bridge object (fallback mode); script calls PBVideoNative.setActive. */
     private inner class VideoControlBridge {
         @android.webkit.JavascriptInterface
         fun setActive(active: Boolean) {
-            videoControlActive = active
+            videoControlActiveFallback = active
         }
     }
 
@@ -341,8 +415,20 @@ class SystemWebViewEngine(
             // Enable third-party cookies (required for many iframe embeds)
             android.webkit.CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
 
-            // Bridge for the injected video controller to report activation state.
+            // Video controller transports — the two solutions run side by side:
+            //  • MAIN frame: PBVideoNative interface (activation) + evaluateJavascript
+            //    (commands). Always available; the proven default path.
+            //  • IFRAMES: a per-frame message channel, added only when the WebView
+            //    supports it. The injected script picks its transport by frame type.
             addJavascriptInterface(VideoControlBridge(), "PBVideoNative")
+            if (multiFrame && videoControlScript.isNotEmpty()) {
+                WebViewCompat.addWebMessageListener(
+                    this, "pbVideoChannel", setOf("*")
+                ) { _, message, _, isMainFrame, replyProxy ->
+                    message.data?.let { handleFrameMessage(it, replyProxy, isMainFrame) }
+                }
+                WebViewCompat.addDocumentStartJavaScript(this, videoControlScript, setOf("*"))
+            }
 
             // Handle Downloads via Android DownloadManager
             setDownloadListener { url, userAgent, contentDisposition, mimeType, contentLength ->
@@ -450,7 +536,8 @@ class SystemWebViewEngine(
 
             // Inject the video controller (window.__pbvc) for phone D-pad playback control.
             // Self-guards via window.__pbvcInjected, so re-injection on soft navs is harmless.
-            if (videoControlScript.isNotEmpty()) {
+            // Multi-frame mode injects at document start into all frames instead (see setup).
+            if (!multiFrame && videoControlScript.isNotEmpty()) {
                 view?.evaluateJavascript(videoControlScript, null)
             }
 
@@ -593,5 +680,11 @@ class SystemWebViewEngine(
                 ByteArrayInputStream(ByteArray(0))
             )
         }
+    }
+
+    // Declared last so all property initializers (incl. lazy delegates that
+    // setupWebView() reads) are constructed before it runs.
+    init {
+        setupWebView()
     }
 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
@@ -217,15 +217,71 @@ class SystemWebViewEngine(
     fun scrollBy(dx: Float, dy: Float) {
         scrollAccumulatorX += dx
         scrollAccumulatorY += dy
-        
+
         val scrollX = scrollAccumulatorX.toInt()
         val scrollY = scrollAccumulatorY.toInt()
-        
+
         if (scrollX != 0 || scrollY != 0) {
             webView.scrollBy(scrollX, scrollY)
             scrollAccumulatorX -= scrollX
             scrollAccumulatorY -= scrollY
         }
+    }
+
+    /**
+     * Scroll the element under the cursor rather than the whole document. Plain
+     * [scrollBy] only moves the top-level viewport, so inner `overflow:scroll/auto`
+     * regions (sidebars, modals, chat panes, horizontal carousels) never respond to
+     * the touchpad. Here we hit-test the cursor position, walk up to the nearest
+     * scrollable ancestor, and scroll that; if none is found we fall back to the
+     * window. Handles horizontal (dx) and vertical (dy) together.
+     *
+     * [xDevice]/[yDevice] are cursor coordinates in the WebView's device pixels
+     * (same space as touch dispatch); we convert to CSS px via devicePixelRatio in JS.
+     * Limitation: cross-origin iframes are unreachable from the main frame's JS — the
+     * same boundary that applies to the video-control path.
+     */
+    fun wheelScrollAt(xDevice: Float, yDevice: Float, dx: Float, dy: Float) {
+        if (dx == 0f && dy == 0f) return
+        val js = """
+            (function(){
+              try {
+                var dpr = window.devicePixelRatio || 1;
+                var x = ${xDevice} / dpr, y = ${yDevice} / dpr;
+                var dx = ${dx}, dy = ${dy};
+                function scrollable(node){
+                  while (node && node.nodeType === 1 &&
+                         node !== document.body && node !== document.documentElement){
+                    var s = getComputedStyle(node);
+                    var canY = (s.overflowY === 'auto' || s.overflowY === 'scroll') &&
+                               node.scrollHeight > node.clientHeight + 1;
+                    var canX = (s.overflowX === 'auto' || s.overflowX === 'scroll') &&
+                               node.scrollWidth > node.clientWidth + 1;
+                    if ((dy && canY) || (dx && canX)) return node;
+                    node = node.parentElement;
+                  }
+                  return null;
+                }
+                var el = document.elementFromPoint(x, y);
+                var t = el ? scrollable(el) : null;
+                if (t){ if (dx) t.scrollLeft += dx; if (dy) t.scrollTop += dy; }
+                else { window.scrollBy(dx, dy); }
+              } catch(e) {}
+            })();
+        """.trimIndent()
+        webView.evaluateJavascript(js, null)
+    }
+
+    /**
+     * Relative pinch-zoom of the whole page using the WebView's built-in zoom
+     * (enabled via setSupportZoom/builtInZoomControls). [factor] is a multiplier
+     * applied to the current zoom (e.g. 1.05 = zoom in 5%); clamped per-event so a
+     * single jittery gesture can't jump scale.
+     */
+    fun zoomBy(factor: Float) {
+        if (factor.isNaN() || factor <= 0f) return
+        val clamped = factor.coerceIn(0.8f, 1.25f)
+        webView.zoomBy(clamped)
     }
 
     fun simulateClick(x: Float, y: Float) {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
@@ -104,31 +104,67 @@ class SystemWebViewEngine(
     /** Periodic playback status (a `{"type":"status",…}` JSON string) for the phone scrubber. */
     var onVideoStatus: ((String) -> Unit)? = null
 
-    // Iframe videos currently reporting a screen-dominating video, keyed by their
-    // reply proxy, with the absolute on-screen video area used to pick the largest.
-    // (The main frame never reports here — it uses PBVideoNative.)
-    private data class FrameVideo(val score: Double)
+    // Every frame (main + iframes) reporting a screen-dominating video, keyed by its
+    // reply proxy. `score` is the absolute on-screen video area (comparable across
+    // frames); `playing` and `isMain` feed target selection. Unified pathway: the main
+    // frame reports here too now, over the same channel as iframes.
+    private data class FrameVideo(val score: Double, val playing: Boolean, val isMain: Boolean)
     private val activeFrames = LinkedHashMap<JavaScriptReplyProxy, FrameVideo>()
 
-    // Which solution the D-pad uses. Default = MAIN frame (the proven
-    // evaluateJavascript + PBVideoNative path; works on the vast majority of sites).
-    // The remote's "iFrame" toggle flips to the channel-based iframe solution. The
-    // two are fully independent so neither can regress the other.
-    private var preferIframe = false
+    // Target selection. By default the D-pad auto-follows the best frame (see
+    // [pickBestProxy]); [stickyProxy] is the current auto pick, kept across reports
+    // with hysteresis so a flickering score can't bounce the target. The user can pin
+    // a specific frame via [cycleVideoTarget] ("switch source"); [overrideProxy] holds
+    // that pin until its frame goes inactive or the user cycles again.
+    private var stickyProxy: JavaScriptReplyProxy? = null
+    private var overrideProxy: JavaScriptReplyProxy? = null
 
-    fun setVideoTarget(iframe: Boolean) { preferIframe = iframe }
+    /** Manual override: pin the D-pad to the next active frame in round-robin order. */
+    fun cycleVideoTarget() {
+        if (activeFrames.isEmpty()) { overrideProxy = null; return }
+        val keys = activeFrames.keys.toList()
+        val current = overrideProxy ?: currentProxy()
+        val nextIndex = (keys.indexOf(current) + 1).mod(keys.size)
+        overrideProxy = keys[nextIndex]
+    }
 
-    // Main-frame activation flag, set via the PBVideoNative bridge.
+    // Main-frame activation flag for the LEGACY path, set via the PBVideoNative bridge
+    // (only used when multiFrame is unsupported).
     @Volatile
     private var videoControlActiveFallback = false
 
     fun isVideoControlActive(): Boolean =
-        if (preferIframe) (multiFrame && activeFrames.isNotEmpty())
-        else videoControlActiveFallback
+        if (multiFrame) activeFrames.isNotEmpty() else videoControlActiveFallback
 
-    // Iframe command target: the largest iframe video (absolute on-screen area).
-    private fun currentProxy(): JavaScriptReplyProxy? =
-        activeFrames.maxByOrNull { it.value.score }?.key
+    /**
+     * Which frame the D-pad drives. A manual pin wins while its frame stays active;
+     * otherwise auto-pick: prefer frames whose video is actually playing, then the
+     * largest on-screen area, but keep the incumbent unless a challenger beats it by a
+     * clear margin (hysteresis) so the target doesn't thrash between near-equal frames.
+     */
+    private fun currentProxy(): JavaScriptReplyProxy? {
+        if (activeFrames.isEmpty()) { stickyProxy = null; overrideProxy = null; return null }
+        overrideProxy?.let { if (activeFrames.containsKey(it)) return it else overrideProxy = null }
+        val incumbent = stickyProxy?.takeIf { activeFrames.containsKey(it) }
+        val best = pickBestProxy(incumbent)
+        stickyProxy = best
+        return best
+    }
+
+    private fun pickBestProxy(incumbent: JavaScriptReplyProxy?): JavaScriptReplyProxy? {
+        val playing = activeFrames.entries.filter { it.value.playing }
+        val pool = if (playing.isNotEmpty()) playing else activeFrames.entries.toList()
+        val top = pool.maxByOrNull { it.value.score } ?: return incumbent
+        if (incumbent != null) {
+            val inc = activeFrames[incumbent]
+            // Keep the incumbent if it's still in the candidate pool and the challenger
+            // isn't at least 25% larger — avoids bouncing between similar-sized videos.
+            if (inc != null && pool.any { it.key === incumbent } && top.value.score < inc.score * 1.25) {
+                return incumbent
+            }
+        }
+        return top.key
+    }
 
     fun videoToggle() = sendVideoCommand("toggle")
     fun videoSeek(deltaSeconds: Int) = sendVideoCommand("seek,$deltaSeconds")
@@ -137,13 +173,13 @@ class SystemWebViewEngine(
     fun videoSetRate(rate: Double) = sendVideoCommand("rate,$rate")
 
     private fun sendVideoCommand(cmd: String) {
-        if (preferIframe) {
-            // Iframe solution: post to the owning frame's channel; result comes back
-            // asynchronously via the message listener -> onVideoResult.
+        if (multiFrame) {
+            // Unified channel pathway: post to the current target frame (main or iframe);
+            // result comes back asynchronously via the message listener -> onVideoResult.
             currentProxy()?.postMessage(cmd)
             return
         }
-        // Main-frame solution (proven): evaluateJavascript and map the return value.
+        // LEGACY fallback (no channel support): evaluateJavascript on the main frame.
         val arg = cmd.substringAfter(',', "")
         val kind: String
         val js: String
@@ -161,23 +197,28 @@ class SystemWebViewEngine(
         }
     }
 
-    /** Parse an iframe -> native message (activation change or command result). */
+    /** Parse a frame -> native message (activation change, command result, or status). */
     private fun handleFrameMessage(
         data: String,
         proxy: JavaScriptReplyProxy,
         isMainFrame: Boolean
     ) {
-        // The channel is the iframe-only solution; ignore any main-frame report
-        // (the main frame uses the PBVideoNative + evaluateJavascript path).
-        if (isMainFrame) return
+        // Unified pathway: the main frame reports over the channel too now, so we no
+        // longer ignore it — every frame is a candidate target.
         try {
             val o = org.json.JSONObject(data)
             when (o.optString("type")) {
                 "active" -> {
                     if (o.optBoolean("active")) {
-                        activeFrames[proxy] = FrameVideo(score = o.optDouble("score", 0.0))
+                        activeFrames[proxy] = FrameVideo(
+                            score = o.optDouble("score", 0.0),
+                            playing = o.optBoolean("playing"),
+                            isMain = isMainFrame
+                        )
                     } else {
                         activeFrames.remove(proxy)
+                        if (proxy === overrideProxy) overrideProxy = null
+                        if (proxy === stickyProxy) stickyProxy = null
                     }
                 }
                 "result" -> {
@@ -186,9 +227,9 @@ class SystemWebViewEngine(
                     if (kind != "none" && value != "none") onVideoResult?.invoke(kind, value)
                 }
                 "status" -> {
-                    // Forward only when iframes are the active target, so we don't push
-                    // an iframe's status while the main frame is being controlled.
-                    if (preferIframe) onVideoStatus?.invoke(data)
+                    // Forward only the current target frame's status, so a background
+                    // frame can't push its scrubber state over the one being controlled.
+                    if (proxy === currentProxy()) onVideoStatus?.invoke(data)
                 }
             }
         } catch (e: Exception) {
@@ -196,7 +237,11 @@ class SystemWebViewEngine(
         }
     }
 
-    /** JS-exposed bridge object (fallback mode); script calls PBVideoNative.setActive. */
+    /**
+     * JS-exposed bridge object for the LEGACY path only (WebViews without channel
+     * support). The script calls these instead of posting to pbVideoChannel. In
+     * multiFrame mode the script uses the channel and these are never called.
+     */
     private inner class VideoControlBridge {
         @android.webkit.JavascriptInterface
         fun setActive(active: Boolean) {
@@ -205,8 +250,8 @@ class SystemWebViewEngine(
 
         @android.webkit.JavascriptInterface
         fun onStatus(json: String) {
-            // Main-frame status; forward only when the main frame is the active target.
-            if (!preferIframe) onVideoStatus?.invoke(json)
+            // Legacy path is main-frame only, so there's no other target to guard against.
+            onVideoStatus?.invoke(json)
         }
     }
 

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerActivity.kt
@@ -318,6 +318,13 @@ abstract class PlayerActivity : ComponentActivity() {
         adapter?.setLoudnessEnhancer(enabled)
     }
 
+    override fun onResume() {
+        super.onResume()
+        // Reclaim the server context for the player whenever we're foregrounded (e.g.
+        // after returning from a browser launched on top), so context_query is correct.
+        ServerService.notifyContextPlayer()
+    }
+
     override fun onDestroy() {
         if (current?.get() === this) {
             current = null

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
@@ -59,7 +59,9 @@ class ServerService : Service() {
     private val contextIdleReceiver = object : android.content.BroadcastReceiver() {
         override fun onReceive(context: android.content.Context, intent: Intent) {
             if (intent.action == ACTION_CONTEXT_IDLE) {
-                setContextIdleInternal()
+                // Only clear if a browser still owns the context — a player launched on
+                // top of the browser must not be reset to idle by the browser teardown.
+                setContextIdleInternal(setOf("browser", "browser_external"))
             }
         }
     }
@@ -550,7 +552,23 @@ class ServerService : Service() {
         FileLogger.d(TAG, "activeContext set to player by activity lifecycle")
     }
 
-    internal fun setContextIdleInternal() {
+    internal fun setContextBrowserInternal() {
+        activeContext = "browser"
+        broadcastContext()
+        FileLogger.d(TAG, "activeContext set to browser by activity lifecycle")
+    }
+
+    /**
+     * Reset to idle, but only if the current context is one the caller owns. This
+     * prevents a torn-down activity from clobbering the context of whatever took its
+     * place (e.g. browser->player handoff: the browser's onDestroy must not flip the
+     * now-playing context back to idle). Pass null to force-reset unconditionally.
+     */
+    internal fun setContextIdleInternal(onlyIfOneOf: Set<String>? = null) {
+        if (onlyIfOneOf != null && activeContext !in onlyIfOneOf) {
+            FileLogger.d(TAG, "idle reset skipped; activeContext=$activeContext not owned by caller")
+            return
+        }
         activeContext = "idle"
         broadcastContext()
         FileLogger.d(TAG, "activeContext reset to idle by activity lifecycle")
@@ -832,6 +850,11 @@ class ServerService : Service() {
             _staticInstance?.setContextPlayerInternal()
         }
 
+        /** Mark activeContext as "browser" — called from the internal WebView's onResume. */
+        fun notifyContextBrowser() {
+            _staticInstance?.setContextBrowserInternal()
+        }
+
         /**
          * Reset activeContext to "idle" from a player or browser activity when it finishes.
          * Called from PlayerActivity.onDestroy() and (via broadcast) from the TV browser app.
@@ -839,7 +862,9 @@ class ServerService : Service() {
          * the PairingScreen after the first playback session ends.
          */
         fun notifyContextIdle() {
-            _staticInstance?.setContextIdleInternal()
+            // Player-side callers (PlayerActivity/PrePlay teardown): only clear if a
+            // player still owns the context, so a browser opened afterwards survives.
+            _staticInstance?.setContextIdleInternal(setOf("player"))
         }
 
         @Volatile


### PR DESCRIPTION
This PR implements phone-driven playback control for videos within the TV player's system WebView and redesigns the phone remote's input mode interface.

### Summary of Changes:

1. **WebView Video Control & Injected JS:**
   - Injected script (`pb-video-control.js`) that detects active video elements (based on coverage >=60% of viewport) in both the main frame and cross-origin iframes.
   - Unified communication transport over `WebMessageListener` (`pbVideoChannel`) where supported (fallback to legacy `PBVideoNative` on older WebViews).
   - Smart target selection: auto-picks the active playing/largest video frame with 25% hysteresis to prevent thrashing, plus a manual "Source" toggle override.
   - Added support for a live scrubber, volume adjustment, and playback controls.

2. **Native Video Overlay & Context Routing:**
   - Native feedback overlay rendered on the TV for volume and seek actions.
   - Robust `activeContext` ownership rules in `ServerService` to prevent browser/player handoff state clobbering.

3. **Remote Control Redesign:**
   - Introduced a new top mode-selection chip (Context, D-Pad, Touchpad, Keyboard) with per-context persistence.
   - Integrated a now-playing strip at the bottom of the remote for system WebView playback control.