### PR TITLE
chore: bump Android Phone to 0.9.0 and TV Player to 0.8.0

### DIFF
--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.9.0] — 2026-07-04 (versionCode 217)
+
+### Added
+- **In-App Updates**: Implemented dynamic updates check on cold start, local APK downloader (`ApkInstaller`), and a manual "Check for updates" option in Settings.
+
+### Fixed
+- **Touchpad Area Gestures**: Locked the touchpad two-finger gestures to a single mode (zoom or scroll) for its lifetime using accumulator logic, and fixed a panY calculation typo.
+
 ## [0.8.0] — 2026-07-03 (versionCode 216)
 
 ### Added

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 216
-        versionName = "0.8.0"
+        versionCode = 217
+        versionName = "0.9.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,11 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [0.8.0] — 2026-07-04 (versionCode 219)
+
+### Added
+- **In-App Updates**: Implemented updates check on cold start, updates downloader, Settings integration, and update prompt dialog logic.
+
 ## GeckoView Plugin [0.3.2] — 2026-07-01 (versionCode 210)
 
 ### Fixed

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 218
-        versionName = "0.7.2"
+        versionCode = 219
+        versionName = "0.8.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
This PR uprevs the Android Phone and Android TV Player versions and updates their changelogs for the recently merged features (in-app updates and touchpad gesture fixes).

### Changes Summary

* **Android Phone App (`mobile/android`)**:
  * **Uprevs & Changelog**: Upreved Android Phone to `0.9.0` (versionCode `217`) in [build.gradle.kts](file:///Users/atulmehla/repos/personal/playbridgeapp/PlayBridge/mobile/android/app/build.gradle.kts) and updated [CHANGELOG.md](file:///Users/atulmehla/repos/personal/playbridgeapp/PlayBridge/mobile/android/CHANGELOG.md) to log in-app updates and touchpad area gesture fixes.

* **Android TV Player App (`tv/android/player`)**:
  * **Uprevs & Changelog**: Upreved TV Player to `0.8.0` (versionCode `219`) in [build.gradle.kts](file:///Users/atulmehla/repos/personal/playbridgeapp/PlayBridge/tv/android/player/app/build.gradle.kts) and updated [CHANGELOG.md](file:///Users/atulmehla/repos/personal/playbridgeapp/PlayBridge/tv/android/CHANGELOG.md) to log the self-update flow implementation.

### Verification
* Verified configuration compilation and version changes locally.
