### PR TITLE
feat: in-app update check + install for phone and TV

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -68,13 +68,21 @@ jobs:
       if: steps.check_tag.outputs.skipped == 'false'
       run: chmod +x gradlew
 
-    - name: Build Release APK + AAB
+    - name: Build Release APK
       if: steps.check_tag.outputs.skipped == 'false'
       env:
         PLAYBRIDGE_STORE_PASSWORD: ${{ secrets.PLAYBRIDGE_STORE_PASSWORD }}
         PLAYBRIDGE_KEY_ALIAS: ${{ secrets.PLAYBRIDGE_KEY_ALIAS }}
         PLAYBRIDGE_KEY_PASSWORD: ${{ secrets.PLAYBRIDGE_KEY_PASSWORD }}
-      run: ./gradlew assembleRelease bundleRelease
+      run: ./gradlew assembleRelease
+
+    - name: Build Release AAB
+      if: steps.check_tag.outputs.skipped == 'false'
+      env:
+        PLAYBRIDGE_STORE_PASSWORD: ${{ secrets.PLAYBRIDGE_STORE_PASSWORD }}
+        PLAYBRIDGE_KEY_ALIAS: ${{ secrets.PLAYBRIDGE_KEY_ALIAS }}
+        PLAYBRIDGE_KEY_PASSWORD: ${{ secrets.PLAYBRIDGE_KEY_PASSWORD }}
+      run: ./gradlew bundleRelease
 
     - name: Rename outputs
       if: steps.check_tag.outputs.skipped == 'false'
@@ -160,13 +168,21 @@ jobs:
       if: steps.check_tag.outputs.skipped == 'false'
       run: chmod +x gradlew
 
-    - name: Build Release APK + AAB
+    - name: Build Release APK
       if: steps.check_tag.outputs.skipped == 'false'
       env:
         PLAYBRIDGE_STORE_PASSWORD: ${{ secrets.PLAYBRIDGE_STORE_PASSWORD }}
         PLAYBRIDGE_KEY_ALIAS: ${{ secrets.PLAYBRIDGE_KEY_ALIAS }}
         PLAYBRIDGE_KEY_PASSWORD: ${{ secrets.PLAYBRIDGE_KEY_PASSWORD }}
-      run: ./gradlew :player:app:assembleRelease :player:app:bundleRelease
+      run: ./gradlew :player:app:assembleRelease
+
+    - name: Build Release AAB
+      if: steps.check_tag.outputs.skipped == 'false'
+      env:
+        PLAYBRIDGE_STORE_PASSWORD: ${{ secrets.PLAYBRIDGE_STORE_PASSWORD }}
+        PLAYBRIDGE_KEY_ALIAS: ${{ secrets.PLAYBRIDGE_KEY_ALIAS }}
+        PLAYBRIDGE_KEY_PASSWORD: ${{ secrets.PLAYBRIDGE_KEY_PASSWORD }}
+      run: ./gradlew :player:app:bundleRelease
 
     - name: Rename outputs
       if: steps.check_tag.outputs.skipped == 'false'
@@ -252,13 +268,21 @@ jobs:
       if: steps.check_tag.outputs.skipped == 'false'
       run: chmod +x gradlew
 
-    - name: Build Release APK + AAB
+    - name: Build Release APK
       if: steps.check_tag.outputs.skipped == 'false'
       env:
         PLAYBRIDGE_STORE_PASSWORD: ${{ secrets.PLAYBRIDGE_STORE_PASSWORD }}
         PLAYBRIDGE_KEY_ALIAS: ${{ secrets.PLAYBRIDGE_KEY_ALIAS }}
         PLAYBRIDGE_KEY_PASSWORD: ${{ secrets.PLAYBRIDGE_KEY_PASSWORD }}
-      run: ./gradlew :geckoview-plugin:app:assembleRelease :geckoview-plugin:app:bundleRelease
+      run: ./gradlew :geckoview-plugin:app:assembleRelease
+
+    - name: Build Release AAB
+      if: steps.check_tag.outputs.skipped == 'false'
+      env:
+        PLAYBRIDGE_STORE_PASSWORD: ${{ secrets.PLAYBRIDGE_STORE_PASSWORD }}
+        PLAYBRIDGE_KEY_ALIAS: ${{ secrets.PLAYBRIDGE_KEY_ALIAS }}
+        PLAYBRIDGE_KEY_PASSWORD: ${{ secrets.PLAYBRIDGE_KEY_PASSWORD }}
+      run: ./gradlew :geckoview-plugin:app:bundleRelease
 
     - name: Rename outputs
       if: steps.check_tag.outputs.skipped == 'false'

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
     <!-- One-time user-approved exemption so Doze/OEM app-sleep can't freeze the
          local proxy while casting phone files with the app backgrounded. -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <!-- Self-update: install a downloaded APK when the app was sideloaded (not from Play). -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <!-- Explicitly remove QUERY_ALL_PACKAGES permission potentially merged from dependencies -->
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:node="remove" tools:ignore="QueryAllPackagesPermission" />
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/PlayBridgeApplication.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/PlayBridgeApplication.kt
@@ -32,5 +32,8 @@ class PlayBridgeApplication : Application() {
 
         // Start backup trigger
         BackupTrigger(this, applicationScope).start()
+
+        // Remove any leftover self-update APK from a previous session (cacheDir/updates).
+        com.playbridge.sender.update.ApkInstaller.cleanupStaleApks(this)
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
@@ -212,6 +212,7 @@ class BrowserActivity : ComponentActivity() {
     private val addonRepository: com.playbridge.sender.data.library.AddonRepository by inject()
     private val downloadRepository: com.playbridge.sender.downloads.engine.DownloadRepository by inject()
     private val browserViewModel: com.playbridge.sender.browser.BrowserViewModel by viewModel()
+    private val updateChecker: com.playbridge.sender.update.UpdateChecker by inject()
 
     /**
      * Phase-2 cutover: route browser/cast-sheet downloads through the new WorkManager
@@ -335,6 +336,9 @@ class BrowserActivity : ComponentActivity() {
         }
         VideoDetector.init(applicationContext)
 
+        // Fire-and-forget update check on cold start; only surfaces UI if a newer build exists.
+        updateChecker.check(manual = false)
+
         // Capture a web link that launched us (tapped in another app); consumed in Compose.
         pendingLinkUrl.value = parseLinkIntent(intent)
 
@@ -435,6 +439,11 @@ class BrowserActivity : ComponentActivity() {
                     TvDeviceGuard.dismiss(context)
                     showTvWarning = false
                 })
+            }
+            // Update-available notify / download / install flow. Gated behind the
+            // wrong-device dialog so we never stack two dialogs; it surfaces once that's gone.
+            if (!showTvWarning) {
+                com.playbridge.sender.update.UpdateGate(updateChecker)
             }
             val connectionState by connectionViewModel.connectionState.collectAsState()
             val activeDlnaTarget by connectionViewModel.activeDlnaTarget.collectAsState()

--- a/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
@@ -246,4 +246,13 @@ val appModule = module {
         )
     }
     single { SettingsRepository(get()) }
+
+    // 8. In-app update flow (sideload self-update vs Play Store redirect)
+    single { com.playbridge.sender.update.ApkInstaller(androidContext()) }
+    single {
+        com.playbridge.sender.update.UpdateChecker(
+            appContext = androidContext(),
+            installer = get(),
+        )
+    }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/settings/SettingsScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/settings/SettingsScreen.kt
@@ -266,15 +266,24 @@ private fun SettingsHubContent(
                 }
             }
             if (versionName != null) {
+                val updateChecker: com.playbridge.sender.update.UpdateChecker =
+                    org.koin.compose.koinInject()
+                val updateState by updateChecker.state.collectAsState()
+                val checking = updateState is
+                    com.playbridge.sender.update.UpdateState.Checking
+                // The dialog/progress UI itself is rendered once at the activity root
+                // (BrowserActivity); here we only expose the manual trigger.
+
                 Spacer(modifier = Modifier.height(12.dp))
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .clickable(enabled = !checking) { updateChecker.check(manual = true) }
                         .padding(16.dp),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        "Version $versionName",
+                        if (checking) "Checking for updates…" else "Version $versionName · Check for updates",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )

--- a/mobile/android/app/src/main/java/com/playbridge/sender/update/ApkInstaller.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/update/ApkInstaller.kt
@@ -1,0 +1,119 @@
+package com.playbridge.sender.update
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Downloads a phone-app APK and hands it to the system package installer.
+ *
+ * We deliberately use the classic `ACTION_VIEW` + [FileProvider] flow (rather than a
+ * silent `PackageInstaller` session): it shows the OS's own install screen that ends with
+ * a **Done / Open** choice, so the user stays in control and can relaunch via "Open".
+ */
+class ApkInstaller(private val appContext: Context) {
+
+    private val http: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .followRedirects(true)      // GitHub → release-assets host hop
+            .followSslRedirects(true)
+            .build()
+    }
+
+    /**
+     * Download [url] into `cacheDir/updates/update.apk`, reporting progress as a 0f..1f
+     * fraction (or null when the server sends no Content-Length). Returns the file.
+     */
+    suspend fun download(url: String, onProgress: (Float?) -> Unit): File =
+        withContext(Dispatchers.IO) {
+            val dir = File(appContext.cacheDir, "updates").apply { mkdirs() }
+            val out = File(dir, "update.apk")
+            if (out.exists()) out.delete()
+
+            val request = Request.Builder()
+                .url(url)
+                .header("User-Agent", "PlayBridge-Phone-Updater")
+                .build()
+
+            http.newCall(request).execute().use { resp ->
+                if (!resp.isSuccessful) throw IllegalStateException("Download HTTP ${resp.code}")
+                val body = resp.body ?: throw IllegalStateException("Empty download body")
+                val total = body.contentLength()
+                body.byteStream().use { input ->
+                    out.outputStream().use { output ->
+                        val buffer = ByteArray(64 * 1024)
+                        var downloaded = 0L
+                        var lastReported = -1
+                        while (true) {
+                            val read = input.read(buffer)
+                            if (read < 0) break
+                            output.write(buffer, 0, read)
+                            downloaded += read
+                            if (total > 0) {
+                                val pct = (downloaded * 100 / total).toInt()
+                                if (pct != lastReported) {
+                                    lastReported = pct
+                                    onProgress(downloaded.toFloat() / total)
+                                }
+                            } else {
+                                onProgress(null)
+                            }
+                        }
+                        output.flush()
+                    }
+                }
+            }
+            Log.i(TAG, "download: saved ${out.length()} bytes to $out")
+            out
+        }
+
+    /**
+     * Hand [apk] to the system installer via `ACTION_VIEW`. The OS renders the standard
+     * install UI (and its Done/Open completion screen). Requires the app to be allowed to
+     * install unknown apps — check with `canRequestPackageInstalls()` first.
+     */
+    fun launchInstall(apk: File) {
+        val authority = "${appContext.packageName}.fileprovider"
+        val uri = FileProvider.getUriForFile(appContext, authority, apk)
+        Log.i(TAG, "launchInstall: $uri")
+        val intent = Intent(Intent.ACTION_VIEW)
+            .setDataAndType(uri, "application/vnd.android.package-archive")
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        appContext.startActivity(intent)
+    }
+
+    companion object {
+        private const val TAG = "ApkInstaller"
+
+        /**
+         * Delete a leftover downloaded APK from a previous session once it's old enough
+         * that any install has finished reading it. Called on app startup.
+         *
+         * We only remove files older than [maxAgeMillis] (default 1h) so we never race a
+         * still-open system-installer session that's reading the file via its FileProvider
+         * URI. The in-session case is already handled: [download] deletes the prior file
+         * before writing a new one.
+         */
+        fun cleanupStaleApks(context: Context, maxAgeMillis: Long = 60 * 60 * 1000L) {
+            val dir = File(context.cacheDir, "updates")
+            val files = dir.listFiles() ?: return
+            val now = System.currentTimeMillis()
+            files.forEach { f ->
+                if (now - f.lastModified() > maxAgeMillis) {
+                    runCatching { f.delete() }
+                        .onSuccess { if (it) Log.i(TAG, "cleanup: deleted stale ${f.name}") }
+                }
+            }
+        }
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/update/UpdateChecker.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/update/UpdateChecker.kt
@@ -1,0 +1,280 @@
+package com.playbridge.sender.update
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Owns the "is there a newer phone build?" check and drives the update flow.
+ *
+ * Version resolution reuses the website's download endpoint instead of the GitHub API:
+ * a GET to [DOWNLOAD_ENDPOINT] with redirects disabled returns a `Location` pointing at
+ * the latest release asset, e.g.
+ * `…/releases/download/phone-v0.8.0/playbridge-phone-0.8.0-app-universal-release.apk`.
+ * We parse the version from the filename and keep the URL for the sideload download. This
+ * gives us both facts in one cached request with no API rate limits.
+ *
+ * Registered as a Koin singleton so cold-start and the Settings button share one [state].
+ */
+class UpdateChecker(
+    private val appContext: Context,
+    private val installer: ApkInstaller,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    private val _state = MutableStateFlow<UpdateState>(UpdateState.Idle)
+    val state: StateFlow<UpdateState> = _state.asStateFlow()
+
+    /** Guards against overlapping checks (cold start + a fast manual tap). */
+    private val checking = AtomicBoolean(false)
+
+    private val http: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .followRedirects(false) // we want to read the 302 Location ourselves
+            .followSslRedirects(false)
+            .build()
+    }
+
+    /**
+     * Check for a newer version.
+     *
+     * @param manual true when the user tapped "Check for updates" — surfaces Checking /
+     *   Up to date / Error states. Cold-start (false) stays silent unless an update exists.
+     */
+    fun check(manual: Boolean) {
+        if (!checking.compareAndSet(false, true)) return
+        // Don't stomp an in-flight download/install with a background check.
+        val current = _state.value
+        if (!manual && (current is UpdateState.Downloading ||
+                current is UpdateState.Installing ||
+                current is UpdateState.Available)
+        ) {
+            checking.set(false)
+            return
+        }
+        Log.i(TAG, "check(manual=$manual) starting")
+        _state.value = UpdateState.Checking(manual)
+        scope.launch {
+            val result = runCatching { resolveLatest() }
+            checking.set(false)
+            result.onSuccess { info ->
+                when {
+                    // null == already on the latest version (not an error).
+                    info == null -> {
+                        Log.i(TAG, "check: up to date")
+                        _state.value = if (manual) UpdateState.UpToDate else UpdateState.Idle
+                    }
+                    // Play Store users: on an automatic check, hold off nagging until the
+                    // build has been out long enough that the Store has likely rolled it
+                    // out. A manual check ignores the grace period.
+                    !manual && info.source == InstallSource.PLAY_STORE &&
+                        !isPlayGraceElapsed(info.version) -> {
+                        Log.i(
+                            TAG,
+                            "check: ${info.version} available but within Play rollout grace — suppressing"
+                        )
+                        _state.value = UpdateState.Idle
+                    }
+                    else -> {
+                        Log.i(TAG, "check: update available ${info.version} (${info.source})")
+                        _state.value = UpdateState.Available(info)
+                    }
+                }
+            }.onFailure { e ->
+                Log.w(TAG, "check: failed", e)
+                _state.value = if (manual) {
+                    UpdateState.Error(e.message ?: "Update check failed.", manual = true)
+                } else UpdateState.Idle
+            }
+        }
+    }
+
+    /** Resolve the latest [UpdateInfo], or null if there is nothing newer than installed. */
+    private suspend fun resolveLatest(): UpdateInfo? = withContext(Dispatchers.IO) {
+        val installed = installedVersion()
+            ?: throw IllegalStateException("Can't read installed version")
+        Log.d(TAG, "resolveLatest: installed=$installed, GET $DOWNLOAD_ENDPOINT")
+
+        // GET (not HEAD) with redirects disabled: the Cloudflare Pages function only
+        // handles GET, and a 302 carries no body, so this reads the Location header
+        // without downloading the APK.
+        val request = Request.Builder()
+            .url(DOWNLOAD_ENDPOINT)
+            .get()
+            .header("User-Agent", "PlayBridge-Phone-Updater")
+            .build()
+
+        http.newCall(request).execute().use { resp ->
+            Log.d(TAG, "resolveLatest: HTTP ${resp.code}, Location=${resp.header("Location")}")
+
+            if (!resp.isRedirect) {
+                throw IllegalStateException(
+                    "Expected a redirect from download endpoint but got HTTP ${resp.code}"
+                )
+            }
+            val location = resp.header("Location")
+                ?: throw IllegalStateException("Redirect (HTTP ${resp.code}) had no Location header")
+
+            val rawVersion = FILENAME_VERSION.find(location)?.groupValues?.getOrNull(1)
+            val latest = AppVersion.parse(rawVersion)
+                ?: throw IllegalStateException("Couldn't parse version from redirect: $location")
+            val source = installSource()
+            Log.d(TAG, "resolveLatest: latest=$latest, installed=$installed, source=$source")
+
+            if (latest <= installed) {
+                Log.d(TAG, "resolveLatest: no update (latest <= installed)")
+                return@withContext null
+            }
+
+            // Stamp the first time we saw this version so the Play grace window can start.
+            recordFirstSeen(latest)
+
+            UpdateInfo(version = latest, apkUrl = location, source = source)
+        }
+    }
+
+    /** User accepted an [UpdateState.Available] update. Branch on install source. */
+    fun accept(info: UpdateInfo) {
+        Log.i(TAG, "accept: ${info.version} via ${info.source}")
+        when (info.source) {
+            InstallSource.PLAY_STORE -> {
+                openPlayStore()
+                _state.value = UpdateState.Idle
+            }
+            InstallSource.SIDELOADED -> downloadAndInstall(info)
+        }
+    }
+
+    private fun downloadAndInstall(info: UpdateInfo) {
+        scope.launch {
+            Log.i(TAG, "downloadAndInstall: ${info.apkUrl}")
+            _state.value = UpdateState.Downloading(info, fraction = null)
+            val apk = runCatching {
+                installer.download(info.apkUrl) { fraction ->
+                    _state.value = UpdateState.Downloading(info, fraction)
+                }
+            }.getOrElse { e ->
+                Log.w(TAG, "APK download failed", e)
+                _state.value = UpdateState.Error(e.message ?: "Download failed.", manual = true)
+                return@launch
+            }
+            // Hand off to the system installer, which shows its own Done/Open screen.
+            // We can't observe its outcome, so just clear our UI once it's launched.
+            runCatching { installer.launchInstall(apk) }
+                .onSuccess {
+                    Log.i(TAG, "install: handed off to system installer")
+                    _state.value = UpdateState.Idle
+                }
+                .onFailure { e ->
+                    Log.w(TAG, "install: couldn't launch system installer", e)
+                    _state.value = UpdateState.Error(
+                        e.message ?: "Couldn't open the installer.", manual = true
+                    )
+                }
+        }
+    }
+
+    /** True when the app may install packages; otherwise route the user to grant it. */
+    fun canInstall(): Boolean = appContext.packageManager.canRequestPackageInstalls()
+
+    /** Open the system "install unknown apps" screen for this package. */
+    fun requestInstallPermission() {
+        val intent = Intent(
+            android.provider.Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+            Uri.parse("package:${appContext.packageName}"),
+        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        runCatching { appContext.startActivity(intent) }
+    }
+
+    fun dismiss() {
+        _state.value = UpdateState.Idle
+    }
+
+    private fun openPlayStore() {
+        val market = Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=${appContext.packageName}"))
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        val web = Intent(Intent.ACTION_VIEW, Uri.parse(PLAY_WEB_URL))
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        runCatching { appContext.startActivity(market) }
+            .recoverCatching { appContext.startActivity(web) }
+    }
+
+    private fun installedVersion(): AppVersion? = runCatching {
+        AppVersion.parse(
+            appContext.packageManager.getPackageInfo(appContext.packageName, 0).versionName
+        )
+    }.getOrNull()
+
+    private fun installSource(): InstallSource {
+        val pm = appContext.packageManager
+        val installer = runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                pm.getInstallSourceInfo(appContext.packageName).installingPackageName
+            } else {
+                @Suppress("DEPRECATION")
+                pm.getInstallerPackageName(appContext.packageName)
+            }
+        }.getOrNull()
+        Log.d(TAG, "installSource: installer package = $installer")
+        return if (installer == PLAY_STORE_PACKAGE) InstallSource.PLAY_STORE else InstallSource.SIDELOADED
+    }
+
+    private fun prefs() =
+        appContext.getSharedPreferences("update_checker", Context.MODE_PRIVATE)
+
+    /** Record when a given version was first seen (used to start the Play grace window). */
+    private fun recordFirstSeen(version: AppVersion) {
+        val key = "first_seen_$version"
+        val p = prefs()
+        if (!p.contains(key)) {
+            p.edit().putLong(key, System.currentTimeMillis()).apply()
+            Log.d(TAG, "recordFirstSeen: $version first seen now")
+        }
+    }
+
+    /**
+     * True once [PLAY_GRACE_MILLIS] has elapsed since we first detected [version] — i.e.
+     * the Store has had time to roll it out, so nudging a Play user is now reasonable.
+     */
+    private fun isPlayGraceElapsed(version: AppVersion): Boolean {
+        val firstSeen = prefs().getLong("first_seen_$version", System.currentTimeMillis())
+        val elapsed = System.currentTimeMillis() - firstSeen
+        val done = elapsed >= PLAY_GRACE_MILLIS
+        Log.d(TAG, "isPlayGraceElapsed($version): elapsed=${elapsed}ms, grace=${PLAY_GRACE_MILLIS}ms -> $done")
+        return done
+    }
+
+    companion object {
+        private const val TAG = "UpdateChecker"
+        private const val DOWNLOAD_ENDPOINT = "https://playbridge.app/download/android"
+        private const val PLAY_STORE_PACKAGE = "com.android.vending"
+        private const val PLAY_WEB_URL =
+            "https://play.google.com/store/apps/details?id=com.playbridge.sender"
+
+        /**
+         * How long after first detecting a new version we wait before nudging a Play Store
+         * user on an automatic check — Play rollout/propagation takes time and the Store
+         * auto-updates anyway. Manual checks ignore this. Currently 3 days.
+         */
+        private const val PLAY_GRACE_MILLIS = 3L * 24 * 60 * 60 * 1000
+
+        /** Matches `…playbridge-phone-0.8.0-…` in the resolved asset filename/URL. */
+        private val FILENAME_VERSION = Regex("""playbridge-phone-(\d+(?:\.\d+)+)""")
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/update/UpdateGate.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/update/UpdateGate.kt
@@ -1,0 +1,127 @@
+package com.playbridge.sender.update
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import android.widget.Toast
+import androidx.compose.runtime.collectAsState
+
+/**
+ * Renders the update flow driven by [UpdateChecker.state]. Drop it once near the top of
+ * the activity's composition; it shows nothing while [UpdateState.Idle].
+ *
+ * - [UpdateState.Available] → notify dialog (Play Store or sideload action)
+ * - [UpdateState.Downloading] / [UpdateState.Installing] → progress dialog
+ * - manual [UpdateState.Checking] / [UpdateState.UpToDate] / [UpdateState.Error] → toast
+ */
+@Composable
+fun UpdateGate(checker: UpdateChecker) {
+    val context = LocalContext.current
+    val state by checker.state.collectAsState()
+
+    // Lightweight feedback for the manual "Check for updates" path.
+    LaunchedEffect(state) {
+        when (val s = state) {
+            is UpdateState.UpToDate ->
+                Toast.makeText(context, "You're on the latest version.", Toast.LENGTH_SHORT).show()
+            is UpdateState.Error ->
+                if (s.manual) Toast.makeText(context, s.message, Toast.LENGTH_LONG).show()
+            else -> Unit
+        }
+    }
+
+    when (val s = state) {
+        is UpdateState.Available -> AvailableDialog(
+            info = s.info,
+            onAccept = {
+                if (s.info.source == InstallSource.SIDELOADED && !checker.canInstall()) {
+                    checker.requestInstallPermission()
+                } else {
+                    checker.accept(s.info)
+                }
+            },
+            onDismiss = checker::dismiss,
+        )
+
+        is UpdateState.Downloading -> ProgressDialog(
+            title = "Downloading ${s.info.version}",
+            fraction = s.fraction,
+        )
+
+        is UpdateState.Installing -> ProgressDialog(
+            title = "Installing ${s.info.version}",
+            fraction = null,
+        )
+
+        else -> Unit
+    }
+}
+
+@Composable
+private fun AvailableDialog(
+    info: UpdateInfo,
+    onAccept: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val isPlay = info.source == InstallSource.PLAY_STORE
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Update available") },
+        text = {
+            Text(
+                if (isPlay) {
+                    "Version ${info.version} is available. Open the Play Store to update."
+                } else {
+                    "Version ${info.version} is available. Download and install it now?"
+                }
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onAccept) {
+                Text(if (isPlay) "Open Play Store" else "Update")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Later") }
+        },
+    )
+}
+
+@Composable
+private fun ProgressDialog(title: String, fraction: Float?) {
+    AlertDialog(
+        onDismissRequest = { /* non-cancelable while working */ },
+        title = { Text(title) },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Spacer(Modifier.height(8.dp))
+                if (fraction != null) {
+                    LinearProgressIndicator(
+                        progress = { fraction.coerceIn(0f, 1f) },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        "${(fraction.coerceIn(0f, 1f) * 100).toInt()}%",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                } else {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+            }
+        },
+        confirmButton = {},
+    )
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/update/UpdateModels.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/update/UpdateModels.kt
@@ -1,0 +1,85 @@
+package com.playbridge.sender.update
+
+/**
+ * How the app was installed on this device. Decides which update path we take:
+ * a Play Store copy is sent to the store listing; anything else self-updates.
+ */
+enum class InstallSource {
+    /** Installed by Google Play (`com.android.vending`). */
+    PLAY_STORE,
+
+    /** Sideloaded APK, adb, or a third-party store — we handle the update ourselves. */
+    SIDELOADED,
+}
+
+/**
+ * A dotted-triple app version (e.g. `0.8.0`) parsed for comparison.
+ *
+ * Non-numeric suffixes are ignored so `0.8.0` and any future `0.8.0-rc1`-style tag still
+ * parse to their numeric core. Missing components default to 0 (`0.8` == `0.8.0`).
+ */
+data class AppVersion(val parts: List<Int>) : Comparable<AppVersion> {
+
+    override fun compareTo(other: AppVersion): Int {
+        val max = maxOf(parts.size, other.parts.size)
+        for (i in 0 until max) {
+            val a = parts.getOrElse(i) { 0 }
+            val b = other.parts.getOrElse(i) { 0 }
+            if (a != b) return a.compareTo(b)
+        }
+        return 0
+    }
+
+    override fun toString(): String = parts.joinToString(".")
+
+    companion object {
+        /** Parse `"0.8.0"` (or `null`/garbage → null). Trims a leading `v`. */
+        fun parse(raw: String?): AppVersion? {
+            if (raw.isNullOrBlank()) return null
+            val cleaned = raw.trim().removePrefix("v").removePrefix("V")
+            val parts = cleaned
+                .split('.')
+                .map { chunk -> chunk.takeWhile { it.isDigit() } }
+                .takeWhile { it.isNotEmpty() }
+                .map { it.toInt() }
+            return if (parts.isEmpty()) null else AppVersion(parts)
+        }
+    }
+}
+
+/**
+ * Details of an available update resolved from the download endpoint.
+ *
+ * @param version   latest version parsed from the release asset filename
+ * @param apkUrl    direct download URL for the sideload path (the redirect target)
+ * @param source    how the current app was installed — decides the update action
+ */
+data class UpdateInfo(
+    val version: AppVersion,
+    val apkUrl: String,
+    val source: InstallSource,
+)
+
+/** UI-facing state for the whole check → notify → download → install flow. */
+sealed interface UpdateState {
+    /** Nothing to show. */
+    data object Idle : UpdateState
+
+    /** A check is running. [manual] checks surface this; cold-start checks stay quiet. */
+    data class Checking(val manual: Boolean) : UpdateState
+
+    /** Already on the latest version. Only shown for [manual] checks. */
+    data object UpToDate : UpdateState
+
+    /** An update exists — show the notify dialog. */
+    data class Available(val info: UpdateInfo) : UpdateState
+
+    /** Downloading the APK (sideload path). [fraction] is 0f..1f, or null if size unknown. */
+    data class Downloading(val info: UpdateInfo, val fraction: Float?) : UpdateState
+
+    /** APK handed to the system installer; awaiting the user's confirm screen. */
+    data class Installing(val info: UpdateInfo) : UpdateState
+
+    /** Something failed. Only surfaced for [manual] checks (or an in-progress download). */
+    data class Error(val message: String, val manual: Boolean) : UpdateState
+}

--- a/mobile/android/app/src/main/res/xml/file_paths.xml
+++ b/mobile/android/app/src/main/res/xml/file_paths.xml
@@ -4,4 +4,6 @@
     <external-path name="downloads" path="Download/" />
     <!-- Exported log files shared from the in-app Logs viewer (cacheDir/logs/) -->
     <cache-path name="logs" path="logs/" />
+    <!-- Downloaded self-update APK handed to the system installer (cacheDir/updates/) -->
+    <cache-path name="updates" path="updates/" />
 </paths>

--- a/tv/android/player/app/src/main/AndroidManifest.xml
+++ b/tv/android/player/app/src/main/AndroidManifest.xml
@@ -19,6 +19,9 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- Self-update: install a downloaded APK when the app was sideloaded (not from Play). -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
     <!-- Auto-start on boot -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
@@ -226,6 +229,17 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </receiver>
+
+        <!-- FileProvider for handing the downloaded self-update APK to the system installer. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/tv/android/player/app/src/main/java/com/playbridge/player/MainActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/MainActivity.kt
@@ -84,6 +84,9 @@ class MainActivity : ComponentActivity() {
             _openPairingRequest.value = true
         }
 
+        // Fire-and-forget update check on cold start; only surfaces UI if a newer build exists.
+        com.playbridge.player.update.UpdateChecker.getInstance(this).check(manual = false)
+
         setContent {
             val appTheme = remember { mutableStateOf(AppTheme.fromPrefs(this)) }
             var showPhoneWarning by remember { mutableStateOf(DeviceGuard.shouldWarn(this)) }
@@ -105,6 +108,14 @@ class MainActivity : ComponentActivity() {
                         showOverlayRationale = false
                     },
                     onDismiss = { showOverlayRationale = false }
+                )
+            }
+            // Update-available notify / download / install flow. Gated behind the
+            // cold-start guard dialogs so we never stack two dialogs (bad with D-pad focus);
+            // once those are dismissed the update dialog surfaces on its own.
+            if (!showPhoneWarning && !showOverlayRationale) {
+                com.playbridge.player.update.UpdateGate(
+                    com.playbridge.player.update.UpdateChecker.getInstance(this)
                 )
             }
             PlayBridgeTVTheme(theme = appTheme.value) {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/PlayBridgeApplication.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/PlayBridgeApplication.kt
@@ -36,6 +36,9 @@ class PlayBridgeApplication : Application() {
 
         // Preload AdBlocker in background so filters are ready
         com.playbridge.player.browser.AdBlocker.preload(this)
+
+        // Remove any leftover self-update APK from a previous session (cacheDir/updates).
+        com.playbridge.player.update.ApkInstaller.cleanupStaleApks(this)
     }
 
 

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/SettingsScreen.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/SettingsScreen.kt
@@ -440,6 +440,22 @@ fun SettingsScreen(
                             )
                         }
                         item {
+                            val updateChecker = remember {
+                                com.playbridge.player.update.UpdateChecker.getInstance(context)
+                            }
+                            val updateState by updateChecker.state.collectAsState()
+                            val checking = updateState is
+                                com.playbridge.player.update.UpdateState.Checking
+                            // The dialog/progress UI itself is rendered once at the activity
+                            // root (MainActivity); here we only expose the manual trigger.
+                            SettingClickableItem(
+                                label = "Check for updates",
+                                description = if (checking) "Checking…" else "Tap to check for a newer version",
+                                enabled = !checking,
+                                onClick = { updateChecker.check(manual = true) }
+                            )
+                        }
+                        item {
                             SettingClickableItem(
                                 label = "GeckoView Engine (Optional Plugin)",
                                 description = if (isGeckoInstalled) "Installed" else "Not Installed (click to learn more/sideload)",

--- a/tv/android/player/app/src/main/java/com/playbridge/player/update/ApkInstaller.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/update/ApkInstaller.kt
@@ -1,0 +1,119 @@
+package com.playbridge.player.update
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Downloads a TV-player APK and hands it to the system package installer.
+ *
+ * We deliberately use the classic `ACTION_VIEW` + [FileProvider] flow (rather than a
+ * silent `PackageInstaller` session): it shows the OS's own install screen that ends with
+ * a **Done / Open** choice, so the user stays in control and can relaunch via "Open".
+ */
+class ApkInstaller(private val appContext: Context) {
+
+    private val http: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .followRedirects(true)      // GitHub → release-assets host hop
+            .followSslRedirects(true)
+            .build()
+    }
+
+    /**
+     * Download [url] into `cacheDir/updates/update.apk`, reporting progress as a 0f..1f
+     * fraction (or null when the server sends no Content-Length). Returns the file.
+     */
+    suspend fun download(url: String, onProgress: (Float?) -> Unit): File =
+        withContext(Dispatchers.IO) {
+            val dir = File(appContext.cacheDir, "updates").apply { mkdirs() }
+            val out = File(dir, "update.apk")
+            if (out.exists()) out.delete()
+
+            val request = Request.Builder()
+                .url(url)
+                .header("User-Agent", "PlayBridge-TV-Updater")
+                .build()
+
+            http.newCall(request).execute().use { resp ->
+                if (!resp.isSuccessful) throw IllegalStateException("Download HTTP ${resp.code}")
+                val body = resp.body ?: throw IllegalStateException("Empty download body")
+                val total = body.contentLength()
+                body.byteStream().use { input ->
+                    out.outputStream().use { output ->
+                        val buffer = ByteArray(64 * 1024)
+                        var downloaded = 0L
+                        var lastReported = -1
+                        while (true) {
+                            val read = input.read(buffer)
+                            if (read < 0) break
+                            output.write(buffer, 0, read)
+                            downloaded += read
+                            if (total > 0) {
+                                val pct = (downloaded * 100 / total).toInt()
+                                if (pct != lastReported) {
+                                    lastReported = pct
+                                    onProgress(downloaded.toFloat() / total)
+                                }
+                            } else {
+                                onProgress(null)
+                            }
+                        }
+                        output.flush()
+                    }
+                }
+            }
+            Log.i(TAG, "download: saved ${out.length()} bytes to $out")
+            out
+        }
+
+    /**
+     * Hand [apk] to the system installer via `ACTION_VIEW`. The OS renders the standard
+     * install UI (and its Done/Open completion screen). Requires the app to be allowed to
+     * install unknown apps — check with `canRequestPackageInstalls()` first.
+     */
+    fun launchInstall(apk: File) {
+        val authority = "${appContext.packageName}.fileprovider"
+        val uri = FileProvider.getUriForFile(appContext, authority, apk)
+        Log.i(TAG, "launchInstall: $uri")
+        val intent = Intent(Intent.ACTION_VIEW)
+            .setDataAndType(uri, "application/vnd.android.package-archive")
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        appContext.startActivity(intent)
+    }
+
+    companion object {
+        private const val TAG = "ApkInstaller"
+
+        /**
+         * Delete a leftover downloaded APK from a previous session once it's old enough
+         * that any install has finished reading it. Called on app startup.
+         *
+         * We only remove files older than [maxAgeMillis] (default 1h) so we never race a
+         * still-open system-installer session that's reading the file via its FileProvider
+         * URI. The in-session case is already handled: [download] deletes the prior file
+         * before writing a new one.
+         */
+        fun cleanupStaleApks(context: Context, maxAgeMillis: Long = 60 * 60 * 1000L) {
+            val dir = File(context.cacheDir, "updates")
+            val files = dir.listFiles() ?: return
+            val now = System.currentTimeMillis()
+            files.forEach { f ->
+                if (now - f.lastModified() > maxAgeMillis) {
+                    runCatching { f.delete() }
+                        .onSuccess { if (it) Log.i(TAG, "cleanup: deleted stale ${f.name}") }
+                }
+            }
+        }
+    }
+}

--- a/tv/android/player/app/src/main/java/com/playbridge/player/update/UpdateChecker.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/update/UpdateChecker.kt
@@ -1,0 +1,293 @@
+package com.playbridge.player.update
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Owns the "is there a newer TV-player build?" check and drives the update flow.
+ *
+ * Version resolution reuses the website's download endpoint instead of the GitHub API:
+ * a GET to [DOWNLOAD_ENDPOINT] with redirects disabled returns a `Location` pointing at
+ * the latest release asset, e.g.
+ * `…/releases/download/tv-player-v0.7.2/playbridge-tv-player-0.7.2-app-universal-release.apk`.
+ * We parse the version from the filename and keep the URL for the sideload download. This
+ * gives us both facts in one cached request with no API rate limits.
+ *
+ * The TV app has no DI container, so use [getInstance] for a process-wide singleton shared
+ * by [com.playbridge.player.MainActivity] (cold-start) and the Settings screen (manual).
+ */
+class UpdateChecker private constructor(
+    private val appContext: Context,
+    private val installer: ApkInstaller,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    private val _state = MutableStateFlow<UpdateState>(UpdateState.Idle)
+    val state: StateFlow<UpdateState> = _state.asStateFlow()
+
+    /** Guards against overlapping checks (cold start + a fast manual tap). */
+    private val checking = AtomicBoolean(false)
+
+    private val http: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .followRedirects(false) // we want to read the 302 Location ourselves
+            .followSslRedirects(false)
+            .build()
+    }
+
+    /**
+     * Check for a newer version.
+     *
+     * @param manual true when the user tapped "Check for updates" — surfaces Checking /
+     *   Up to date / Error states. Cold-start (false) stays silent unless an update exists.
+     */
+    fun check(manual: Boolean) {
+        if (!checking.compareAndSet(false, true)) return
+        // Don't stomp an in-flight download/install with a background check.
+        val current = _state.value
+        if (!manual && (current is UpdateState.Downloading ||
+                current is UpdateState.Installing ||
+                current is UpdateState.Available)
+        ) {
+            checking.set(false)
+            return
+        }
+        Log.i(TAG, "check(manual=$manual) starting")
+        _state.value = UpdateState.Checking(manual)
+        scope.launch {
+            val result = runCatching { resolveLatest() }
+            checking.set(false)
+            result.onSuccess { info ->
+                when {
+                    // null == already on the latest version (not an error).
+                    info == null -> {
+                        Log.i(TAG, "check: up to date")
+                        _state.value = if (manual) UpdateState.UpToDate else UpdateState.Idle
+                    }
+                    // Play Store users: on an automatic check, hold off nagging until the
+                    // build has been out long enough that the Store has likely rolled it
+                    // out. A manual check ignores the grace period.
+                    !manual && info.source == InstallSource.PLAY_STORE &&
+                        !isPlayGraceElapsed(info.version) -> {
+                        Log.i(
+                            TAG,
+                            "check: ${info.version} available but within Play rollout grace — suppressing"
+                        )
+                        _state.value = UpdateState.Idle
+                    }
+                    else -> {
+                        Log.i(TAG, "check: update available ${info.version} (${info.source})")
+                        _state.value = UpdateState.Available(info)
+                    }
+                }
+            }.onFailure { e ->
+                Log.w(TAG, "check: failed", e)
+                _state.value = if (manual) {
+                    UpdateState.Error(e.message ?: "Update check failed.", manual = true)
+                } else UpdateState.Idle
+            }
+        }
+    }
+
+    /** Resolve the latest [UpdateInfo], or null if there is nothing newer than installed. */
+    private suspend fun resolveLatest(): UpdateInfo? = withContext(Dispatchers.IO) {
+        val installed = installedVersion()
+            ?: throw IllegalStateException("Can't read installed version")
+        Log.d(TAG, "resolveLatest: installed=$installed, GET $DOWNLOAD_ENDPOINT")
+
+        // GET (not HEAD) with redirects disabled: the Cloudflare Pages function only
+        // handles GET, and a 302 carries no body, so this reads the Location header
+        // without downloading the APK.
+        val request = Request.Builder()
+            .url(DOWNLOAD_ENDPOINT)
+            .get()
+            .header("User-Agent", "PlayBridge-TV-Updater")
+            .build()
+
+        http.newCall(request).execute().use { resp ->
+            Log.d(TAG, "resolveLatest: HTTP ${resp.code}, Location=${resp.header("Location")}")
+
+            if (!resp.isRedirect) {
+                throw IllegalStateException(
+                    "Expected a redirect from download endpoint but got HTTP ${resp.code}"
+                )
+            }
+            val location = resp.header("Location")
+                ?: throw IllegalStateException("Redirect (HTTP ${resp.code}) had no Location header")
+
+            val rawVersion = FILENAME_VERSION.find(location)?.groupValues?.getOrNull(1)
+            val latest = AppVersion.parse(rawVersion)
+                ?: throw IllegalStateException("Couldn't parse version from redirect: $location")
+            val source = installSource()
+            Log.d(TAG, "resolveLatest: latest=$latest, installed=$installed, source=$source")
+
+            if (latest <= installed) {
+                Log.d(TAG, "resolveLatest: no update (latest <= installed)")
+                return@withContext null
+            }
+
+            // Stamp the first time we saw this version so the Play grace window can start.
+            recordFirstSeen(latest)
+
+            UpdateInfo(version = latest, apkUrl = location, source = source)
+        }
+    }
+
+    /** User accepted an [UpdateState.Available] update. Branch on install source. */
+    fun accept(info: UpdateInfo) {
+        Log.i(TAG, "accept: ${info.version} via ${info.source}")
+        when (info.source) {
+            InstallSource.PLAY_STORE -> {
+                openPlayStore()
+                _state.value = UpdateState.Idle
+            }
+            InstallSource.SIDELOADED -> downloadAndInstall(info)
+        }
+    }
+
+    private fun downloadAndInstall(info: UpdateInfo) {
+        scope.launch {
+            Log.i(TAG, "downloadAndInstall: ${info.apkUrl}")
+            _state.value = UpdateState.Downloading(info, fraction = null)
+            val apk = runCatching {
+                installer.download(info.apkUrl) { fraction ->
+                    _state.value = UpdateState.Downloading(info, fraction)
+                }
+            }.getOrElse { e ->
+                Log.w(TAG, "APK download failed", e)
+                _state.value = UpdateState.Error(e.message ?: "Download failed.", manual = true)
+                return@launch
+            }
+            // Hand off to the system installer, which shows its own Done/Open screen.
+            // We can't observe its outcome, so just clear our UI once it's launched.
+            runCatching { installer.launchInstall(apk) }
+                .onSuccess {
+                    Log.i(TAG, "install: handed off to system installer")
+                    _state.value = UpdateState.Idle
+                }
+                .onFailure { e ->
+                    Log.w(TAG, "install: couldn't launch system installer", e)
+                    _state.value = UpdateState.Error(
+                        e.message ?: "Couldn't open the installer.", manual = true
+                    )
+                }
+        }
+    }
+
+    /** True when the app may install packages; otherwise route the user to grant it. */
+    fun canInstall(): Boolean = appContext.packageManager.canRequestPackageInstalls()
+
+    /** Open the system "install unknown apps" screen for this package. */
+    fun requestInstallPermission() {
+        val intent = Intent(
+            android.provider.Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+            Uri.parse("package:${appContext.packageName}"),
+        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        runCatching { appContext.startActivity(intent) }
+    }
+
+    fun dismiss() {
+        _state.value = UpdateState.Idle
+    }
+
+    private fun openPlayStore() {
+        val market = Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=${appContext.packageName}"))
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        val web = Intent(Intent.ACTION_VIEW, Uri.parse(PLAY_WEB_URL))
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        runCatching { appContext.startActivity(market) }
+            .recoverCatching { appContext.startActivity(web) }
+    }
+
+    private fun installedVersion(): AppVersion? = runCatching {
+        AppVersion.parse(
+            appContext.packageManager.getPackageInfo(appContext.packageName, 0).versionName
+        )
+    }.getOrNull()
+
+    private fun installSource(): InstallSource {
+        val pm = appContext.packageManager
+        val installer = runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                pm.getInstallSourceInfo(appContext.packageName).installingPackageName
+            } else {
+                @Suppress("DEPRECATION")
+                pm.getInstallerPackageName(appContext.packageName)
+            }
+        }.getOrNull()
+        Log.d(TAG, "installSource: installer package = $installer")
+        return if (installer == PLAY_STORE_PACKAGE) InstallSource.PLAY_STORE else InstallSource.SIDELOADED
+    }
+
+    private fun prefs() =
+        appContext.getSharedPreferences("update_checker", Context.MODE_PRIVATE)
+
+    /** Record when a given version was first seen (used to start the Play grace window). */
+    private fun recordFirstSeen(version: AppVersion) {
+        val key = "first_seen_$version"
+        val p = prefs()
+        if (!p.contains(key)) {
+            p.edit().putLong(key, System.currentTimeMillis()).apply()
+            Log.d(TAG, "recordFirstSeen: $version first seen now")
+        }
+    }
+
+    /**
+     * True once [PLAY_GRACE_MILLIS] has elapsed since we first detected [version] — i.e.
+     * the Store has had time to roll it out, so nudging a Play user is now reasonable.
+     */
+    private fun isPlayGraceElapsed(version: AppVersion): Boolean {
+        val firstSeen = prefs().getLong("first_seen_$version", System.currentTimeMillis())
+        val elapsed = System.currentTimeMillis() - firstSeen
+        val done = elapsed >= PLAY_GRACE_MILLIS
+        Log.d(TAG, "isPlayGraceElapsed($version): elapsed=${elapsed}ms, grace=${PLAY_GRACE_MILLIS}ms -> $done")
+        return done
+    }
+
+    companion object {
+        private const val TAG = "UpdateChecker"
+        private const val DOWNLOAD_ENDPOINT = "https://playbridge.app/download/tv-player"
+        private const val PLAY_STORE_PACKAGE = "com.android.vending"
+        private const val PLAY_WEB_URL =
+            "https://play.google.com/store/apps/details?id=com.playbridge.player"
+
+        /**
+         * How long after first detecting a new version we wait before nudging a Play Store
+         * user on an automatic check — Play rollout/propagation takes time and the Store
+         * auto-updates anyway. Manual checks ignore this. Currently 3 days.
+         */
+        private const val PLAY_GRACE_MILLIS = 3L * 24 * 60 * 60 * 1000
+
+        /** Matches `…playbridge-tv-player-0.7.2-…` in the resolved asset filename/URL. */
+        private val FILENAME_VERSION = Regex("""playbridge-tv-player-(\d+(?:\.\d+)+)""")
+
+        @Volatile
+        private var instance: UpdateChecker? = null
+
+        /** Process-wide singleton (the TV app has no DI container). */
+        fun getInstance(context: Context): UpdateChecker =
+            instance ?: synchronized(this) {
+                instance ?: UpdateChecker(
+                    appContext = context.applicationContext,
+                    installer = ApkInstaller(context.applicationContext),
+                ).also { instance = it }
+            }
+    }
+}

--- a/tv/android/player/app/src/main/java/com/playbridge/player/update/UpdateGate.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/update/UpdateGate.kt
@@ -1,0 +1,129 @@
+package com.playbridge.player.update
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import android.widget.Toast
+
+/**
+ * Renders the update flow driven by [UpdateChecker.state]. Drop it once near the top of
+ * the activity's composition; it shows nothing while [UpdateState.Idle].
+ *
+ * Uses standard Material3 [AlertDialog] / [TextButton], whose buttons are D-pad focusable,
+ * so the whole flow is navigable with a TV remote.
+ *
+ * - [UpdateState.Available] → notify dialog (Play Store or sideload action)
+ * - [UpdateState.Downloading] / [UpdateState.Installing] → progress dialog
+ * - manual [UpdateState.UpToDate] / [UpdateState.Error] → toast
+ */
+@Composable
+fun UpdateGate(checker: UpdateChecker) {
+    val context = LocalContext.current
+    val state by checker.state.collectAsState()
+
+    LaunchedEffect(state) {
+        when (val s = state) {
+            is UpdateState.UpToDate ->
+                Toast.makeText(context, "You're on the latest version.", Toast.LENGTH_SHORT).show()
+            is UpdateState.Error ->
+                if (s.manual) Toast.makeText(context, s.message, Toast.LENGTH_LONG).show()
+            else -> Unit
+        }
+    }
+
+    when (val s = state) {
+        is UpdateState.Available -> AvailableDialog(
+            info = s.info,
+            onAccept = {
+                if (s.info.source == InstallSource.SIDELOADED && !checker.canInstall()) {
+                    checker.requestInstallPermission()
+                } else {
+                    checker.accept(s.info)
+                }
+            },
+            onDismiss = checker::dismiss,
+        )
+
+        is UpdateState.Downloading -> ProgressDialog(
+            title = "Downloading ${s.info.version}",
+            fraction = s.fraction,
+        )
+
+        is UpdateState.Installing -> ProgressDialog(
+            title = "Installing ${s.info.version}",
+            fraction = null,
+        )
+
+        else -> Unit
+    }
+}
+
+@Composable
+private fun AvailableDialog(
+    info: UpdateInfo,
+    onAccept: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val isPlay = info.source == InstallSource.PLAY_STORE
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Update available") },
+        text = {
+            Text(
+                if (isPlay) {
+                    "Version ${info.version} is available. Open the Play Store to update."
+                } else {
+                    "Version ${info.version} is available. Download and install it now?"
+                }
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onAccept) {
+                Text(if (isPlay) "Open Play Store" else "Update")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Later") }
+        },
+    )
+}
+
+@Composable
+private fun ProgressDialog(title: String, fraction: Float?) {
+    AlertDialog(
+        onDismissRequest = { /* non-cancelable while working */ },
+        title = { Text(title) },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Spacer(Modifier.height(8.dp))
+                if (fraction != null) {
+                    LinearProgressIndicator(
+                        progress = { fraction.coerceIn(0f, 1f) },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        "${(fraction.coerceIn(0f, 1f) * 100).toInt()}%",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                } else {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+            }
+        },
+        confirmButton = {},
+    )
+}

--- a/tv/android/player/app/src/main/java/com/playbridge/player/update/UpdateModels.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/update/UpdateModels.kt
@@ -1,0 +1,85 @@
+package com.playbridge.player.update
+
+/**
+ * How the app was installed on this device. Decides which update path we take:
+ * a Play Store copy is sent to the store listing; anything else self-updates.
+ */
+enum class InstallSource {
+    /** Installed by Google Play (`com.android.vending`). */
+    PLAY_STORE,
+
+    /** Sideloaded APK, adb, or a third-party store — we handle the update ourselves. */
+    SIDELOADED,
+}
+
+/**
+ * A dotted-triple app version (e.g. `0.7.2`) parsed for comparison.
+ *
+ * Non-numeric suffixes are ignored so `0.7.2` and any future `0.7.2-rc1`-style tag still
+ * parse to their numeric core. Missing components default to 0 (`0.7` == `0.7.0`).
+ */
+data class AppVersion(val parts: List<Int>) : Comparable<AppVersion> {
+
+    override fun compareTo(other: AppVersion): Int {
+        val max = maxOf(parts.size, other.parts.size)
+        for (i in 0 until max) {
+            val a = parts.getOrElse(i) { 0 }
+            val b = other.parts.getOrElse(i) { 0 }
+            if (a != b) return a.compareTo(b)
+        }
+        return 0
+    }
+
+    override fun toString(): String = parts.joinToString(".")
+
+    companion object {
+        /** Parse `"0.7.2"` (or `null`/garbage → null). Trims a leading `v`. */
+        fun parse(raw: String?): AppVersion? {
+            if (raw.isNullOrBlank()) return null
+            val cleaned = raw.trim().removePrefix("v").removePrefix("V")
+            val parts = cleaned
+                .split('.')
+                .map { chunk -> chunk.takeWhile { it.isDigit() } }
+                .takeWhile { it.isNotEmpty() }
+                .map { it.toInt() }
+            return if (parts.isEmpty()) null else AppVersion(parts)
+        }
+    }
+}
+
+/**
+ * Details of an available update resolved from the download endpoint.
+ *
+ * @param version   latest version parsed from the release asset filename
+ * @param apkUrl    direct download URL for the sideload path (the redirect target)
+ * @param source    how the current app was installed — decides the update action
+ */
+data class UpdateInfo(
+    val version: AppVersion,
+    val apkUrl: String,
+    val source: InstallSource,
+)
+
+/** UI-facing state for the whole check → notify → download → install flow. */
+sealed interface UpdateState {
+    /** Nothing to show. */
+    data object Idle : UpdateState
+
+    /** A check is running. [manual] checks surface this; cold-start checks stay quiet. */
+    data class Checking(val manual: Boolean) : UpdateState
+
+    /** Already on the latest version. Only shown for [manual] checks. */
+    data object UpToDate : UpdateState
+
+    /** An update exists — show the notify dialog. */
+    data class Available(val info: UpdateInfo) : UpdateState
+
+    /** Downloading the APK (sideload path). [fraction] is 0f..1f, or null if size unknown. */
+    data class Downloading(val info: UpdateInfo, val fraction: Float?) : UpdateState
+
+    /** APK handed to the system installer; awaiting the user's confirm screen. */
+    data class Installing(val info: UpdateInfo) : UpdateState
+
+    /** Something failed. Only surfaced for [manual] checks (or an in-progress download). */
+    data class Error(val message: String, val manual: Boolean) : UpdateState
+}

--- a/tv/android/player/app/src/main/res/xml/file_paths.xml
+++ b/tv/android/player/app/src/main/res/xml/file_paths.xml
@@ -2,4 +2,6 @@
 <paths>
     <!-- Matches getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS) where downloads are saved -->
     <external-files-path name="downloads" path="Download/" />
+    <!-- Downloaded self-update APK handed to the system installer (cacheDir/updates/) -->
+    <cache-path name="updates" path="updates/" />
 </paths>


### PR DESCRIPTION
Add a self-update flow to both the phone (sender) and TV (player) apps:
- Resolves the latest version from the /download/{android,tv-player}
  redirect filename (no GitHub API, reuses the cached website endpoint).
- Detects install source: Play Store installs are sent to the listing;
  sideloaded installs download the APK and hand it to the system
  installer via ACTION_VIEW + FileProvider (native Done/Open screen).
- Checks on cold start (silent unless newer) plus a manual
  'Check for updates' entry in Settings.
- Play rollout grace period so Play users aren't nudged before the
  Store has propagated a release; manual checks bypass it.
- Startup cleanup of stale downloaded APKs in cacheDir/updates.
- Update dialog gated behind cold-start guard dialogs to avoid stacking.
