### PR TITLE
chore: bump project versions and update changelogs for v0.6.0

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.0+18] — 2026-06-28
+
+### Added
+- **SAS Pairing Handshake**: Implemented the Secure Association Service (SAS) pairing flow, prompting the user with a short authentication string matching the phone for secure out-of-band receiver authentication. (#66)
+- **Pairing UI**: Integrated verification screens and validation flows into the pairing screen setup. (#66)
+
 ## [0.5.0+17] — 2026-06-22
 
 ### Added

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: playbridge_desktop
 description: "PlayBridge desktop receiver — accepts cast commands from the phone and plays via libmpv."
 publish_to: 'none'
-version: 0.5.0+17
+version: 0.6.0+18
 
 environment:
   sdk: ^3.6.0

--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.0] — 2026-06-28 (versionCode 212)
+
+### Added
+- **SAS Pairing Handshake**: Integrated Secure Association Service (SAS) pairing handshake using cryptographically verified short authentication strings (SAS) for secure receiver pairing. (#66)
+- **Premium Glassmorphic Remote**: Redesigned the remote control UI with a modern glassmorphic aesthetic, interactive touch targets, and a segmented controller for switching control modes. (#65)
+- **WorkManager Downloads Rewrite**: Completely overhauled the download engine with a `WorkManager`-backed queue, concurrent segment downloading, on-the-fly HLS to MP4 transmuxing, and proper `MediaStore` publishing. (#63)
+- **Cast Connection Routing**: Implemented a robust reconnect supervisor, connection routing framework, and optimized Foreground Service (FGS) behaviors for background casting durability. (#62)
+- **Reactive Watch Route**: Made the watch navigation route reactive and added exclusion filters to the logs viewer. (#64)
+
 ## [0.5.0] — 2026-06-22 (versionCode 211)
 
 ### Added

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 211
-        versionName = "0.5.0"
+        versionCode = 212
+        versionName = "0.6.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,13 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [0.6.0] — 2026-06-28 (versionCode 213)
+
+### Added
+- **SAS Pairing Handshake**: Implemented the Secure Association Service (SAS) pairing handshake using cryptographically verified short authentication strings (SAS) for secure, out-of-band receiver authentication. (#66)
+- **User Script Management**: Added a custom user script manager supporting dynamic JavaScript injection into the system WebView. (#61)
+- **YouTube Keep-Alive Script**: Integrated a YouTube keep-alive script to prevent media playback freezes in background WebView instances. (#61)
+
 ## Player [0.5.0] — 2026-06-22 (versionCode 212)
 
 ### Added

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 212
-        versionName = "0.5.0"
+        versionCode = 213
+        versionName = "0.6.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/apple/CHANGELOG.md
+++ b/tv/apple/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.0] — 2026-06-28 (build 5)
+
+### Added
+- **SAS Pairing Handshake**: Implemented the Secure Association Service (SAS) pairing handshake, generating and displaying short authentication strings for secure out-of-band authentication. (#66)
+- **Pairing View**: Updated the pairing UI with verification screens and controls to validate connecting senders. (#66)
+
 ## [0.2.0] — 2026-06-21 (build 4)
 
 ### Added

--- a/tv/apple/PlayBridge TV/PlayBridge TV.xcodeproj/project.pbxproj
+++ b/tv/apple/PlayBridge TV/PlayBridge TV.xcodeproj/project.pbxproj
@@ -345,7 +345,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsArbitraryLoadsForMedia = YES;
@@ -358,7 +358,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.playbridge.PlayBridge-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -378,7 +378,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsArbitraryLoadsForMedia = YES;
@@ -391,7 +391,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.playbridge.PlayBridge-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;


### PR DESCRIPTION
> [!WARNING]
> **BREAKING CHANGE INCLUDED:** This release uprevs project versions to v0.6.0, which ships the new cryptographically verified Short Authentication String (SAS) pairing handshake. Once deployed, older sender clients will be unable to pair with updated receivers, and vice versa. All sender clients and receivers must be updated together.

This PR bumps project version numbers and updates changelogs for the upcoming v0.6.0 release across the Android TV player, Android phone client, Apple TV receiver, and Desktop sender application.

### Version Bumps:
- **Android Phone Client:** Bumped to `0.6.0` (versionCode `212`)
- **Android TV Player:** Bumped to `0.6.0` (versionCode `213`)
- **Apple TV Receiver:** Bumped to `0.3.0` (build `5`)
- **Desktop Application:** Bumped to `0.6.0+18`