### PR TITLE
feat: implement WebView user script management and YouTube keep-alive script

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -5,6 +5,8 @@ import android.content.Intent
 import android.widget.Toast
 import androidx.core.net.toUri
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.*
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
@@ -195,6 +197,55 @@ fun AppNavHost(
     val nowPlayingEpisodeStart by connectionCoordinator.nowPlayingEpisodeStart.collectAsState()
 
     val context = LocalContext.current
+
+    val installedUserScripts by connectionCoordinator.installedUserScripts.collectAsState()
+    var showUserScripts by remember { mutableStateOf(false) }
+
+    // Picks any .js file from the phone and ships it to the TV as a user script (e.g. the
+    // opt-in ad-skipper). Neither app bundles such scripts; the user supplies the file. The
+    // file's own name is used so scripts can be listed/removed by name on the TV.
+    val userScriptPicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.GetContent()
+    ) { uri ->
+        if (uri != null) {
+            try {
+                var name = "user.js"
+                context.contentResolver.query(uri, arrayOf(android.provider.OpenableColumns.DISPLAY_NAME), null, null, null)?.use { c ->
+                    if (c.moveToFirst()) {
+                        val idx = c.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+                        if (idx >= 0) c.getString(idx)?.let { name = it }
+                    }
+                }
+                val content = context.contentResolver.openInputStream(uri)
+                    ?.bufferedReader()?.use { it.readText() }
+                if (!content.isNullOrBlank()) {
+                    connectionViewModel.webSocketClient.send(
+                        com.playbridge.shared.protocol.createUserScriptJson(name, content)
+                    )
+                    android.widget.Toast.makeText(context, "Sent $name to TV", android.widget.Toast.LENGTH_SHORT).show()
+                } else {
+                    android.widget.Toast.makeText(context, "Script file was empty", android.widget.Toast.LENGTH_SHORT).show()
+                }
+            } catch (e: Exception) {
+                android.widget.Toast.makeText(context, "Couldn't read script: ${e.message}", android.widget.Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    if (showUserScripts) {
+        UserScriptsSheet(
+            scripts = installedUserScripts,
+            onInstall = { userScriptPicker.launch("*/*") },
+            onRemove = { name ->
+                // Empty content tells the TV to delete that script.
+                connectionViewModel.webSocketClient.send(
+                    com.playbridge.shared.protocol.createUserScriptJson(name, "")
+                )
+            },
+            onDismiss = { showUserScripts = false }
+        )
+    }
+
     val clipboardManager = LocalClipboardManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
@@ -810,7 +861,14 @@ fun AppNavHost(
                             connectionViewModel.webSocketClient.sendMouseCommand("up", 0f, 0f)
                         },
                         onBrowserControl = { action ->
-                            connectionViewModel.webSocketClient.send(com.playbridge.shared.protocol.createBrowserControlCommandJson(action))
+                            if (action == "manage_user_scripts") {
+                                // Phone-side action: open the user-script manager and ask the
+                                // TV for its current list — not a browser command.
+                                connectionViewModel.webSocketClient.send(com.playbridge.shared.protocol.createUserScriptQueryJson())
+                                showUserScripts = true
+                            } else {
+                                connectionViewModel.webSocketClient.send(com.playbridge.shared.protocol.createBrowserControlCommandJson(action))
+                            }
                         },
                         onPlayerControl = { command ->
                             connectionViewModel.webSocketClient.send(com.playbridge.shared.protocol.createControlCommandJson(command))
@@ -1490,6 +1548,56 @@ fun AppNavHost(
                 ).show()
             },
         )
+    }
+}
+
+/**
+ * Manage the user scripts installed on the TV: list them, remove one, or install another
+ * from a file on the phone. The app ships no scripts — the user supplies the .js files.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun UserScriptsSheet(
+    scripts: List<String>,
+    onInstall: () -> Unit,
+    onRemove: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Text(
+            "User scripts on TV",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(start = 24.dp, end = 24.dp, bottom = 8.dp),
+        )
+        if (scripts.isEmpty()) {
+            Text(
+                "None installed.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 4.dp),
+            )
+        } else {
+            scripts.forEach { name ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 24.dp, end = 12.dp, top = 2.dp, bottom = 2.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(name, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.weight(1f))
+                    IconButton(onClick = { onRemove(name) }) {
+                        Icon(Icons.Default.Delete, contentDescription = "Remove $name", tint = MaterialTheme.colorScheme.error)
+                    }
+                }
+            }
+        }
+        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+        TextButton(onClick = onInstall, modifier = Modifier.padding(start = 16.dp, bottom = 8.dp)) {
+            Icon(Icons.Default.Add, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text("Install from file…")
+        }
+        Spacer(Modifier.height(16.dp))
     }
 }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -1488,6 +1488,15 @@ private fun BrowserMoreSheet(
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 onClick = { onBrowserControl("video_unmute"); onDismiss() }
             )
+            // Scripts — manage user scripts installed on the TV (install from a file,
+            // list, remove). The app ships none; you supply the .js. Handled phone-side
+            // in AppNavHost (opens the manager + queries the TV).
+            LabeledIconButton(
+                icon = Icons.Default.Code,
+                label = "Scripts",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                onClick = { onBrowserControl("manage_user_scripts"); onDismiss() }
+            )
         }
         Spacer(Modifier.height(16.dp))
     }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionCoordinator.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionCoordinator.kt
@@ -28,6 +28,9 @@ class ConnectionCoordinator(
     val tvSubtitleTracks = MutableStateFlow<List<MediaTrack>>(emptyList())
     val tvPlayerSettings = MutableStateFlow(TvPlayerSettings())
     
+    // Names of user scripts currently installed on the TV (for the management UI).
+    val installedUserScripts = MutableStateFlow<List<String>>(emptyList())
+
     // TMDb Sync & Now Playing Metadata states
     val nowPlayingTvId = MutableStateFlow<Int?>(null)
     val nowPlayingSeason = MutableStateFlow<Int?>(null)
@@ -106,6 +109,13 @@ class ConnectionCoordinator(
                             tvAudioTracks.value = parseTracks(json.optJSONArray("audio"))
                             tvSubtitleTracks.value = parseTracks(json.optJSONArray("subtitle"))
                             Log.d(TAG, "TV Audio/Subtitle tracks updated")
+                        }
+                        "user_scripts" -> {
+                            val arr = json.optJSONArray("names")
+                            installedUserScripts.value = buildList {
+                                if (arr != null) for (i in 0 until arr.length()) add(arr.optString(i))
+                            }
+                            Log.d(TAG, "TV user scripts: ${installedUserScripts.value}")
                         }
                         "player_settings" -> {
                             tvPlayerSettings.value = TvPlayerSettings(

--- a/shared/src/androidMain/kotlin/com/playbridge/shared/protocol/IncomingMessage.kt
+++ b/shared/src/androidMain/kotlin/com/playbridge/shared/protocol/IncomingMessage.kt
@@ -43,6 +43,13 @@ sealed class IncomingMessage {
     data class Browser(val payload: playbridge.BrowserPayload) : IncomingMessage()
     data class BrowserControl(val payload: playbridge.BrowserControlPayload) : IncomingMessage()
     data object ContextQuery : IncomingMessage()
+    /**
+     * User-supplied browser script the phone installs onto the TV (e.g. an ad-skipper we
+     * deliberately don't ship). [content] blank means uninstall. Plain JSON, no proto.
+     */
+    data class UserScript(val name: String, val content: String) : IncomingMessage()
+    /** Phone asks the TV which user scripts are installed; TV replies with `user_scripts`. */
+    data object UserScriptQuery : IncomingMessage()
     data class Unknown(val type: String, val raw: String) : IncomingMessage()
 }
 
@@ -152,6 +159,27 @@ fun createMouseCommandJson(event: String, dx: Float = 0f, dy: Float = 0f): Strin
 
 fun createBrowserControlCommandJson(action: String): String =
     envelope("browser_control", browserControlAdapter.toJson(BrowserControlPayload(action = action)))
+
+/**
+ * Install (or, with blank [content], uninstall) a user-supplied browser script on the TV.
+ * Standalone message (not a Wire command) so it needs no proto change.
+ */
+fun createUserScriptJson(name: String, content: String): String =
+    buildJsonObject {
+        put("type", "user_script")
+        put("name", name)
+        put("content", content)
+    }.toString()
+
+/** Phone → TV: list the installed user scripts. */
+fun createUserScriptQueryJson(): String = """{"type":"user_script_query"}"""
+
+/** TV → phone: the names of the currently-installed user scripts. */
+fun createUserScriptsJson(names: List<String>): String =
+    buildJsonObject {
+        put("type", "user_scripts")
+        put("names", buildJsonArray { names.forEach { add(it) } })
+    }.toString()
 
 fun createContextQueryJson(): String =
     buildJsonObject {
@@ -270,6 +298,11 @@ fun parseIncomingMessage(text: String): IncomingMessage {
                 val payloadJson = root["payload"]?.toString()
                 parseCommandAction(action, payloadJson, text)
             }
+            "user_script" -> IncomingMessage.UserScript(
+                name = root["name"]?.jsonPrimitive?.contentOrNull ?: "user.js",
+                content = root["content"]?.jsonPrimitive?.contentOrNull ?: ""
+            )
+            "user_script_query" -> IncomingMessage.UserScriptQuery
             else -> IncomingMessage.Unknown(type, text)
         }
     } catch (e: Exception) {

--- a/tv/android/player/app/src/main/assets/pb-video-control.js
+++ b/tv/android/player/app/src/main/assets/pb-video-control.js
@@ -91,7 +91,16 @@
       // requires a trusted user gesture, which this injected call doesn't carry — setting
       // muted=false silently fails on YouTube and can even block an unmuted play(). Unmute
       // is handled natively via a real synthesized tap (see BrowserActivity video_unmute).
-      if (v.paused) { v.play(); } else { v.pause(); }
+      if (v.paused) {
+        v.play();
+      } else {
+        // Mark interaction ONLY for an explicit pause, so a user script can tell this
+        // deliberate pause apart from an automatic/idle one and honour it. Other commands
+        // (seek/volume) must NOT mark — otherwise repeated seeking looks like activity and
+        // the idle guard would wrongly honour YouTube's "Continue watching?" pause.
+        markInteraction();
+        v.pause();
+      }
       return v.paused ? 'paused' : 'playing';
     },
     seek: function (delta) {
@@ -153,6 +162,9 @@
   // ── Command execution (shared by channel + fallback) ──────────────────────
   // Returns {kind, value} so native can render the right overlay.
   function execute(cmd) {
+    // NOTE: do NOT mark interaction for every command — only an explicit pause does
+    // (see api.toggle). Marking on seek/volume would make repeated seeking look like
+    // activity, and the idle guard would then honour YouTube's "Continue watching?" pause.
     var parts = String(cmd).split(',');
     var op = parts[0];
     switch (op) {
@@ -210,6 +222,16 @@
     }
   }
 
+  // Optional bridge: a user script (e.g. pb-youtube-keepalive.js) may expose
+  // window.__pbMarkInteraction to learn when the viewer deliberately acts, so it can tell a
+  // genuine action apart from idleness. A remote command is a deliberate action, so we call
+  // it here. No-op if no such script is loaded.
+  function markInteraction() {
+    if (typeof window.__pbMarkInteraction === 'function') {
+      try { window.__pbMarkInteraction(); } catch (e) { /* ignore */ }
+    }
+  }
+
   function activeStatusJson() {
     var v = find();
     return JSON.stringify({
@@ -218,9 +240,13 @@
       position: v ? Math.round((v.currentTime || 0) * 1000) : 0,
       duration: (v && isFinite(v.duration)) ? Math.round(v.duration * 1000) : 0,
       title: (document.title || ''),
-      // Lets native auto-unmute on fullscreen only when actually muted (so it never
-      // pauses an already-audible video). Extra field; older phone parsers ignore it.
-      muted: !!(v && v.muted)
+      // Lets native auto-unmute only when actually muted (so it never taps an already-
+      // audible video). Extra field; older phone parsers ignore it.
+      muted: !!(v && v.muted),
+      // Optional user scripts may set window.__pbSuppressUnmute to tell native to hold off
+      // its auto-unmute tap while a transient overlay/interstitial is on screen (the tap
+      // would land on that instead of the player). Undefined (=> false) when none set it.
+      suppressUnmute: !!window.__pbSuppressUnmute
     });
   }
 

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
@@ -185,13 +185,14 @@ class SystemWebViewEngine(
             val before = activeVideoMuted
             if (o.has("muted")) activeVideoMuted = o.optBoolean("muted")
             val state = o.optString("state")
+            val suppressUnmute = o.optBoolean("suppressUnmute", false)
             if (state == "idle") { activeVideoMuted = null; autoUnmuteDone = false }
             if (activeVideoMuted != before) Log.d(TAG, "activeVideoMuted: $before -> $activeVideoMuted")
-            // Auto-unmute ONLY a muted *and actively playing* video — that's the real
-            // autoplay-muted case where a tap is consumed by the "tap to unmute" affordance
-            // instead of toggling playback. Tapping a paused or already-audible video would
-            // just pause/unpause it. Once per session (reset on idle/navigation).
-            if (activeVideoMuted == true && state == "playing" && !autoUnmuteDone) {
+            // Auto-unmute ONLY a muted *and actively playing* video, and never while an
+            // optional script asks us to hold off (a transient overlay is up — the tap would
+            // land on it). That leaves the real autoplay-muted case where a tap is consumed by
+            // the "tap to unmute" affordance instead of toggling playback. Once per session.
+            if (activeVideoMuted == true && state == "playing" && !suppressUnmute && !autoUnmuteDone) {
                 autoUnmuteDone = true
                 Log.d(TAG, "auto-unmute: muted+playing video active, requesting native tap")
                 onRequestUnmuteTap?.invoke()
@@ -559,6 +560,28 @@ class SystemWebViewEngine(
         }
     }
 
+    /**
+     * Read every OPTIONAL user-supplied *.js from the app's external files dir
+     * (Android/data/<pkg>/files/). NOT shipped in the APK — these are scripts the user
+     * installs themselves (via `adb push`, a file manager, or "Install script" from the
+     * phone, which writes here). Lets a user run their own scripts (e.g. a YouTube
+     * ad-skipper we deliberately don't distribute). Read fresh each call so installing or
+     * removing one takes effect on the next page load. Each script must self-guard against
+     * double injection.
+     */
+    private fun externalUserScripts(): List<String> {
+        return try {
+            val dir = context.getExternalFilesDir(null) ?: return emptyList()
+            dir.listFiles { f -> f.isFile && f.name.endsWith(".js") }
+                ?.sortedBy { it.name }
+                ?.mapNotNull { if (it.canRead()) it.readText() else null }
+                ?: emptyList()
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not read external user scripts", e)
+            emptyList()
+        }
+    }
+
     private fun setupWebView() {
         webView.apply {
             isFocusable = true
@@ -754,6 +777,13 @@ class SystemWebViewEngine(
             if (!multiFrame && videoControlScript.isNotEmpty()) {
                 view?.evaluateJavascript(videoControlScript, null)
             }
+
+            // Optional, user-supplied scripts (e.g. the YouTube "Continue watching?" guard
+            // or an ad-skipper). NOT shipped in the APK — loaded only from the app's
+            // external files dir, where the user (or the phone's script manager) puts them.
+            // Read fresh each page load so installing/removing one takes effect without a
+            // reinstall. Each script self-guards against double injection.
+            externalUserScripts().forEach { view?.evaluateJavascript(it, null) }
 
             // Inject cosmetic filters (element hiding CSS)
             val cosmeticCss = adBlocker.getCosmeticFilterCss()

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
@@ -524,6 +524,30 @@ class ServerService : Service() {
             is IncomingMessage.PairingRequest, is IncomingMessage.Auth -> {
                 // Handled inside WebSocketServer's auth loop — should never reach here.
             }
+            is IncomingMessage.UserScript -> {
+                // Persist a user-supplied browser script (e.g. the opt-in ad-skipper we
+                // don't ship) into the app's external files dir, where SystemWebViewEngine
+                // picks up any *.js on the next page load. Blank content uninstalls it.
+                // Sanitise the name to a bare *.js filename — no path traversal.
+                val safeName = msg.name.substringAfterLast('/').substringAfterLast('\\')
+                    .filter { it.isLetterOrDigit() || it == '.' || it == '_' || it == '-' }
+                    .ifBlank { "user.js" }
+                    .let { if (it.endsWith(".js")) it else "$it.js" }
+                try {
+                    val file = java.io.File(getExternalFilesDir(null), safeName)
+                    if (msg.content.isBlank()) {
+                        val removed = file.delete()
+                        FileLogger.i(TAG, "User script uninstall: $safeName removed=$removed")
+                    } else {
+                        file.writeText(msg.content)
+                        FileLogger.i(TAG, "User script installed: $safeName (${msg.content.length} chars)")
+                    }
+                } catch (e: Exception) {
+                    FileLogger.w(TAG, "Failed to write user script $safeName: ${e.message}")
+                }
+                broadcastUserScripts()   // let the phone's manager refresh
+            }
+            is IncomingMessage.UserScriptQuery -> broadcastUserScripts()
             is IncomingMessage.Unknown -> {
                 FileLogger.w(TAG, "Unknown message: ${msg.type}. Raw: ${msg.raw}")
             }
@@ -533,6 +557,22 @@ class ServerService : Service() {
     private fun broadcastContext() {
         scope.launch {
             webSocketServer?.broadcastStatus(createContextJson(activeContext))
+        }
+    }
+
+    /** Send the phone the names of installed user scripts (the *.js in external files dir). */
+    private fun broadcastUserScripts() {
+        val names = try {
+            getExternalFilesDir(null)?.listFiles { f -> f.isFile && f.name.endsWith(".js") }
+                ?.map { it.name }?.sorted() ?: emptyList()
+        } catch (e: Exception) {
+            FileLogger.w(TAG, "Failed to list user scripts: ${e.message}")
+            emptyList()
+        }
+        scope.launch {
+            webSocketServer?.broadcastStatus(
+                com.playbridge.shared.protocol.createUserScriptsJson(names)
+            )
         }
     }
 

--- a/tv/android/player/optional-userscripts/README.md
+++ b/tv/android/player/optional-userscripts/README.md
@@ -1,0 +1,47 @@
+# Optional user scripts (NOT shipped in the APK)
+
+Scripts here are **not** bundled into the app and are **not** injected by default. The
+published build contains none of this code. The TV player only runs one of these if you
+place it on the device yourself, into the player app's external files dir.
+
+
+## How to load one
+
+### Option A — from the phone (easiest)
+
+In the phone app's browser remote, open the **More** sheet and tap **Scripts**. The manager
+lists the scripts currently installed on the TV and lets you:
+
+- **Install from file…** — pick a `.js` saved on the phone; it's sent over the existing
+  paired connection and saved on the TV under its own filename.
+- **Remove** (trash icon) — deletes that script from the TV.
+
+Nothing is bundled in either app — you supply the file. (Implemented as the `user_script` /
+`user_script_query` WebSocket messages → `ServerService` writes/lists/deletes in the dir
+below and reports the list back to the phone.)
+
+### Option B — directly onto the device
+
+Copy the script into the player app's external files dir:
+
+```
+/sdcard/Android/data/com.playbridge.player/files/<script-name>.js
+```
+
+For example, with adb:
+
+```
+adb push userscript.js \
+  /sdcard/Android/data/com.playbridge.player/files/userscript.js
+```
+
+Either way, the player reads every `*.js` in that dir fresh on each page load, so it takes
+effect on the next navigation. **Remove it to turn it back off** — delete the file, or from
+the phone send an empty `user_script` for that name (the TV deletes it).
+
+
+## Adding your own
+
+The player loads **every** `*.js` in the dir (see `SystemWebViewEngine.externalUserScripts`),
+so any filename works. Each script should be a self-contained IIFE that self-guards against
+double injection (it's re-injected on every page load).

--- a/tv/android/player/optional-userscripts/pb-youtube-keepalive.js
+++ b/tv/android/player/optional-userscripts/pb-youtube-keepalive.js
@@ -1,0 +1,105 @@
+/*
+ * PlayBridge YouTube keep-alive — OPTIONAL, user-loaded script (NOT bundled in the app).
+ *
+ * Stops YouTube's "Video paused. Continue watching?" idle prompt from interrupting
+ * playback while casting (the viewer never touches the TV, so YouTube's idle timer fires).
+ *
+ * Install it the same way as any user script (see this folder's README): from the phone's
+ * script manager, or by dropping it into the player app's external files dir. The published
+ * build ships no YouTube-specific code; this is purely opt-in.
+ *
+ * Approach adapted from the YouTube NonStop browser extension (MIT-licensed):
+ * https://github.com/lawfx/YoutubeNonStop. Rather than trying to RESUME after YouTube's
+ * idle pause — which needs a trusted user gesture we can't synthesise — it SUPPRESSES the
+ * pause: the <video> element's pause() is overridden so an idle-triggered pause is ignored
+ * (the video keeps playing) and the confirm dialog is dismissed in plain JS (no gesture
+ * needed, since playback never actually stopped).
+ *
+ * Self-gates to YouTube hosts and self-guards against double injection. Loaded via
+ * onPageFinished, so it runs in the main frame (the YouTube watch page); embedded YouTube
+ * iframes aren't covered, but the idle prompt is a watch-page feature anyway.
+ *
+ * Bridge: exposes window.__pbMarkInteraction(), which pb-video-control.js calls ONLY for an
+ * explicit remote pause — so this guard honours a deliberate pause but still suppresses
+ * YouTube's idle pause. (Seeks and other remote commands must NOT mark interaction, or
+ * repeated seeking would look like activity and the idle pause would be wrongly honoured.)
+ */
+(function () {
+  'use strict';
+  if (window.__pbYtGuardInjected) return;
+  window.__pbYtGuardInjected = true;
+
+  var IDLE_MS = 5000;
+  var lastInteraction = Date.now();
+  function markInteraction() { lastInteraction = Date.now(); }
+  function isIdle() { return Date.now() - lastInteraction >= IDLE_MS; }
+
+  // Exposed for the video controller (remote commands count as interaction). Set
+  // unconditionally so the bridge exists even on non-YouTube pages (where it's a no-op).
+  window.__pbMarkInteraction = markInteraction;
+
+  var IS_YT = /(^|\.)youtube\.com$/i.test(location.hostname) ||
+              /(^|\.)youtube-nocookie\.com$/i.test(location.hostname);
+  if (!IS_YT) return;
+
+  // Real user input resets the idle timer; remote commands do so via __pbMarkInteraction.
+  ['pointerdown', 'pointerup', 'keydown', 'keyup', 'touchstart'].forEach(function (ev) {
+    document.addEventListener(ev, markInteraction, true);
+  });
+
+  function visible(el) {
+    if (!el) return false;
+    var r = el.getBoundingClientRect();
+    if (r.width < 2 || r.height < 2) return false;
+    var s = getComputedStyle(el);
+    return s.visibility !== 'hidden' && s.display !== 'none' && parseFloat(s.opacity || '1') > 0.1;
+  }
+
+  // The AFFIRMATIVE confirm control of YouTube's idle dialog only — never a generic button,
+  // so we can't accidentally activate "No", an end-screen suggestion, etc.
+  function continueTarget() {
+    var sels = [
+      'yt-confirm-dialog-renderer #confirm-button',                 // desktop youtube.com
+      'tp-yt-paper-dialog #confirm-button',
+      'ytm-confirmation-dialog-renderer .yt-spec-button-shape-next--filled' // m.youtube.com
+    ];
+    for (var i = 0; i < sels.length; i++) {
+      var el = document.querySelector(sels[i]);
+      if (visible(el)) return el;
+    }
+    var dlg = document.querySelector('yt-confirm-dialog-renderer, ytm-confirmation-dialog-renderer, [role="dialog"]');
+    if (dlg && visible(dlg)) {
+      var btns = dlg.querySelectorAll('button, [role="button"], a, tp-yt-paper-button');
+      for (var j = 0; j < btns.length; j++) {
+        var t = (btns[j].textContent || '').trim().toLowerCase();
+        if (visible(btns[j]) && (t === 'yes' || t === 'continue' || t.indexOf('continue watching') === 0)) {
+          return btns[j];
+        }
+      }
+    }
+    return null;
+  }
+
+  function guardPause(v) {
+    if (!v || v.__pbPauseGuarded) return;
+    v.__pbPauseGuarded = true;
+    var realPause = v.pause.bind(v);
+    v.__pbRealPause = realPause;
+    v.pause = function () {
+      // Honour pauses that follow a real/remote interaction; swallow idle auto-pauses
+      // (YouTube's "are you still watching") so the video keeps playing.
+      if (!isIdle()) return realPause();
+    };
+  }
+
+  // YouTube swaps the <video> on SPA navigation, so re-guard periodically, and dismiss the
+  // confirm dialog if one is up while idle (the video plays behind it).
+  setInterval(function () {
+    var v = document.querySelector('video');
+    if (v) guardPause(v);
+    if (isIdle()) {
+      var btn = continueTarget();
+      if (btn) { try { btn.click(); } catch (e) { /* ignore */ } }
+    }
+  }, 1000);
+})();


### PR DESCRIPTION
This PR implements a framework to manage and install optional user scripts on the TV player from the phone, along with a script to suppress YouTube's idle pause.

### Summary of Changes:

1. **User Script Storage & Injection (TV Player):**
   - Read and inject custom `*.js` scripts from the app's external files directory on each page load.
   - Built a communication layer over WebSocket using custom JSON messages (`user_script` to add/remove scripts, and `user_script_query` to query scripts).

2. **User Script Management UI (Mobile App):**
   - Added a "Scripts" management option to the remote's **More** sheet.
   - Designed a `UserScriptsSheet` modal to list, delete, or upload user scripts from the phone's storage.

3. **YouTube Keep-Alive User Script (`pb-youtube-keepalive.js`):**
   - Prevents YouTube's idle-triggered pause ("Video paused. Continue watching?") by intercepting `<video>.pause()` and auto-clicking the confirmation prompt.
   - Integrated with the player status updates by adding a `suppressUnmute` field to prevent native unmute taps during transient YouTube overlays.