### PR TITLE
ci: strip REQUEST_INSTALL_PACKAGES permission from Play Store bundles

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -76,6 +76,10 @@ jobs:
         PLAYBRIDGE_KEY_PASSWORD: ${{ secrets.PLAYBRIDGE_KEY_PASSWORD }}
       run: ./gradlew assembleRelease
 
+    - name: Strip restricted permissions for Play Store build
+      if: steps.check_tag.outputs.skipped == 'false'
+      run: sed -i '/REQUEST_INSTALL_PACKAGES/d' app/src/main/AndroidManifest.xml
+
     - name: Build Release AAB
       if: steps.check_tag.outputs.skipped == 'false'
       env:
@@ -175,6 +179,10 @@ jobs:
         PLAYBRIDGE_KEY_ALIAS: ${{ secrets.PLAYBRIDGE_KEY_ALIAS }}
         PLAYBRIDGE_KEY_PASSWORD: ${{ secrets.PLAYBRIDGE_KEY_PASSWORD }}
       run: ./gradlew :player:app:assembleRelease
+
+    - name: Strip restricted permissions for Play Store build
+      if: steps.check_tag.outputs.skipped == 'false'
+      run: sed -i '/REQUEST_INSTALL_PACKAGES/d' app/src/main/AndroidManifest.xml
 
     - name: Build Release AAB
       if: steps.check_tag.outputs.skipped == 'false'


### PR DESCRIPTION
This PR updates the CI build steps to dynamically strip the restricted `REQUEST_INSTALL_PACKAGES` permission from both the Android Phone and Android TV Player manifests before creating the release AAB bundles for the Play Store.

### Changes Summary

* **CI / Actions Workflow (`.github/workflows/android_build.yml`)**:
  * Added a step to run `sed -i '/REQUEST_INSTALL_PACKAGES/d' app/src/main/AndroidManifest.xml` after compiling the release APKs and before building the AAB packages.
  * This keeps the permission inside sideloaded APK releases (for self-update features) while ensuring Google Play Console compliance for store bundles.

### Verification
* Verified syntax of `sed` step alignment in both build jobs.
