### PR TITLE
fix(tv): declare bluetooth hardware feature optional for play store compatibility

### DIFF
--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,16 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## GeckoView Plugin [0.3.1] — 2026-07-01 (versionCode 209)
+
+### Fixed
+- **Google Play TV Compatibility**: Declared `android.hardware.bluetooth` as optional in the plugin manifest to ensure wide device compatibility. (#70)
+
+## Player [0.7.1] — 2026-07-01 (versionCode 217)
+
+### Fixed
+- **Google Play TV Compatibility**: Declared `android.hardware.bluetooth` as optional to prevent Google Play from listing the player as incompatible on uncertified/generic TV boxes that do not support Bluetooth. (#70)
+
 ## GeckoView Plugin [0.3.0] — 2026-06-30 (versionCode 208)
 
 ### Added

--- a/tv/android/geckoview-plugin/app/build.gradle.kts
+++ b/tv/android/geckoview-plugin/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "com.playbridge.geckoview.plugin"
         minSdk = 26
         targetSdk = 36
-        versionCode = 208
-        versionName = "0.3.0"
+        versionCode = 209
+        versionName = "0.3.1"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/geckoview-plugin/app/src/main/AndroidManifest.xml
+++ b/tv/android/geckoview-plugin/app/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
     <uses-feature
         android:name="android.software.leanback"
         android:required="false" />
+    <uses-feature
+        android:name="android.hardware.bluetooth"
+        android:required="false" />
 
     <application
         android:name=".PlayBridgeBrowserApplication"

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 216
-        versionName = "0.7.0"
+        versionCode = 217
+        versionName = "0.7.1"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/player/app/src/main/AndroidManifest.xml
+++ b/tv/android/player/app/src/main/AndroidManifest.xml
@@ -49,6 +49,13 @@
     <uses-feature
         android:name="android.hardware.wifi"
         android:required="false" />
+    <!-- FOREGROUND_SERVICE_CONNECTED_DEVICE implicitly marks
+         android.hardware.bluetooth as REQUIRED, which makes Google Play list the app as
+         "not compatible" on generic/uncertified TV boxes that don't declare bluetooth features.
+         Declare it optional. See issue #70. -->
+    <uses-feature
+        android:name="android.hardware.bluetooth"
+        android:required="false" />
 
     <!-- Android 11+ Package Visibility Rules:
          Allow this app to query the system for other apps that can handle video playback intents.


### PR DESCRIPTION
This PR uprevs the Android TV Player (to `0.7.1`) and the GeckoView Plugin (to `0.3.1`) and declares `android.hardware.bluetooth` as optional in their manifests.

### Changes Summary

* **Android TV Player (`tv/android/player`)**:
  * **Google Play TV Compatibility**: Declared `android.hardware.bluetooth` as optional to prevent Google Play from listing the player as incompatible on uncertified/generic TV boxes that do not support Bluetooth. (#70)
  * **Uprevs & Changelog**: Updated player version to `0.7.1` (versionCode `217`) in [build.gradle.kts](file:///Users/atulmehla/repos/personal/playbridgeapp/PlayBridge/tv/android/player/app/build.gradle.kts) and updated [CHANGELOG.md](file:///Users/atulmehla/repos/personal/playbridgeapp/PlayBridge/tv/android/CHANGELOG.md).

* **GeckoView Plugin (`tv/android/geckoview-plugin`)**:
  * **Google Play TV Compatibility**: Declared `android.hardware.bluetooth` as optional in the plugin manifest to ensure wide device compatibility. (#70)
  * **Uprevs & Changelog**: Updated plugin version to `0.3.1` (versionCode `209`) in [build.gradle.kts](file:///Users/atulmehla/repos/personal/playbridgeapp/PlayBridge/tv/android/geckoview-plugin/app/build.gradle.kts) and updated [CHANGELOG.md](file:///Users/atulmehla/repos/personal/playbridgeapp/PlayBridge/tv/android/CHANGELOG.md).

### Verification
* Verified configuration compilation and version changes locally.
