### PR TITLE
feat: redesign remote control screen with premium glassmorphism and segmented mode selector

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -7,7 +7,8 @@ import android.net.Uri
 import com.playbridge.sender.library.*
 import com.playbridge.sender.browser.*
 import com.playbridge.sender.connection.WebSocketClient
-
+import androidx.compose.foundation.Canvas
+import androidx.compose.ui.geometry.Offset
 import android.view.HapticFeedbackConstants
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateColorAsState
@@ -25,6 +26,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import kotlinx.coroutines.launch
@@ -68,7 +70,6 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.foundation.Canvas
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.StrokeCap
@@ -77,13 +78,16 @@ import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import kotlin.math.abs
 import kotlin.math.sin
 
 /** Live playback status synced from the TV via `status` messages. */
 data class TvPlaybackStatus(
-    val state: String,       // playing | paused | buffering | ended
+    val state: String,
     val positionMs: Long,
     val durationMs: Long,
     val title: String?
@@ -113,23 +117,8 @@ data class SubtitleOption(
 )
 
 /**
- * Full-screen remote control.
- *
- * The body follows the TV's active context. **player** shows a now-playing surface:
- * title, a live seekbar (drag to seek), transport controls, and the TV's episode list
- * (tap to jump). **browser** shows the Touchpad/D-Pad hero + browser controls. **idle**
- * (e.g. just after Stop) shows a calm "nothing playing" state that can reveal the input
- * surface on demand. A persistent connected-TV tile anchors the top across all three.
- *
- * @param activeContext  TV's active context: "player", "browser", or "idle"
- * @param playbackState  TV playback state ("playing"/"paused"/…), null if unknown
- * @param positionMs      Current playback position from the TV
- * @param durationMs      Total duration from the TV (0 if unknown/live)
- * @param mediaTitle      Title of what's playing on the TV
- * @param episodes        The TV's current playlist (for episode selection)
- * @param currentEpisodeIndex Index of the episode currently playing
- * @param onSeekTo        Seek the TV to an absolute position (ms)
- * @param onJumpToEpisode Jump the TV playlist to the given index
+ * Full-screen remote control. Redesigned with a high-tech glassmorphism aesthetic,
+ * horizontal episode carousels, and a segmented mode selector for excellent UX.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -167,8 +156,6 @@ fun RemoteControlScreen(
     onSwitchEngine: (String) -> Unit = {},
     onAddSubtitleUrl: (String) -> Unit = {},
     onSearchSubtitles: (suspend () -> List<SubtitleOption>)? = null,
-    // Connected-device status pill: shows what you're controlling (and which protocol for DLNA).
-    // It's status-only — switching/disconnecting lives in the cast picker (Library / cast sheet).
     tvName: String? = null,
     connectionState: WebSocketClient.ConnectionState = WebSocketClient.ConnectionState.Disconnected
 ) {
@@ -176,9 +163,7 @@ fun RemoteControlScreen(
     var showAddSubtitle by remember { mutableStateOf(false) }
     var showSubtitlesSheet by remember { mutableStateOf(false) }
     val remoteContext = remoteContextOf(activeContext)
-    // The interaction surface is chosen via the mode chip (Context / D-Pad / Touchpad /
-    // Keyboard) and remembered separately per context: player defaults to Context (its
-    // scrubber + controls), browser to Touchpad. Picking a mode sticks for that context.
+
     var modeByContext by remember {
         mutableStateOf(
             mapOf(
@@ -194,14 +179,11 @@ fun RemoteControlScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Remote") },
+                title = { Text("Remote", fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
                     }
-                },
-                actions = {
-                    RemoteModeChip(selected = selectedMode, onSelect = { selectMode(it) })
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = Color.Transparent
@@ -213,20 +195,20 @@ fun RemoteControlScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .padding(horizontal = 20.dp)
+                .padding(horizontal = 16.dp)
                 .padding(bottom = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // Persistent connected-device status pill — the constant anchor across player/browser/
-            // idle, so the controls below can crossfade without the screen feeling like it teleported.
-            // Status-only: it states what you're controlling (and tags DLNA); switching/disconnecting
-            // happens at the cast picker, not here (so native and DLNA read identically).
             ConnectedTvChip(
                 deviceName = tvName,
                 connectionState = connectionState,
                 isDlna = dlnaMode
             )
             Spacer(modifier = Modifier.height(12.dp))
+
+            // Segmented Mode Selector for immediate UX clarity
+            RemoteModeSegmentedRow(selected = selectedMode, onSelect = { selectMode(it) })
+            Spacer(modifier = Modifier.height(16.dp))
 
             AnimatedContent(
                 targetState = selectedMode to remoteContext,
@@ -244,16 +226,10 @@ fun RemoteControlScreen(
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     when (mode) {
-                        // Adaptive view: player controls, browser now-playing, or idle.
                         RemoteMode.CONTEXT -> when (ctx) {
                             RemoteContext.PLAYER -> {
-                                // ── Now Playing: title only — the seek control lives down in the
-                                //    SeekVolumeBar (swipe ◄► to seek, ▲▼ for volume). ──
-                                NowPlayingPanel(
-                                    title = mediaTitle
-                                )
+                                NowPlayingPanel(title = mediaTitle)
 
-                                // Native-only: track pickers/settings — hidden for DLNA renderers.
                                 if (!dlnaMode) {
                                     TrackChipsRow(
                                         audioTracks = audioTracks,
@@ -264,16 +240,13 @@ fun RemoteControlScreen(
                                     )
                                 }
 
-                                // ── Episode list (fills available space) ──
-                                EpisodesList(
+                                EpisodesCarousel(
                                     episodes = episodes,
                                     currentIndex = currentEpisodeIndex,
                                     onJumpToEpisode = onJumpToEpisode,
                                     modifier = Modifier.weight(1f)
                                 )
 
-                                // ── Combined seek + volume bar ──
-                                // Swipe left/right to scrub, up/down for volume (volume native-only).
                                 SeekVolumeBar(
                                     positionMs = positionMs,
                                     durationMs = durationMs,
@@ -310,9 +283,6 @@ fun RemoteControlScreen(
                             )
                         }
 
-                        // Explicit input surfaces — work in any context (the TV routes by
-                        // its own context). The surface fills the space, with the current
-                        // context's bottom controls kept below it for quick access.
                         RemoteMode.DPAD -> {
                             Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
                                 DpadArea(onRemoteKey = onRemoteKey)
@@ -381,42 +351,14 @@ fun RemoteControlScreen(
     }
 }
 
-
-/**
- * The interaction surface the user picks from the mode chip. CONTEXT is the adaptive
- * view (player controls / browser now-playing); the others are explicit input surfaces
- * that work regardless of the TV's context (the TV routes the keys/mouse by context).
- */
-private enum class RemoteMode(val label: String) {
-    CONTEXT("Context"), DPAD("D-Pad"), TOUCHPAD("Touchpad"), KEYBOARD("Keyboard")
+private enum class RemoteMode(val label: String, val icon: ImageVector) {
+    CONTEXT("Context", Icons.Default.Dashboard),
+    DPAD("D-Pad", Icons.Default.Gamepad),
+    TOUCHPAD("Touchpad", Icons.Default.TouchApp),
+    KEYBOARD("Keyboard", Icons.Default.Keyboard)
 }
 
-/** Which TV surface the remote is controlling, derived from the TV's reported context. */
 private enum class RemoteContext { PLAYER, BROWSER, IDLE }
-
-/** Dropdown chip in the app bar that selects the interaction mode. */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun RemoteModeChip(selected: RemoteMode, onSelect: (RemoteMode) -> Unit) {
-    var expanded by remember { mutableStateOf(false) }
-    Box(modifier = Modifier.padding(end = 8.dp)) {
-        AssistChip(
-            onClick = { expanded = true },
-            label = { Text(selected.label) },
-            trailingIcon = {
-                Icon(Icons.Default.ArrowDropDown, contentDescription = "Change mode")
-            }
-        )
-        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            RemoteMode.entries.forEach { mode ->
-                DropdownMenuItem(
-                    text = { Text(mode.label) },
-                    onClick = { onSelect(mode); expanded = false }
-                )
-            }
-        }
-    }
-}
 
 private fun remoteContextOf(active: String): RemoteContext = when (active) {
     "player" -> RemoteContext.PLAYER
@@ -424,12 +366,62 @@ private fun remoteContextOf(active: String): RemoteContext = when (active) {
     else -> RemoteContext.IDLE
 }
 
-/**
- * Persistent connected-device status pill at the top of the remote: states what you're controlling,
- * and tags the protocol ("DLNA") so the active casting flow is unmistakable. Status-only — switching
- * and disconnecting live in the cast picker. Native maps [connectionState]; DLNA ([isDlna]) is always
- * "connected" to its renderer.
- */
+/** Reusable Glassmorphic Surface Modifier */
+private fun Modifier.glassSurface(
+    shape: RoundedCornerShape = RoundedCornerShape(24.dp),
+    alpha: Float = 0.1f
+): Modifier = this
+    .clip(shape)
+    .background(
+        Brush.verticalGradient(
+            colors = listOf(
+                Color.White.copy(alpha = alpha + 0.04f),
+                Color.White.copy(alpha = alpha)
+            )
+        )
+    )
+    .border(1.dp, Color.White.copy(alpha = 0.15f), shape)
+
+/** Segmented Row for switching remote modes instantly */
+@Composable
+private fun RemoteModeSegmentedRow(selected: RemoteMode, onSelect: (RemoteMode) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .glassSurface(RoundedCornerShape(50), alpha = 0.05f)
+            .padding(4.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        RemoteMode.entries.forEach { mode ->
+            val isSelected = mode == selected
+            Row(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(50))
+                    .background(if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent)
+                    .clickable { onSelect(mode) }
+                    .padding(vertical = 8.dp),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    mode.icon,
+                    contentDescription = mode.label,
+                    modifier = Modifier.size(16.dp),
+                    tint = if (isSelected) Color.Black else Color.White.copy(alpha = 0.6f)
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    mode.label,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                    color = if (isSelected) Color.Black else Color.White.copy(alpha = 0.6f)
+                )
+            }
+        }
+    }
+}
+
 @Composable
 private fun ConnectedTvChip(
     deviceName: String?,
@@ -467,12 +459,10 @@ private fun ConnectedTvChip(
     Surface(
         shape = RoundedCornerShape(50),
         color = accent.copy(alpha = 0.15f),
-        border = androidx.compose.foundation.BorderStroke(1.dp, accent.copy(alpha = 0.5f))
+        border = BorderStroke(1.dp, accent.copy(alpha = 0.5f))
     ) {
         Row(
-            modifier = Modifier
-                .heightIn(min = 36.dp)
-                .padding(horizontal = 14.dp),
+            modifier = Modifier.heightIn(min = 36.dp).padding(horizontal = 14.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
@@ -491,7 +481,6 @@ private fun ConnectedTvChip(
     }
 }
 
-/** Small uppercase protocol tag (e.g. "DLNA") so the active casting flow is unmistakable. */
 @Composable
 private fun ProtocolBadge(text: String, accent: Color) {
     Surface(shape = RoundedCornerShape(4.dp), color = accent.copy(alpha = 0.25f)) {
@@ -505,12 +494,6 @@ private fun ProtocolBadge(text: String, accent: Color) {
     }
 }
 
-/**
- * The browser CONTEXT view: a now-playing strip (title + SeekVolumeBar with sine wave
- * seek/volume/play-pause) when the WebView reports a controllable video, then the
- * browser controls. The raw input surfaces (touchpad/d-pad/keyboard) are now separate
- * modes chosen from the mode chip.
- */
 @Composable
 private fun ColumnScope.BrowserContextView(
     playbackState: String?,
@@ -522,19 +505,13 @@ private fun ColumnScope.BrowserContextView(
     onBrowserControl: (String) -> Unit,
     onRemoteKey: (String) -> Unit
 ) {
-    val videoActive = playbackState == "playing" || playbackState == "paused" ||
-        playbackState == "buffering"
+    val videoActive = playbackState == "playing" || playbackState == "paused" || playbackState == "buffering"
     if (videoActive) {
-        // Title only — the seek control lives in the SeekVolumeBar below.
-        NowPlayingPanel(
-            title = mediaTitle
-        )
+        NowPlayingPanel(title = mediaTitle)
     }
 
-    // Push the controls to the bottom; the top stays calm when nothing's playing.
     Spacer(modifier = Modifier.weight(1f))
 
-    // ── Combined seek + volume bar (same as player context) ──
     if (videoActive) {
         SeekVolumeBar(
             positionMs = positionMs,
@@ -548,20 +525,12 @@ private fun ColumnScope.BrowserContextView(
             onPlayPauseToggle = { onBrowserControl("toggle_play") }
         )
     } else {
-        VolumeRow(
-            onVolumeUp = { onRemoteKey("volume_up") },
-            onVolumeDown = { onRemoteKey("volume_down") }
-        )
+        VolumeRow(onVolumeUp = { onRemoteKey("volume_up") }, onVolumeDown = { onRemoteKey("volume_down") })
     }
 
-    // ── Browser Controls: Back · Refresh · Ad Block · Fullscreen · Source · Unmute · Home ──
     BrowserContextRow(onBrowserControl = onBrowserControl, onRemoteKey = onRemoteKey)
 }
 
-/**
- * Context-appropriate bottom controls kept beneath the D-Pad / Touchpad surfaces:
- * browser nav + volume in browser context, media transport in player context.
- */
 @Composable
 private fun ColumnScope.ModeBottomBar(
     ctx: RemoteContext,
@@ -574,25 +543,14 @@ private fun ColumnScope.ModeBottomBar(
 ) {
     when (ctx) {
         RemoteContext.BROWSER -> {
-            VolumeRow(
-                onVolumeUp = { onRemoteKey("volume_up") },
-                onVolumeDown = { onRemoteKey("volume_down") }
-            )
+            VolumeRow(onVolumeUp = { onRemoteKey("volume_up") }, onVolumeDown = { onRemoteKey("volume_down") })
             BrowserContextRow(onBrowserControl = onBrowserControl, onRemoteKey = onRemoteKey)
         }
-        RemoteContext.PLAYER -> MediaControlRow(
-            onPlayerControl = onPlayerControl,
-            showLoop = !dlnaMode,
-            showSeek = !isLive
-        )
+        RemoteContext.PLAYER -> MediaControlRow(onPlayerControl = onPlayerControl, showLoop = !dlnaMode, showSeek = !isLive)
         RemoteContext.IDLE -> { /* nothing to control */ }
     }
 }
 
-/**
- * Calm placeholder shown when the TV is idle (e.g. right after Stop). Offers to reveal the
- * input surface on demand instead of dropping the user straight onto a touchpad.
- */
 @Composable
 private fun IdleEmptyState(
     tvName: String?,
@@ -611,16 +569,8 @@ private fun IdleEmptyState(
             tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f)
         )
         Spacer(modifier = Modifier.height(12.dp))
-        Text(
-            "Nothing playing",
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.SemiBold
-        )
-        Text(
-            "on ${tvName ?: "your TV"}",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        Text("Nothing playing", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Text("on ${tvName ?: "your TV"}", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
         Spacer(modifier = Modifier.height(20.dp))
         FilledTonalButton(onClick = onShowControls) {
             Icon(Icons.Default.TouchApp, contentDescription = null, modifier = Modifier.size(18.dp))
@@ -630,11 +580,6 @@ private fun IdleEmptyState(
     }
 }
 
-/**
- * Keyboard input for browsing the TV. The phone's text field streams its full contents to the
- * TV on every change (`text:<base64>`), which the TV writes into its focused web input — so
- * typing and deleting both work. The Enter button submits (`key_enter`).
- */
 @Composable
 private fun KeyboardArea(onRemoteKey: (String) -> Unit) {
     var text by remember { mutableStateOf("") }
@@ -648,9 +593,7 @@ private fun KeyboardArea(onRemoteKey: (String) -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .clip(RoundedCornerShape(20.dp))
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f))
-            .border(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f), RoundedCornerShape(20.dp))
+            .glassSurface(RoundedCornerShape(24.dp), alpha = 0.05f)
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
@@ -675,7 +618,7 @@ private fun KeyboardArea(onRemoteKey: (String) -> Unit) {
                 }
             }
         )
-        Button(onClick = { onRemoteKey("key_enter") }) {
+        Button(onClick = { onRemoteKey("key_enter") }, modifier = Modifier.fillMaxWidth()) {
             Icon(Icons.Default.Done, contentDescription = null, modifier = Modifier.size(18.dp))
             Spacer(Modifier.width(6.dp))
             Text("Enter")
@@ -685,46 +628,24 @@ private fun KeyboardArea(onRemoteKey: (String) -> Unit) {
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
 }
 
-/** Slim horizontal −/＋ volume rocker shown just above the bottom controls in every context. */
 @Composable
-private fun VolumeRow(
-    onVolumeUp: () -> Unit,
-    onVolumeDown: () -> Unit
-) {
+private fun VolumeRow(onVolumeUp: () -> Unit, onVolumeDown: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(16.dp))
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+            .glassSurface(RoundedCornerShape(16.dp), alpha = 0.05f)
             .padding(vertical = 4.dp),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        IconButton(onClick = onVolumeDown) {
-            Icon(Icons.Default.Remove, contentDescription = "Volume down")
-        }
-        Icon(
-            Icons.AutoMirrored.Filled.VolumeUp,
-            contentDescription = null,
-            modifier = Modifier.size(20.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        IconButton(onClick = onVolumeUp) {
-            Icon(Icons.Default.Add, contentDescription = "Volume up")
-        }
+        IconButton(onClick = onVolumeDown) { Icon(Icons.Default.Remove, contentDescription = "Volume down") }
+        Icon(Icons.AutoMirrored.Filled.VolumeUp, contentDescription = null, modifier = Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+        IconButton(onClick = onVolumeUp) { Icon(Icons.Default.Add, contentDescription = "Volume up") }
     }
 }
 
-/** Drag-axis lock for the combined seek/volume gesture surface. */
 private enum class DragAxis { HORIZONTAL, VERTICAL }
 
-/**
- * Combined seek + volume control that sits where the volume rocker used to be (player context).
- * Swipe **left/right** to scrub the seekbar (absolute seek sent on release); swipe **up/down**
- * to step the volume. The gesture locks to whichever axis the drag starts on. Seeking needs a
- * finite duration (disabled for live / unknown-duration streams); volume is gated by
- * [enableVolume] (native receiver only — DLNA volume isn't wired).
- */
 @Composable
 private fun SeekVolumeBar(
     positionMs: Long,
@@ -744,74 +665,50 @@ private fun SeekVolumeBar(
     var dragging by remember { mutableStateOf(false) }
     var dragMs by remember { mutableFloatStateOf(0f) }
     var activeAxis by remember { mutableStateOf<DragAxis?>(null) }
-    var volumeDirection by remember { mutableStateOf<String?>(null) } // "up" or "down"
+    var volumeDirection by remember { mutableStateOf<String?>(null) }
     var touchDownTime by remember { mutableLongStateOf(0L) }
     var isAggressive by remember { mutableStateOf(false) }
 
-    // Vertical travel required for one volume step.
     val volumeStepPx = with(LocalDensity.current) { 28.dp.toPx() }
-    // Horizontal travel between seek "ticks" — keeps the scrub haptic tied to finger
-    // movement so normal and fast seeking feel consistent.
     val seekStepPx = with(LocalDensity.current) { 16.dp.toPx() }
 
-    // Haptics: a tick when an axis engages / on each volume step, and a firmer buzz
-    // when "fast" (hold-then-drag) mode kicks in.
     val view = LocalView.current
     val tick: () -> Unit = { view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK) }
     val thud: () -> Unit = { view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS) }
 
-    // Sine wave playback animations
     val phase by rememberInfiniteTransition(label = "sineWavePhase").animateFloat(
         initialValue = 0f,
         targetValue = (2 * Math.PI).toFloat(),
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 2000, easing = LinearEasing),
+            animation = tween(durationMillis = if (isPlaying) 1500 else 3000, easing = LinearEasing),
             repeatMode = RepeatMode.Restart
         ),
         label = "phase"
     )
 
-    val targetAmplitude = if (isPlaying && !dragging) 5.dp else 0.dp
-    val amplitude by animateDpAsState(
-        targetValue = targetAmplitude,
-        animationSpec = tween(durationMillis = 300),
-        label = "amplitude"
-    )
+    val targetAmplitude = if (isPlaying && !dragging) 7.dp else 0.dp
+    val amplitude by animateDpAsState(targetValue = targetAmplitude, animationSpec = tween(durationMillis = 300), label = "amplitude")
 
-    // The whole bar lifts (and gains a shadow) while actively seeking / adjusting volume.
-    val lift by animateDpAsState(
-        targetValue = if (activeAxis != null) 10.dp else 0.dp,
-        animationSpec = tween(durationMillis = 160),
-        label = "seekBarLift",
-    )
+    val lift by animateDpAsState(targetValue = if (activeAxis != null) 12.dp else 0.dp, animationSpec = tween(durationMillis = 160), label = "seekBarLift")
 
     val displayMs = if (dragging && hasDuration) dragMs else currentPosition.toFloat()
-    val fraction = if (hasDuration && durationMs > 0L)
-        (displayMs / durationMs.toFloat()).coerceIn(0f, 1f) else 0f
+    val fraction = if (hasDuration && durationMs > 0L) (displayMs / durationMs.toFloat()).coerceIn(0f, 1f) else 0f
 
     val primary = MaterialTheme.colorScheme.primary
+    val activeColor by animateColorAsState(targetValue = if (isAggressive) Color(0xFFFF5252) else primary, animationSpec = tween(200), label = "activeColor")
+    val thumbScale by animateFloatAsState(targetValue = if (dragging) 1.5f else 1.0f, animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy), label = "thumbScale")
 
-    // Vertical offset to center the popups vertically on the screen (above the seekbar)
-    val popupOffset = with(LocalDensity.current) {
-        IntOffset(0, -180.dp.roundToPx())
-    }
+    val popupOffset = with(LocalDensity.current) { IntOffset(0, -180.dp.roundToPx()) }
 
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .offset(y = -lift)
-            .shadow(elevation = lift, shape = RoundedCornerShape(24.dp), clip = false)
-            .height(76.dp)
-            .clip(RoundedCornerShape(24.dp))
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.15f))
-            .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.12f)), RoundedCornerShape(24.dp))
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null
-            ) {
-                if (!dragging && activeAxis == null) {
-                    onPlayPauseToggle()
-                }
+            .shadow(elevation = lift, shape = RoundedCornerShape(28.dp), clip = false)
+            .height(86.dp)
+            .glassSurface(RoundedCornerShape(28.dp), alpha = 0.05f)
+            .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) {
+                if (!dragging && activeAxis == null) onPlayPauseToggle()
             }
             .onSizeChanged { widthPx = it.width.toFloat() }
             .pointerInput(Unit) {
@@ -828,14 +725,9 @@ private fun SeekVolumeBar(
                     onDragStart = {
                         val dragStartTime = System.currentTimeMillis()
                         isAggressive = (dragStartTime - touchDownTime) >= 400L
-                        // Firmer buzz to confirm the user held long enough for fast mode.
                         if (isAggressive) thud()
-
-                        axis = null
-                        volAccum = 0f
-                        seekAccum = 0f
-                        dragMs = currentPosition.toFloat()
-                        volumeDirection = null
+                        axis = null; volAccum = 0f; seekAccum = 0f
+                        dragMs = currentPosition.toFloat(); volumeDirection = null
                     },
                     onDrag = { change, drag ->
                         change.consume()
@@ -843,365 +735,190 @@ private fun SeekVolumeBar(
                             axis = if (abs(drag.x) >= abs(drag.y)) DragAxis.HORIZONTAL else DragAxis.VERTICAL
                             activeAxis = axis
                             if (axis == DragAxis.HORIZONTAL && hasDuration) dragging = true
-                            // Light tick the moment a seek/volume gesture locks in.
                             tick()
                         }
                         when (axis) {
                             DragAxis.HORIZONTAL -> if (hasDuration && widthPx > 0f) {
-                                val rangeMs = if (isAggressive) {
-                                    durationMs.toFloat()
-                                } else {
-                                    (durationMs / 10L).coerceIn(120_000L, 600_000L).toFloat()
-                                }
+                                val rangeMs = if (isAggressive) durationMs.toFloat() else (durationMs / 10L).coerceIn(120_000L, 600_000L).toFloat()
                                 val deltaMs = (drag.x / widthPx) * rangeMs
                                 dragMs = (dragMs + deltaMs).coerceIn(0f, durationMs.toFloat())
-                                // Tick steadily as the finger scrubs (normal and fast alike).
                                 seekAccum += abs(drag.x)
-                                while (seekAccum >= seekStepPx) {
-                                    tick()
-                                    seekAccum -= seekStepPx
-                                }
+                                while (seekAccum >= seekStepPx) { tick(); seekAccum -= seekStepPx }
                             }
                             DragAxis.VERTICAL -> if (enableVolume) {
-                                if (volumeDirection == null) {
-                                    volumeDirection = if (drag.y < 0) "up" else "down"
-                                }
-                                volAccum -= drag.y // swipe up (negative y) raises volume
+                                if (volumeDirection == null) volumeDirection = if (drag.y < 0) "up" else "down"
+                                volAccum -= drag.y
                                 val stepPx = if (isAggressive) volumeStepPx / 2.5f else volumeStepPx
-                                while (volAccum >= stepPx) {
-                                    onVolumeUp()
-                                    tick()
-                                    volAccum -= stepPx
-                                    volumeDirection = "up"
-                                }
-                                while (volAccum <= -stepPx) {
-                                    onVolumeDown()
-                                    tick()
-                                    volAccum += stepPx
-                                    volumeDirection = "down"
-                                }
+                                while (volAccum >= stepPx) { onVolumeUp(); tick(); volAccum -= stepPx; volumeDirection = "up" }
+                                while (volAccum <= -stepPx) { onVolumeDown(); tick(); volAccum += stepPx; volumeDirection = "down" }
                             }
                             else -> {}
                         }
                     },
                     onDragEnd = {
                         if (axis == DragAxis.HORIZONTAL && hasDuration) onSeekTo(dragMs.toLong())
-                        dragging = false
-                        activeAxis = null
-                        axis = null
-                        volumeDirection = null
-                        isAggressive = false
+                        dragging = false; activeAxis = null; axis = null; volumeDirection = null; isAggressive = false
                     },
                     onDragCancel = {
-                        dragging = false
-                        activeAxis = null
-                        axis = null
-                        volumeDirection = null
-                        isAggressive = false
-                    },
+                        dragging = false; activeAxis = null; axis = null; volumeDirection = null; isAggressive = false
+                    }
                 )
             },
         contentAlignment = Alignment.CenterStart
     ) {
-        // --- Redesigned UX: Visual axis guides and guides in background ---
-        // Horizontal guide line
         Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(1.dp)
-                .background(Color.White.copy(alpha = 0.08f))
+            modifier = Modifier.fillMaxWidth().height(1.dp)
+                .background(Brush.horizontalGradient(listOf(Color.Transparent, Color.White.copy(alpha = if (activeAxis == DragAxis.HORIZONTAL) 0.5f else 0.1f), Color.Transparent)))
                 .align(Alignment.Center)
         )
-        // Vertical guide line
         if (enableVolume) {
             Box(
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .width(1.dp)
-                    .background(Color.White.copy(alpha = 0.08f))
+                modifier = Modifier.fillMaxHeight().width(1.dp)
+                    .background(Brush.verticalGradient(listOf(Color.Transparent, Color.White.copy(alpha = if (activeAxis == DragAxis.VERTICAL) 0.5f else 0.1f), Color.Transparent)))
                     .align(Alignment.Center)
             )
         }
 
-        // --- Arrow Indicators to suggest directions ---
-        // Left Seek arrow
-        Icon(
-            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
-            contentDescription = null,
-            tint = if (activeAxis == DragAxis.HORIZONTAL) primary else Color.White.copy(alpha = 0.3f),
-            modifier = Modifier
-                .align(Alignment.CenterStart)
-                .padding(start = 8.dp)
-                .size(24.dp)
-        )
-        // Right Seek arrow
-        Icon(
-            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-            contentDescription = null,
-            tint = if (activeAxis == DragAxis.HORIZONTAL) primary else Color.White.copy(alpha = 0.3f),
-            modifier = Modifier
-                .align(Alignment.CenterEnd)
-                .padding(end = 8.dp)
-                .size(24.dp)
-        )
-        // Top Volume arrow
+        Icon(Icons.AutoMirrored.Filled.KeyboardArrowLeft, contentDescription = null, tint = if (activeAxis == DragAxis.HORIZONTAL) activeColor else Color.White.copy(alpha = 0.3f), modifier = Modifier.align(Alignment.CenterStart).padding(start = 12.dp).size(24.dp))
+        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = if (activeAxis == DragAxis.HORIZONTAL) activeColor else Color.White.copy(alpha = 0.3f), modifier = Modifier.align(Alignment.CenterEnd).padding(end = 12.dp).size(24.dp))
+        
         if (enableVolume) {
-            Icon(
-                imageVector = Icons.Filled.KeyboardArrowUp,
-                contentDescription = null,
-                tint = if (activeAxis == DragAxis.VERTICAL) primary else Color.White.copy(alpha = 0.3f),
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .padding(top = 2.dp)
-                    .size(14.dp)
-            )
-        }
-        // Bottom Volume arrow
-        if (enableVolume) {
-            Icon(
-                imageVector = Icons.Filled.KeyboardArrowDown,
-                contentDescription = null,
-                tint = if (activeAxis == DragAxis.VERTICAL) primary else Color.White.copy(alpha = 0.3f),
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(bottom = 2.dp)
-                    .size(14.dp)
-            )
+            Icon(Icons.Filled.KeyboardArrowUp, contentDescription = null, tint = if (activeAxis == DragAxis.VERTICAL) activeColor else Color.White.copy(alpha = 0.3f), modifier = Modifier.align(Alignment.TopCenter).padding(top = 4.dp).size(16.dp))
+            Icon(Icons.Filled.KeyboardArrowDown, contentDescription = null, tint = if (activeAxis == DragAxis.VERTICAL) activeColor else Color.White.copy(alpha = 0.3f), modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 4.dp).size(16.dp))
         }
 
-        // --- Content Column containing labels and progress bar ---
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 16.dp, vertical = 10.dp),
+            modifier = Modifier.fillMaxSize().padding(horizontal = 52.dp, vertical = 14.dp),
             verticalArrangement = Arrangement.SpaceBetween,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // Top Status Label Row
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp),
+                modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                // Seek label
                 val seekLabel = if (activeAxis == DragAxis.HORIZONTAL) {
-                    if (isAggressive) "Fast Seek ◄►" else "Seeking ◄►"
+                    if (isAggressive) "FAST SEEK ◄►" else "SEEKING ◄►"
                 } else {
-                    if (isPlaying) "◄► Seek · Tap ❙❙" else "◄► Seek · Tap ▶"
+                    if (isPlaying) "◄► SEEK · TAP ❙❙" else "◄► SEEK · TAP ▶"
                 }
-                Text(
-                    text = seekLabel,
-                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
-                    fontWeight = FontWeight.SemiBold,
-                    color = if (activeAxis == DragAxis.HORIZONTAL) primary else Color.White.copy(alpha = 0.5f),
-                    maxLines = 1
-                )
+                Text(seekLabel, style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.sp), color = if (activeAxis == DragAxis.HORIZONTAL) activeColor else Color.White.copy(alpha = 0.5f), maxLines = 1)
+                
                 if (enableVolume) {
-                    Text(
-                        text = "  ·  ",
-                        style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
-                        color = Color.White.copy(alpha = 0.2f)
-                    )
-                    // Volume label
+                    Text("  ·  ", style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp), color = Color.White.copy(alpha = 0.2f))
                     val volumeLabel = if (activeAxis == DragAxis.VERTICAL) {
-                        if (isAggressive) "Fast Vol ▲▼" else "Volume ▲▼"
-                    } else "▲▼ Volume"
-                    Text(
-                        text = volumeLabel,
-                        style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
-                        fontWeight = FontWeight.SemiBold,
-                        color = if (activeAxis == DragAxis.VERTICAL) primary else Color.White.copy(alpha = 0.5f),
-                        maxLines = 1
-                    )
+                        if (isAggressive) "FAST VOL ▲▼" else "VOLUME ▲▼"
+                    } else "▲▼ VOLUME"
+                    Text(volumeLabel, style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.sp), color = if (activeAxis == DragAxis.VERTICAL) activeColor else Color.White.copy(alpha = 0.5f), maxLines = 1)
                 }
             }
 
-            // Center Progress Bar
             if (hasDuration) {
                 val ampPx = with(LocalDensity.current) { amplitude.toPx() }
-                val wavelength = with(LocalDensity.current) { 60.dp.toPx() }
-                val strokeActiveWidth = with(LocalDensity.current) { 3.dp.toPx() }
+                val wavelength = with(LocalDensity.current) { 50.dp.toPx() }
+                val tickHeight = with(LocalDensity.current) { 4.dp.toPx() }
+                val strokeActiveWidth = with(LocalDensity.current) { 4.dp.toPx() }
                 val strokeInactiveWidth = with(LocalDensity.current) { 2.dp.toPx() }
 
-                Canvas(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 20.dp)
-                        .height(20.dp)
-                ) {
+                Canvas(modifier = Modifier.fillMaxWidth().height(24.dp)) {
                     val width = size.width
                     val height = size.height
                     val centerY = height / 2f
                     val amp = ampPx
-
                     val activeWidth = width * fraction
 
-                    // Draw active path (0 to activeWidth)
+                    val tickCount = 30
+                    val tickSpacing = width / tickCount
+                    for (i in 0..tickCount) {
+                        val x = i * tickSpacing
+                        drawLine(color = Color.White.copy(alpha = 0.1f), start = Offset(x, centerY - tickHeight), end = Offset(x, centerY + tickHeight), strokeWidth = 1f)
+                    }
+
+                    fun getWaveY(x: Float, p: Float): Float {
+                        val safeX = x.coerceIn(0f, width)
+                        val envelope = if (width > 0f) sin(Math.PI * (safeX / width)).toFloat() else 0f
+                        val angle = (2 * Math.PI * x / wavelength).toFloat() + p
+                        return centerY + amp * envelope * sin(angle)
+                    }
+
+                    if (activeWidth < width) {
+                        val inactivePath = Path().apply {
+                            moveTo(activeWidth, getWaveY(activeWidth, phase))
+                            var x = activeWidth + 1f
+                            while (x <= width) { lineTo(x, getWaveY(x, phase)); x += 2f }
+                        }
+                        drawPath(path = inactivePath, color = Color.White.copy(alpha = 0.15f), style = Stroke(width = strokeInactiveWidth, cap = StrokeCap.Round))
+                    }
+
                     if (activeWidth > 0f) {
                         val activePath = Path().apply {
-                            moveTo(0f, centerY + amp * sin(phase))
+                            moveTo(0f, getWaveY(0f, phase))
                             var x = 1f
-                            while (x <= activeWidth) {
-                                val angle = (2 * Math.PI * x / wavelength).toFloat() + phase
-                                lineTo(x, centerY + amp * sin(angle))
-                                x += 2f
-                            }
+                            while (x <= activeWidth) { lineTo(x, getWaveY(x, phase)); x += 2f }
                         }
                         drawPath(
                             path = activePath,
-                            color = primary,
+                            brush = Brush.horizontalGradient(colors = listOf(activeColor.copy(alpha = 0.8f), Color.White), startX = 0f, endX = activeWidth),
                             style = Stroke(width = strokeActiveWidth, cap = StrokeCap.Round)
                         )
-                    }
 
-                    // Draw inactive path (activeWidth to width)
-                    if (activeWidth < width) {
-                        val inactivePath = Path().apply {
-                            moveTo(activeWidth, centerY + amp * sin((2 * Math.PI * activeWidth / wavelength).toFloat() + phase))
-                            var x = activeWidth + 1f
-                            while (x <= width) {
-                                val angle = (2 * Math.PI * x / wavelength).toFloat() + phase
-                                lineTo(x, centerY + amp * sin(angle))
-                                x += 2f
-                            }
+                        if (fraction > 0f && fraction < 1f) {
+                            val thumbX = activeWidth
+                            val barWidth = 3.dp.toPx() * thumbScale
+                            val barHeight = 18.dp.toPx() * thumbScale
+                            drawLine(
+                                color = Color.White,
+                                start = Offset(thumbX, centerY - barHeight / 2),
+                                end = Offset(thumbX, centerY + barHeight / 2),
+                                strokeWidth = barWidth,
+                                cap = StrokeCap.Round
+                            )
                         }
-                        drawPath(
-                            path = inactivePath,
-                            color = Color.White.copy(alpha = 0.12f),
-                            style = Stroke(width = strokeInactiveWidth, cap = StrokeCap.Round)
-                        )
                     }
                 }
             } else {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 20.dp)
-                        .height(1.dp)
-                        .background(Color.White.copy(alpha = 0.12f))
-                )
+                Box(modifier = Modifier.fillMaxWidth().height(2.dp).background(Color.White.copy(alpha = 0.2f)))
             }
 
-            // Bottom Time Row
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(
-                    text = if (hasDuration) formatTime(displayMs.toLong()) else formatTime(currentPosition),
-                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.sp),
-                    color = Color.White.copy(alpha = 0.6f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Visible
-                )
-                Text(
-                    text = if (isLive) "LIVE" else if (durationMs > 0L) formatTime(durationMs) else "--:--",
-                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.sp),
-                    color = Color.White.copy(alpha = 0.6f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Visible
-                )
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(if (hasDuration) formatTime(displayMs.toLong()) else formatTime(currentPosition), style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.sp), color = Color.White.copy(alpha = 0.7f), maxLines = 1, overflow = TextOverflow.Visible)
+                Text(if (isLive) "● LIVE" else if (durationMs > 0L) formatTime(durationMs) else "--:--", style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.sp, fontWeight = if (isLive) FontWeight.Bold else FontWeight.Normal), color = if (isLive) activeColor else Color.White.copy(alpha = 0.7f), maxLines = 1, overflow = TextOverflow.Visible)
             }
         }
     }
 
-    // --- Seek HUD Overlay popup ---
     if (dragging && activeAxis == DragAxis.HORIZONTAL && hasDuration) {
         val deltaMs = dragMs.toLong() - currentPosition
-        Popup(
-            alignment = Alignment.Center,
-            offset = popupOffset,
-            properties = PopupProperties(
-                focusable = false,
-                dismissOnBackPress = false,
-                dismissOnClickOutside = false
-            )
-        ) {
-            Surface(
-                color = Color.Black.copy(alpha = 0.75f),
-                shape = RoundedCornerShape(18.dp),
-                border = BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
-            ) {
-                Column(
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        text = if (isAggressive) "Fast Seek" else "Seek",
-                        color = primary,
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Bold
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        "${formatTime(dragMs.toLong())} / ${formatTime(durationMs)}",
-                        color = Color.White,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold
-                    )
+        Popup(alignment = Alignment.Center, offset = popupOffset, properties = PopupProperties(focusable = false, dismissOnBackPress = false, dismissOnClickOutside = false)) {
+            Surface(color = Color.Black.copy(alpha = 0.85f), shape = RoundedCornerShape(20.dp), border = BorderStroke(1.dp, activeColor.copy(alpha = 0.5f))) {
+                Column(modifier = Modifier.padding(horizontal = 28.dp, vertical = 18.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(if (isAggressive) "Fast Seek" else "Seek", color = activeColor, style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold, letterSpacing = 1.sp))
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text("${formatTime(dragMs.toLong())} / ${formatTime(durationMs)}", color = Color.White, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                     val sign = if (deltaMs >= 0) "+" else "-"
-                    Text(
-                        "$sign${formatTime(abs(deltaMs))}",
-                        color = Color.White.copy(alpha = 0.8f),
-                        style = MaterialTheme.typography.labelMedium
-                    )
+                    Text("$sign${formatTime(abs(deltaMs))}", color = Color.White.copy(alpha = 0.8f), style = MaterialTheme.typography.labelMedium)
                 }
             }
         }
     }
 
-    // --- Volume HUD Overlay popup ---
     if (activeAxis == DragAxis.VERTICAL && enableVolume) {
-        Popup(
-            alignment = Alignment.Center,
-            offset = popupOffset,
-            properties = PopupProperties(
-                focusable = false,
-                dismissOnBackPress = false,
-                dismissOnClickOutside = false
-            )
-        ) {
-            Surface(
-                color = Color.Black.copy(alpha = 0.75f),
-                shape = RoundedCornerShape(18.dp),
-                border = BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
-            ) {
-                Column(
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    val volumeIcon = when (volumeDirection) {
-                        "down" -> Icons.AutoMirrored.Filled.VolumeDown
-                        else -> Icons.AutoMirrored.Filled.VolumeUp
-                    }
-                    Icon(
-                        imageVector = volumeIcon,
-                        contentDescription = null,
-                        tint = Color.White,
-                        modifier = Modifier.size(28.dp)
-                    )
+        Popup(alignment = Alignment.Center, offset = popupOffset, properties = PopupProperties(focusable = false, dismissOnBackPress = false, dismissOnClickOutside = false)) {
+            Surface(color = Color.Black.copy(alpha = 0.85f), shape = RoundedCornerShape(20.dp), border = BorderStroke(1.dp, activeColor.copy(alpha = 0.5f))) {
+                Column(modifier = Modifier.padding(horizontal = 28.dp, vertical = 22.dp), horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    val volumeIcon = when (volumeDirection) { "down" -> Icons.AutoMirrored.Filled.VolumeDown else -> Icons.AutoMirrored.Filled.VolumeUp }
+                    Icon(volumeIcon, contentDescription = null, tint = activeColor, modifier = Modifier.size(32.dp))
                     val volumeLabel = when (volumeDirection) {
-                        "up" -> if (isAggressive) "Volume Up (Fast) ▲" else "Volume Up ▲"
-                        "down" -> if (isAggressive) "Volume Down (Fast) ▼" else "Volume Down ▼"
+                        "up" -> if (isAggressive) "Volume Up (Fast)" else "Volume Up"
+                        "down" -> if (isAggressive) "Volume Down (Fast)" else "Volume Down"
                         else -> if (isAggressive) "Volume (Fast)" else "Volume"
                     }
-                    Text(
-                        volumeLabel,
-                        color = Color.White,
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.Bold
-                    )
+                    Text(volumeLabel, color = Color.White, style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold, letterSpacing = 1.sp))
                 }
             }
         }
     }
 }
-
 
 @Composable
 private fun TouchpadArea(
@@ -1218,13 +935,7 @@ private fun TouchpadArea(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .clip(RoundedCornerShape(20.dp))
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f))
-            .border(
-                width = 1.dp,
-                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-                shape = RoundedCornerShape(20.dp)
-            )
+            .glassSurface(RoundedCornerShape(24.dp), alpha = 0.05f)
             .pointerInput(Unit) {
                 awaitPointerEventScope {
                     while (true) {
@@ -1233,34 +944,21 @@ private fun TouchpadArea(
 
                         if (pointerCount >= 2) {
                             isScrolling = true
-                            // Two fingers = scroll OR pinch-zoom. Decide per-frame by
-                            // whether the fingers' separation changed more than their
-                            // shared (centroid) translation: distance-dominant → zoom,
-                            // translation-dominant → scroll.
                             val pressed = event.changes.filter { it.pressed }
                             val a = pressed.getOrNull(0)
                             val b = pressed.getOrNull(1)
-                            if (a != null && b != null &&
-                                a.previousPressed && b.previousPressed
-                            ) {
+                            if (a != null && b != null && a.previousPressed && b.previousPressed) {
                                 val curDist = (a.position - b.position).getDistance()
-                                val prevDist =
-                                    (a.previousPosition - b.previousPosition).getDistance()
-                                val panX = ((a.position.x + b.position.x) -
-                                    (a.previousPosition.x + b.previousPosition.x)) / 2f
-                                val panY = ((a.position.y + b.position.y) -
-                                    (a.previousPosition.y + b.previousPosition.y)) / 2f
+                                val prevDist = (a.previousPosition - b.previousPosition).getDistance()
+                                val panX = ((a.position.x + b.position.x) - (a.previousPosition.x + b.previousPosition.x)) / 2f
+                                val panY = ((a.position.y + b.previousPosition.y) - (a.previousPosition.y + b.previousPosition.y)) / 2f
                                 val distDelta = curDist - prevDist
-                                if (prevDist > 0f &&
-                                    kotlin.math.abs(distDelta) > kotlin.math.abs(panY) &&
-                                    kotlin.math.abs(distDelta) > kotlin.math.abs(panX)
-                                ) {
+                                if (prevDist > 0f && abs(distDelta) > abs(panY) && abs(distDelta) > abs(panX)) {
                                     onPinchZoom(curDist / prevDist)
                                 } else {
                                     onMouseScroll(panX, panY * 2f)
                                 }
-                                a.consume()
-                                b.consume()
+                                a.consume(); b.consume()
                             }
                         } else if (pointerCount == 1 && !isScrolling) {
                             val change = event.changes.first()
@@ -1275,82 +973,68 @@ private fun TouchpadArea(
                     }
                 }
             }
+            .pointerInput(Unit) { detectTapGestures(onTap = { onMouseClick() }) }
             .pointerInput(Unit) {
-                detectTapGestures(onTap = { onMouseClick() })
-            }
-            .pointerInput(Unit) {
-                // Long-press then drag → click-drag on the TV (e.g. seekbar scrubbing)
                 detectDragGesturesAfterLongPress(
-                    onDragStart = {
-                        isDragging = true
-                        onMouseDown()
-                    },
-                    onDrag = { change, dragAmount ->
-                        change.consume()
-                        onMouseMove(dragAmount.x * 1.5f, dragAmount.y * 1.5f)
-                    },
-                    onDragEnd = {
-                        if (isDragging) {
-                            isDragging = false
-                            onMouseUp()
-                        }
-                    },
-                    onDragCancel = {
-                        if (isDragging) {
-                            isDragging = false
-                            onMouseUp()
-                        }
-                    }
+                    onDragStart = { isDragging = true; onMouseDown() },
+                    onDrag = { change, dragAmount -> change.consume(); onMouseMove(dragAmount.x * 1.5f, dragAmount.y * 1.5f) },
+                    onDragEnd = { if (isDragging) { isDragging = false; onMouseUp() } },
+                    onDragCancel = { if (isDragging) { isDragging = false; onMouseUp() } }
                 )
             },
         contentAlignment = Alignment.Center
     ) {
+        // High-tech grid overlay for spatial awareness
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val gridColor = Color.White.copy(alpha = 0.05f)
+            val cols = 3
+            val rows = 3
+            val colWidth = size.width / cols
+            val rowHeight = size.height / rows
+            
+            for (i in 1 until cols) {
+                drawLine(gridColor, Offset(i * colWidth, 0f), Offset(i * colWidth, size.height), strokeWidth = 1f)
+            }
+            for (i in 1 until rows) {
+                drawLine(gridColor, Offset(0f, i * rowHeight), Offset(size.width, i * rowHeight), strokeWidth = 1f)
+            }
+        }
+        
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            Icon(
-                Icons.Default.TouchApp,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.15f)
-            )
+            Icon(Icons.Default.TouchApp, contentDescription = null, modifier = Modifier.size(48.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.15f))
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 "1 finger: move  •  2 fingers: scroll  •  Pinch: zoom  •  Tap: click  •  Long-press+drag: drag",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
-                textAlign = TextAlign.Center
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 24.dp)
             )
         }
     }
 }
 
-
 @Composable
 private fun DpadArea(onRemoteKey: (String) -> Unit) {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            // Up
             DpadBtn(Icons.Default.KeyboardArrowUp, "Up") { onRemoteKey("dpad_up") }
 
-            // Left, OK, Right
             Row(
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 DpadBtn(Icons.AutoMirrored.Filled.KeyboardArrowLeft, "Left") { onRemoteKey("dpad_left") }
 
-                // OK button (larger, primary color)
                 FilledTonalButton(
                     onClick = { onRemoteKey("dpad_center") },
-                    modifier = Modifier.size(80.dp),
+                    modifier = Modifier.size(80.dp).shadow(8.dp, CircleShape),
                     shape = CircleShape,
                     colors = ButtonDefaults.filledTonalButtonColors(
                         containerColor = MaterialTheme.colorScheme.primary,
@@ -1363,7 +1047,6 @@ private fun DpadArea(onRemoteKey: (String) -> Unit) {
                 DpadBtn(Icons.AutoMirrored.Filled.KeyboardArrowRight, "Right") { onRemoteKey("dpad_right") }
             }
 
-            // Down
             DpadBtn(Icons.Default.KeyboardArrowDown, "Down") { onRemoteKey("dpad_down") }
         }
     }
@@ -1373,14 +1056,13 @@ private fun DpadArea(onRemoteKey: (String) -> Unit) {
 private fun DpadBtn(icon: ImageVector, desc: String, onClick: () -> Unit) {
     FilledTonalButton(
         onClick = onClick,
-        modifier = Modifier.size(64.dp),
+        modifier = Modifier.size(64.dp).shadow(4.dp, CircleShape),
         shape = CircleShape,
         contentPadding = PaddingValues(0.dp)
     ) {
         Icon(icon, contentDescription = desc, modifier = Modifier.size(32.dp))
     }
 }
-
 
 @Composable
 private fun MediaControlRow(
@@ -1393,226 +1075,87 @@ private fun MediaControlRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(16.dp))
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+            .glassSurface(RoundedCornerShape(16.dp), alpha = 0.05f)
             .padding(vertical = 8.dp),
         horizontalArrangement = Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        // Seek -10s
         if (showSeek) {
-            LabeledIconButton(
-                icon = Icons.Default.Replay10,
-                label = "-10s",
-                tint = MaterialTheme.colorScheme.onSurface,
-                onClick = { onPlayerControl("seek_back") }
-            )
+            LabeledIconButton(icon = Icons.Default.Replay10, label = "-10s", tint = MaterialTheme.colorScheme.onSurface, onClick = { onPlayerControl("seek_back") })
         }
-
-        // Seek +10s
         if (showSeek) {
-            LabeledIconButton(
-                icon = Icons.Default.Forward10,
-                label = "+10s",
-                tint = MaterialTheme.colorScheme.onSurface,
-                onClick = { onPlayerControl("seek_forward") }
-            )
+            LabeledIconButton(icon = Icons.Default.Forward10, label = "+10s", tint = MaterialTheme.colorScheme.onSurface, onClick = { onPlayerControl("seek_forward") })
         }
-
-        // Loop toggle
         if (showLoop) {
-            LabeledIconButton(
-                icon = Icons.Default.Repeat,
-                label = "Loop",
-                tint = if (isLooping) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
-                onClick = {
-                    val next = !isLooping
-                    onPlayerControl(if (next) "loop_on" else "loop_off")
-                    isLooping = next
-                }
-            )
+            LabeledIconButton(icon = Icons.Default.Repeat, label = "Loop", tint = if (isLooping) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface, onClick = {
+                val next = !isLooping
+                onPlayerControl(if (next) "loop_on" else "loop_off")
+                isLooping = next
+            })
         }
-
-        // Stop
-        LabeledIconButton(
-            icon = Icons.Default.Stop,
-            label = "Stop",
-            tint = MaterialTheme.colorScheme.error,
-            onClick = { onPlayerControl("stop") }
-        )
+        LabeledIconButton(icon = Icons.Default.Stop, label = "Stop", tint = MaterialTheme.colorScheme.error, onClick = { onPlayerControl("stop") })
     }
 }
 
-
 @Composable
-private fun BrowserContextRow(
-    onBrowserControl: (String) -> Unit,
-    onRemoteKey: (String) -> Unit
-) {
+private fun BrowserContextRow(onBrowserControl: (String) -> Unit, onRemoteKey: (String) -> Unit) {
     var isVideoMaximized by remember { mutableStateOf(false) }
     var showMoreSheet by remember { mutableStateOf(false) }
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(16.dp))
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+            .glassSurface(RoundedCornerShape(16.dp), alpha = 0.05f)
             .padding(vertical = 8.dp),
         horizontalArrangement = Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        // Back — goes back one page (exits when no history left)
-        LabeledIconButton(
-            icon = Icons.AutoMirrored.Filled.ArrowBack,
-            label = "Back",
-            tint = MaterialTheme.colorScheme.onSurface,
-            onClick = { onRemoteKey("back") }
-        )
-        // Forward — goes forward one page
-        LabeledIconButton(
-            icon = Icons.AutoMirrored.Filled.ArrowForward,
-            label = "Forward",
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            onClick = { onBrowserControl("forward") }
-        )
-        // Refresh
-        LabeledIconButton(
-            icon = Icons.Default.Refresh,
-            label = "Refresh",
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            onClick = { onBrowserControl("refresh") }
-        )
-        // Maximize / Restore Video
-        LabeledIconButton(
-            icon = if (isVideoMaximized) Icons.Default.FullscreenExit else Icons.Default.Fullscreen,
-            label = if (isVideoMaximized) "Restore" else "Fullscreen",
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            onClick = {
-                onBrowserControl(if (isVideoMaximized) "restore_video" else "maximize_video")
-                isVideoMaximized = !isVideoMaximized
-            }
-        )
-        // Home — exits the browser
-        LabeledIconButton(
-            icon = Icons.Default.Home,
-            label = "Home",
-            tint = MaterialTheme.colorScheme.onSurface,
-            onClick = { onRemoteKey("home") }
-        )
-        // More — overflow sheet for the less-frequent page/video controls
-        LabeledIconButton(
-            icon = Icons.Default.MoreHoriz,
-            label = "More",
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            onClick = { showMoreSheet = true }
-        )
+        LabeledIconButton(icon = Icons.AutoMirrored.Filled.ArrowBack, label = "Back", tint = MaterialTheme.colorScheme.onSurface, onClick = { onRemoteKey("back") })
+        LabeledIconButton(icon = Icons.AutoMirrored.Filled.ArrowForward, label = "Forward", tint = MaterialTheme.colorScheme.onSurfaceVariant, onClick = { onBrowserControl("forward") })
+        LabeledIconButton(icon = Icons.Default.Refresh, label = "Refresh", tint = MaterialTheme.colorScheme.onSurfaceVariant, onClick = { onBrowserControl("refresh") })
+        LabeledIconButton(icon = if (isVideoMaximized) Icons.Default.FullscreenExit else Icons.Default.Fullscreen, label = if (isVideoMaximized) "Restore" else "Fullscreen", tint = MaterialTheme.colorScheme.onSurfaceVariant, onClick = {
+            onBrowserControl(if (isVideoMaximized) "restore_video" else "maximize_video")
+            isVideoMaximized = !isVideoMaximized
+        })
+        LabeledIconButton(icon = Icons.Default.Home, label = "Home", tint = MaterialTheme.colorScheme.onSurface, onClick = { onRemoteKey("home") })
+        LabeledIconButton(icon = Icons.Default.MoreHoriz, label = "More", tint = MaterialTheme.colorScheme.onSurfaceVariant, onClick = { showMoreSheet = true })
     }
 
     if (showMoreSheet) {
-        BrowserMoreSheet(
-            onBrowserControl = onBrowserControl,
-            onDismiss = { showMoreSheet = false }
-        )
+        BrowserMoreSheet(onBrowserControl = onBrowserControl, onDismiss = { showMoreSheet = false })
     }
 }
 
-/**
- * Overflow sheet for the browser controls that don't earn a spot in the main row:
- * ad-blocker toggle, the D-pad video "source" override, and manual unmute.
- */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun BrowserMoreSheet(
-    onBrowserControl: (String) -> Unit,
-    onDismiss: () -> Unit
-) {
+private fun BrowserMoreSheet(onBrowserControl: (String) -> Unit, onDismiss: () -> Unit) {
     ModalBottomSheet(onDismissRequest = onDismiss) {
-        Text(
-            "More controls",
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(start = 24.dp, bottom = 4.dp)
-        )
+        Text("More controls", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(start = 24.dp, bottom = 4.dp))
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 16.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 16.dp),
             horizontalArrangement = Arrangement.SpaceEvenly,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Ad Block — toggle uBlock on the TV browser
-            LabeledIconButton(
-                icon = Icons.Default.Shield,
-                label = "Ad Block",
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                onClick = { onBrowserControl("toggle_ublock"); onDismiss() }
-            )
-            // Source — cycle the D-pad's video target when auto-selection picks the wrong
-            // player (the TV auto-follows the largest on-screen video by default).
-            LabeledIconButton(
-                icon = Icons.Default.Layers,
-                label = "Source",
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                onClick = { onBrowserControl("video_target_cycle"); onDismiss() }
-            )
-            // Unmute — manual fallback for muted players the TV didn't auto-unmute.
-            LabeledIconButton(
-                icon = Icons.AutoMirrored.Filled.VolumeUp,
-                label = "Unmute",
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                onClick = { onBrowserControl("video_unmute"); onDismiss() }
-            )
-            // Scripts — manage user scripts installed on the TV (install from a file,
-            // list, remove). The app ships none; you supply the .js. Handled phone-side
-            // in AppNavHost (opens the manager + queries the TV).
-            LabeledIconButton(
-                icon = Icons.Default.Code,
-                label = "Scripts",
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                onClick = { onBrowserControl("manage_user_scripts"); onDismiss() }
-            )
+            LabeledIconButton(icon = Icons.Default.Shield, label = "Ad Block", tint = MaterialTheme.colorScheme.onSurfaceVariant, onClick = { onBrowserControl("toggle_ublock"); onDismiss() })
+            LabeledIconButton(icon = Icons.Default.Layers, label = "Source", tint = MaterialTheme.colorScheme.onSurfaceVariant, onClick = { onBrowserControl("video_target_cycle"); onDismiss() })
+            LabeledIconButton(icon = Icons.AutoMirrored.Filled.VolumeUp, label = "Unmute", tint = MaterialTheme.colorScheme.onSurfaceVariant, onClick = { onBrowserControl("video_unmute"); onDismiss() })
+            LabeledIconButton(icon = Icons.Default.Code, label = "Scripts", tint = MaterialTheme.colorScheme.onSurfaceVariant, onClick = { onBrowserControl("manage_user_scripts"); onDismiss() })
         }
         Spacer(Modifier.height(16.dp))
     }
 }
 
-
 @Composable
-private fun LabeledIconButton(
-    icon: ImageVector,
-    label: String,
-    tint: Color,
-    onClick: () -> Unit
-) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.padding(horizontal = 4.dp)
-    ) {
-        IconButton(onClick = onClick) {
-            Icon(icon, contentDescription = label, tint = tint)
-        }
-        Text(
-            label,
-            style = MaterialTheme.typography.labelSmall,
-            color = tint.copy(alpha = 0.7f),
-            fontSize = 10.sp
-        )
+private fun LabeledIconButton(icon: ImageVector, label: String, tint: Color, onClick: () -> Unit) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(horizontal = 4.dp)) {
+        IconButton(onClick = onClick) { Icon(icon, contentDescription = label, tint = tint) }
+        Text(label, style = MaterialTheme.typography.labelSmall, color = tint.copy(alpha = 0.7f), fontSize = 10.sp)
     }
 }
 
-
-/**
- * Title + live seekbar. The slider tracks the TV's reported position, except while
- * the user is dragging — on release it sends an absolute seek to the TV.
- */
 @Composable
-private fun NowPlayingPanel(
-    title: String?,
-    episodeLabel: String? = null
-) {
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+private fun NowPlayingPanel(title: String?, episodeLabel: String? = null) {
+    Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
             text = title ?: "Playing on TV",
             style = MaterialTheme.typography.titleMedium,
@@ -1621,30 +1164,24 @@ private fun NowPlayingPanel(
             textAlign = TextAlign.Center
         )
         if (episodeLabel != null) {
-            Text(
-                text = episodeLabel,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            Text(text = episodeLabel, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }
 }
 
-
-/** The TV's current playlist; tapping an entry jumps the TV to that episode. */
 @Composable
-private fun EpisodesList(
+private fun EpisodesCarousel(
     episodes: List<PlaylistEpisode>,
     currentIndex: Int,
     onJumpToEpisode: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     if (episodes.size <= 1) {
-        // Single item (or none): nothing to choose between.
         Spacer(modifier = modifier)
         return
     }
 
+    val scrollState = rememberScrollState()
     Column(modifier = modifier.fillMaxWidth()) {
         Text(
             text = "Up Next",
@@ -1652,43 +1189,41 @@ private fun EpisodesList(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(vertical = 8.dp)
         )
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
+        LazyRow(
+            modifier = Modifier.fillMaxSize(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(vertical = 4.dp)
+        ) {
             items(episodes) { ep ->
                 val isCurrent = ep.index == currentIndex
-                Row(
+                Column(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(
-                            if (isCurrent) MaterialTheme.colorScheme.primaryContainer
-                            else Color.Transparent
+                        .width(140.dp)
+                        .height(80.dp)
+                        .glassSurface(RoundedCornerShape(16.dp), alpha = if (isCurrent) 0.2f else 0.05f)
+                        .border(
+                            width = if (isCurrent) 1.dp else 0.dp,
+                            color = if (isCurrent) MaterialTheme.colorScheme.primary else Color.Transparent,
+                            shape = RoundedCornerShape(16.dp)
                         )
                         .clickable { onJumpToEpisode(ep.index) }
-                        .padding(horizontal = 12.dp, vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        .padding(12.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     if (isCurrent) {
-                        Icon(
-                            Icons.Default.PlayArrow,
-                            contentDescription = "Now playing",
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(20.dp)
-                        )
+                        Icon(Icons.Default.PlayArrow, contentDescription = "Now playing", tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp))
                     } else {
-                        Text(
-                            text = "${ep.index + 1}",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(20.dp),
-                            textAlign = TextAlign.Center
-                        )
+                        Text(text = "${ep.index + 1}", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, fontWeight = FontWeight.Bold)
                     }
+                    Spacer(modifier = Modifier.height(4.dp))
                     Text(
                         text = shortEpisodeLabel(ep.title),
-                        style = MaterialTheme.typography.bodyMedium,
+                        style = MaterialTheme.typography.bodySmall,
                         fontWeight = if (isCurrent) FontWeight.SemiBold else FontWeight.Normal,
-                        maxLines = 1
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center
                     )
                 }
             }
@@ -1696,8 +1231,6 @@ private fun EpisodesList(
     }
 }
 
-
-/** A row of compact dropdown chips for audio/subtitle track + a "More" settings button. */
 @Composable
 private fun TrackChipsRow(
     audioTracks: List<MediaTrack>,
@@ -1712,13 +1245,7 @@ private fun TrackChipsRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         if (audioTracks.isNotEmpty()) {
-            TrackChip(
-                icon = Icons.Default.VolumeUp,
-                label = "Audio",
-                tracks = audioTracks,
-                onSelect = onSelectAudio,
-                modifier = Modifier.weight(1f)
-            )
+            TrackChip(icon = Icons.Default.VolumeUp, label = "Audio", tracks = audioTracks, onSelect = onSelectAudio, modifier = Modifier.weight(1f))
         }
         if (subtitleTracks.isNotEmpty()) {
             val selectedName = subtitleTracks.firstOrNull { it.selected }?.name ?: "—"
@@ -1728,49 +1255,23 @@ private fun TrackChipsRow(
                 color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
                 modifier = Modifier.weight(1f).height(40.dp)
             ) {
-                Row(
-                    modifier = Modifier.padding(horizontal = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(6.dp)
-                ) {
-                    Icon(
-                        Icons.Default.Subtitles,
-                        contentDescription = "Subtitles",
-                        modifier = Modifier.size(18.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Text(
-                        text = "Subs: $selectedName",
-                        style = MaterialTheme.typography.labelLarge,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.weight(1f)
-                    )
-                    Icon(
-                        Icons.Default.ArrowDropDown,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                Row(modifier = Modifier.padding(horizontal = 12.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Icon(Icons.Default.Subtitles, contentDescription = "Subtitles", modifier = Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text(text = "Subs: $selectedName", style = MaterialTheme.typography.labelLarge, maxLines = 1, overflow = TextOverflow.Ellipsis, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.weight(1f))
+                    Icon(Icons.Default.ArrowDropDown, contentDescription = null, modifier = Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
         }
         if (audioTracks.isEmpty() && subtitleTracks.isEmpty()) {
             Spacer(modifier = Modifier.weight(1f))
         }
-        // "More" — opens the full player settings sheet.
         Surface(
             onClick = onMore,
             shape = RoundedCornerShape(20.dp),
             color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
             modifier = Modifier.height(40.dp)
         ) {
-            Row(
-                modifier = Modifier.padding(horizontal = 14.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(6.dp)
-            ) {
+            Row(modifier = Modifier.padding(horizontal = 14.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                 Icon(Icons.Default.Tune, contentDescription = "More", modifier = Modifier.size(18.dp))
                 Text("More", style = MaterialTheme.typography.labelLarge)
             }
@@ -1800,56 +1301,25 @@ private fun TrackChip(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            Icon(
-                icon,
-                contentDescription = label,
-                modifier = Modifier.size(18.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Text(
-                text = "$label: $selectedName",
-                style = MaterialTheme.typography.labelLarge,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.weight(1f)
-            )
-            Icon(
-                Icons.Default.ArrowDropDown,
-                contentDescription = null,
-                modifier = Modifier.size(18.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            Icon(icon, contentDescription = label, modifier = Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(text = "$label: $selectedName", style = MaterialTheme.typography.labelLarge, maxLines = 1, overflow = TextOverflow.Ellipsis, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.weight(1f))
+            Icon(Icons.Default.ArrowDropDown, contentDescription = null, modifier = Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
         }
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             tracks.forEach { track ->
                 DropdownMenuItem(
                     text = { Text(track.name) },
-                    onClick = {
-                        onSelect(track.id)
-                        expanded = false
-                    },
-                    leadingIcon = if (track.selected) {
-                        { Icon(Icons.Default.Check, contentDescription = "Selected") }
-                    } else null
+                    onClick = { onSelect(track.id); expanded = false },
+                    leadingIcon = if (track.selected) { { Icon(Icons.Default.Check, contentDescription = "Selected") } } else null
                 )
             }
         }
     }
 }
 
-
 private val EPISODE_MARKER = Regex("""S\d+\s*E\d+.*""", RegexOption.IGNORE_CASE)
+private fun shortEpisodeLabel(title: String): String = EPISODE_MARKER.find(title)?.value ?: title
 
-/**
- * Drop the redundant series-name prefix from an episode title for list display,
- * e.g. "Breaking Bad S2E5 - Breakage" -> "S2E5 - Breakage". Titles without an
- * SxEy marker (movies, single items) are left unchanged.
- */
-private fun shortEpisodeLabel(title: String): String =
-    EPISODE_MARKER.find(title)?.value ?: title
-
-/** Format milliseconds as m:ss (or h:mm:ss past an hour). */
 private fun formatTime(ms: Long): String {
     if (ms <= 0L) return "0:00"
     val totalSec = ms / 1000
@@ -1859,8 +1329,6 @@ private fun formatTime(ms: Long): String {
     return if (h > 0) "%d:%02d:%02d".format(h, m, s) else "%d:%02d".format(m, s)
 }
 
-
-/** Full player settings: mirrors the TV's settings panel (speed/scaling/audio/subtitle/filter/engine). */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun PlayerSettingsSheet(
@@ -1875,41 +1343,25 @@ private fun PlayerSettingsSheet(
 ) {
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 20.dp)
-                .padding(bottom = 24.dp),
+            modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).padding(horizontal = 20.dp).padding(bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            Text(
-                "Player settings",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold
-            )
+            Text("Player settings", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
 
             SettingRow("Speed") {
                 ChipGroup(
-                    options = listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f)
-                        .map { (if (it == 1.0f) "1x" else "${it}x") to it.toString() },
+                    options = listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f).map { (if (it == 1.0f) "1x" else "${it}x") to it.toString() },
                     selectedKey = settings.speed.toString(),
                     onSelect = { it.toFloatOrNull()?.let(onSetSpeed) }
                 )
             }
 
             SettingRow("Scaling") {
-                ChipGroup(
-                    options = listOf("Fit" to "Fit", "Fill" to "Fill", "Zoom" to "Zoom"),
-                    selectedKey = settings.scaling,
-                    onSelect = onSetScaling
-                )
+                ChipGroup(options = listOf("Fit" to "Fit", "Fill" to "Fill", "Zoom" to "Zoom"), selectedKey = settings.scaling, onSelect = onSetScaling)
             }
 
             SettingRow("Subtitle offset") {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                     FilledTonalButton(onClick = { onAdjustSubtitleOffset(-250L) }) { Text("−250ms") }
                     Text("${settings.subtitleOffsetMs} ms", style = MaterialTheme.typography.bodyMedium)
                     FilledTonalButton(onClick = { onAdjustSubtitleOffset(250L) }) { Text("+250ms") }
@@ -1922,14 +1374,7 @@ private fun PlayerSettingsSheet(
             }
 
             SettingRow("Player engine") {
-                ChipGroup(
-                    options = listOf(
-                        "ExoPlayer" to "exo",
-                        "MPV" to "mpv"
-                    ),
-                    selectedKey = settings.engine,
-                    onSelect = onSwitchEngine
-                )
+                ChipGroup(options = listOf("ExoPlayer" to "exo", "MPV" to "mpv"), selectedKey = settings.engine, onSelect = onSwitchEngine)
             }
 
             FilledTonalButton(onClick = onAddSubtitle, modifier = Modifier.fillMaxWidth()) {
@@ -1944,36 +1389,20 @@ private fun PlayerSettingsSheet(
 @Composable
 private fun SettingRow(label: String, content: @Composable () -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Text(
-            label,
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        Text(label, style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onSurfaceVariant)
         content()
     }
 }
 
 @Composable
-private fun ChipGroup(
-    options: List<Pair<String, String>>,
-    selectedKey: String,
-    onSelect: (String) -> Unit
-) {
-    Row(
-        modifier = Modifier.horizontalScroll(rememberScrollState()),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
+private fun ChipGroup(options: List<Pair<String, String>>, selectedKey: String, onSelect: (String) -> Unit) {
+    Row(modifier = Modifier.horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         options.forEach { (label, key) ->
-            FilterChip(
-                selected = key == selectedKey,
-                onClick = { onSelect(key) },
-                label = { Text(label) }
-            )
+            FilterChip(selected = key == selectedKey, onClick = { onSelect(key) }, label = { Text(label) })
         }
     }
 }
 
-/** Add an external subtitle to the TV: paste a URL, or search (when now-playing metadata is known). */
 @Composable
 private fun AddSubtitleDialog(
     onSearchSubtitles: (suspend () -> List<SubtitleOption>)?,
@@ -1987,9 +1416,7 @@ private fun AddSubtitleDialog(
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
 
-    val filePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent()
-    ) { uri: Uri? ->
+    val filePickerLauncher = rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) { uri: Uri? ->
         if (uri != null) {
             val fileName = runCatching {
                 val cursor = context.contentResolver.query(uri, null, null, null, null)
@@ -2006,11 +1433,7 @@ private fun AddSubtitleDialog(
                 return@rememberLauncherForActivityResult
             }
 
-            val mime = when {
-                fileName.endsWith(".vtt", ignoreCase = true) -> "text/vtt"
-                else -> "application/x-subrip"
-            }
-
+            val mime = when { fileName.endsWith(".vtt", ignoreCase = true) -> "text/vtt" else -> "application/x-subrip" }
             val proxyServer = com.playbridge.sender.cast.dlna.DlnaProxyHolder.proxy(context)
             val proxyUrl = proxyServer.publishLocal(uri, mime)
             val urlWithFragment = "$proxyUrl#${java.net.URLEncoder.encode(fileName, "UTF-8")}"
@@ -2023,29 +1446,13 @@ private fun AddSubtitleDialog(
         title = { Text("Add subtitle") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Button(
-                    onClick = { filePickerLauncher.launch("*/*") },
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.filledTonalButtonColors()
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.UploadFile,
-                        contentDescription = "Upload local file",
-                        modifier = Modifier.size(18.dp)
-                    )
+                Button(onClick = { filePickerLauncher.launch("*/*") }, modifier = Modifier.fillMaxWidth(), colors = ButtonDefaults.filledTonalButtonColors()) {
+                    Icon(imageVector = Icons.Default.UploadFile, contentDescription = "Upload local file", modifier = Modifier.size(18.dp))
                     Spacer(modifier = Modifier.width(8.dp))
                     Text("Choose Local Subtitle File")
                 }
-
                 HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-
-                OutlinedTextField(
-                    value = url,
-                    onValueChange = { url = it },
-                    label = { Text("Subtitle URL (.srt / .vtt)") },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
+                OutlinedTextField(value = url, onValueChange = { url = it }, label = { Text("Subtitle URL (.srt / .vtt)") }, singleLine = true, modifier = Modifier.fillMaxWidth())
                 if (onSearchSubtitles != null) {
                     FilledTonalButton(
                         onClick = {
@@ -2061,57 +1468,31 @@ private fun AddSubtitleDialog(
                     ) { Text(if (searching) "Searching…" else "Search subtitles") }
 
                     if (searched && results.isEmpty() && !searching) {
-                        Text(
-                            "No subtitles found",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                        Text("No subtitles found", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                     if (results.isNotEmpty()) {
                         LazyColumn(modifier = Modifier.heightIn(max = 220.dp)) {
                             items(results) { opt ->
-                                Text(
-                                    opt.label,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .clickable { onAddUrl(opt.url) }
-                                        .padding(vertical = 10.dp)
-                                )
+                                Text(opt.label, style = MaterialTheme.typography.bodyMedium, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.fillMaxWidth().clickable { onAddUrl(opt.url) }.padding(vertical = 10.dp))
                             }
                         }
                     }
                 }
             }
         },
-        confirmButton = {
-            TextButton(
-                onClick = { if (url.isNotBlank()) onAddUrl(url.trim()) },
-                enabled = url.isNotBlank()
-            ) { Text("Add") }
-        },
+        confirmButton = { TextButton(onClick = { if (url.isNotBlank()) onAddUrl(url.trim()) }, enabled = url.isNotBlank()) { Text("Add") } },
         dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }
     )
 }
-
 
 private const val OFF_KEY = "__off__"
 private const val EMBEDDED_KEY = "__embedded__"
 private const val REMOTE_KEY = "__remote__"
 private const val EXTERNAL_KEY = "__external__"
 
-private data class SubGroup(
-    val key: String,
-    val label: String,
-    val tracks: List<MediaTrack>,
-    val hasSelected: Boolean
-)
-
+private data class SubGroup(val key: String, val label: String, val tracks: List<MediaTrack>, val hasSelected: Boolean)
 private data class SubInfo(val langKey: String, val langDisplay: String, val optionLabel: String)
 
-// Mapping from language token to display name
 private val LANG_TOKENS: Map<String, String> = buildMap {
     fun add(display: String, vararg tokens: String) { tokens.forEach { put(it, display) } }
     add("English", "english", "en", "eng")
@@ -2153,18 +1534,11 @@ private val LANG_TOKENS: Map<String, String> = buildMap {
 private fun languageOf(segment: String): String? = LANG_TOKENS[segment.trim().lowercase()]
 
 private fun classifySub(t: MediaTrack): SubInfo {
-    if (t.id == "off" || t.id == "none") {
-        return SubInfo(OFF_KEY, "Off", "Off")
-    }
-
+    if (t.id == "off" || t.id == "none") return SubInfo(OFF_KEY, "Off", "Off")
     val isExternal = t.type == "external_sub" || t.id.startsWith("external_") || t.id.contains("://")
-    if (!isExternal) {
-        return SubInfo(EMBEDDED_KEY, "Embedded", t.name)
-    }
+    if (!isExternal) return SubInfo(EMBEDDED_KEY, "Embedded", t.name)
 
-    if (!t.name.contains("OpenSubtitles #")) {
-        return SubInfo(REMOTE_KEY, "Phone Remote", t.name.ifBlank { "Remote Subtitle" })
-    }
+    if (!t.name.contains("OpenSubtitles #")) return SubInfo(REMOTE_KEY, "Phone Remote", t.name.ifBlank { "Remote Subtitle" })
 
     val segs = t.name.split(" · ", " • ").map { it.trim() }.filter { it.isNotEmpty() }
     val lang = segs.firstNotNullOfOrNull { languageOf(it) }
@@ -2187,39 +1561,19 @@ private fun groupSubtitleTracks(tracks: List<MediaTrack>): List<SubGroup> {
     }
     
     val groups = mutableListOf<SubGroup>()
-    if (off != null) {
-        groups.add(SubGroup(OFF_KEY, "Off", listOf(off), off.selected))
-    }
-
-    byLang[EMBEDDED_KEY]?.let { (display, list) ->
-        groups.add(SubGroup(EMBEDDED_KEY, display, list, list.any { it.selected }))
-    }
-
-    byLang[REMOTE_KEY]?.let { (display, list) ->
-        groups.add(SubGroup(REMOTE_KEY, display, list, list.any { it.selected }))
-    }
-
-    byLang.filterKeys { it != EMBEDDED_KEY && it != REMOTE_KEY && it != EXTERNAL_KEY }.forEach { (k, v) ->
-        groups.add(SubGroup(k, v.first, v.second, v.second.any { it.selected }))
-    }
-
-    byLang[EXTERNAL_KEY]?.let { (display, list) ->
-        groups.add(SubGroup(EXTERNAL_KEY, display, list, list.any { it.selected }))
-    }
+    if (off != null) groups.add(SubGroup(OFF_KEY, "Off", listOf(off), off.selected))
+    byLang[EMBEDDED_KEY]?.let { (display, list) -> groups.add(SubGroup(EMBEDDED_KEY, display, list, list.any { it.selected })) }
+    byLang[REMOTE_KEY]?.let { (display, list) -> groups.add(SubGroup(REMOTE_KEY, display, list, list.any { it.selected })) }
+    byLang.filterKeys { it != EMBEDDED_KEY && it != REMOTE_KEY && it != EXTERNAL_KEY }.forEach { (k, v) -> groups.add(SubGroup(k, v.first, v.second, v.second.any { it.selected })) }
+    byLang[EXTERNAL_KEY]?.let { (display, list) -> groups.add(SubGroup(EXTERNAL_KEY, display, list, list.any { it.selected })) }
 
     return groups
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SubtitlesBottomSheet(
-    tracks: List<MediaTrack>,
-    onSelect: (String) -> Unit,
-    onDismiss: () -> Unit
-) {
+private fun SubtitlesBottomSheet(tracks: List<MediaTrack>, onSelect: (String) -> Unit, onDismiss: () -> Unit) {
     val groups = remember(tracks) { groupSubtitleTracks(tracks) }
-    
-    // Find the group that contains the currently selected track, or fallback to the first non-Off group, or the first group
     val initialGroupKey = remember(groups) {
         groups.firstOrNull { g -> g.tracks.any { it.selected } && g.key != OFF_KEY }?.key
             ?: groups.firstOrNull { it.key != OFF_KEY }?.key
@@ -2235,26 +1589,13 @@ private fun SubtitlesBottomSheet(
         dragHandle = { BottomSheetDefaults.DragHandle() }
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .navigationBarsPadding()
-                .padding(horizontal = 24.dp)
-                .padding(bottom = 24.dp)
+            modifier = Modifier.fillMaxWidth().navigationBarsPadding().padding(horizontal = 24.dp).padding(bottom = 24.dp)
         ) {
-            Text(
-                text = "Subtitles",
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-
+            Text("Subtitles", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Categories horizontal chips row
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .horizontalScroll(rememberScrollState()),
+                modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -2267,15 +1608,7 @@ private fun SubtitlesBottomSheet(
                             val countSuffix = if (group.key != OFF_KEY && group.tracks.isNotEmpty()) " (${group.tracks.size})" else ""
                             Text(group.label + countSuffix)
                         },
-                        leadingIcon = if (group.hasSelected) {
-                            {
-                                Icon(
-                                    imageVector = Icons.Default.Check,
-                                    contentDescription = "Active selection",
-                                    modifier = Modifier.size(16.dp)
-                                )
-                            }
-                        } else null,
+                        leadingIcon = if (group.hasSelected) { { Icon(Icons.Default.Check, "Active", Modifier.size(16.dp)) } } else null,
                         shape = RoundedCornerShape(20.dp)
                     )
                 }
@@ -2291,37 +1624,21 @@ private fun SubtitlesBottomSheet(
                     items(currentGroup.tracks, key = { it.id }) { track ->
                         val isSelected = track.selected
                         val displayLabel = if (currentGroup.key == OFF_KEY) "Off" else classifySub(track).optionLabel
-                        
                         Surface(
-                            onClick = {
-                                onSelect(track.id)
-                                onDismiss()
-                            },
+                            onClick = { onSelect(track.id); onDismiss() },
                             shape = RoundedCornerShape(12.dp),
                             color = if (isSelected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
                             border = if (isSelected) BorderStroke(1.dp, MaterialTheme.colorScheme.primary) else null,
                             modifier = Modifier.fillMaxWidth()
                         ) {
                             Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.SpaceBetween
                             ) {
-                                Text(
-                                    text = displayLabel,
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-                                    color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
-                                )
+                                Text(displayLabel, style = MaterialTheme.typography.bodyLarge, fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal, color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface)
                                 if (isSelected) {
-                                    Icon(
-                                        imageVector = Icons.Default.Check,
-                                        contentDescription = "Selected",
-                                        tint = MaterialTheme.colorScheme.primary,
-                                        modifier = Modifier.size(20.dp)
-                                    )
+                                    Icon(Icons.Default.Check, "Selected", tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp))
                                 }
                             }
                         }
@@ -2331,4 +1648,3 @@ private fun SubtitlesBottomSheet(
         }
     }
 }
-


### PR DESCRIPTION
This PR refactors and redesigns the phone remote control's screen layout and aesthetic style, improving UX and input efficiency.

### Summary of Changes:

1. **Segmented Mode Selector Row (`RemoteControlScreen.kt`):**
   - Replaced the dropdown `RemoteModeChip` in the app bar with a dedicated `RemoteModeSegmentedRow` right above the control panel.
   - Added dashboard, gamepad, touch, and keyboard icons to each mode option for instant visual recognition.

2. **UI & Layout Cleanup:**
   - Cleaned up redundant documentation and comments.
   - Simplified the view tree layout structure, collapsing spacing and styles to follow a unified alignment system.