### PR TITLE
feat: enhance remote control UI, add logs exclude filters, and make watch route reactive

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -182,6 +182,8 @@ fun AppNavHost(
     val activeDlnaTarget by connectionViewModel.activeDlnaTarget.collectAsState()
     val dlnaStatus by connectionViewModel.dlnaStatus.collectAsState()
     val dlnaMediaTitle by connectionViewModel.dlnaMediaTitle.collectAsState()
+    // Authoritative routing intent — reactive so screens follow device-picker changes live.
+    val routeTargetsTv by connectionViewModel.routeTargetsTv.collectAsState()
     val allHistory by historyDao.getAll().collectAsState(initial = emptyList())
     val installedAddons by addonDao.getAll().collectAsState(initial = emptyList())
 
@@ -948,6 +950,10 @@ fun AppNavHost(
                         tvName = tvDevice?.name,
                         isTvConnected = connectionState is WebSocketClient.ConnectionState.Connected,
                         isDlnaActive = activeDlnaTarget != null,
+                        routeTargetsTv = routeTargetsTv,
+                        onSetWatchRoute = { toTv ->
+                            if (toTv) connectionViewModel.selectNativeRoute() else connectionViewModel.selectThisDevice()
+                        },
                         onDominantColorChange = { libraryDetailAccent = it },
                         selectedTvDevice = tvDevice,
                         onTvDeviceSelect = { device -> connectionViewModel.connect(device) },

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
@@ -90,7 +90,12 @@ class CastSessionManager(
         _route.map { it !is Route.ThisDevice }.stateIn(scope, SharingStarted.Eagerly, false)
 
     private fun persistBaseRoute(value: String) {
-        routePrefs.edit().putString(ROUTE_KEY, value).apply()
+        // Keep the legacy `watch_on_tv` mirror in lockstep so every screen that still reads
+        // it (CastSheet, PhoneFiles, …) agrees with the authoritative route.
+        routePrefs.edit()
+            .putString(ROUTE_KEY, value)
+            .putBoolean("watch_on_tv", value == "native")
+            .apply()
     }
 
     /** User picked "This Device": route phone-local. Does NOT tear down any connection. */
@@ -363,6 +368,8 @@ class CastSessionManager(
         // Selecting a renderer is an explicit routing choice; it also supersedes any native
         // link, so stop the native reconnect supervisor.
         _route.value = Route.Dlna(device.uuid, device.name)
+        // DLNA is a cast target → mirror "watch on TV" for legacy readers.
+        routePrefs.edit().putBoolean("watch_on_tv", true).apply()
         hasConnectedThisSession = false
         reconnectAttempt = 0
         reconnectJob?.cancel()

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -68,7 +68,18 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.foundation.Canvas
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import kotlin.math.abs
+import kotlin.math.sin
 
 /** Live playback status synced from the TV via `status` messages. */
 data class TvPlaybackStatus(
@@ -239,13 +250,7 @@ fun RemoteControlScreen(
                                 // ── Now Playing: title only — the seek control lives down in the
                                 //    SeekVolumeBar (swipe ◄► to seek, ▲▼ for volume). ──
                                 NowPlayingPanel(
-                                    title = mediaTitle,
-                                    episodeLabel = null,
-                                    positionMs = positionMs,
-                                    durationMs = durationMs,
-                                    isLive = isLive,
-                                    onSeekTo = onSeekTo,
-                                    showProgress = false
+                                    title = mediaTitle
                                 )
 
                                 // Native-only: track pickers/settings — hidden for DLNA renderers.
@@ -273,13 +278,14 @@ fun RemoteControlScreen(
                                     positionMs = positionMs,
                                     durationMs = durationMs,
                                     isLive = isLive,
+                                    isPlaying = playbackState == null || playbackState == "playing" || playbackState == "buffering",
                                     enableVolume = !dlnaMode,
                                     onSeekTo = onSeekTo,
                                     onVolumeUp = { onRemoteKey("volume_up") },
-                                    onVolumeDown = { onRemoteKey("volume_down") }
+                                    onVolumeDown = { onRemoteKey("volume_down") },
+                                    onPlayPauseToggle = { onPlayerControl(if (playbackState == "playing") "pause" else "play") }
                                 )
                                 MediaControlRow(
-                                    isPlaying = playbackState == null || playbackState == "playing" || playbackState == "buffering",
                                     onPlayerControl = onPlayerControl,
                                     showLoop = !dlnaMode,
                                     showSeek = !isLive
@@ -290,6 +296,8 @@ fun RemoteControlScreen(
                                 playbackState = playbackState,
                                 positionMs = positionMs,
                                 durationMs = durationMs,
+                                isLive = isLive,
+                                dlnaMode = dlnaMode,
                                 mediaTitle = mediaTitle,
                                 onBrowserControl = onBrowserControl,
                                 onRemoteKey = onRemoteKey
@@ -498,15 +506,18 @@ private fun ProtocolBadge(text: String, accent: Color) {
 }
 
 /**
- * The browser CONTEXT view: a now-playing strip (title + scrubber + play/pause) when the
- * WebView reports a controllable video, then volume and the browser controls. The raw input
- * surfaces (touchpad/d-pad/keyboard) are now separate modes chosen from the mode chip.
+ * The browser CONTEXT view: a now-playing strip (title + SeekVolumeBar with sine wave
+ * seek/volume/play-pause) when the WebView reports a controllable video, then the
+ * browser controls. The raw input surfaces (touchpad/d-pad/keyboard) are now separate
+ * modes chosen from the mode chip.
  */
 @Composable
 private fun ColumnScope.BrowserContextView(
     playbackState: String?,
     positionMs: Long,
     durationMs: Long,
+    isLive: Boolean,
+    dlnaMode: Boolean,
     mediaTitle: String?,
     onBrowserControl: (String) -> Unit,
     onRemoteKey: (String) -> Unit
@@ -514,37 +525,34 @@ private fun ColumnScope.BrowserContextView(
     val videoActive = playbackState == "playing" || playbackState == "paused" ||
         playbackState == "buffering"
     if (videoActive) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 4.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            NowPlayingPanel(
-                title = mediaTitle,
-                episodeLabel = null,
-                positionMs = positionMs,
-                durationMs = durationMs,
-                onSeekTo = { ms -> onBrowserControl("seek_to:$ms") }
-            )
-            IconButton(onClick = { onBrowserControl("toggle_play") }) {
-                Icon(
-                    imageVector = if (playbackState == "playing") Icons.Default.Pause
-                                  else Icons.Default.PlayArrow,
-                    contentDescription = "Play/Pause",
-                    tint = MaterialTheme.colorScheme.onSurface
-                )
-            }
-        }
+        // Title only — the seek control lives in the SeekVolumeBar below.
+        NowPlayingPanel(
+            title = mediaTitle
+        )
     }
 
     // Push the controls to the bottom; the top stays calm when nothing's playing.
     Spacer(modifier = Modifier.weight(1f))
 
-    VolumeRow(
-        onVolumeUp = { onRemoteKey("volume_up") },
-        onVolumeDown = { onRemoteKey("volume_down") }
-    )
+    // ── Combined seek + volume bar (same as player context) ──
+    if (videoActive) {
+        SeekVolumeBar(
+            positionMs = positionMs,
+            durationMs = durationMs,
+            isLive = isLive,
+            isPlaying = playbackState == "playing" || playbackState == "buffering",
+            enableVolume = !dlnaMode,
+            onSeekTo = { ms -> onBrowserControl("seek_to:$ms") },
+            onVolumeUp = { onRemoteKey("volume_up") },
+            onVolumeDown = { onRemoteKey("volume_down") },
+            onPlayPauseToggle = { onBrowserControl("toggle_play") }
+        )
+    } else {
+        VolumeRow(
+            onVolumeUp = { onRemoteKey("volume_up") },
+            onVolumeDown = { onRemoteKey("volume_down") }
+        )
+    }
 
     // ── Browser Controls: Back · Refresh · Ad Block · Fullscreen · Source · Unmute · Home ──
     BrowserContextRow(onBrowserControl = onBrowserControl, onRemoteKey = onRemoteKey)
@@ -573,7 +581,6 @@ private fun ColumnScope.ModeBottomBar(
             BrowserContextRow(onBrowserControl = onBrowserControl, onRemoteKey = onRemoteKey)
         }
         RemoteContext.PLAYER -> MediaControlRow(
-            isPlaying = playbackState == null || playbackState == "playing" || playbackState == "buffering",
             onPlayerControl = onPlayerControl,
             showLoop = !dlnaMode,
             showSeek = !isLive
@@ -723,10 +730,12 @@ private fun SeekVolumeBar(
     positionMs: Long,
     durationMs: Long,
     isLive: Boolean,
+    isPlaying: Boolean,
     enableVolume: Boolean,
     onSeekTo: (Long) -> Unit,
     onVolumeUp: () -> Unit,
     onVolumeDown: () -> Unit,
+    onPlayPauseToggle: () -> Unit,
 ) {
     val hasDuration = durationMs > 0L && !isLive
     val currentPosition by rememberUpdatedState(positionMs)
@@ -750,6 +759,24 @@ private fun SeekVolumeBar(
     val view = LocalView.current
     val tick: () -> Unit = { view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK) }
     val thud: () -> Unit = { view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS) }
+
+    // Sine wave playback animations
+    val phase by rememberInfiniteTransition(label = "sineWavePhase").animateFloat(
+        initialValue = 0f,
+        targetValue = (2 * Math.PI).toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "phase"
+    )
+
+    val targetAmplitude = if (isPlaying && !dragging) 5.dp else 0.dp
+    val amplitude by animateDpAsState(
+        targetValue = targetAmplitude,
+        animationSpec = tween(durationMillis = 300),
+        label = "amplitude"
+    )
 
     // The whole bar lifts (and gains a shadow) while actively seeking / adjusting volume.
     val lift by animateDpAsState(
@@ -778,6 +805,14 @@ private fun SeekVolumeBar(
             .clip(RoundedCornerShape(24.dp))
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.15f))
             .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.12f)), RoundedCornerShape(24.dp))
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            ) {
+                if (!dragging && activeAxis == null) {
+                    onPlayPauseToggle()
+                }
+            }
             .onSizeChanged { widthPx = it.width.toFloat() }
             .pointerInput(Unit) {
                 awaitEachGesture {
@@ -938,71 +973,112 @@ private fun SeekVolumeBar(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 36.dp).padding(top = 18.dp, bottom = 18.dp),
+                .padding(horizontal = 16.dp, vertical = 10.dp),
             verticalArrangement = Arrangement.SpaceBetween,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // Top Status Label Row: seek text on left half, volume text on right half
+            // Top Status Label Row
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp),
+                horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Box(
-                    modifier = Modifier.weight(1f),
-                    contentAlignment = Alignment.Center
-                ) {
-                    val seekLabel = if (activeAxis == DragAxis.HORIZONTAL) {
-                        if (isAggressive) "Fast Seeking ◄►" else "Seeking ◄►"
-                    } else "Swipe ◄► Seek"
-                    Text(
-                        text = seekLabel,
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.SemiBold,
-                        color = if (activeAxis == DragAxis.HORIZONTAL) primary else Color.White.copy(alpha = 0.6f)
-                    )
+                // Seek label
+                val seekLabel = if (activeAxis == DragAxis.HORIZONTAL) {
+                    if (isAggressive) "Fast Seek ◄►" else "Seeking ◄►"
+                } else {
+                    if (isPlaying) "◄► Seek · Tap ❙❙" else "◄► Seek · Tap ▶"
                 }
+                Text(
+                    text = seekLabel,
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (activeAxis == DragAxis.HORIZONTAL) primary else Color.White.copy(alpha = 0.5f),
+                    maxLines = 1
+                )
                 if (enableVolume) {
-                    Box(
-                        modifier = Modifier.weight(1f),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        val volumeLabel = if (activeAxis == DragAxis.VERTICAL) {
-                            if (isAggressive) "Fast Volume ▲▼" else "Adjusting Volume ▲▼"
-                        } else "Swipe ▲▼ Volume"
-                        Text(
-                            text = volumeLabel,
-                            style = MaterialTheme.typography.labelSmall,
-                            fontWeight = FontWeight.SemiBold,
-                            color = if (activeAxis == DragAxis.VERTICAL) primary else Color.White.copy(alpha = 0.6f)
-                        )
-                    }
+                    Text(
+                        text = "  ·  ",
+                        style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                        color = Color.White.copy(alpha = 0.2f)
+                    )
+                    // Volume label
+                    val volumeLabel = if (activeAxis == DragAxis.VERTICAL) {
+                        if (isAggressive) "Fast Vol ▲▼" else "Volume ▲▼"
+                    } else "▲▼ Volume"
+                    Text(
+                        text = volumeLabel,
+                        style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                        fontWeight = FontWeight.SemiBold,
+                        color = if (activeAxis == DragAxis.VERTICAL) primary else Color.White.copy(alpha = 0.5f),
+                        maxLines = 1
+                    )
                 }
             }
 
             // Center Progress Bar
             if (hasDuration) {
-                Box(
+                val ampPx = with(LocalDensity.current) { amplitude.toPx() }
+                val wavelength = with(LocalDensity.current) { 60.dp.toPx() }
+                val strokeActiveWidth = with(LocalDensity.current) { 3.dp.toPx() }
+                val strokeInactiveWidth = with(LocalDensity.current) { 2.dp.toPx() }
+
+                Canvas(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(6.dp)
-                        .clip(RoundedCornerShape(3.dp))
-                        .background(Color.White.copy(alpha = 0.12f))
+                        .padding(horizontal = 20.dp)
+                        .height(20.dp)
                 ) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxHeight()
-                            .fillMaxWidth(fraction)
-                            .background(
-                                Brush.horizontalGradient(
-                                    colors = listOf(primary, primary.copy(alpha = 0.7f))
-                                )
-                            )
-                    )
+                    val width = size.width
+                    val height = size.height
+                    val centerY = height / 2f
+                    val amp = ampPx
+
+                    val activeWidth = width * fraction
+
+                    // Draw active path (0 to activeWidth)
+                    if (activeWidth > 0f) {
+                        val activePath = Path().apply {
+                            moveTo(0f, centerY + amp * sin(phase))
+                            var x = 1f
+                            while (x <= activeWidth) {
+                                val angle = (2 * Math.PI * x / wavelength).toFloat() + phase
+                                lineTo(x, centerY + amp * sin(angle))
+                                x += 2f
+                            }
+                        }
+                        drawPath(
+                            path = activePath,
+                            color = primary,
+                            style = Stroke(width = strokeActiveWidth, cap = StrokeCap.Round)
+                        )
+                    }
+
+                    // Draw inactive path (activeWidth to width)
+                    if (activeWidth < width) {
+                        val inactivePath = Path().apply {
+                            moveTo(activeWidth, centerY + amp * sin((2 * Math.PI * activeWidth / wavelength).toFloat() + phase))
+                            var x = activeWidth + 1f
+                            while (x <= width) {
+                                val angle = (2 * Math.PI * x / wavelength).toFloat() + phase
+                                lineTo(x, centerY + amp * sin(angle))
+                                x += 2f
+                            }
+                        }
+                        drawPath(
+                            path = inactivePath,
+                            color = Color.White.copy(alpha = 0.12f),
+                            style = Stroke(width = strokeInactiveWidth, cap = StrokeCap.Round)
+                        )
+                    }
                 }
             } else {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .padding(horizontal = 20.dp)
                         .height(1.dp)
                         .background(Color.White.copy(alpha = 0.12f))
                 )
@@ -1010,18 +1086,24 @@ private fun SeekVolumeBar(
 
             // Bottom Time Row
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp),
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 Text(
                     text = if (hasDuration) formatTime(displayMs.toLong()) else formatTime(currentPosition),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = Color.White.copy(alpha = 0.5f)
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.sp),
+                    color = Color.White.copy(alpha = 0.6f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Visible
                 )
                 Text(
                     text = if (isLive) "LIVE" else if (durationMs > 0L) formatTime(durationMs) else "--:--",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = Color.White.copy(alpha = 0.5f)
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.sp),
+                    color = Color.White.copy(alpha = 0.6f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Visible
                 )
             }
         }
@@ -1302,7 +1384,6 @@ private fun DpadBtn(icon: ImageVector, desc: String, onClick: () -> Unit) {
 
 @Composable
 private fun MediaControlRow(
-    isPlaying: Boolean,
     onPlayerControl: (String) -> Unit,
     showLoop: Boolean = true,
     showSeek: Boolean = true,
@@ -1327,14 +1408,6 @@ private fun MediaControlRow(
                 onClick = { onPlayerControl("seek_back") }
             )
         }
-
-        // Play/Pause toggle — reflects the TV's actual state
-        LabeledIconButton(
-            icon = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-            label = if (isPlaying) "Pause" else "Play",
-            tint = MaterialTheme.colorScheme.primary,
-            onClick = { onPlayerControl(if (isPlaying) "pause" else "play") }
-        )
 
         // Seek +10s
         if (showSeek) {
@@ -1534,25 +1607,8 @@ private fun LabeledIconButton(
 @Composable
 private fun NowPlayingPanel(
     title: String?,
-    episodeLabel: String?,
-    positionMs: Long,
-    durationMs: Long,
-    isLive: Boolean = false,
-    onSeekTo: (Long) -> Unit,
-    // When false, only the title/episode label show — the seek control is rendered
-    // elsewhere (the SeekVolumeBar in the player context).
-    showProgress: Boolean = true
+    episodeLabel: String? = null
 ) {
-    val hasDuration = durationMs > 0L
-    var dragging by remember { mutableStateOf(false) }
-    var dragValue by remember { mutableFloatStateOf(0f) }
-
-    // Stop dragging once the TV's reported position catches up to where we seeked.
-    LaunchedEffect(positionMs) { if (dragging) dragging = false }
-
-    val sliderValue = (if (dragging) dragValue else positionMs.toFloat())
-        .coerceIn(0f, if (hasDuration) durationMs.toFloat() else 0f)
-
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
@@ -1570,38 +1626,6 @@ private fun NowPlayingPanel(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-        }
-
-        if (showProgress) {
-            Slider(
-                value = sliderValue,
-                onValueChange = {
-                    dragging = true
-                    dragValue = it
-                },
-                onValueChangeFinished = {
-                    if (hasDuration) onSeekTo(dragValue.toLong())
-                },
-                valueRange = 0f..(if (hasDuration) durationMs.toFloat() else 1f),
-                enabled = hasDuration,
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            Row(modifier = Modifier.fillMaxWidth()) {
-                // Show the real elapsed position even when duration is unknown (DLNA streams that
-                // don't report a total) — sliderValue is clamped to [0,duration] and would pin to 0.
-                Text(
-                    text = formatTime(if (dragging) dragValue.toLong() else positionMs),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(modifier = Modifier.weight(1f))
-                Text(
-                    text = if (isLive) "LIVE" else if (hasDuration) formatTime(durationMs) else "--:--",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = if (isLive) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
         }
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/settings/SettingsRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/settings/SettingsRepository.kt
@@ -33,6 +33,7 @@ class SettingsRepository(
         val IPTV_SORT_ASCENDING = booleanPreferencesKey("iptv_sort_ascending")
         val IPTV_ACTIVE_FIRST = booleanPreferencesKey("iptv_active_first")
         val SEND_SUBTITLES_TO_TV = booleanPreferencesKey("send_subtitles_to_tv")
+        val LOGS_EXCLUDE_FILTERS = stringSetPreferencesKey("logs_exclude_filters")
     }
 
     // 2. Flow definitions for reactive Compose collectors
@@ -59,6 +60,7 @@ class SettingsRepository(
     /** When exploring a playlist, float probe-confirmed live channels to the top. */
     val iptvActiveFirst: Flow<Boolean> = dataStore.data.catch { handleException(it) }.map { it[Keys.IPTV_ACTIVE_FIRST] ?: true }
     val sendSubtitlesToTv: Flow<Boolean> = dataStore.data.catch { handleException(it) }.map { it[Keys.SEND_SUBTITLES_TO_TV] ?: true }
+    val logsExcludeFilters: Flow<Set<String>> = dataStore.data.catch { handleException(it) }.map { it[Keys.LOGS_EXCLUDE_FILTERS] ?: emptySet() }
 
     // 3. Mutator methods
     suspend fun setAutoSwitchToRemote(value: Boolean) = write { it[Keys.AUTO_SWITCH_TO_REMOTE] = value }
@@ -77,6 +79,7 @@ class SettingsRepository(
     suspend fun setIptvSortAscending(value: Boolean) = write { it[Keys.IPTV_SORT_ASCENDING] = value }
     suspend fun setIptvActiveFirst(value: Boolean) = write { it[Keys.IPTV_ACTIVE_FIRST] = value }
     suspend fun setSendSubtitlesToTv(value: Boolean) = write { it[Keys.SEND_SUBTITLES_TO_TV] = value }
+    suspend fun setLogsExcludeFilters(value: Set<String>) = write { it[Keys.LOGS_EXCLUDE_FILTERS] = value }
     
     suspend fun addPopupWhitelist(host: String) = write { prefs ->
         val current = prefs[Keys.POPUP_WHITELIST] ?: emptySet()

--- a/mobile/android/app/src/main/java/com/playbridge/sender/diagnostics/LogcatReader.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/diagnostics/LogcatReader.kt
@@ -70,9 +70,13 @@ object LogcatReader {
      * When [includeNoise] is false (default) framework/OEM noise is dropped, and we request a
      * larger tail so there are still ~[maxLines] real app lines left after filtering.
      */
-    suspend fun snapshot(maxLines: Int = 1000, includeNoise: Boolean = false): List<LogLine> =
+    suspend fun snapshot(
+        maxLines: Int = 3000,
+        includeNoise: Boolean = false,
+        excludeFilters: Set<String> = emptySet()
+    ): List<LogLine> =
         withContext(Dispatchers.IO) {
-        val tail = if (includeNoise) maxLines else (maxLines * 4).coerceAtMost(5000)
+        val tail = if (includeNoise) maxLines else (maxLines * 6).coerceAtMost(20000)
         val out = ArrayList<LogLine>(tail)
         var process: java.lang.Process? = null
         try {
@@ -84,7 +88,19 @@ object LogcatReader {
             BufferedReader(InputStreamReader(process.inputStream)).use { reader ->
                 var line = reader.readLine()
                 while (line != null) {
-                    parse(line)?.let { out.add(it) }
+                    val parsed = parse(line)
+                    if (parsed != null) {
+                        if (out.isNotEmpty() && shouldGroup(parsed, out.last())) {
+                            val lastIdx = out.lastIndex
+                            val last = out[lastIdx]
+                            out[lastIdx] = last.copy(
+                                message = last.message + "\n" + parsed.message,
+                                raw = last.raw + "\n" + parsed.raw
+                            )
+                        } else {
+                            out.add(parsed)
+                        }
+                    }
                     line = reader.readLine()
                 }
             }
@@ -102,8 +118,13 @@ object LogcatReader {
             process?.destroy()
         }
         val filtered = if (includeNoise) out else out.filterNot { isNoise(it) }
-        if (filtered.size > maxLines) filtered.subList(filtered.size - maxLines, filtered.size).toList()
-        else filtered
+        val userFiltered = if (excludeFilters.isEmpty()) filtered else filtered.filterNot { line ->
+            excludeFilters.any { filter ->
+                line.tag.contains(filter, ignoreCase = true) || line.message.contains(filter, ignoreCase = true)
+            }
+        }
+        if (userFiltered.size > maxLines) userFiltered.subList(userFiltered.size - maxLines, userFiltered.size).toList()
+        else userFiltered
     }
 
     /** Clears the log buffer. Returns true on success. */
@@ -114,6 +135,27 @@ object LogcatReader {
         } catch (e: Exception) {
             false
         }
+    }
+
+    fun shouldGroup(parsed: LogLine, last: LogLine): Boolean {
+        if (parsed.level == Level.UNKNOWN) return true
+
+        val msg = parsed.message.trim()
+        if (msg.startsWith("at ") ||
+            msg.startsWith("Caused by:") ||
+            msg.startsWith("Suppressed:") ||
+            (msg.startsWith("...") && msg.endsWith("more"))) {
+            return true
+        }
+
+        if (parsed.tag == last.tag) {
+            if (msg.contains("Exception:") || msg.contains("Error:") ||
+                msg.endsWith("Exception") || msg.endsWith("Error")) {
+                return true
+            }
+        }
+
+        return false
     }
 
     private fun parse(line: String): LogLine? {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/diagnostics/LogsScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/diagnostics/LogsScreen.kt
@@ -34,7 +34,12 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
@@ -55,6 +60,8 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.TimeUnit
+import com.playbridge.sender.data.settings.SettingsRepository
+import org.koin.compose.koinInject
 
 private enum class LogTab { PHONE, TV }
 
@@ -72,6 +79,10 @@ fun LogsScreen(
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+
+    val settingsRepository: SettingsRepository = koinInject()
+    val excludeFilters by settingsRepository.logsExcludeFilters.collectAsState(initial = emptySet())
+    var excludeFiltersDialogOpen by remember { mutableStateOf(false) }
 
     var tab by remember { mutableStateOf(LogTab.PHONE) }
     var query by remember { mutableStateOf("") }
@@ -93,10 +104,18 @@ fun LogsScreen(
     val tvAvailable = tvIp != null && tvPort != null
 
     // Poll the phone logcat while the Phone tab is visible.
-    LaunchedEffect(tab, includeSystem) {
+    LaunchedEffect(tab, includeSystem, excludeFilters) {
         if (tab == LogTab.PHONE) {
+            phoneLines = emptyList()
             while (true) {
-                phoneLines = LogcatReader.snapshot(includeNoise = includeSystem)
+                val snap = LogcatReader.snapshot(
+                    includeNoise = includeSystem,
+                    excludeFilters = excludeFilters
+                )
+                phoneLines = if (phoneLines.isEmpty()) snap else {
+                    val merged = (phoneLines + snap).distinctBy { it.raw }
+                    if (merged.size > 3000) merged.takeLast(3000) else merged
+                }
                 delay(1500)
             }
         }
@@ -114,6 +133,15 @@ fun LogsScreen(
     }
 
     val listState = rememberLazyListState()
+    val isAtBottom = remember {
+        derivedStateOf {
+            val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()
+            lastVisibleItem == null || lastVisibleItem.index == listState.layoutInfo.totalItemsCount - 1
+        }
+    }
+    LaunchedEffect(isAtBottom.value) {
+        autoScroll = isAtBottom.value
+    }
     LaunchedEffect(filteredPhone.size, autoScroll, tab) {
         if (tab == LogTab.PHONE && autoScroll && filteredPhone.isNotEmpty()) {
             listState.scrollToItem(filteredPhone.lastIndex)
@@ -125,6 +153,13 @@ fun LogsScreen(
     detail?.let { entry ->
         LogDetailScreen(entry = entry, onBack = { detail = null })
         return
+    }
+
+    if (excludeFiltersDialogOpen) {
+        ExcludeFiltersDialog(
+            settingsRepository = settingsRepository,
+            onDismiss = { excludeFiltersDialogOpen = false }
+        )
     }
 
     Scaffold(
@@ -151,7 +186,10 @@ fun LogsScreen(
                                 menuOpen = false
                                 scope.launch {
                                     if (tab == LogTab.PHONE) {
-                                        phoneLines = LogcatReader.snapshot(includeNoise = includeSystem)
+                                        phoneLines = LogcatReader.snapshot(
+                                            includeNoise = includeSystem,
+                                            excludeFilters = excludeFilters
+                                        )
                                     } else if (tvAvailable) {
                                         tvLoading = true
                                         tvLines = fetchTvLogs(tvIp!!, tvPort!!)
@@ -179,6 +217,14 @@ fun LogsScreen(
                             )
                         }
                         DropdownMenuItem(
+                            text = { Text("Exclude filters") },
+                            leadingIcon = { Icon(Icons.Default.Tune, contentDescription = null) },
+                            onClick = {
+                                excludeFiltersDialogOpen = true
+                                menuOpen = false
+                            }
+                        )
+                        DropdownMenuItem(
                             text = { Text("Share") },
                             leadingIcon = { Icon(Icons.Default.Share, contentDescription = null) },
                             onClick = {
@@ -202,7 +248,10 @@ fun LogsScreen(
                                     if (tab == LogTab.PHONE) {
                                         LogcatReader.clear()
                                         CrashLogger.clear()
-                                        phoneLines = LogcatReader.snapshot(includeNoise = includeSystem)
+                                        phoneLines = LogcatReader.snapshot(
+                                            includeNoise = includeSystem,
+                                            excludeFilters = excludeFilters
+                                        )
                                         Toast.makeText(context, "Phone logs cleared", Toast.LENGTH_SHORT).show()
                                     } else if (tvAvailable) {
                                         clearTvLogs(tvIp!!, tvPort!!)
@@ -298,6 +347,7 @@ fun LogsScreen(
                             state = listState,
                             modifier = Modifier
                                 .fillMaxSize()
+                                .drawVerticalScrollbar(listState, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f))
                                 .padding(horizontal = 8.dp)
                         ) {
                             items(filteredPhone) { line ->
@@ -321,8 +371,29 @@ fun LogsScreen(
                             // tab and support tap-to-detail; filter separately so typing in the
                             // search box doesn't re-run the regex over every line. The combined TV
                             // log is chronological oldest→newest, so reverse it to show newest first.
-                            val tvParsed = remember(lines) {
-                                lines.filter { it.isNotBlank() }.map { parseTvLine(it) }.asReversed()
+                            val tvParsed = remember(lines, excludeFilters) {
+                                val grouped = mutableListOf<LogcatReader.LogLine>()
+                                for (line in lines) {
+                                    if (line.isBlank()) continue
+                                    val parsed = parseTvLine(line)
+                                    if (grouped.isNotEmpty() && LogcatReader.shouldGroup(parsed, grouped.last())) {
+                                        val lastIdx = grouped.lastIndex
+                                        val last = grouped[lastIdx]
+                                        grouped[lastIdx] = last.copy(
+                                            message = last.message + "\n" + parsed.message,
+                                            raw = last.raw + "\n" + parsed.raw
+                                        )
+                                    } else {
+                                        grouped.add(parsed)
+                                    }
+                                }
+                                val filtered = if (excludeFilters.isEmpty()) grouped else grouped.filterNot { entry ->
+                                    excludeFilters.any { filter ->
+                                        entry.tag.contains(filter, ignoreCase = true) ||
+                                        entry.message.contains(filter, ignoreCase = true)
+                                    }
+                                }
+                                filtered.asReversed()
                             }
                             val tvEntries = remember(tvParsed, query) {
                                 if (query.isBlank()) tvParsed
@@ -332,9 +403,12 @@ fun LogsScreen(
                             }
                             // Render each line as its own item so only on-screen lines lay out,
                             // instead of one giant Text node measuring the whole log on the main thread.
+                            val tvListState = rememberLazyListState()
                             LazyColumn(
+                                state = tvListState,
                                 modifier = Modifier
                                     .fillMaxSize()
+                                    .drawVerticalScrollbar(tvListState, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f))
                                     .padding(horizontal = 8.dp)
                             ) {
                                 items(tvEntries) { line ->
@@ -619,4 +693,90 @@ private suspend fun shareLogs(context: Context, text: String, source: String) {
             }
         }
     }
+}
+
+@Composable
+private fun ExcludeFiltersDialog(
+    settingsRepository: SettingsRepository,
+    onDismiss: () -> Unit
+) {
+    val scope = rememberCoroutineScope()
+    val excludeFilters by settingsRepository.logsExcludeFilters.collectAsState(initial = emptySet())
+    var textValue by remember(excludeFilters) {
+        mutableStateOf(excludeFilters.joinToString("\n"))
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Exclude Filters") },
+        text = {
+            Column {
+                Text(
+                    text = "Specify tags or message keywords to ignore/exclude (one per line). Matches are case-insensitive.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(bottom = 12.dp)
+                )
+                OutlinedTextField(
+                    value = textValue,
+                    onValueChange = { textValue = it },
+                    placeholder = { Text("e.g. OkHttp\nChromium\nViewRootImpl") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(150.dp),
+                    maxLines = 10
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val newFilters = textValue.split("\n")
+                        .map { it.trim() }
+                        .filter { it.isNotEmpty() }
+                        .toSet()
+                    scope.launch {
+                        settingsRepository.setLogsExcludeFilters(newFilters)
+                        onDismiss()
+                    }
+                }
+            ) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
+}
+
+fun Modifier.drawVerticalScrollbar(
+    state: LazyListState,
+    color: Color
+): Modifier = this.drawWithContent {
+    drawContent()
+    val layoutInfo = state.layoutInfo
+    val totalItems = layoutInfo.totalItemsCount
+    val visibleItemsInfo = layoutInfo.visibleItemsInfo
+    if (visibleItemsInfo.isEmpty() || visibleItemsInfo.size >= totalItems) return@drawWithContent
+
+    val firstVisibleItem = visibleItemsInfo.first()
+    val firstVisibleIndex = firstVisibleItem.index
+    val visibleItemsCount = visibleItemsInfo.size
+
+    val sizeFraction = visibleItemsCount.toFloat() / totalItems
+    val scrollFraction = firstVisibleIndex.toFloat() / (totalItems - visibleItemsCount).coerceAtMost(1)
+
+    val thickness = 4.dp.toPx()
+    val viewportHeight = size.height
+    val knobHeight = (viewportHeight * sizeFraction).coerceIn(32.dp.toPx(), viewportHeight / 2)
+    val knobTop = (viewportHeight - knobHeight) * scrollFraction
+
+    drawRoundRect(
+        color = color,
+        topLeft = Offset(size.width - thickness - 2.dp.toPx(), knobTop),
+        size = Size(thickness, knobHeight),
+        cornerRadius = CornerRadius(thickness / 2, thickness / 2)
+    )
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryDetailScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryDetailScreen.kt
@@ -95,6 +95,10 @@ fun LibraryDetailScreen(
     isTvConnected: Boolean = false,
     /** A DLNA renderer is the active cast target (no WS session) — suppresses native reconnects. */
     isDlnaActive: Boolean = false,
+    /** Authoritative routing intent (reactive): true = a TV/DLNA target, false = This Device. */
+    routeTargetsTv: Boolean = false,
+    /** Change the authoritative route from this screen's Watch-on-TV / This-Device toggle. */
+    onSetWatchRoute: (Boolean) -> Unit = {},
     selectedTvDevice: TvDevice? = null,
     onTvDeviceSelect: ((TvDevice) -> Unit)? = null,
     onOpenConnectionScreen: () -> Unit = {},
@@ -165,21 +169,12 @@ fun LibraryDetailScreen(
     // Persist watch mode preference in browser_prefs
     val browserPrefs = remember { context.getSharedPreferences("browser_prefs", android.content.Context.MODE_PRIVATE) }
     val browserSettings = remember { context.getSharedPreferences("browser_settings", android.content.Context.MODE_PRIVATE) }
-    var watchOnTv by remember {
-        mutableStateOf(
-            if (browserPrefs.contains("watch_on_tv")) {
-                browserPrefs.getBoolean("watch_on_tv", tvName != null)
-            } else {
-                tvName != null
-            }
-        )
-    }
-
-    // NOTE: routing intent is authoritative and user-controlled (see
-    // CONNECTION_ROUTING_PLAN.md). We deliberately do NOT flip watchOnTv just because a
-    // connection exists — that conflation caused "This Device" plays to jump to the TV.
-    // watchOnTv changes only via the user's explicit Watch-on-TV / This-Device choice,
-    // which the device picker mirrors into the persisted `watch_on_tv` pref + Route.
+    // Routing intent is authoritative and reactive: it follows the device picker / route
+    // live (see CONNECTION_ROUTING_PLAN.md). Deriving it from [routeTargetsTv] — rather than
+    // a one-time snapshot of the old `watch_on_tv` pref — is what fixes "switch to This
+    // Device on this screen, but it still casts to the TV": the previous local state never
+    // updated until the screen was recomposed from scratch.
+    val watchOnTv = routeTargetsTv
 
     // Player mode (mirrors CastSheet; persisted to browser_prefs/tv_player_mode)
     val settingsRepository: com.playbridge.sender.data.settings.SettingsRepository = org.koin.compose.koinInject()
@@ -798,10 +793,7 @@ fun LibraryDetailScreen(
                                 tvName = tvName,
                                 isTvConnected = isTvConnected,
                                 watchOnTv = watchOnTv,
-                                onWatchOnTvChange = {
-                                    watchOnTv = it
-                                    browserPrefs.edit { putBoolean("watch_on_tv", it) }
-                                },
+                                onWatchOnTvChange = { onSetWatchRoute(it) },
                                 selectedTvDevice = selectedTvDevice,
                                 onOpenConnectionScreen = onOpenConnectionScreen,
                                 onWatchOnTv = {
@@ -895,10 +887,7 @@ fun LibraryDetailScreen(
                                     tvName = tvName,
                                     isTvConnected = isTvConnected,
                                     watchOnTv = watchOnTv,
-                                    onWatchOnTvChange = {
-                                        watchOnTv = it
-                                        browserPrefs.edit { putBoolean("watch_on_tv", it) }
-                                    },
+                                    onWatchOnTvChange = { onSetWatchRoute(it) },
                                     watchLabel = epResume
                                         ?.let { "Resume $epLabel · ${formatResumeTime(it.positionMs)}" }
                                         ?: "Watch $epLabel",

--- a/tv/android/player/app/src/main/assets/pb-video-control.js
+++ b/tv/android/player/app/src/main/assets/pb-video-control.js
@@ -201,13 +201,79 @@
     }
   }
 
+  function repeatChar(char, count) {
+    var out = "";
+    for (var i = 0; i < count; i++) out += char;
+    return out;
+  }
+
+  function fmtTime(totalSec) {
+    if (!isFinite(totalSec) || totalSec < 0) return "0:00";
+    var s = Math.floor(totalSec);
+    var h = Math.floor(s / 3600);
+    var m = Math.floor((s % 3600) / 60);
+    var sec = s % 60;
+    if (h > 0) {
+      return h + ":" + (m < 10 ? "0" : "") + m + ":" + (sec < 10 ? "0" : "") + sec;
+    } else {
+      return m + ":" + (sec < 10 ? "0" : "") + sec;
+    }
+  }
+
+  function progressBar(frac) {
+    var slots = 16;
+    var filled = Math.round(Math.max(0, Math.min(1, frac)) * slots);
+    return repeatChar("█", filled) + repeatChar("░", slots - filled);
+  }
+
+  function showFeedbackOverlay(kind, value) {
+    var text = "";
+    switch (kind) {
+      case 'toggle':
+        text = (value === 'playing') ? '▶' : '❙❙';
+        break;
+      case 'seek':
+        var parts = value.split(',');
+        var t = parseFloat(parts[0]) || 0;
+        var d = parseFloat(parts[1]) || 0;
+        var frac = d > 0 ? t / d : 0;
+        text = fmtTime(t) + "   /   " + fmtTime(d) + "\n" + progressBar(frac);
+        break;
+      case 'vol':
+        var vol = parseFloat(value) || 0;
+        text = "🔊  " + Math.round(vol * 100) + "%\n" + progressBar(vol);
+        break;
+      case 'rate':
+        var r = parseFloat(value) || 1;
+        text = (r + "").replace(/\.0$/, "") + "×";
+        break;
+      default:
+        return;
+    }
+
+    if (window.pbVideoChannel) {
+      try {
+        window.pbVideoChannel.postMessage(JSON.stringify({
+          type: 'overlay',
+          visible: true,
+          text: text,
+          style: 'minimal',
+          autoDismissMs: 1500
+        }));
+      } catch (e) { /* ignore */ }
+    }
+  }
+
   // Bind the channel (any frame) so native can post commands and read results.
   function bindChannel() {
     if (channel || !window.pbVideoChannel) return;
     channel = window.pbVideoChannel;
     channel.onmessage = function (e) {
       var res = execute(e.data);
-      channel.postMessage(JSON.stringify({ type: 'result', kind: res.kind, value: res.value }));
+      if (res.kind !== 'none' && res.value !== 'none') {
+        showFeedbackOverlay(res.kind, res.value);
+      }
+      channel.postMessage(JSON.stringify({ type: 'result', kind: 'none', value: 'none' }));
     };
   }
 

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
@@ -82,11 +82,11 @@ class BrowserActivity : ComponentActivity() {
     private var fullscreenContainer: FrameLayout? = null
     private var contentContainer: FrameLayout? = null
 
-    // Native video-control feedback overlay (rendered over the WebView, because a DOM
-    // overlay is hidden behind the video surface in fullscreen).
-    private var videoOverlayView: android.widget.TextView? = null
-    private val videoOverlayHideHandler = Handler(Looper.getMainLooper())
-    private val videoOverlayHideRunnable = Runnable { videoOverlayView?.visibility = View.GONE }
+    // Custom overlay support controlled by user scripts
+    private var customOverlayView: android.widget.FrameLayout? = null
+    private var customOverlayTextView: android.widget.TextView? = null
+    private val customOverlayHideHandler = Handler(Looper.getMainLooper())
+    private val customOverlayHideRunnable = Runnable { customOverlayView?.visibility = android.view.View.GONE }
 
     private val commandReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -248,6 +248,11 @@ class BrowserActivity : ComponentActivity() {
         // Same "status" message the native player emits, so the phone parses it as-is.
         engine?.onVideoStatus = { json ->
             com.playbridge.player.server.ServerService.broadcastStatus(json)
+        }
+
+        // Custom overlay support controlled by user scripts
+        engine?.onVideoOverlay = { visible, text, style, bgColor, textColor, autoDismissMs ->
+            showCustomVideoOverlay(visible, text, style, bgColor, textColor, autoDismissMs)
         }
 
         // Auto-unmute: when a muted video becomes the active control target (in-page
@@ -439,7 +444,7 @@ class BrowserActivity : ComponentActivity() {
             // that lack YouTube's tap-to-unmute affordance — and resumes playback if the
             // tap paused it. Delay lets the tap's effect register before that check.
             cursorHideHandler.postDelayed({ engine?.videoUnmute() }, 150)
-            showVideoFeedback("🔊")
+            showCustomVideoOverlay(visible = true, text = "🔊", style = "minimal", bgColorStr = null, textColorStr = null, autoDismissMs = 1500)
         }
     }
 
@@ -541,42 +546,118 @@ class BrowserActivity : ComponentActivity() {
         }
     }
 
-    // ── Native video-control feedback overlay ────────────────────────────────
 
-    private fun showVideoFeedback(text: String) {
+
+    private fun showCustomVideoOverlay(
+        visible: Boolean,
+        text: String,
+        style: String,
+        bgColorStr: String?,
+        textColorStr: String?,
+        autoDismissMs: Long = 0L
+    ) {
         runOnUiThread {
+            customOverlayHideHandler.removeCallbacks(customOverlayHideRunnable)
+            if (!visible) {
+                customOverlayView?.visibility = android.view.View.GONE
+                return@runOnUiThread
+            }
+
             val density = resources.displayMetrics.density
             fun dp(v: Int) = (v * density).toInt()
-            var ov = videoOverlayView
-            if (ov == null) {
-                ov = android.widget.TextView(this).apply {
-                    setTextColor(Color.WHITE)
+
+            var ov = customOverlayView
+            var tv = customOverlayTextView
+
+            if (ov == null || tv == null) {
+                ov = android.widget.FrameLayout(this)
+                tv = android.widget.TextView(this).apply {
                     textSize = 24f
                     typeface = android.graphics.Typeface.DEFAULT_BOLD
                     gravity = android.view.Gravity.CENTER
                     setLineSpacing(dp(4).toFloat(), 1f)
                     setPadding(dp(30), dp(22), dp(30), dp(22))
-                    background = android.graphics.drawable.GradientDrawable().apply {
-                        cornerRadius = dp(18).toFloat()
-                        setColor(Color.parseColor("#D2141618"))
-                    }
-                    elevation = dp(48).toFloat()
-                    visibility = View.GONE
                 }
-                rootContainer.addView(
-                    ov,
+                ov.addView(
+                    tv,
                     FrameLayout.LayoutParams(
                         FrameLayout.LayoutParams.WRAP_CONTENT,
                         FrameLayout.LayoutParams.WRAP_CONTENT
                     ).apply { gravity = android.view.Gravity.CENTER }
                 )
-                videoOverlayView = ov
+                rootContainer.addView(ov)
+                customOverlayView = ov
+                customOverlayTextView = tv
             }
-            ov.text = text
-            ov.visibility = View.VISIBLE
+
+            val lp = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT
+            )
+
+            when (style) {
+                "fullscreen" -> {
+                    lp.width = FrameLayout.LayoutParams.MATCH_PARENT
+                    lp.height = FrameLayout.LayoutParams.MATCH_PARENT
+                    lp.gravity = android.view.Gravity.CENTER
+                }
+                "half-screen" -> {
+                    lp.width = FrameLayout.LayoutParams.MATCH_PARENT
+                    val displayMetrics = resources.displayMetrics
+                    lp.height = displayMetrics.heightPixels / 2
+                    lp.gravity = android.view.Gravity.BOTTOM
+                }
+                "minimal" -> {
+                    lp.width = FrameLayout.LayoutParams.WRAP_CONTENT
+                    lp.height = FrameLayout.LayoutParams.WRAP_CONTENT
+                    lp.gravity = android.view.Gravity.BOTTOM or android.view.Gravity.CENTER_HORIZONTAL
+                    lp.bottomMargin = dp(40)
+                }
+            }
+            ov.layoutParams = lp
+
+            val defaultBgColor = when (style) {
+                "fullscreen" -> android.graphics.Color.BLACK
+                "half-screen" -> android.graphics.Color.parseColor("#E6121416")
+                else -> android.graphics.Color.parseColor("#D2141618")
+            }
+            val bgColor = if (bgColorStr != null) {
+                try { android.graphics.Color.parseColor(bgColorStr) } catch (e: Exception) { defaultBgColor }
+            } else {
+                defaultBgColor
+            }
+
+            if (style == "minimal" || style == "half-screen") {
+                ov.background = android.graphics.drawable.GradientDrawable().apply {
+                    cornerRadius = dp(18).toFloat()
+                    setColor(bgColor)
+                }
+                if (style == "minimal") {
+                    lp.leftMargin = dp(20)
+                    lp.rightMargin = dp(20)
+                }
+            } else {
+                ov.background = null
+                ov.setBackgroundColor(bgColor)
+            }
+
+            val textColor = if (textColorStr != null) {
+                try { android.graphics.Color.parseColor(textColorStr) } catch (e: Exception) { android.graphics.Color.WHITE }
+            } else {
+                android.graphics.Color.WHITE
+            }
+            tv.setTextColor(textColor)
+            tv.text = text
+
+            ov.visibility = android.view.View.VISIBLE
             ov.bringToFront()
-            videoOverlayHideHandler.removeCallbacks(videoOverlayHideRunnable)
-            videoOverlayHideHandler.postDelayed(videoOverlayHideRunnable, 1500)
+            if (cursorView?.visibility == android.view.View.VISIBLE) {
+                cursorView?.bringToFront()
+            }
+
+            if (autoDismissMs > 0) {
+                customOverlayHideHandler.postDelayed(customOverlayHideRunnable, autoDismissMs)
+            }
         }
     }
 
@@ -600,8 +681,8 @@ class BrowserActivity : ComponentActivity() {
     private fun renderVideoResult(kind: String, value: String) {
         when (kind) {
             "toggle" -> when (value) {
-                "playing" -> showVideoFeedback("▶")
-                "paused" -> showVideoFeedback("❙❙")
+                "playing" -> showCustomVideoOverlay(visible = true, text = "▶", style = "minimal", bgColorStr = null, textColorStr = null, autoDismissMs = 1500)
+                "paused" -> showCustomVideoOverlay(visible = true, text = "❙❙", style = "minimal", bgColorStr = null, textColorStr = null, autoDismissMs = 1500)
             }
             "seek" -> {
                 val parts = value.split(",")
@@ -609,15 +690,36 @@ class BrowserActivity : ComponentActivity() {
                 val t = parts[0].toDoubleOrNull() ?: return
                 val d = parts[1].toDoubleOrNull() ?: 0.0
                 val frac = if (d > 0) t / d else 0.0
-                showVideoFeedback("${fmtTime(t)}   /   ${fmtTime(d)}\n${progressBar(frac)}")
+                showCustomVideoOverlay(
+                    visible = true,
+                    text = "${fmtTime(t)}   /   ${fmtTime(d)}\n${progressBar(frac)}",
+                    style = "minimal",
+                    bgColorStr = null,
+                    textColorStr = null,
+                    autoDismissMs = 1500
+                )
             }
             "vol" -> {
                 val vol = value.toDoubleOrNull() ?: return
-                showVideoFeedback("🔊  ${Math.round(vol * 100)}%\n${progressBar(vol)}")
+                showCustomVideoOverlay(
+                    visible = true,
+                    text = "🔊  ${Math.round(vol * 100)}%\n${progressBar(vol)}",
+                    style = "minimal",
+                    bgColorStr = null,
+                    textColorStr = null,
+                    autoDismissMs = 1500
+                )
             }
             "rate" -> {
                 val r = value.toDoubleOrNull() ?: return
-                showVideoFeedback("${r.toString().removeSuffix(".0")}×")
+                showCustomVideoOverlay(
+                    visible = true,
+                    text = "${r.toString().removeSuffix(".0")}×",
+                    style = "minimal",
+                    bgColorStr = null,
+                    textColorStr = null,
+                    autoDismissMs = 1500
+                )
             }
         }
     }
@@ -772,7 +874,7 @@ class BrowserActivity : ComponentActivity() {
                 // Manual override: pin the D-pad to the next on-screen video (main or
                 // any iframe). Auto-selection resumes when that frame goes inactive.
                 engine?.cycleVideoTarget()
-                showVideoFeedback("Switched video source")
+                showCustomVideoOverlay(visible = true, text = "Switched video source", style = "minimal", bgColorStr = null, textColorStr = null, autoDismissMs = 1500)
             }
             "toggle_play" -> engine?.videoToggle()
             "video_unmute" -> {
@@ -781,8 +883,8 @@ class BrowserActivity : ComponentActivity() {
                 // *trusted* gesture (a real tap) that injected JS can't supply.
                 when (engine?.isActiveVideoMuted()) {
                     true -> autoUnmuteActiveVideo()
-                    false -> showVideoFeedback("Audio is on")
-                    null -> showVideoFeedback("No active video")
+                    false -> showCustomVideoOverlay(visible = true, text = "Audio is on", style = "minimal", bgColorStr = null, textColorStr = null, autoDismissMs = 1500)
+                    null -> showCustomVideoOverlay(visible = true, text = "No active video", style = "minimal", bgColorStr = null, textColorStr = null, autoDismissMs = 1500)
                 }
             }
             "forward" -> engine?.goForward()
@@ -901,7 +1003,7 @@ class BrowserActivity : ComponentActivity() {
 
     override fun onDestroy() {
         cursorHideHandler.removeCallbacks(cursorHideRunnable)
-        videoOverlayHideHandler.removeCallbacks(videoOverlayHideRunnable)
+        customOverlayHideHandler.removeCallbacks(customOverlayHideRunnable)
         unregisterReceiver(commandReceiver)
         scope.cancel()
         engine?.destroy()

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
@@ -110,6 +110,9 @@ class SystemWebViewEngine(
     /** Periodic playback status (a `{"type":"status",…}` JSON string) for the phone scrubber. */
     var onVideoStatus: ((String) -> Unit)? = null
 
+    /** Callback for custom overlays: (visible, text, style, bgColor, textColor, autoDismissMs). */
+    var onVideoOverlay: ((Boolean, String, String, String?, String?, Long) -> Unit)? = null
+
     // Every frame (main + iframes) reporting a screen-dominating video, keyed by its
     // reply proxy. `score` is the absolute on-screen video area (comparable across
     // frames); `playing` and `isMain` feed target selection. Unified pathway: the main
@@ -311,6 +314,15 @@ class SystemWebViewEngine(
                     val kind = o.optString("kind")
                     val value = o.optString("value")
                     if (kind != "none" && value != "none") onVideoResult?.invoke(kind, value)
+                }
+                "overlay" -> {
+                    val visible = o.optBoolean("visible", false)
+                    val text = o.optString("text", "")
+                    val style = o.optString("style", "fullscreen")
+                    val bgColor = if (o.has("backgroundColor")) o.optString("backgroundColor") else null
+                    val textColor = if (o.has("textColor")) o.optString("textColor") else null
+                    val autoDismissMs = o.optLong("autoDismissMs", 0L)
+                    onVideoOverlay?.invoke(visible, text, style, bgColor, textColor, autoDismissMs)
                 }
                 "status" -> {
                     // Forward only the current target frame's status, so a background


### PR DESCRIPTION
This PR introduces UX enhancements for the phone remote's playback progress indicator, adds logs exclude filters to the mobile diagnostics panel, makes the media routing reactive on the library detail screen, and adds support for custom video overlays in the TV player.

### Summary of Changes:

1. **Remote Control UI & Custom Overlays:**
   - Redesigned the remote's `SeekVolumeBar` on the phone to draw a beautiful animated sine wave in Canvas (via sine-wave math/phase mapping) instead of a plain horizontal bar.
   - Refactored `MediaControlRow` and `NowPlayingPanel` to clean up progress/playback redundancy.
   - Upgraded the TV player's `BrowserActivity` and `SystemWebViewEngine` to support custom screen overlay properties (style, background color, text color, duration) sent from WebView scripts.

2. **Diagnostics Logs Filters & Scrollbar Improvements:**
   - Created an `ExcludeFiltersDialog` in `LogsScreen.kt` that lets users specify case-insensitive tag/message keywords to filter out logcat noise.
   - Persisted filter choices via `SettingsRepository` and dynamically applied them in `LogcatReader`.
   - Added a smooth custom scrollbar (`drawVerticalScrollbar` modifier) to the logs lazy column.

3. **Reactive Library Screen Media Routing:**
   - Bound the `LibraryDetailScreen`'s local watch state reactively to the authoritative `routeTargetsTv` state rather than a static shared preference snapshot. This ensures the UI instantly reflects routing changes when switching devices.