### PR TITLE
chore: uprev versions and update changelogs (round 3)

### DIFF
--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.0] — 2026-06-22 (versionCode 211)
+
+### Added
+- **Remote Control Redesign**: New interface supporting toggleable TV control modes: Media Player mode (gestures / playback chips) and Web Navigation mode (D-pad / web controls). (#59)
+- **Binary Protocol Updates**: Updated shared binary protocols for remote interactions. (#59)
+- **Cast Sheet Updates**: Improved remote status and cast session handling in `CastSheet`. (#59)
+
 ## [0.4.0] — 2026-06-22 (versionCode 210)
 
 ### Added

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 210
-        versionName = "0.4.0"
+        versionCode = 211
+        versionName = "0.5.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,12 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [0.5.0] — 2026-06-22 (versionCode 212)
+
+### Added
+- **WebView Video Controls**: Injects a custom video control script (`pb-video-control.js`) into the System WebView to enable remote control commands over web playback. (#59)
+- **Browser Integration**: Integrated navigation controls and remote key event translation into `BrowserActivity`. (#59)
+
 ## Player [0.4.0] — 2026-06-22 (versionCode 211)
 
 ### Added

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 211
-        versionName = "0.4.0"
+        versionCode = 212
+        versionName = "0.5.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
Bumps versions and updates changelogs for modified projects (Android TV Player and Android Phone) to cover recent WebView video controls and remote control mode redesign updates.