### PR TITLE
fix(android): resolve bundle tool signing failure by adding keyPassword fallback

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -39,9 +39,11 @@ android {
     signingConfigs {
         create("release") {
             storeFile = file("../../keystore/release.jks").absoluteFile
-            storePassword = System.getenv("PLAYBRIDGE_STORE_PASSWORD") ?: findProperty("PLAYBRIDGE_STORE_PASSWORD")?.toString()
+            val storePw = System.getenv("PLAYBRIDGE_STORE_PASSWORD") ?: findProperty("PLAYBRIDGE_STORE_PASSWORD")?.toString()
+            val keyPw = System.getenv("PLAYBRIDGE_KEY_PASSWORD") ?: findProperty("PLAYBRIDGE_KEY_PASSWORD")?.toString()
+            storePassword = storePw
             keyAlias = System.getenv("PLAYBRIDGE_KEY_ALIAS") ?: findProperty("PLAYBRIDGE_KEY_ALIAS")?.toString()
-            keyPassword = System.getenv("PLAYBRIDGE_KEY_PASSWORD") ?: findProperty("PLAYBRIDGE_KEY_PASSWORD")?.toString()
+            keyPassword = if (keyPw.isNullOrBlank()) storePw else keyPw
         }
     }
 

--- a/tv/android/geckoview-plugin/app/build.gradle.kts
+++ b/tv/android/geckoview-plugin/app/build.gradle.kts
@@ -35,9 +35,11 @@ android {
     signingConfigs {
         create("release") {
             storeFile = file("../../../keystore/release.jks").absoluteFile
-            storePassword = System.getenv("PLAYBRIDGE_STORE_PASSWORD") ?: findProperty("PLAYBRIDGE_STORE_PASSWORD")?.toString()
+            val storePw = System.getenv("PLAYBRIDGE_STORE_PASSWORD") ?: findProperty("PLAYBRIDGE_STORE_PASSWORD")?.toString()
+            val keyPw = System.getenv("PLAYBRIDGE_KEY_PASSWORD") ?: findProperty("PLAYBRIDGE_KEY_PASSWORD")?.toString()
+            storePassword = storePw
             keyAlias = System.getenv("PLAYBRIDGE_KEY_ALIAS") ?: findProperty("PLAYBRIDGE_KEY_ALIAS")?.toString()
-            keyPassword = System.getenv("PLAYBRIDGE_KEY_PASSWORD") ?: findProperty("PLAYBRIDGE_KEY_PASSWORD")?.toString()
+            keyPassword = if (keyPw.isNullOrBlank()) storePw else keyPw
         }
     }
 

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -45,9 +45,11 @@ android {
     signingConfigs {
         create("release") {
             storeFile = file("../../../keystore/release.jks").absoluteFile
-            storePassword = System.getenv("PLAYBRIDGE_STORE_PASSWORD") ?: findProperty("PLAYBRIDGE_STORE_PASSWORD")?.toString()
+            val storePw = System.getenv("PLAYBRIDGE_STORE_PASSWORD") ?: findProperty("PLAYBRIDGE_STORE_PASSWORD")?.toString()
+            val keyPw = System.getenv("PLAYBRIDGE_KEY_PASSWORD") ?: findProperty("PLAYBRIDGE_KEY_PASSWORD")?.toString()
+            storePassword = storePw
             keyAlias = System.getenv("PLAYBRIDGE_KEY_ALIAS") ?: findProperty("PLAYBRIDGE_KEY_ALIAS")?.toString()
-            keyPassword = System.getenv("PLAYBRIDGE_KEY_PASSWORD") ?: findProperty("PLAYBRIDGE_KEY_PASSWORD")?.toString()
+            keyPassword = if (keyPw.isNullOrBlank()) storePw else keyPw
         }
     }
 


### PR DESCRIPTION
This PR resolves the `signReleaseBundle` task failure in CI by adding a fallback for `keyPassword` to `storePassword` when it is blank or null.

### Root Cause:
The `bundletool` executable (used to build/sign Android App Bundles) strictly requires the `keyPassword` parameter. Unlike standard APK packaging (which automatically defaults to the `storePassword` if they are identical), `bundletool` crashes with `FinalizeBundleTask$BundleToolRunnable` if `keyPassword` is not explicitly set to a valid non-empty string. 

Because `PLAYBRIDGE_KEY_PASSWORD` is often left empty in repo secrets when the passwords are identical, the env var evaluates to `""`, causing the bundle tool run to crash.

### Solution:
Updated the `signingConfigs` block across all three Android apps to dynamically fall back to `storePassword` if `keyPassword` is blank:
- `mobile/android/app/build.gradle.kts`
- `tv/android/player/app/build.gradle.kts`
- `tv/android/geckoview-plugin/app/build.gradle.kts`