### PR TITLE
fix(tv): declare touchscreen source for injected events and improve touchpad clicks

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheet.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheet.kt
@@ -440,14 +440,16 @@ fun CastSheet(
                 }
             }
 
-            // Compact player + TV selectors side by side
-            // Options reflect what the selected TV reported it supports (see TvCapabilityOptions).
-            val playerOptions = if (castAction == "browse") {
+            // Engine + proxy selectors side by side.
+            // The player-engine picker was removed from the cast sheet — play/queue always use
+            // the TV's own default player. In Browse mode we still offer the browser-engine
+            // picker (a separate capability), derived from what the selected TV reported.
+            val browserOptions = if (castAction == "browse") {
                 TvCapabilityOptions.browserOptions(selectedTvDevice)
             } else {
-                TvCapabilityOptions.playerOptions(selectedTvDevice)
+                emptyList()
             }
-            val selectedPlayerLabel = playerOptions.find { it.first == playerMode }?.second ?: "TV Default"
+            val selectedBrowserLabel = browserOptions.find { it.first == playerMode }?.second ?: "TV Default"
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -455,12 +457,14 @@ fun CastSheet(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                ChipDropdown(
-                    selectedLabel = selectedPlayerLabel,
-                    options = playerOptions,
-                    selectedValue = playerMode,
-                    onSelect = onPlayerModeChange
-                )
+                if (castAction == "browse") {
+                    ChipDropdown(
+                        selectedLabel = selectedBrowserLabel,
+                        options = browserOptions,
+                        selectedValue = playerMode,
+                        onSelect = onPlayerModeChange
+                    )
+                }
                 if (castAction != "browse" && proxyAvailable) {
                     ChipDropdown(
                         selectedLabel = proxyMode.label,

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -1008,6 +1008,12 @@ private fun TouchpadArea(
                     var accumPan = 0f
                     val gestureSlop = 24f
 
+                    var downTime = 0L
+                    var downPos = androidx.compose.ui.geometry.Offset.Zero
+                    var maxMoveDist = 0f
+                    val clickSlop = 15f // pixels
+                    val clickTimeout = 300L // ms
+
                     while (true) {
                         val event = awaitPointerEvent()
                         val pointerCount = event.changes.count { it.pressed }
@@ -1047,21 +1053,36 @@ private fun TouchpadArea(
                             }
                         } else if (pointerCount == 1 && !isScrolling) {
                             val change = event.changes.first()
+                            if (change.pressed && !change.previousPressed) {
+                                downTime = System.currentTimeMillis()
+                                downPos = change.position
+                                maxMoveDist = 0f
+                            }
                             if (change.pressed && change.previousPressed) {
                                 val delta = change.position - change.previousPosition
+                                val totalDist = (change.position - downPos).getDistance()
+                                if (totalDist > maxMoveDist) {
+                                    maxMoveDist = totalDist
+                                }
                                 onMouseMove(delta.x * 1.5f, delta.y * 1.5f)
                                 change.consume()
                             }
                         } else if (pointerCount == 0) {
+                            val upTime = System.currentTimeMillis()
+                            val duration = upTime - downTime
+                            if (!isScrolling && duration < clickTimeout && maxMoveDist < clickSlop && downTime > 0L) {
+                                onMouseClick()
+                            }
+
                             isScrolling = false
                             twoFingerMode = TwoFingerMode.UNDECIDED
                             accumZoom = 0f
                             accumPan = 0f
+                            downTime = 0L
                         }
                     }
                 }
             }
-            .pointerInput(Unit) { detectTapGestures(onTap = { onMouseClick() }) }
             .pointerInput(Unit) {
                 detectDragGesturesAfterLongPress(
                     onDragStart = { isDragging = true; onMouseDown() },

--- a/tv/android/geckoview-plugin/app/src/main/java/com/playbridge/geckoview/plugin/BrowserActivity.kt
+++ b/tv/android/geckoview-plugin/app/src/main/java/com/playbridge/geckoview/plugin/BrowserActivity.kt
@@ -250,6 +250,7 @@ class BrowserActivity : ComponentActivity() {
      */
     private fun dispatchTouchToActiveView(action: Int, x: Float, y: Float, downTime: Long, eventTime: Long) {
         val event = android.view.MotionEvent.obtain(downTime, eventTime, action, x, y, 0)
+        event.source = android.view.InputDevice.SOURCE_TOUCHSCREEN
         val targetView = engine?.getView()
         targetView?.dispatchTouchEvent(event)
         event.recycle()

--- a/tv/android/geckoview-plugin/app/src/main/java/com/playbridge/geckoview/plugin/GeckoViewEngine.kt
+++ b/tv/android/geckoview-plugin/app/src/main/java/com/playbridge/geckoview/plugin/GeckoViewEngine.kt
@@ -86,9 +86,11 @@ class GeckoViewEngine(
         val downEvent = MotionEvent.obtain(
             downTime, eventTime, MotionEvent.ACTION_DOWN, x, y, 0
         )
+        downEvent.source = android.view.InputDevice.SOURCE_TOUCHSCREEN
         val upEvent = MotionEvent.obtain(
             downTime, eventTime + 100, MotionEvent.ACTION_UP, x, y, 0
         )
+        upEvent.source = android.view.InputDevice.SOURCE_TOUCHSCREEN
 
         geckoView.dispatchTouchEvent(downEvent)
         geckoView.dispatchTouchEvent(upEvent)

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
@@ -480,6 +480,7 @@ class BrowserActivity : ComponentActivity() {
      */
     private fun dispatchTouchToActiveView(action: Int, x: Float, y: Float, downTime: Long, eventTime: Long) {
         val event = android.view.MotionEvent.obtain(downTime, eventTime, action, x, y, 0)
+        event.source = android.view.InputDevice.SOURCE_TOUCHSCREEN
         val targetView = when {
             fullscreenView != null -> fullscreenView
             else -> engine?.getView()

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
@@ -461,9 +461,11 @@ class SystemWebViewEngine(
         val downEvent = android.view.MotionEvent.obtain(
             downTime, eventTime, android.view.MotionEvent.ACTION_DOWN, x, y, 0
         )
+        downEvent.source = android.view.InputDevice.SOURCE_TOUCHSCREEN
         val upEvent = android.view.MotionEvent.obtain(
             downTime, eventTime + 100, android.view.MotionEvent.ACTION_UP, x, y, 0
         )
+        upEvent.source = android.view.InputDevice.SOURCE_TOUCHSCREEN
 
         webView.dispatchTouchEvent(downEvent)
         webView.dispatchTouchEvent(upEvent)


### PR DESCRIPTION
This PR addresses TV webview input source mapping, remote control touchpad click detection conflicts, and cast sheet UI cleanups.

### Changes Summary

* **Android TV Player / GeckoView Plugin**:
  * Set `source = InputDevice.SOURCE_TOUCHSCREEN` on injected `MotionEvent` touch and click events. This fixes issues where webviews ignored injected mouse events.
* **Android Phone App (`mobile/android`)**:
  * **Remote Touchpad Click Detection**: Refactored touchpad click tracking to determine taps natively inside the main drag pointer events handler. This avoids conflicts where drag events would block or be blocked by a separate `detectTapGestures` detector.
  * **Cast Sheet UI**: Aligned dropdown selector actions to only present browser engine options during Browse actions.

### Verification
* Verified compilation of sender and player modules.
