### PR TITLE
chore: bump Android Phone version to 0.8.1 and update changelog

### DIFF
--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.1] — 2026-07-04 (versionCode 217)
+
+### Fixed
+- **Remote Touchpad Gestures**: Resolved touchpad two-finger gesture lock bugs by using accumulator logic to isolate zoom and scroll modes, and fixed a typo that miscalculated y-axis pan values.
+
 ## [0.8.0] — 2026-07-03 (versionCode 216)
 
 ### Added

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 216
-        versionName = "0.8.0"
+        versionCode = 217
+        versionName = "0.8.1"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
This PR uprevs the Android Phone app to version `0.8.1` (versionCode `217`) and updates its changelog for the touchpad two-finger scroll/zoom gesture fixes from PR #81.

### Changes Summary

* **Android Phone App (`mobile/android`)**:
  * **Uprevs & Changelog**: Updated Android Phone to `0.8.1` (versionCode `217`) in [build.gradle.kts](file:///Users/atulmehla/repos/personal/playbridgeapp/PlayBridge/mobile/android/app/build.gradle.kts) and updated [CHANGELOG.md](file:///Users/atulmehla/repos/personal/playbridgeapp/PlayBridge/mobile/android/CHANGELOG.md) to log the remote touchpad gesture fixes.

### Verification
* Verified configuration compilation and version changes locally.
