### PR TITLE
fix(web): resolve android and tv download redirects and rate limits

### DIFF
--- a/web/site/functions/download/[platform].ts
+++ b/web/site/functions/download/[platform].ts
@@ -31,9 +31,9 @@ export const onRequestGet: PagesFunction<unknown, 'platform'> = async (context) 
     const finalArch = arch || 'universal';
     assetPattern = `^playbridge-tv-player-.*-${finalArch}-release\\.apk$`;
   } else if (cleanPlatform === 'tv-browser') {
-    tagPrefix = 'tv-browser-v';
+    tagPrefix = 'tv-geckoview-plugin-v';
     const finalArch = arch || 'universal';
-    assetPattern = `^playbridge-tv-browser-.*-${finalArch}-release\\.apk$`;
+    assetPattern = `^playbridge-tv-geckoview-plugin-.*-${finalArch}-release\\.apk$`;
   } else if (cleanPlatform === 'macos') {
     tagPrefix = 'desktop-v';
     assetPattern = '^playbridge-desktop-macos-.*\\.zip$';
@@ -63,13 +63,15 @@ export const onRequestGet: PagesFunction<unknown, 'platform'> = async (context) 
   }
 
   try {
-    const githubUrl = `https://api.github.com/repos/${GITHUB_REPO}/releases`;
-    const apiResponse = await fetch(githubUrl, {
-      headers: {
-        'User-Agent': 'PlayBridge-Downloader',
-        'Accept': 'application/vnd.github+json'
-      }
-    });
+    const githubUrl = `https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100`;
+    const headers: Record<string, string> = {
+      'User-Agent': 'PlayBridge-Downloader',
+      'Accept': 'application/vnd.github+json'
+    };
+    if (context.env && (context.env as any).GITHUB_TOKEN) {
+      headers['Authorization'] = `Bearer ${(context.env as any).GITHUB_TOKEN}`;
+    }
+    const apiResponse = await fetch(githubUrl, { headers });
 
     if (!apiResponse.ok) {
       throw new Error(`GitHub API returned status ${apiResponse.status}`);

--- a/web/site/static/_redirects
+++ b/web/site/static/_redirects
@@ -1,9 +1,9 @@
-# Short links to GitHub releases
-/android       https://github.com/playbridge/playbridge/releases/latest        302
-/androidtv     https://github.com/playbridge/playbridge-tv/releases/latest     302
-/appletv       https://github.com/playbridge/playbridge-tvos/releases/latest   302
-/desktop       https://github.com/playbridge/playbridge-desktop/releases/latest 302
-/firefox       https://github.com/playbridge/playbridge-firefox/releases/latest 302
-/github        https://github.com/playbridge                                   302
-/docs          https://github.com/playbridge/playbridge#documentation          302
-/contribute    https://github.com/playbridge/playbridge/blob/main/CONTRIBUTING.md 302
+# Short links to GitHub releases and assets
+/android       /download/android                                               302
+/androidtv     /download/tv-player                                             302
+/appletv       https://github.com/playbridgeapp/playbridge/tree/main/tv/apple  302
+/desktop       https://github.com/playbridgeapp/playbridge/releases            302
+/firefox       /download/firefox                                               302
+/github        https://github.com/playbridgeapp/playbridge                     302
+/docs          https://github.com/playbridgeapp/playbridge#documentation       302
+/contribute    https://github.com/playbridgeapp/playbridge/blob/main/CONTRIBUTING.md 302


### PR DESCRIPTION
### Summary
This PR fixes download redirection issues and 404 errors for the Android phone and TV platforms.

### Changes
1. **Dynamic Redirection Fixes (`web/site/functions/download/[platform].ts`)**:
   - Fixed the TV Browser plugin routing mapping (GitHub release tags use `tv-geckoview-plugin-v` and asset names match `playbridge-tv-geckoview-plugin-*.apk`, not `tv-browser-v`).
   - Added support for authenticating the GitHub API call with the `GITHUB_TOKEN` environment variable, avoiding rate limits on Cloudflare Pages.
   - Querying `per_page=100` releases to prevent pagination from cutting off older platforms.
2. **Static Redirects (`web/site/static/_redirects`)**:
   - Corrected the GitHub organization name from `playbridge` to `playbridgeapp` across all rules.
   - Updated the `/android` and `/androidtv` short links to redirect through the dynamic Cloudflare Pages functions (`/download/android` and `/download/tv-player`) for a direct-download experience instead of pointing to the releases list page.
