### PR TITLE
fix(phone): lock touchpad two-finger gesture and uprev to 0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,15 @@ PlayBridge is an open-source casting suite: browse on your phone, play on the bi
 
 ## Features
 
-- **Browse & detect**: a full phone browser (GeckoView) that detects videos on the page — direct files, HLS, DASH, and MSE/blob players — and casts them with one tap.
-- **Library & discovery**: a Stremio-style library with catalogs, add-ons, and a watchlist; pick an episode and send it straight to the TV.
+- **Browse & detect**: a full phone browser (GeckoView, with built-in ad-blocking) that detects videos on the page — direct files, HLS, DASH, and MSE/blob players — and casts them with one tap.
+- **Library & discovery**: a Stremio-style library with catalogs, add-ons (including sandboxed JavaScript scrapers), a watchlist, and Collections; pick an episode and send it straight to the TV.
 - **Cast anywhere**: native receivers for Android TV / Fire TV, Apple TV, and desktop — or cast to any DLNA/UPnP renderer without installing anything on it.
 - **Binge-ready**: episode queue with lazy auto-advance, watch-progress tracking, and resume ("Resume · 23:14") that actually seeks the TV to where you left off.
 - **Phone as remote**: touchpad, D-pad, keyboard, and transport controls, context-aware for the browser and player.
-- **Local files**: cast videos from your phone's storage to any receiver.
+- **Local files & IPTV**: cast videos from your phone's storage to any receiver, and load M3U/IPTV playlists.
+- **Downloads**: save streams to your phone with a WorkManager-backed queue, on-the-fly HLS→MP4 transmuxing, and publishing to your gallery.
 - **Dual player engines**: ExoPlayer and MPV on the TV, with automatic fallback when a stream misbehaves.
+- **Secure pairing**: connections are verified with a short 6-digit code and encrypted over `wss://` with certificate pinning.
 - **Private by design**: everything stays on your local network — no account, no cloud, GPLv3.
 
 ## Installation
@@ -103,6 +105,7 @@ PlayBridge is an open-source casting suite: browse on your phone, play on the bi
 - **Desktop (receiver)**: download the build for your OS from [Releases](https://github.com/playbridgeapp/playbridge/releases) (`playbridge-desktop-windows-*.zip`, `-linux-*.tar.gz`, `-macos-*.zip`). Linux needs `libmpv2`; the macOS build is unsigned (right-click → Open on first launch).
 - **DLNA TVs**: nothing to install — the phone discovers renderers on your network automatically.
 - **Android Phone (sender)**: download the latest `phone` APK from [Releases](https://github.com/playbridgeapp/playbridge/releases) and install it.
+- **Staying up to date**: the phone and TV apps can check for new releases and install updates from within the app, so sideloaded builds don't go stale.
 
 ### Closed Testing (Google Play)
 
@@ -122,7 +125,7 @@ To participate in the Google Play closed testing track, you need to first join t
 1. Connect your phone and receiver to the **same Wi-Fi network**, and open the PlayBridge app on both.
 2. On the phone, tap the **device chip** (top of the Library and browser cast screens) — it lists discovered receivers. Tap yours to connect.
    - *Not discovered?* Tap **"All devices & manual connect"** and enter the receiver's IP address (shown on its screen).
-3. On first connect, the receiver asks **"Allow device to connect?"** — select **Allow** with your TV remote.
+3. On first connect, the receiver displays a **6-digit pairing code**. Enter it on the phone to verify and secure the connection — devices you've already paired reconnect automatically.
 4. Browse any video site in the phone browser, play a video, and tap cast when PlayBridge detects the stream — or send a movie/episode directly from the Library.
 
 ## Components

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -980,6 +980,8 @@ private fun SeekVolumeBar(
     }
 }
 
+private enum class TwoFingerMode { UNDECIDED, SCROLL, ZOOM }
+
 @Composable
 private fun TouchpadArea(
     onMouseMove: (dx: Float, dy: Float) -> Unit,
@@ -998,6 +1000,14 @@ private fun TouchpadArea(
             .glassSurface(RoundedCornerShape(24.dp), alpha = 0.05f)
             .pointerInput(Unit) {
                 awaitPointerEventScope {
+                    // Two-finger gesture is locked to one mode for its whole lifetime so a
+                    // scroll never flips into a zoom (or vice-versa) mid-drag. We accumulate
+                    // evidence until one axis clears the slop, then commit.
+                    var twoFingerMode = TwoFingerMode.UNDECIDED
+                    var accumZoom = 0f
+                    var accumPan = 0f
+                    val gestureSlop = 24f
+
                     while (true) {
                         val event = awaitPointerEvent()
                         val pointerCount = event.changes.count { it.pressed }
@@ -1011,12 +1021,27 @@ private fun TouchpadArea(
                                 val curDist = (a.position - b.position).getDistance()
                                 val prevDist = (a.previousPosition - b.previousPosition).getDistance()
                                 val panX = ((a.position.x + b.position.x) - (a.previousPosition.x + b.previousPosition.x)) / 2f
-                                val panY = ((a.position.y + b.previousPosition.y) - (a.previousPosition.y + b.previousPosition.y)) / 2f
+                                val panY = ((a.position.y + b.position.y) - (a.previousPosition.y + b.previousPosition.y)) / 2f
                                 val distDelta = curDist - prevDist
-                                if (prevDist > 0f && abs(distDelta) > abs(panY) && abs(distDelta) > abs(panX)) {
-                                    onPinchZoom(curDist / prevDist)
-                                } else {
-                                    onMouseScroll(panX, panY * 2f)
+
+                                if (twoFingerMode == TwoFingerMode.UNDECIDED) {
+                                    accumZoom += abs(distDelta)
+                                    accumPan += abs(panX) + abs(panY)
+                                    if (accumZoom > gestureSlop || accumPan > gestureSlop) {
+                                        twoFingerMode = if (accumZoom > accumPan) {
+                                            TwoFingerMode.ZOOM
+                                        } else {
+                                            TwoFingerMode.SCROLL
+                                        }
+                                    }
+                                }
+
+                                when (twoFingerMode) {
+                                    TwoFingerMode.ZOOM ->
+                                        if (prevDist > 0f) onPinchZoom(curDist / prevDist)
+                                    TwoFingerMode.SCROLL ->
+                                        onMouseScroll(panX, panY * 2f)
+                                    TwoFingerMode.UNDECIDED -> { /* still gathering slop */ }
                                 }
                                 a.consume(); b.consume()
                             }
@@ -1029,6 +1054,9 @@ private fun TouchpadArea(
                             }
                         } else if (pointerCount == 0) {
                             isScrolling = false
+                            twoFingerMode = TwoFingerMode.UNDECIDED
+                            accumZoom = 0f
+                            accumPan = 0f
                         }
                     }
                 }


### PR DESCRIPTION
This PR uprevs the Android Phone app to `0.8.1` (versionCode `217`), fixes the touchpad two-finger zoom/scroll gestures locking behavior, and updates the README details.

### Changes Summary

* **Android Phone App (`mobile/android`)**:
  * **Remote Touchpad Gestures**: Locked the two-finger touchpad gesture to a single mode (ZOOM or SCROLL) for its lifetime using accumulated drag distance, and fixed a typo in `panY` calculation where `b.previousPosition.y` was referenced instead of `b.position.y`.
  * **Uprevs & Changelog**: Updated Android Phone to `0.8.1` (versionCode `217`) in [build.gradle.kts](file:///Users/atulmehla/repos/personal/playbridgeapp/PlayBridge/mobile/android/app/build.gradle.kts) and updated [CHANGELOG.md](file:///Users/atulmehla/repos/personal/playbridgeapp/PlayBridge/mobile/android/CHANGELOG.md).
* **README**:
  * Added documentation details for newer feature additions (cosmetic ad-blocking, JS scraper add-ons, local casting & IPTV, WorkManager-backed downloads, secure WSS pairing with cert pinning, and in-app update checks).

### Verification
* Verified configuration compilation and version changes locally.
