### PR TITLE
Android: playback, connection, media-notification and theme fixes

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
@@ -396,7 +396,13 @@ class BrowserActivity : ComponentActivity() {
         }
 
         setContent {
-            var currentScreen by remember {
+            // rememberSaveable + Screen.Saver: survives Activity recreation (memory-pressure
+            // destroy while the in-app player / another Activity is in front), so Back
+            // returns to the exact screen — e.g. a library detail page — instead of
+            // resetting to the persisted main tab.
+            var currentScreen by androidx.compose.runtime.saveable.rememberSaveable(
+                stateSaver = Screen.Saver
+            ) {
                 val sp = getSharedPreferences("browser_prefs", android.content.Context.MODE_PRIVATE)
                 // First launch (no main screen ever persisted) lands on the Dashboard,
                 // which doubles as the home for the one-time onboarding overlay.
@@ -2085,11 +2091,16 @@ class BrowserActivity : ComponentActivity() {
                     )
                 }
 
-                // Pairing/Connection Dialog Popup
+                // Pairing/Connection Dialog Popup. Also shown across the reconnect retry
+                // cycle (linear, 3 attempts) so the user sees progress and can bail out —
+                // Cancel routes playback to This Device instead of silently retrying.
                 val state = connectionState
+                val reconnect by connectionViewModel.reconnectStatus.collectAsState()
+                val isPairingState = state is WebSocketClient.ConnectionState.WaitingForCodeInput ||
+                    state is WebSocketClient.ConnectionState.VerifyingCode
                 if (state is WebSocketClient.ConnectionState.Connecting ||
-                    state is WebSocketClient.ConnectionState.WaitingForCodeInput ||
-                    state is WebSocketClient.ConnectionState.VerifyingCode) {
+                    isPairingState ||
+                    reconnect != null) {
 
                     var codeText by remember { mutableStateOf("") }
                     val focusRequester = remember { FocusRequester() }
@@ -2105,12 +2116,21 @@ class BrowserActivity : ComponentActivity() {
                     }
 
                     AlertDialog(
-                        onDismissRequest = { connectionViewModel.disconnect() },
+                        onDismissRequest = {
+                            if (isPairingState) connectionViewModel.disconnect()
+                            else connectionViewModel.cancelConnectingToThisDevice()
+                        },
                         title = {
                             Text(
-                                text = when (state) {
-                                    is WebSocketClient.ConnectionState.WaitingForCodeInput -> "Pairing with ${state.serverName}"
-                                    is WebSocketClient.ConnectionState.VerifyingCode -> "Verifying Code"
+                                text = when {
+                                    state is WebSocketClient.ConnectionState.WaitingForCodeInput ->
+                                        "Pairing with ${state.serverName}"
+                                    state is WebSocketClient.ConnectionState.VerifyingCode ->
+                                        "Verifying Code"
+                                    reconnect != null ->
+                                        "Reconnecting to ${reconnect?.deviceName ?: "TV"}"
+                                    state is WebSocketClient.ConnectionState.Connecting ->
+                                        "Connecting to ${state.serverName}"
                                     else -> "Connecting to TV"
                                 },
                                 style = MaterialTheme.typography.titleMedium,
@@ -2171,31 +2191,62 @@ class BrowserActivity : ComponentActivity() {
                                     ) {
                                         CircularProgressIndicator(modifier = Modifier.size(36.dp), strokeWidth = 3.dp)
                                     }
+                                    val rc = reconnect
                                     Text(
-                                        text = if (state is WebSocketClient.ConnectionState.VerifyingCode)
-                                            "Verifying code with ${state.serverName}…"
-                                        else
-                                            "Connecting to TV…",
+                                        text = when {
+                                            state is WebSocketClient.ConnectionState.VerifyingCode ->
+                                                "Verifying code with ${state.serverName}…"
+                                            rc != null ->
+                                                "Reconnecting… (attempt ${rc.attempt})"
+                                            state is WebSocketClient.ConnectionState.Connecting ->
+                                                "Connecting to ${state.serverName}…"
+                                            else -> "Connecting to TV…"
+                                        },
                                         style = MaterialTheme.typography.bodyMedium,
                                         textAlign = TextAlign.Center,
                                         modifier = Modifier.fillMaxWidth()
                                     )
+                                    if (rc != null || state is WebSocketClient.ConnectionState.Connecting) {
+                                        Text(
+                                            text = "Play on this device instead, or keep waiting for the TV.",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            textAlign = TextAlign.Center,
+                                            modifier = Modifier.fillMaxWidth()
+                                        )
+                                    }
                                 }
                             }
                         },
                         confirmButton = {
-                            if (state is WebSocketClient.ConnectionState.WaitingForCodeInput) {
-                                Button(
-                                    onClick = { connectionViewModel.submitPairingCode(codeText) },
-                                    enabled = codeText.length == 6
-                                ) {
-                                    Text("Verify")
+                            when {
+                                state is WebSocketClient.ConnectionState.WaitingForCodeInput -> {
+                                    Button(
+                                        onClick = { connectionViewModel.submitPairingCode(codeText) },
+                                        enabled = codeText.length == 6
+                                    ) {
+                                        Text("Verify")
+                                    }
+                                }
+                                // Reconnect cycle: let the user extend the retry window.
+                                reconnect != null -> {
+                                    Button(onClick = { connectionViewModel.keepTryingReconnect() }) {
+                                        Text("Keep trying")
+                                    }
                                 }
                             }
                         },
                         dismissButton = {
-                            TextButton(onClick = { connectionViewModel.disconnect() }) {
-                                Text("Cancel")
+                            TextButton(onClick = {
+                                if (isPairingState) {
+                                    connectionViewModel.disconnect()
+                                } else {
+                                    // Connecting/reconnecting: bail out to phone-local playback.
+                                    connectionViewModel.cancelConnectingToThisDevice()
+                                }
+                            }) {
+                                // The dismiss action means "play here" everywhere except pairing.
+                                Text(if (isPairingState) "Cancel" else "Play on this device")
                             }
                         }
                     )

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/Screen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/Screen.kt
@@ -28,4 +28,76 @@ sealed class Screen {
     data class IptvDetail(val playlistId: Long) : Screen()
     object Collections : Screen()
     data class CollectionDetail(val collectionId: Long) : Screen()
+
+    companion object {
+        /**
+         * Saver so the current screen survives Activity recreation (e.g. the shell being
+         * destroyed for memory while the in-app player sits in front of it — without this,
+         * Back from the player landed on the default Browser screen instead of where the
+         * user actually was, like a library detail page).
+         */
+        val Saver: androidx.compose.runtime.saveable.Saver<Screen, String> =
+            androidx.compose.runtime.saveable.Saver(
+                save = { screen ->
+                    when (screen) {
+                        Browser -> "browser"
+                        Tabs -> "tabs"
+                        Extensions -> "extensions"
+                        Connection -> "connection"
+                        Downloads -> "downloads"
+                        Settings -> "settings"
+                        History -> "history"
+                        CastHistory -> "casthistory"
+                        Bookmarks -> "bookmarks"
+                        Home -> "home"
+                        Remote -> "remote"
+                        Library -> "library"
+                        DebridLibrary -> "debridlibrary"
+                        AddonSettings -> "addonsettings"
+                        Dashboard -> "dashboard"
+                        PhoneFiles -> "phonefiles"
+                        Iptv -> "iptv"
+                        Collections -> "collections"
+                        is LibraryDetail -> "librarydetail|${screen.id}|${screen.type}|${screen.source ?: ""}"
+                        is IptvDetail -> "iptvdetail|${screen.playlistId}"
+                        is CollectionDetail -> "collectiondetail|${screen.collectionId}"
+                    }
+                },
+                restore = { value ->
+                    val parts = value.split("|")
+                    when (parts[0]) {
+                        "browser" -> Browser
+                        "tabs" -> Tabs
+                        "extensions" -> Extensions
+                        "connection" -> Connection
+                        "downloads" -> Downloads
+                        "settings" -> Settings
+                        "history" -> History
+                        "casthistory" -> CastHistory
+                        "bookmarks" -> Bookmarks
+                        "home" -> Home
+                        "remote" -> Remote
+                        "library" -> Library
+                        "debridlibrary" -> DebridLibrary
+                        "addonsettings" -> AddonSettings
+                        "dashboard" -> Dashboard
+                        "phonefiles" -> PhoneFiles
+                        "iptv" -> Iptv
+                        "collections" -> Collections
+                        "librarydetail" -> parts.getOrNull(1)?.let { id ->
+                            LibraryDetail(
+                                id = id,
+                                type = parts.getOrNull(2) ?: "movie",
+                                source = parts.getOrNull(3)?.takeIf { it.isNotEmpty() },
+                            )
+                        } ?: Browser
+                        "iptvdetail" -> parts.getOrNull(1)?.toLongOrNull()
+                            ?.let { IptvDetail(it) } ?: Browser
+                        "collectiondetail" -> parts.getOrNull(1)?.toLongOrNull()
+                            ?.let { CollectionDetail(it) } ?: Browser
+                        else -> Browser
+                    }
+                },
+            )
+    }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/SheetOverlayContainer.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/SheetOverlayContainer.kt
@@ -148,6 +148,15 @@ fun SheetOverlayContainer(
 
         // 3. Cast Sheet
         if (showVideoSheet) {
+            // Opening the cast sheet implies intent to play elsewhere: stop the page's
+            // own playback immediately, and leave it stopped across the sheet's lifetime
+            // and dismissal (no auto-resume — the user presses play on the page if they
+            // want local playback back). Runs once per sheet opening.
+            LaunchedEffect(Unit) {
+                val selectedId = Components.store.state.selectedTabId
+                val session = selectedId?.let { Components.tabManager.sessions[it] }
+                if (session != null) Components.tabManager.pauseMedia(session)
+            }
             val collectionsViewModel: com.playbridge.sender.collection.CollectionsViewModel = koinViewModel()
             val castSheetContext = LocalContext.current
             // Set when "Save to Collection" is tapped on a card → shows the collection picker.

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/TabManager.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/TabManager.kt
@@ -197,6 +197,12 @@ class TabManager {
                     val engineSession = tab.engineState.engineSession
                     if (engineSession != null) {
                         if (sessions[tab.id] !== engineSession) {
+                            // Session replaced (crash restore / recreation): the OLD
+                            // session's media observer dies without onMediaDeactivated —
+                            // drop its hold on the media notification (no-op otherwise).
+                            if (sessions[tab.id] != null) {
+                                com.playbridge.sender.cast.MediaPlaybackService.deactivate(tab.id)
+                            }
                             sessions[tab.id] = engineSession
                             engineSession.register(
                                 MediaSessionObserver(
@@ -464,6 +470,10 @@ class TabManager {
         crashGivenUp.remove(tabId)
         sessions.remove(tabId)
         VideoDetector.clearTab(tabId)
+        // A tab closed while its media session was active never fires
+        // onMediaDeactivated — release its hold on the media notification service
+        // here or the notification sticks around forever. No-op for other tabs.
+        com.playbridge.sender.cast.MediaPlaybackService.deactivate(tabId)
         // NOTE: the engine session itself is closed by EngineMiddleware
         // (TabsRemovedMiddleware) when the tab is removed from the store.
     }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
@@ -106,10 +106,22 @@ class CastSessionManager(
         _route.value = Route.ThisDevice
         persistBaseRoute("this")
         // Leaving the TV route: stop trying to keep the native link alive.
-        hasConnectedThisSession = false
-        reconnectAttempt = 0
-        reconnectJob?.cancel()
-        _reconnecting.value = false
+        stopReconnectSupervisor()
+    }
+
+    /**
+     * Stand the reconnect supervisor down. Runs inside the manager's single-threaded
+     * scope: callers are on arbitrary threads (UI picks, DLNA selection), while the
+     * supervisor's counters/job are otherwise only touched by scope coroutines.
+     */
+    private fun stopReconnectSupervisor() {
+        scope.launch {
+            hasConnectedThisSession = false
+            reconnectAttempt = 0
+            reconnectJob?.cancel()
+            _reconnecting.value = false
+            _reconnectStatus.value = null
+        }
     }
 
     /** User picked the native TV receiver. Connecting is a separate concern (caller/Stage B). */
@@ -343,6 +355,8 @@ class CastSessionManager(
                         reconnectAttempt = 0
                         reconnectJob?.cancel()
                         _reconnecting.value = false
+                        _reconnectStatus.value = null
+                        cancelReconnectGaveUpNotification()
                     }
                     is WebSocketClient.ConnectionState.Error,
                     is WebSocketClient.ConnectionState.Disconnected -> {
@@ -356,6 +370,7 @@ class CastSessionManager(
                         hasConnectedThisSession = false
                         reconnectJob?.cancel()
                         _reconnecting.value = false
+                        _reconnectStatus.value = null
                     }
                     else -> Unit
                 }
@@ -368,34 +383,82 @@ class CastSessionManager(
     private var reconnectAttempt = 0
     private var reconnectJob: Job? = null
 
+    /** What the "Reconnecting…" popup shows; null when no retry cycle is running. */
+    data class ReconnectStatus(val attempt: Int, val maxAttempts: Int, val deviceName: String)
+
+    private val _reconnectStatus = MutableStateFlow<ReconnectStatus?>(null)
+    val reconnectStatus: StateFlow<ReconnectStatus?> = _reconnectStatus.asStateFlow()
+
+    /**
+     * User pressed Cancel on the reconnect/connecting popup: stop chasing the TV and
+     * route playback to this phone.
+     */
+    fun cancelReconnect() {
+        _reconnectStatus.value = null
+        selectThisDevice() // also stands the supervisor down
+    }
+
+    /**
+     * User pressed "Keep trying" on the reconnect popup: refresh the retry budget and,
+     * if the supervisor had stood down, kick off a new cycle.
+     */
+    fun keepTryingReconnect() {
+        scope.launch {
+            reconnectAttempt = 0
+            if (reconnectJob?.isActive != true &&
+                _route.value is Route.NativeTv &&
+                hasConnectedThisSession
+            ) {
+                scheduleReconnect()
+            }
+        }
+    }
+
     private fun scheduleReconnect() {
         if (reconnectJob?.isActive == true) return
-        // Bound the effort: after RECONNECT_GIVE_UP attempts, stand down (release the FGS so
-        // we don't pin the process / show a misleading notification while the TV is gone).
-        // The user can reconnect manually, which resets the counter.
+        // Budget exhausted: how we stand down depends on whether the user is watching.
+        //  - Foreground (interactive): the user was actively using the TV; a route left
+        //    pointing at a dead receiver makes every play action fail, so fall back to
+        //    this phone and tell them (they can re-pick the TV, or hit "Keep trying").
+        //  - Background: never silently change the route — a screen-off session (episode
+        //    queue topping up) must resume on the TV when it returns. Just stand down and
+        //    notify; the foreground-return / Wi-Fi hooks re-arm and reconnect later.
         if (reconnectAttempt >= RECONNECT_GIVE_UP) {
-            Log.i(TAG, "Reconnect: giving up after $reconnectAttempt attempts")
             _reconnecting.value = false
+            _reconnectStatus.value = null
+            if (isForeground) {
+                Log.i(TAG, "Reconnect: gave up after $reconnectAttempt attempts (foreground) — routing to This Device")
+                selectThisDevice()
+                notifyReconnectGaveUp(backgrounded = false)
+            } else {
+                Log.i(TAG, "Reconnect: gave up after $reconnectAttempt attempts (background) — standing down, route unchanged")
+                notifyReconnectGaveUp(backgrounded = true)
+            }
             return
         }
         _reconnecting.value = true
         reconnectJob = scope.launch {
             val attempt = reconnectAttempt
             reconnectAttempt += 1
-            val step = attempt.coerceAtMost(RECONNECT_MAX_STEP)
-            val backoff = (RECONNECT_BASE_MS shl step).coerceAtMost(RECONNECT_MAX_MS)
-            val jitter = (0L..RECONNECT_JITTER_MS).random()
-            delay(backoff + jitter)
+            // Surface the retry cycle so the connecting popup can show progress (1-based).
+            val deviceName = runCatching { connectionStore.tvDevice.first() }.getOrNull()
+                ?.name ?: "TV"
+            _reconnectStatus.value = ReconnectStatus(attempt + 1, RECONNECT_GIVE_UP, deviceName)
+            // Linear pacing over a realistic window: real drops (router reboot, TV Wi-Fi
+            // waking from standby, AP roaming) take tens of seconds, so retry steadily for
+            // ~90s rather than giving up in a few. On a LAN a 3s retry is cheap.
+            delay(RECONNECT_DELAY_MS)
             // Re-check: the user may have switched route or a connection may have come up.
             if (_route.value !is Route.NativeTv) {
                 _reconnecting.value = false
+                _reconnectStatus.value = null
                 return@launch
             }
             val s = webSocketClient.connectionState.value
             if (s is WebSocketClient.ConnectionState.Connected ||
                 s is WebSocketClient.ConnectionState.Connecting
             ) return@launch
-            Log.d(TAG, "Reconnect attempt $attempt after ${backoff + jitter}ms")
+            Log.d(TAG, "Reconnect attempt ${attempt + 1}/$RECONNECT_GIVE_UP")
             // Pass the saved record: if discovery has UUID-matched the TV at a new address
             // (router restart / DHCP change), the attempt targets the fresh IP, not the
             // dead one cached from the previous socket.
@@ -412,6 +475,15 @@ class CastSessionManager(
     // runs for the NativeTv route. This hook reattaches on every return to the foreground.
     // ------------------------------------------------------------------
 
+    /**
+     * Whether the app is currently in the foreground. Drives the retry policy's key
+     * decision: an *interactive* reconnect (user watching) may auto-fall back to the
+     * phone when the TV can't be reached, but a *background* one must never silently
+     * change the route — it just stands down and notifies, so a backgrounded session
+     * (screen off, episode queue topping up) resumes on the TV when it returns.
+     */
+    @Volatile private var isForeground = false
+
     private fun registerForegroundObserver() {
         // ProcessLifecycleOwner must be touched on the main thread; Koin may build this
         // singleton off it.
@@ -419,7 +491,12 @@ class CastSessionManager(
             androidx.lifecycle.ProcessLifecycleOwner.get().lifecycle.addObserver(
                 object : androidx.lifecycle.DefaultLifecycleObserver {
                     override fun onStart(owner: androidx.lifecycle.LifecycleOwner) {
+                        isForeground = true
                         onAppForegrounded()
+                    }
+
+                    override fun onStop(owner: androidx.lifecycle.LifecycleOwner) {
+                        isForeground = false
                     }
                 }
             )
@@ -435,16 +512,19 @@ class CastSessionManager(
      * scheduled backoff tick (if any is even pending).
      */
     private fun attemptRecovery(reason: String) {
-        // Fresh retry budget: conditions changed, so a TV that took longer than the
-        // backoff window to come back (e.g. router reboot) gets retried.
-        reconnectAttempt = 0
-        if (!routePrefs.getBoolean("auto_connect_tv", true)) return
-        val state = webSocketClient.connectionState.value
-        val eligible = state is WebSocketClient.ConnectionState.Disconnected ||
-            state is WebSocketClient.ConnectionState.Error
-        if (!eligible) return
-        Log.d(TAG, "attemptRecovery($reason)")
+        // Callers arrive on arbitrary threads (main-thread lifecycle observer,
+        // ConnectivityManager binder thread) — hop into the manager's single-threaded
+        // scope before touching supervisor state so nothing races the reconnect loop.
         scope.launch {
+            if (!routePrefs.getBoolean("auto_connect_tv", true)) return@launch
+            val state = webSocketClient.connectionState.value
+            val eligible = state is WebSocketClient.ConnectionState.Disconnected ||
+                state is WebSocketClient.ConnectionState.Error
+            if (!eligible) return@launch
+            // Fresh retry budget: conditions changed, so a TV that took longer than the
+            // backoff window to come back (e.g. router reboot) gets retried.
+            reconnectAttempt = 0
+            Log.d(TAG, "attemptRecovery($reason)")
             // reconnect() internally no-ops when there was no prior link this process
             // (cold start — ConnectionViewModel's auto-connect owns that) or when the
             // user disconnected deliberately.
@@ -493,10 +573,7 @@ class CastSessionManager(
         _route.value = Route.Dlna(device.uuid, device.name)
         // DLNA is a cast target → mirror "watch on TV" for legacy readers.
         routePrefs.edit().putBoolean("watch_on_tv", true).apply()
-        hasConnectedThisSession = false
-        reconnectAttempt = 0
-        reconnectJob?.cancel()
-        _reconnecting.value = false
+        stopReconnectSupervisor()
         dlnaStatusJob = scope.launch { target.status().collect { _dlnaStatus.value = it } }
         Log.d(TAG, "Active DLNA target: ${device.name} ($controlUrl)")
     }
@@ -599,6 +676,60 @@ class CastSessionManager(
         }.onFailure { Log.w(TAG, "Battery-optimization exemption request failed", it) }
     }
 
+    /**
+     * One-shot "Lost connection to your TV" notification when the reconnect supervisor
+     * exhausts its retry budget. Best-effort: wrapped so a missing POST_NOTIFICATIONS
+     * grant (API 33+) or OEM quirk can never break the supervisor.
+     *
+     * [backgrounded] tailors the message: a background stand-down left the route on the
+     * TV (it'll resume when reachable), while a foreground give-up switched to the phone.
+     */
+    private fun notifyReconnectGaveUp(backgrounded: Boolean) {
+        runCatching {
+            val mgr = context.getSystemService(Context.NOTIFICATION_SERVICE)
+                as android.app.NotificationManager
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O &&
+                mgr.getNotificationChannel(RECONNECT_CHANNEL_ID) == null
+            ) {
+                mgr.createNotificationChannel(
+                    android.app.NotificationChannel(
+                        RECONNECT_CHANNEL_ID,
+                        "TV connection",
+                        android.app.NotificationManager.IMPORTANCE_DEFAULT,
+                    )
+                )
+            }
+            val contentPi = context.packageManager.getLaunchIntentForPackage(context.packageName)
+                ?.let { launch ->
+                    android.app.PendingIntent.getActivity(
+                        context, 0, launch,
+                        android.app.PendingIntent.FLAG_UPDATE_CURRENT or
+                            android.app.PendingIntent.FLAG_IMMUTABLE,
+                    )
+                }
+            val message = if (backgrounded) {
+                "Couldn't reach your TV. It'll reconnect when you reopen the app."
+            } else {
+                "Playback switched to this phone. Pick the TV again to reconnect."
+            }
+            val notif = androidx.core.app.NotificationCompat.Builder(context, RECONNECT_CHANNEL_ID)
+                .setSmallIcon(com.playbridge.sender.R.drawable.ic_launcher_foreground)
+                .setContentTitle("Lost connection to your TV")
+                .setContentText(message)
+                .setAutoCancel(true)
+                .apply { contentPi?.let { setContentIntent(it) } }
+                .build()
+            mgr.notify(RECONNECT_NOTIF_ID, notif)
+        }.onFailure { Log.w(TAG, "Could not post reconnect notification: ${it.message}") }
+    }
+
+    private fun cancelReconnectGaveUpNotification() {
+        runCatching {
+            (context.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager)
+                .cancel(RECONNECT_NOTIF_ID)
+        }
+    }
+
     /** Stop playback on the active target and end the session (notification Stop action). */
     fun endSession() {
         val dlna = _dlnaCast.value
@@ -611,7 +742,7 @@ class CastSessionManager(
         if (native != null) {
             scope.launch { runCatching { native.stop() } } // also flips tvActiveContext → "idle"
         } else {
-            connectionCoordinator.tvActiveContext.value = "idle"
+            connectionCoordinator.markIdle()
         }
     }
 
@@ -619,12 +750,14 @@ class CastSessionManager(
         /** How long a session may be "inactive" before the FGS is torn down. */
         private const val STOP_GRACE_MS = 3_000L
 
-        // Reconnect backoff: 1s, 2s, 4s, 8s, then capped at 10s, each with up to 0.5s jitter.
-        private const val RECONNECT_BASE_MS = 1_000L
-        private const val RECONNECT_MAX_MS = 10_000L
-        private const val RECONNECT_JITTER_MS = 500L
-        private const val RECONNECT_MAX_STEP = 4
-        // Stop retrying after this many consecutive failed attempts (~1 minute of backoff).
-        private const val RECONNECT_GIVE_UP = 8
+        // Linear retry pacing: a fixed pause before each attempt (no exponential backoff).
+        private const val RECONNECT_DELAY_MS = 3_000L
+        // ~90s window (30 × 3s): covers router reboots / TV Wi-Fi wake / AP roaming, which
+        // a few-second budget missed entirely. Exhaustion then stands down (see scheduleReconnect).
+        private const val RECONNECT_GIVE_UP = 30
+
+        // "Reconnect gave up" user notification.
+        private const val RECONNECT_CHANNEL_ID = "tv_connection_channel"
+        private const val RECONNECT_NOTIF_ID = 4713
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/MediaPlaybackService.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/MediaPlaybackService.kt
@@ -25,14 +25,37 @@ import kotlinx.coroutines.*
 import com.playbridge.sender.R
 
 /**
- * Foreground service that manages a MediaSession and displays a media notification.
- * This keeps the app alive during background playback and provides controls.
+ * Foreground service that manages a MediaSession and displays a media notification
+ * for background playback — web media (per-tab [MediaSessionObserver]s) and the
+ * in-app player ([com.playbridge.sender.player.PlayerActivity]'s background mode).
+ *
+ * Lifecycle model (mirrors the Media3 pattern used by ArchiveTune):
+ *  - **Owners**: each media source registers via [activate]/[deactivate] with a stable
+ *    id (tab id / "inapp-player"). The service only stops when the last owner leaves,
+ *    so one tab ending can't kill another tab's session.
+ *  - **Foreground only while playing**: on pause the service demotes itself
+ *    (stopForeground(DETACH)) so the notification becomes swipe-dismissible — the old
+ *    behaviour kept an ongoing FGS notification forever when Gecko never reported
+ *    media deactivation (ended/abandoned videos), which is exactly the "stuck
+ *    notification" bug.
+ *  - **Dismiss = cleanup**: a paused notification carries a deleteIntent that stops
+ *    the service (playback state is untouched; playing again re-creates it).
+ *  - **Idle stop**: a session paused for [PAUSED_IDLE_STOP_MS] is torn down.
+ *  - **Task removed**: swiping the app away stops media and the service.
  */
 class MediaPlaybackService : Service() {
 
     private var mediaSession: MediaSession? = null
     private var wakeLock: PowerManager.WakeLock? = null
-    
+
+    /** True while startForeground is in effect (playing). */
+    private var isForegroundActive = false
+
+    /** startForegroundService contract: the first notification must promote. */
+    private var startedForegroundOnce = false
+
+    private var idleStopJob: Job? = null
+
     override fun onBind(intent: Intent?): IBinder? = null
 
     @SuppressLint("WakelockTimeout")
@@ -143,17 +166,18 @@ class MediaPlaybackService : Service() {
         val state = if (isPlaying) PlaybackState.STATE_PLAYING else PlaybackState.STATE_PAUSED
         val playbackState = PlaybackState.Builder()
             .setActions(
-                PlaybackState.ACTION_PLAY or 
-                PlaybackState.ACTION_PAUSE or 
+                PlaybackState.ACTION_PLAY or
+                PlaybackState.ACTION_PAUSE or
                 PlaybackState.ACTION_STOP
             )
             .setState(state, PlaybackState.PLAYBACK_POSITION_UNKNOWN, 1.0f)
             .build()
-        
+
         mediaSession?.setPlaybackState(playbackState)
         showNotification()
-        
+
         if (isPlaying) {
+            cancelIdleStop()
             lastPlayEventTime = System.currentTimeMillis()
             requestAudioFocus()
             if (wakeLock?.isHeld == false) {
@@ -161,12 +185,28 @@ class MediaPlaybackService : Service() {
                 Log.d(TAG, "WakeLock acquired")
             }
         } else {
+            scheduleIdleStop()
             abandonAudioFocus()
             if (wakeLock?.isHeld == true) {
                 wakeLock?.release()
                 Log.d(TAG, "WakeLock released (paused)")
             }
         }
+    }
+
+    /** Paused sessions don't live forever: tear down after [PAUSED_IDLE_STOP_MS]. */
+    private fun scheduleIdleStop() {
+        idleStopJob?.cancel()
+        idleStopJob = scope.launch {
+            delay(PAUSED_IDLE_STOP_MS)
+            Log.d(TAG, "Idle (paused) for ${PAUSED_IDLE_STOP_MS / 60_000} min — stopping service")
+            stopSelf()
+        }
+    }
+
+    private fun cancelIdleStop() {
+        idleStopJob?.cancel()
+        idleStopJob = null
     }
 
     private fun requestAudioFocus() {
@@ -202,10 +242,17 @@ class MediaPlaybackService : Service() {
         val artwork = metadata?.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)
         val isPlaying = mediaSession?.controller?.playbackState?.state == PlaybackState.STATE_PLAYING
 
-        val intent = Intent(this, BrowserActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-        }
-        val pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+        // Tap target: the owning surface (e.g. the in-app player) when one registered
+        // itself, else the browser. FLAG_UPDATE_CURRENT is required — the request code
+        // is fixed, so without it the system would keep serving the first target.
+        val intent = contentIntentOverride?.let { Intent(it) }
+            ?: Intent(this, BrowserActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
+        val pendingIntent = PendingIntent.getActivity(
+            this, 0, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
 
         val playPauseIcon = if (isPlaying) android.R.drawable.ic_media_pause else android.R.drawable.ic_media_play
         val playPauseTitle = if (isPlaying) "Pause" else "Play"
@@ -219,6 +266,9 @@ class MediaPlaybackService : Service() {
             .setContentIntent(pendingIntent)
             .setVisibility(Notification.VISIBILITY_PUBLIC)
             .setStyle(Notification.MediaStyle().setMediaSession(mediaSession?.sessionToken))
+            // Paused → swipe-dismissible; dismissing cleans the service up.
+            .setOngoing(isPlaying)
+            .setDeleteIntent(createPlaybackPendingIntent(ACTION_NOTIFICATION_DISMISSED))
             .addAction(
                 Notification.Action.Builder(
                     Icon.createWithResource(this, playPauseIcon),
@@ -235,7 +285,31 @@ class MediaPlaybackService : Service() {
             )
             .build()
 
-        startForeground(NOTIFICATION_ID, notification)
+        // Foreground only while playing. On pause, DETACH keeps the notification visible
+        // but swipe-dismissible — the always-startForeground behaviour was the "stuck
+        // notification" bug: Gecko doesn't reliably deactivate ended media, leaving an
+        // undismissible ongoing notification behind.
+        if (isPlaying || !startedForegroundOnce) {
+            runCatching { startForeground(NOTIFICATION_ID, notification) }
+                .onSuccess {
+                    isForegroundActive = true
+                    startedForegroundOnce = true
+                }
+                .onFailure {
+                    // FGS promotion can be denied from the background (Android 12+);
+                    // degrade to a plain notification rather than crash.
+                    Log.w(TAG, "startForeground denied: ${it.message}")
+                    getSystemService(NotificationManager::class.java)
+                        .notify(NOTIFICATION_ID, notification)
+                }
+        } else {
+            if (isForegroundActive) {
+                stopForeground(STOP_FOREGROUND_DETACH)
+                isForegroundActive = false
+            }
+            getSystemService(NotificationManager::class.java)
+                .notify(NOTIFICATION_ID, notification)
+        }
     }
 
     private fun createPlaybackPendingIntent(action: String): PendingIntent {
@@ -274,18 +348,40 @@ class MediaPlaybackService : Service() {
                 val isPlaying = intent.getBooleanExtra(EXTRA_IS_PLAYING, false)
                 updatePlaybackState(isPlaying)
             }
+            ACTION_NOTIFICATION_DISMISSED -> {
+                // User swiped the (paused) notification away: tear the service down but
+                // leave playback state alone — playing again re-creates everything.
+                Log.d(TAG, "Notification dismissed — stopping service")
+                stopSelf()
+            }
         }
         return START_NOT_STICKY
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        // App swiped from recents: the UI is gone but the process (and Gecko) may keep
+        // playing with no way to control it. Stop media and go away instead of leaving
+        // an orphaned notification.
+        Log.d(TAG, "Task removed — stopping media and service")
+        MediaControlChannel.tryEmit(MediaControlChannel.Action.STOP)
+        stopSelf()
+        super.onTaskRemoved(rootIntent)
+    }
+
     override fun onDestroy() {
         instance = null
+        cancelIdleStop()
         abandonAudioFocus()
         scope.cancel()
         mediaSession?.isActive = false
         mediaSession?.release()
         if (wakeLock?.isHeld == true) {
             wakeLock?.release()
+        }
+        // A DETACHed (paused) notification survives stopSelf — remove it explicitly so
+        // a dead service can't leave a zombie notification behind.
+        runCatching {
+            getSystemService(NotificationManager::class.java).cancel(NOTIFICATION_ID)
         }
         Log.d(TAG, "MediaPlaybackService destroyed")
         super.onDestroy()
@@ -295,49 +391,107 @@ class MediaPlaybackService : Service() {
         const val CHANNEL_ID = "media_playback_channel"
         const val NOTIFICATION_ID = 101
         const val TAG = "MediaPlaybackService"
-        
+
         const val ACTION_PLAY = "com.playbridge.sender.ACTION_PLAY"
         const val ACTION_PAUSE = "com.playbridge.sender.ACTION_PAUSE"
         const val ACTION_STOP = "com.playbridge.sender.ACTION_STOP"
         const val ACTION_DESTROY_SERVICE = "com.playbridge.sender.ACTION_DESTROY_SERVICE"
         const val ACTION_UPDATE_METADATA = "com.playbridge.sender.ACTION_UPDATE_METADATA"
         const val ACTION_UPDATE_STATE = "com.playbridge.sender.ACTION_UPDATE_STATE"
+        const val ACTION_NOTIFICATION_DISMISSED = "com.playbridge.sender.ACTION_NOTIFICATION_DISMISSED"
 
         const val EXTRA_TITLE = "extra_title"
         const val EXTRA_ARTIST = "extra_artist"
         const val EXTRA_IS_PLAYING = "extra_is_playing"
 
+        /** Owner id used by the in-app player's background-mode session. */
+        const val OWNER_INAPP_PLAYER = "inapp-player"
+
+        /** Paused sessions are torn down after this long (notification is dismissible anyway). */
+        private const val PAUSED_IDLE_STOP_MS = 10L * 60 * 1000
+
         @Volatile
         var instance: MediaPlaybackService? = null
             private set
 
-        fun start(context: Context) {
-            val intent = Intent(context, MediaPlaybackService::class.java)
-            context.startForegroundService(intent)
+        /**
+         * Media sources currently holding the service open (tab ids / OWNER_INAPP_PLAYER).
+         * The service stops only when the LAST owner deactivates — previously any single
+         * tab's deactivation stopped the shared service, and a tab closed while playing
+         * (which never fires onMediaDeactivated) left it running forever.
+         */
+        private val activeOwners: MutableSet<String> =
+            java.util.Collections.synchronizedSet(mutableSetOf())
+
+        /**
+         * Where a notification tap should land. Defaults to the browser; the in-app
+         * player registers itself while its background session is active. Companion
+         * state so it survives service restarts within the owner's lifetime.
+         */
+        @Volatile
+        private var contentIntentOverride: Intent? = null
+
+        /** Set (or clear with null) the notification tap target. */
+        fun setContentIntent(intent: Intent?) {
+            contentIntentOverride = intent
         }
 
-        fun stop(context: Context) {
-            val intent = Intent(context, MediaPlaybackService::class.java).apply {
-                action = ACTION_DESTROY_SERVICE
+        /** Register [ownerId] as an active media source and ensure the service runs. */
+        fun activate(context: Context, ownerId: String) {
+            activeOwners.add(ownerId)
+            if (instance == null) {
+                runCatching {
+                    context.startForegroundService(Intent(context, MediaPlaybackService::class.java))
+                }.onFailure { Log.w(TAG, "Could not start media service: ${it.message}") }
             }
-            context.startService(intent)
+        }
+
+        /** Unregister [ownerId]; stops the service when no owners remain. */
+        fun deactivate(ownerId: String) {
+            if (!activeOwners.remove(ownerId)) return
+            if (activeOwners.isEmpty()) {
+                Log.d(TAG, "Last media owner gone — stopping service")
+                instance?.stopSelf()
+            }
         }
 
         fun sendMetadataUpdate(context: Context, title: String?, artist: String?) {
-            val intent = Intent(context, MediaPlaybackService::class.java).apply {
-                action = ACTION_UPDATE_METADATA
-                putExtra(EXTRA_TITLE, title)
-                putExtra(EXTRA_ARTIST, artist)
+            val svc = instance
+            if (svc != null) {
+                svc.updateMetadata(title, artist)
+                return
             }
-            context.startForegroundService(intent)
+            // Service still starting (startForegroundService is async) — deliver via intent.
+            if (activeOwners.isEmpty()) return
+            runCatching {
+                context.startForegroundService(
+                    Intent(context, MediaPlaybackService::class.java).apply {
+                        action = ACTION_UPDATE_METADATA
+                        putExtra(EXTRA_TITLE, title)
+                        putExtra(EXTRA_ARTIST, artist)
+                    }
+                )
+            }
         }
 
         fun sendStateUpdate(context: Context, isPlaying: Boolean) {
-            val intent = Intent(context, MediaPlaybackService::class.java).apply {
-                action = ACTION_UPDATE_STATE
-                putExtra(EXTRA_IS_PLAYING, isPlaying)
+            val svc = instance
+            if (svc != null) {
+                svc.updatePlaybackState(isPlaying)
+                return
             }
-            context.startForegroundService(intent)
+            // No live service: only a PLAYING update justifies (re)starting it. A paused
+            // update with no service (e.g. right after the user dismissed/stopped it)
+            // must not resurrect the notification.
+            if (!isPlaying || activeOwners.isEmpty()) return
+            runCatching {
+                context.startForegroundService(
+                    Intent(context, MediaPlaybackService::class.java).apply {
+                        action = ACTION_UPDATE_STATE
+                        putExtra(EXTRA_IS_PLAYING, true)
+                    }
+                )
+            }
         }
     }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/MediaSessionDelegate.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/MediaSessionDelegate.kt
@@ -31,7 +31,8 @@ class MediaSessionObserver(
         Log.d(TAG, "onMediaActivated (tabId=$tabId)")
         isActive = true
         tabManager.markTabAsPlaying(tabId)
-        MediaPlaybackService.start(context)
+        // Owner-refcounted: the service stays up until the LAST active tab deactivates.
+        MediaPlaybackService.activate(context, tabId)
 
         controlJob?.cancel()
         controlJob = scope.launch {
@@ -57,7 +58,7 @@ class MediaSessionObserver(
         tabManager.playingTabIds.remove(tabId)
         controlJob?.cancel()
         controlJob = null
-        MediaPlaybackService.stop(context)
+        MediaPlaybackService.deactivate(tabId)
     }
 
     override fun onMediaMetadataChanged(metadata: MediaSession.Metadata) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/dlna/DlnaCastTarget.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/dlna/DlnaCastTarget.kt
@@ -61,11 +61,21 @@ class DlnaCastTarget(
         avTransport.play()
 
         // Resume point: seek once the renderer has begun playback (an immediate Seek is
-        // ignored by most renderers while still TRANSITIONING).
+        // ignored by most renderers while still TRANSITIONING). Poll the transport state
+        // instead of a blind delay — a fixed 2.5s missed slow renderers entirely and
+        // over-waited on fast ones.
         if (media.startPositionMs > 0 && !proxy.isLiveStream) {
             scope.launch {
-                delay(2_500)
-                runCatching { avTransport.seek(formatTime(media.startPositionMs)) }
+                val deadline = System.currentTimeMillis() + RESUME_SEEK_TIMEOUT_MS
+                while (System.currentTimeMillis() < deadline) {
+                    val state = runCatching { avTransport.getTransportState() }.getOrNull()
+                    if (state?.uppercase() == "PLAYING") break
+                    delay(500)
+                }
+                // Re-check liveness: the playlist may only now have been served/parsed.
+                if (!proxy.isLiveStream) {
+                    runCatching { avTransport.seek(formatTime(media.startPositionMs)) }
+                }
             }
         }
 
@@ -167,6 +177,9 @@ class DlnaCastTarget(
 
     companion object {
         private const val POLL_INTERVAL_MS = 1000L
+
+        /** How long to wait for the renderer to reach PLAYING before the resume seek. */
+        private const val RESUME_SEEK_TIMEOUT_MS = 10_000L
 
         /** ms → "HH:MM:SS" for AVTransport REL_TIME (zero-padded — some renderers reject "0:..."). */
         fun formatTime(ms: Long): String {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/dlna/LocalProxyServer.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/dlna/LocalProxyServer.kt
@@ -92,6 +92,7 @@ class LocalProxyServer(
     fun publish(url: String, headers: Map<String, String>, mime: String?): String {
         isLiveStream = false // re-learned when an HLS media playlist is served
         vodDurationMs = 0L
+        cachedLanIp = lanIp() // refresh once per cast; register() reuses it
         return register(Entry.Remote(url, filterHeaders(headers), mime), guessExt(url, mime))
     }
 
@@ -99,6 +100,7 @@ class LocalProxyServer(
     fun publishLocal(uri: Uri, mime: String?): String {
         isLiveStream = false
         vodDurationMs = 0L
+        cachedLanIp = lanIp()
         return register(Entry.Local(uri, mime), extForMime(mime))
     }
 
@@ -110,10 +112,18 @@ class LocalProxyServer(
                 lk != "host" && lk != "accept-encoding" && lk != "connection" && lk != "range"
         }
 
+    /**
+     * LAN IP cached per publish(): register() runs once per URL in a playlist rewrite —
+     * enumerating every NetworkInterface per segment line (thousands for a long VOD,
+     * re-done on every live-playlist refresh) is measurable syscall churn.
+     */
+    @Volatile private var cachedLanIp: String? = null
+
     private fun register(entry: Entry, ext: String): String {
         val token = UUID.randomUUID().toString().replace("-", "").take(16)
         entries[token] = entry
-        return "http://${lanIp()}:$port/$token$ext"
+        val ip = cachedLanIp ?: lanIp().also { cachedLanIp = it }
+        return "http://$ip:$port/$token$ext"
     }
 
     private fun acceptLoop(s: ServerSocket) {
@@ -131,6 +141,9 @@ class LocalProxyServer(
     }
 
     private fun handle(socket: Socket) = socket.use { sock ->
+        // A renderer that opens a connection and never finishes its headers would
+        // otherwise pin this daemon thread forever on readLine().
+        sock.soTimeout = 15_000
         val reader = BufferedReader(InputStreamReader(sock.getInputStream()))
         val requestLine = reader.readLine() ?: return // "GET /<token>.mp4 HTTP/1.1"
         val parts = requestLine.split(" ")

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionCoordinator.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionCoordinator.kt
@@ -185,6 +185,15 @@ class ConnectionCoordinator(
         tvPlaylistState.value = null
     }
 
+    /**
+     * Mark the receiver idle locally (e.g. session ended from the phone while no native
+     * target is connected to confirm it). Keeps external classes from poking
+     * [tvActiveContext] directly.
+     */
+    fun markIdle() {
+        tvActiveContext.value = "idle"
+    }
+
     private fun clearPlayerStates() {
         tvPlaylistState.value = null
         tvPlayback.value = null

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
@@ -185,7 +185,7 @@ class ConnectionViewModel(
                         state is WebSocketClient.ConnectionState.Error)) {
                     hasAttemptedInitialConnect = true
                     Log.d(TAG, "Auto-connecting to saved TV: ${device.name} at ${device.ip}:${device.port}")
-                    webSocketClient.connect(device.ip, device.port, device.token, device.name, phoneDeviceName, phoneDeviceUUID, device.wssPort, device.certFingerprint)
+                    webSocketClient.connect(device.ip, device.port, device.token, device.name, phoneDeviceName, phoneDeviceUUID, device.wssPort, device.certFingerprint, device.uuid)
                 }
             }
         }
@@ -318,7 +318,7 @@ class ConnectionViewModel(
             viewModelScope.launch {
                 val device = tvDevice.first()
                 if (device != null) {
-                    webSocketClient.connect(device.ip, device.port, device.token, device.name, phoneDeviceName, phoneDeviceUUID, device.wssPort, device.certFingerprint)
+                    webSocketClient.connect(device.ip, device.port, device.token, device.name, phoneDeviceName, phoneDeviceUUID, device.wssPort, device.certFingerprint, device.uuid)
                 }
             }
         }
@@ -344,7 +344,7 @@ class ConnectionViewModel(
             Log.d(TAG, "Connecting to: ${merged.name} at ${merged.ip}:${merged.port} (wss=${merged.wssPort})")
             hasAttemptedInitialConnect = true
             activeConnectingDevice = merged
-            webSocketClient.connect(merged.ip, merged.port, merged.token, merged.name, phoneDeviceName, phoneDeviceUUID, merged.wssPort, merged.certFingerprint)
+            webSocketClient.connect(merged.ip, merged.port, merged.token, merged.name, phoneDeviceName, phoneDeviceUUID, merged.wssPort, merged.certFingerprint, merged.uuid)
         }
     }
 
@@ -427,6 +427,23 @@ class ConnectionViewModel(
         webSocketClient.disconnect()
         // Also disable auto-connect so it doesn't immediately reconnect
         setAutoConnectEnabled(false)
+    }
+
+    /** Live retry-cycle info for the "Reconnecting to <TV>" popup (null = no cycle). */
+    val reconnectStatus = castSessionManager.reconnectStatus
+
+    /**
+     * Cancel on the connecting/reconnecting popup: stop dialling the TV and route
+     * playback to this phone, per the popup's promise.
+     */
+    fun cancelConnectingToThisDevice() {
+        disconnect()
+        castSessionManager.cancelReconnect() // clears retry state + selects This Device
+    }
+
+    /** "Keep trying" on the reconnect popup: refresh the retry budget and continue. */
+    fun keepTryingReconnect() {
+        castSessionManager.keepTryingReconnect()
     }
 
     fun removeDeviceFromHistory(device: TvDevice) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/PlaybackProgressTracker.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/PlaybackProgressTracker.kt
@@ -88,10 +88,27 @@ class PlaybackProgressTracker(
     private var lastObservedPositionMs = 0L
     private var lastObservedDurationMs = 0L
 
-    /** Resume-write throttle state. */
-    private var lastSavedKey: String? = null
-    private var lastSavedPosMs = 0L
-    private var lastState: String? = null
+    /**
+     * Resume-write throttle state, one per transport leg. Keeping this per-leg matters:
+     * the native, DLNA and in-app collectors run in the same scope, and a shared throttle
+     * would let one leg's tick suppress (or misattribute) another leg's pause-triggered
+     * resume write.
+     */
+    private class ResumeThrottle {
+        var lastSavedKey: String? = null
+        var lastSavedPosMs = 0L
+        var lastState: String? = null
+
+        fun reset() {
+            lastSavedKey = null
+            lastSavedPosMs = 0L
+            lastState = null
+        }
+    }
+
+    private val nativeThrottle = ResumeThrottle()
+    private val dlnaThrottle = ResumeThrottle()
+    private val inAppThrottle = ResumeThrottle()
     private val writeMutex = Mutex()
 
     /**
@@ -186,7 +203,7 @@ class PlaybackProgressTracker(
                 ) {
                     markEpisodeWatched(tmdbId, s, e)
                 } else if (lastObservedPositionMs >= MIN_RESUME_POSITION_MS && lastObservedDurationMs > 0) {
-                    saveResume(item, lastObservedPositionMs, lastObservedDurationMs)
+                    saveResume(item, lastObservedPositionMs, lastObservedDurationMs, nativeThrottle)
                 }
             }
             lastObservedPositionMs = 0L
@@ -219,7 +236,7 @@ class PlaybackProgressTracker(
             else markMovieWatched(tmdbId)
         } else {
             thresholdArmed = true // seen genuinely-unwatched playback; threshold may fire now
-            maybeSaveResume(item, pb.positionMs, pb.durationMs, pb.state)
+            maybeSaveResume(item, pb.positionMs, pb.durationMs, pb.state, nativeThrottle)
         }
     }
 
@@ -255,7 +272,7 @@ class PlaybackProgressTracker(
             ) {
                 markEpisodeWatched(prevItem.tmdbId, prevItem.season!!, prevItem.episode!!)
             } else if (dlnaLastObservedPosMs >= MIN_RESUME_POSITION_MS && dlnaLastObservedDurMs > 0) {
-                saveResume(prevItem, dlnaLastObservedPosMs, dlnaLastObservedDurMs)
+                saveResume(prevItem, dlnaLastObservedPosMs, dlnaLastObservedDurMs, dlnaThrottle)
             }
             dlnaLastObservedPosMs = 0L
             dlnaLastObservedDurMs = 0L
@@ -281,7 +298,7 @@ class PlaybackProgressTracker(
                 com.playbridge.sender.cast.PlaybackState.PLAYING -> "playing"
                 else -> st.state.name.lowercase()
             }
-            maybeSaveResume(item, st.positionMs, st.durationMs, stateKey)
+            maybeSaveResume(item, st.positionMs, st.durationMs, stateKey, dlnaThrottle)
         }
     }
 
@@ -310,7 +327,7 @@ class PlaybackProgressTracker(
                 inAppLastObservedPosMs >= MIN_RESUME_POSITION_MS && inAppLastObservedDurMs > 0 &&
                 !ProgressRules.isWatched(inAppLastObservedPosMs, inAppLastObservedDurMs)
             ) {
-                saveResume(item, inAppLastObservedPosMs, inAppLastObservedDurMs)
+                saveResume(item, inAppLastObservedPosMs, inAppLastObservedDurMs, inAppThrottle)
             }
             inAppItem = null
             inAppLastObservedPosMs = 0L
@@ -340,7 +357,7 @@ class PlaybackProgressTracker(
             ) {
                 markEpisodeWatched(prevItem.tmdbId, prevItem.season!!, prevItem.episode!!)
             } else if (inAppLastObservedPosMs >= MIN_RESUME_POSITION_MS && inAppLastObservedDurMs > 0) {
-                saveResume(prevItem, inAppLastObservedPosMs, inAppLastObservedDurMs)
+                saveResume(prevItem, inAppLastObservedPosMs, inAppLastObservedDurMs, inAppThrottle)
             }
             inAppLastObservedPosMs = 0L
             inAppLastObservedDurMs = 0L
@@ -359,26 +376,37 @@ class PlaybackProgressTracker(
             else markMovieWatched(item.tmdbId)
         } else {
             inAppThresholdArmed = true
-            maybeSaveResume(item, positionMs, durationMs, if (isPlaying) "playing" else "paused")
+            maybeSaveResume(item, positionMs, durationMs, if (isPlaying) "playing" else "paused", inAppThrottle)
         }
     }
 
     // ── Resume positions ────────────────────────────────────────────────────
 
     /** Throttled persist: on item change, every ≥10s of movement, or on pause. */
-    private suspend fun maybeSaveResume(item: PlayingItem, positionMs: Long, durationMs: Long, state: String?) {
-        val pausedNow = state == "paused" && lastState != "paused"
-        lastState = state
+    private suspend fun maybeSaveResume(
+        item: PlayingItem,
+        positionMs: Long,
+        durationMs: Long,
+        state: String?,
+        throttle: ResumeThrottle,
+    ) {
+        val pausedNow = state == "paused" && throttle.lastState != "paused"
+        throttle.lastState = state
         if (positionMs < MIN_RESUME_POSITION_MS || durationMs <= 0) return
-        val keyChanged = item.key != lastSavedKey
-        val moved = kotlin.math.abs(positionMs - lastSavedPosMs) >= RESUME_SAVE_INTERVAL_MS
+        val keyChanged = item.key != throttle.lastSavedKey
+        val moved = kotlin.math.abs(positionMs - throttle.lastSavedPosMs) >= RESUME_SAVE_INTERVAL_MS
         if (!keyChanged && !moved && !pausedNow) return
-        saveResume(item, positionMs, durationMs)
+        saveResume(item, positionMs, durationMs, throttle)
     }
 
-    private suspend fun saveResume(item: PlayingItem, positionMs: Long, durationMs: Long) {
-        lastSavedKey = item.key
-        lastSavedPosMs = positionMs
+    private suspend fun saveResume(
+        item: PlayingItem,
+        positionMs: Long,
+        durationMs: Long,
+        throttle: ResumeThrottle,
+    ) {
+        throttle.lastSavedKey = item.key
+        throttle.lastSavedPosMs = positionMs
         runCatching {
             resumeDao.upsert(
                 PlaybackResumeEntity(
@@ -426,9 +454,8 @@ class PlaybackProgressTracker(
         sessionTmdbId = null
         lastObservedPositionMs = 0L
         lastObservedDurationMs = 0L
-        lastSavedKey = null
-        lastSavedPosMs = 0L
-        lastState = null
+        nativeThrottle.reset()
+        dlnaThrottle.reset()
         thresholdArmed = false
         dlnaThresholdArmed = false
     }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/TvQueueCoordinator.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/TvQueueCoordinator.kt
@@ -144,10 +144,18 @@ class TvQueueCoordinator(
     private fun matchEpisodeByTitle(p: TvEpisodeQueuePlan, title: String): Int {
         val exact = p.items.indexOfFirst { it.template.title == title }
         if (exact >= 0) return exact
-        return p.items.indexOfFirst {
-            val t = it.template.title
-            !t.isNullOrBlank() && (title.contains(t) || t.contains(title))
+        // Boundary-aware prefix match: the TV reports the template title plus a suffix
+        // (" (n/m)"), so prefix+boundary covers the real case. A plain contains() matched
+        // "Show S1E1" inside "Show S1E10 …" when episode titles are blank, deriving the
+        // wrong current episode.
+        fun boundaryMatch(candidate: String?): Boolean {
+            if (candidate.isNullOrBlank()) return false
+            val longer = if (title.length >= candidate.length) title else candidate
+            val shorter = if (title.length >= candidate.length) candidate else title
+            if (!longer.startsWith(shorter)) return false
+            return longer.length == shorter.length || !longer[shorter.length].isLetterOrDigit()
         }
+        return p.items.indexOfFirst { boundaryMatch(it.template.title) }
     }
 
     private fun clearLocked() {
@@ -158,28 +166,62 @@ class TvQueueCoordinator(
         currentEpisodeIndex = 0
     }
 
-    /** Resolve & enqueue forward until at least [window] episodes are queued ahead of the current one. */
-    private suspend fun topUp() = mutex.withLock {
-        val p = plan ?: return
-        fun queuedAhead() = queuedEpisodeIndices.count { it > currentEpisodeIndex }
-        while (queuedAhead() < window && nextToResolve <= p.items.lastIndex) {
-            val idx = nextToResolve
-            val url = resolveBest(p, idx)
-            if (url != null) {
-                val tmpl = p.items[idx].template
-                val subs = fetchSubtitlesFor(tmpl, url)
-                val payload = tmpl.copy(url = url, subtitles = (tmpl.subtitles + subs).distinct())
-                if (!webSocketClient.send(createQueueAddCommandJson(payload))) {
-                    // Send failed (socket dropped) — leave nextToResolve so we retry on the next tick.
-                    Log.w(TAG, "queue_add failed for episode index $idx; will retry")
-                    return
-                }
-                queuedEpisodeIndices.add(idx)
-                Log.d(TAG, "Queued episode index $idx (current=$currentEpisodeIndex, ${queuedAhead()} ahead)")
-            } else {
-                Log.w(TAG, "No stream resolved for episode index $idx; skipping")
+    /** One unit of top-up work, snapshotted under the lock. */
+    private data class TopUpWork(
+        val plan: TvEpisodeQueuePlan,
+        val index: Int,
+        val epoch: Int,
+        val picks: AutoPickPrefs,
+    )
+
+    /**
+     * Resolve & enqueue forward until at least [window] episodes are queued ahead of the
+     * current one.
+     *
+     * Stream resolution + subtitle fetching are network I/O and deliberately run OUTSIDE
+     * the mutex: holding it across the fetch would block stop()/start()/every signal tick
+     * for the duration of the slowest addon (a user switching series would visibly stall).
+     * The epoch/plan re-check on commit discards results that a supersession made stale —
+     * the same pattern DlnaQueueCoordinator.advance() uses.
+     */
+    private suspend fun topUp() {
+        while (true) {
+            val work = mutex.withLock {
+                val p = plan ?: return
+                val ahead = queuedEpisodeIndices.count { it > currentEpisodeIndex }
+                if (ahead >= window || nextToResolve > p.items.lastIndex) return
+                TopUpWork(p, nextToResolve, epoch, autoPick)
             }
-            nextToResolve++
+
+            // Slow part — no lock held.
+            val url = resolveBest(work.plan, work.index, work.picks)
+            val payload = if (url != null) {
+                val tmpl = work.plan.items[work.index].template
+                val subs = fetchSubtitlesFor(tmpl, url)
+                tmpl.copy(url = url, subtitles = (tmpl.subtitles + subs).distinct())
+            } else {
+                null
+            }
+
+            mutex.withLock {
+                // Superseded (stop/start/re-attach) while resolving — drop the result.
+                if (epoch != work.epoch || plan !== work.plan) return
+                // Another concurrent topUp() already advanced past this index — retry loop.
+                if (nextToResolve != work.index) return@withLock
+                if (payload != null) {
+                    if (!webSocketClient.send(createQueueAddCommandJson(payload))) {
+                        // Send failed (socket dropped) — leave nextToResolve so we retry on the next tick.
+                        Log.w(TAG, "queue_add failed for episode index ${work.index}; will retry")
+                        return
+                    }
+                    queuedEpisodeIndices.add(work.index)
+                    val ahead = queuedEpisodeIndices.count { it > currentEpisodeIndex }
+                    Log.d(TAG, "Queued episode index ${work.index} (current=$currentEpisodeIndex, $ahead ahead)")
+                } else {
+                    Log.w(TAG, "No stream resolved for episode index ${work.index}; skipping")
+                }
+                nextToResolve++
+            }
         }
     }
 
@@ -195,8 +237,8 @@ class TvQueueCoordinator(
         )
     }
 
-    private suspend fun resolveBest(p: TvEpisodeQueuePlan, index: Int): String? =
-        EpisodeStreamResolver.resolveBest(addonRepository, p, index, autoPick)
+    private suspend fun resolveBest(p: TvEpisodeQueuePlan, index: Int, picks: AutoPickPrefs): String? =
+        EpisodeStreamResolver.resolveBest(addonRepository, p, index, picks)
 
     /**
      * When idle, if the TV is already playing a series whose `playlist_status` carries the echoed

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
@@ -119,6 +119,10 @@ class WebSocketClient {
         val deviceUUID: String,
         val wssPort: Int? = null,
         val pin: String? = null,
+        /** The receiver's uuid (from discovery/saved record) — used to match the saved
+         *  device on reconnect. Names collide (two TVs of the same model announce the
+         *  same Build.MODEL); uuids don't. Empty when unknown. */
+        val tvUuid: String = "",
     )
 
     /** Token + SPKI pin issued by the receiver, persisted together by the ViewModel. */
@@ -129,7 +133,8 @@ class WebSocketClient {
 
         sealed class ConnectionState {
             data object Disconnected : ConnectionState()
-            data object Connecting : ConnectionState()
+            /** [serverName] = the receiver being dialled, so UI can say WHICH TV. */
+            data class Connecting(val serverName: String = "TV") : ConnectionState()
             data class Connected(val serverName: String, val secure: Boolean = false) : ConnectionState()
             // New SAS Handshake states.
             // [attemptsLeft] counts down as the user mistypes the 6-digit code; [lastCodeWrong]
@@ -166,15 +171,18 @@ class WebSocketClient {
         deviceUUID: String,
         wssPort: Int? = null,
         certFingerprint: String? = null,
+        tvUuid: String = "",
     ) {
         isUserDisconnect = false
-        targetConnection = TvConnectionInfo(ip, port, token, serverName, deviceName, deviceUUID, wssPort, certFingerprint)
+        targetConnection = TvConnectionInfo(
+            ip, port, token, serverName, deviceName, deviceUUID, wssPort, certFingerprint, tvUuid
+        )
         attemptConnection(ip, port, serverName)
     }
 
     private fun attemptConnection(ip: String, port: Int, serverName: String) {
         // Update state first to prevent race where UI thinks we are connected but socket is null
-        _connectionState.value = ConnectionState.Connecting
+        _connectionState.value = ConnectionState.Connecting(serverName)
         
         if (webSocket != null) {
             try { webSocket?.close(1000, "Reconnecting") } catch(e: Exception) {}
@@ -328,6 +336,7 @@ class WebSocketClient {
                                 scope.launch { _newCredentials.emit(IssuedCredentials(token, pin)) }
                             }
                             emitCapabilities(json)
+                            clearPairingSecrets() // handshake done — drop key material
                             _connectionState.value = ConnectionState.Connected(serverName, isSecure)
                             // Resync: the TV only broadcasts context on its own activity
                             // transitions, so a client (re)connecting mid-playback would
@@ -498,6 +507,21 @@ class WebSocketClient {
         return true
     }
 
+    /**
+     * Drop the ephemeral SAS-handshake material (keys, nonces, shared secret, code).
+     * Called once a session is established and on teardown — there's no reason to keep
+     * key material in memory for the life of the process.
+     */
+    private fun clearPairingSecrets() {
+        senderKeyPair = null
+        nonceS = null
+        commitStr = null
+        tvEphPub = null
+        nonceT = null
+        sharedSecret = null
+        calculatedSas = null
+    }
+
     /** Parse players/browsers from an auth/pairing response and publish them (if any). */
     private fun emitCapabilities(json: JsonObject) {
         val players = parseStringArray(json, "players")
@@ -593,12 +617,19 @@ class WebSocketClient {
         val state = _connectionState.value
         if (state is ConnectionState.Connected || state is ConnectionState.Connecting) return
 
-        // Refresh the endpoint from the saved record if it's the same receiver. Matching is
-        // by receiver name (the saved record carries the TV uuid, but targetConnection only
-        // knows the name the TV announced at connect time). The token/pin are refreshed too:
-        // receivers may rotate the token on every auth, and the store is authoritative.
+        // Refresh the endpoint from the saved record if it's the same receiver. Match by
+        // uuid when both sides know it (names collide: two TVs of the same model announce
+        // the same Build.MODEL); fall back to the announced name only when the uuid is
+        // unavailable. The token/pin are refreshed too: receivers may rotate the token on
+        // every auth, and the store is authoritative.
+        val sameReceiver = freshDevice != null &&
+            (if (conn.tvUuid.isNotEmpty() && freshDevice.uuid.isNotEmpty()) {
+                freshDevice.uuid == conn.tvUuid
+            } else {
+                freshDevice.name == conn.serverName
+            })
         if (freshDevice != null && !freshDevice.isDlna &&
-            freshDevice.token.isNotEmpty() && freshDevice.name == conn.serverName &&
+            freshDevice.token.isNotEmpty() && sameReceiver &&
             (freshDevice.ip != conn.ip || freshDevice.port != conn.port ||
                 freshDevice.wssPort != conn.wssPort || freshDevice.token != conn.token ||
                 (freshDevice.certFingerprint ?: conn.pin) != conn.pin)
@@ -625,6 +656,7 @@ class WebSocketClient {
         pendingDx = 0f
         pendingDy = 0f
         isUserDisconnect = true
+        clearPairingSecrets()
         webSocket?.close(1000, "User disconnect")
         webSocket = null
         _connectionState.value = ConnectionState.Disconnected

--- a/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
@@ -122,12 +122,15 @@ val appModule = module {
 
     // 5a. CastSessionManager — process-wide owner of the active cast target (native/DLNA)
     //     and the CastSessionService foreground lifecycle.
+    //     Single-threaded scope: the reconnect-supervisor state (attempt counter, job,
+    //     hasConnectedThisSession) is mutated from several collectors plus external
+    //     callbacks; serializing the scope removes the data races without locks.
     single {
         com.playbridge.sender.cast.CastSessionManager(
             context = androidContext(),
             webSocketClient = get(),
             connectionCoordinator = get(),
-            scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Default.limitedParallelism(1)),
             connectionStore = get(),
             nsdHelper = get(),
         )
@@ -158,6 +161,9 @@ val appModule = module {
 
     // 5d. PlaybackProgressTracker — auto-updates watchlist progress from TV playback.
     //     createdAtStart: it has no injectors; it must exist to observe.
+    //     Single-threaded scope: the three transport legs (native/DLNA/in-app) share
+    //     non-thread-safe session state (markedKeys/ensuredKeys, threshold arming);
+    //     serializing the scope makes their interleaving safe.
     single(createdAtStart = true) {
         com.playbridge.sender.connection.PlaybackProgressTracker(
             watchlistDao = get(),
@@ -166,7 +172,7 @@ val appModule = module {
             settingsRepository = get(),
             connectionCoordinator = get(),
             castSessionManager = get(),
-            scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Default.limitedParallelism(1))
         )
     }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/player/PlayerActivity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/player/PlayerActivity.kt
@@ -50,7 +50,7 @@ import androidx.compose.material.icons.filled.Replay10
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material.icons.filled.Hearing
+import androidx.compose.material.icons.filled.Headphones
 import androidx.compose.material.icons.filled.ScreenRotation
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.filled.RepeatOne
@@ -162,13 +162,94 @@ data class SubtitleTrack(
 class PlayerActivity : ComponentActivity() {
 
     private var player: ExoPlayer? = null
-    private var isBackgroundModeEnabled = false
+
+    /**
+     * Background-mode toggle, hoisted here (single source of truth shared with the
+     * composable) so returning from the notification can reset the button state.
+     */
+    private val backgroundModeState = mutableStateOf(false)
     private val isInPipModeState = mutableStateOf(false)
     private val addonRepository: AddonRepository by inject()
     private val progressTracker: com.playbridge.sender.connection.PlaybackProgressTracker by inject()
 
     /** True when this playback carries TMDB identity, so onDestroy flushes a final resume. */
     private var tracksProgress = false
+
+    /** Follow the video's aspect for orientation until the user rotates manually. */
+    private var autoOrientationEnabled = true
+
+    /** Called by the manual rotate control: the user's choice wins from now on. */
+    fun disableAutoOrientation() {
+        autoOrientationEnabled = false
+    }
+
+    // ── Background-mode media session ────────────────────────────────────────
+    // While background playback is enabled and the activity leaves the foreground,
+    // playback is exposed through MediaPlaybackService: a media notification with
+    // play/pause/stop, audio focus, and a wake lock — the same owner-refcounted
+    // service the browser uses. Without it, background playback ran with no
+    // controls, no notification, and nothing keeping the process alive.
+    private var backgroundSessionActive = false
+    private var mediaControlJob: kotlinx.coroutines.Job? = null
+
+    private val backgroundStateListener = object : Player.Listener {
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+            if (backgroundSessionActive) {
+                com.playbridge.sender.cast.MediaPlaybackService.sendStateUpdate(this@PlayerActivity, isPlaying)
+            }
+        }
+    }
+
+    private fun startBackgroundMediaSession() {
+        val exo = player ?: return
+        if (backgroundSessionActive) return
+        backgroundSessionActive = true
+        val service = com.playbridge.sender.cast.MediaPlaybackService
+        // Notification taps should land back HERE (singleTask brings this instance
+        // forward), not in the browser.
+        service.setContentIntent(
+            Intent(this, PlayerActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            }
+        )
+        service.activate(this, service.OWNER_INAPP_PLAYER)
+        service.sendMetadataUpdate(
+            this,
+            title = intent.getStringExtra(EXTRA_TITLE) ?: "Video",
+            artist = "PlayBridge Player",
+        )
+        service.sendStateUpdate(this, exo.isPlaying)
+        exo.addListener(backgroundStateListener)
+        // Obey notification controls. lifecycleScope keeps collecting while STOPPED
+        // (it only dies with the activity), which is exactly the window we need.
+        mediaControlJob?.cancel()
+        mediaControlJob = lifecycleScope.launch {
+            com.playbridge.sender.cast.MediaControlChannel.actions.collect { action ->
+                if (!backgroundSessionActive) return@collect
+                val p = player ?: return@collect
+                when (action) {
+                    com.playbridge.sender.cast.MediaControlChannel.Action.PLAY -> p.play()
+                    com.playbridge.sender.cast.MediaControlChannel.Action.PAUSE -> p.pause()
+                    com.playbridge.sender.cast.MediaControlChannel.Action.STOP -> {
+                        p.pause()
+                        finish()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun stopBackgroundMediaSession() {
+        if (!backgroundSessionActive) return
+        backgroundSessionActive = false
+        mediaControlJob?.cancel()
+        mediaControlJob = null
+        player?.removeListener(backgroundStateListener)
+        com.playbridge.sender.cast.MediaPlaybackService.setContentIntent(null)
+        com.playbridge.sender.cast.MediaPlaybackService.deactivate(
+            com.playbridge.sender.cast.MediaPlaybackService.OWNER_INAPP_PLAYER
+        )
+    }
 
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: android.content.res.Configuration) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
@@ -230,6 +311,27 @@ class PlayerActivity : ComponentActivity() {
 
         val exo = buildPlayer(this, headers)
         this.player = exo
+
+        // Match the player orientation to the video: portrait content (e.g. phone
+        // recordings, shorts) rotates the activity to portrait as soon as its size is
+        // known; landscape content keeps the sensor-landscape default. The manual
+        // rotate button disables this so it can't fight a user choice.
+        exo.addListener(object : Player.Listener {
+            override fun onVideoSizeChanged(videoSize: androidx.media3.common.VideoSize) {
+                if (!autoOrientationEnabled) return
+                val w = videoSize.width
+                val h = videoSize.height
+                if (w <= 0 || h <= 0) return
+                // Some containers deliver a rotated frame + rotation metadata.
+                val swapped = videoSize.unappliedRotationDegrees % 180 != 0
+                val isPortraitVideo = if (swapped) w > h else h > w
+                requestedOrientation = if (isPortraitVideo) {
+                    ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+                } else {
+                    ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+                }
+            }
+        })
 
         val initialTitle: String?
         var episodeController: LazyEpisodeController? = null
@@ -317,22 +419,41 @@ class PlayerActivity : ComponentActivity() {
                     onClose = { finish() },
                     onEnded = { finish() },
                     isInPip = isInPip,
-                    onBackgroundModeChanged = { enabled -> this.isBackgroundModeEnabled = enabled }
+                    backgroundMode = backgroundModeState,
+                    onEnterBackgroundMode = {
+                        // The composable already flipped backgroundModeState (shared,
+                        // synchronous) — onStop reads it to decide pause-vs-notify.
+                        moveTaskToBack(true)
+                    }
                 )
             }
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+        // Back in the foreground (e.g. via the notification): the on-screen controls
+        // take over again, and the background toggle resets so the next departure is
+        // a deliberate choice rather than a sticky leftover.
+        stopBackgroundMediaSession()
+        backgroundModeState.value = false
+    }
+
     override fun onStop() {
         super.onStop()
-        // Pause when leaving the foreground, UNLESS background mode is enabled.
-        if (!isBackgroundModeEnabled) {
+        // Pause when leaving the foreground, UNLESS background mode is enabled — in which
+        // case expose playback through the media notification service. Skip on config
+        // changes (rotation would flash a notification) and in PiP (still visible).
+        if (!backgroundModeState.value) {
             player?.playWhenReady = false
+        } else if (!isFinishing && !isChangingConfigurations && !isInPipModeState.value) {
+            startBackgroundMediaSession()
         }
     }
 
     override fun onDestroy() {
         super.onDestroy()
+        stopBackgroundMediaSession()
         // Flush a final resume point and clear the in-app leg (the polling loop is already
         // cancelled with lifecycleScope). Only fires on real close, not on rotation — the
         // activity handles orientation config changes itself.
@@ -733,7 +854,10 @@ private fun PlayerScreen(
     onClose: () -> Unit,
     onEnded: () -> Unit,
     isInPip: Boolean,
-    onBackgroundModeChanged: (Boolean) -> Unit
+    /** Shared with the activity: onStop reads it, notification-return resets it. */
+    backgroundMode: MutableState<Boolean>,
+    /** Send the task home (background mode was just enabled synchronously). */
+    onEnterBackgroundMode: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val window = (context as? Activity)?.window
@@ -781,7 +905,7 @@ private fun PlayerScreen(
     }
 
     // New states
-    var isBackgroundModeEnabled by remember { mutableStateOf(false) }
+    var isBackgroundModeEnabled by backgroundMode
     var repeatMode by remember { mutableIntStateOf(player.repeatMode) }
     var abStartMs by remember { mutableStateOf<Long?>(null) }
     var abEndMs by remember { mutableStateOf<Long?>(null) }
@@ -789,10 +913,7 @@ private fun PlayerScreen(
     var scale by remember { mutableFloatStateOf(1f) }
     var offset by remember { mutableStateOf(Offset.Zero) }
 
-    // Sync background playback toggle to activity
-    LaunchedEffect(isBackgroundModeEnabled) {
-        onBackgroundModeChanged(isBackgroundModeEnabled)
-    }
+    // (Background toggle state is hoisted — the activity shares backgroundMode directly.)
 
     // Precision AB Loop segment repeat
     LaunchedEffect(abStartMs, abEndMs) {
@@ -1401,11 +1522,12 @@ private fun PlayerScreen(
                             .windowInsetsPadding(WindowInsets.navigationBars)
                             .padding(horizontal = 16.dp, vertical = 12.dp)
                     ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
+                        // The 11 fixed-size buttons total ~550dp with spacing — far wider
+                        // than any portrait screen, which overflowed/clipped the single
+                        // row (the broken portrait layout). The two clusters are extracted
+                        // so portrait can stack them as two rows; landscape keeps one row
+                        // with the flexible gap in the middle.
+                        val transportControls: @Composable () -> Unit = {
                             // 1. Lock Controls
                             GlassControl(
                                 onClick = { locked = true; showUnlock = true },
@@ -1414,18 +1536,29 @@ private fun PlayerScreen(
                                 Icon(Icons.Filled.Lock, "Lock controls", tint = Color.White, modifier = Modifier.size(20.dp))
                             }
 
-                            // 2. Background Playback Toggle
+                            // 2. Background Playback Toggle. Enabling it acts immediately:
+                            // the whole point is listening with the screen off / elsewhere,
+                            // so go straight home and let the media notification take over.
+                            // Tapping again (after returning) turns it off.
                             GlassControl(
                                 onClick = {
-                                    isBackgroundModeEnabled = !isBackgroundModeEnabled
-                                    aspectLabel = if (isBackgroundModeEnabled) "Background Playback Enabled" else "Background Playback Disabled"
-                                    markInteraction()
+                                    if (isBackgroundModeEnabled) {
+                                        isBackgroundModeEnabled = false
+                                        aspectLabel = "Background Playback Disabled"
+                                        markInteraction()
+                                    } else {
+                                        isBackgroundModeEnabled = true
+                                        // Sync the activity flag synchronously and background
+                                        // the task — waiting for the LaunchedEffect would race
+                                        // onStop, which reads the flag to decide pause-vs-notify.
+                                        onEnterBackgroundMode()
+                                    }
                                 },
                                 diameter = 40.dp,
                                 background = if (isBackgroundModeEnabled) Color.Green.copy(alpha = 0.25f) else Color.White.copy(alpha = 0.14f)
                             ) {
                                 Icon(
-                                    imageVector = Icons.Filled.Hearing,
+                                    imageVector = Icons.Filled.Headphones,
                                     contentDescription = "Background mode",
                                     tint = if (isBackgroundModeEnabled) Color.Green else Color.White,
                                     modifier = Modifier.size(20.dp)
@@ -1437,8 +1570,12 @@ private fun PlayerScreen(
                                 onClick = {
                                     val activity = context as? Activity
                                     if (activity != null) {
-                                        activity.requestedOrientation = if (activity.requestedOrientation == ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE) {
-                                            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                                        // Manual choice — stop auto-following the video aspect.
+                                        (activity as? PlayerActivity)?.disableAutoOrientation()
+                                        val isLandscapeNow =
+                                            activity.requestedOrientation == ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+                                        activity.requestedOrientation = if (isLandscapeNow) {
+                                            ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
                                         } else {
                                             ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
                                         }
@@ -1550,9 +1687,9 @@ private fun PlayerScreen(
                                 }
                             }
 
-                            // 7. Flexible Spacing Separator
-                            Spacer(Modifier.weight(1f))
+                        }
 
+                        val utilityControls: @Composable () -> Unit = {
                             // 8. Capture Frame (Photo)
                             GlassControl(
                                 onClick = {
@@ -1627,6 +1764,32 @@ private fun PlayerScreen(
                                 diameter = 40.dp
                             ) {
                                 Icon(Icons.Filled.AspectRatio, "Resize", tint = Color.White, modifier = Modifier.size(20.dp))
+                            }
+                        }
+
+                        val isPortraitLayout =
+                            LocalConfiguration.current.screenWidthDp < LocalConfiguration.current.screenHeightDp
+                        if (isPortraitLayout) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) { transportControls() }
+                            Spacer(Modifier.height(8.dp))
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) { utilityControls() }
+                        } else {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                transportControls()
+                                Spacer(Modifier.weight(1f))
+                                utilityControls()
                             }
                         }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/settings/AppearanceSettingsScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/settings/AppearanceSettingsScreen.kt
@@ -28,7 +28,10 @@ fun AppearanceSettingsScreen(onBack: () -> Unit) {
     val settingsRepository: com.playbridge.sender.data.settings.SettingsRepository = koinInject()
     val maxAliveTabsRepository by settingsRepository.maxAliveTabs.collectAsState(initial = 5)
     val coroutineScope = rememberCoroutineScope()
-    var selectedTheme by remember { mutableStateOf(AppTheme.fromPrefs(context)) }
+    // Reactive theme: reading it here subscribes, so the selected row updates instantly
+    // when the theme changes — no Activity.recreate(), which used to reset in-Settings
+    // navigation and break the Back button.
+    val selectedTheme = com.playbridge.sender.ui.theme.ThemeController.current()
 
     Scaffold(
         topBar = {
@@ -61,9 +64,8 @@ fun AppearanceSettingsScreen(onBack: () -> Unit) {
                     isSelected = theme == selectedTheme,
                     onSelect = {
                         if (theme != selectedTheme) {
-                            selectedTheme = theme
-                            prefs.edit { putString("app_theme", theme.name) }
-                            (context as? Activity)?.recreate()
+                            // Persist + apply reactively — the whole app re-themes in place.
+                            com.playbridge.sender.ui.theme.ThemeController.set(context, theme)
                         }
                     }
                 )

--- a/mobile/android/app/src/main/java/com/playbridge/sender/settings/SettingsScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/settings/SettingsScreen.kt
@@ -146,14 +146,17 @@ private fun SettingsHubContent(
                 .padding(innerPadding)
                 .verticalScroll(rememberScrollState())
         ) {
-            val items = remember(isFromLibrary, context) {
+            // Read the reactive theme in composable scope (not inside buildList, which is
+            // not @Composable); keying `items` on it refreshes the subtitle on change.
+            val themeLabel = com.playbridge.sender.ui.theme.ThemeController.current().label
+            val items = remember(isFromLibrary, context, themeLabel) {
                 buildList {
                     // 1. Appearance (Shared)
                     add(
                         SettingsItemData(
                             icon = Icons.Default.Palette,
                             title = "Appearance",
-                            subtitle = "Theme: ${AppTheme.fromPrefs(context).label}",
+                            subtitle = "Theme: $themeLabel",
                             onClick = onAppearance
                         )
                     )

--- a/mobile/android/app/src/main/java/com/playbridge/sender/ui/theme/Theme.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/ui/theme/Theme.kt
@@ -41,6 +41,38 @@ enum class AppTheme(val label: String) {
     }
 }
 
+/**
+ * Process-wide, reactive holder for the active [AppTheme].
+ *
+ * The theme is a Compose [androidx.compose.runtime.MutableState], so changing it
+ * recomposes every subtree reading it — the app re-themes instantly with no
+ * `Activity.recreate()`. Recreating the Activity to apply a theme was the source of a
+ * bug: it reset in-screen navigation (e.g. Settings → Appearance jumped back to the
+ * Settings hub) and corrupted the shell's "return to" target so Back got stuck.
+ */
+object ThemeController {
+    private val state = androidx.compose.runtime.mutableStateOf<AppTheme?>(null)
+
+    /** Read the current theme in composition (subscribes); seeds from prefs on first use. */
+    @Composable
+    fun current(): AppTheme {
+        val context = LocalContext.current
+        val value = state.value
+        if (value != null) return value
+        return AppTheme.fromPrefs(context).also { state.value = it }
+    }
+
+    /** Persist and apply [theme] immediately (recomposes everything reading [current]). */
+    fun set(context: Context, theme: AppTheme) {
+        context.getSharedPreferences("browser_prefs", Context.MODE_PRIVATE)
+            .edit().putString("app_theme", theme.name).apply()
+        state.value = theme
+    }
+
+    /** Non-composable read for callers that just need the persisted value. */
+    fun peek(context: Context): AppTheme = state.value ?: AppTheme.fromPrefs(context)
+}
+
 private val DarkColorScheme = darkColorScheme(
     background = Surface,
     surface = Surface,
@@ -169,8 +201,8 @@ private fun staticSchemeFor(theme: AppTheme): ColorScheme = when (theme) {
 fun PlayBridgeTheme(
     content: @Composable () -> Unit
 ) {
-    val context = LocalContext.current
-    val theme = remember { AppTheme.fromPrefs(context) }
+    // Reactive: changing the theme recomposes this and re-themes the whole tree.
+    val theme = ThemeController.current()
 
     // Flip status-bar and nav-bar icons to dark on light theme so they're
     // visible against the light background. SideEffect runs after every
@@ -201,8 +233,7 @@ fun DynamicColorTheme(
     seedColor: Color?,
     content: @Composable () -> Unit
 ) {
-    val context = LocalContext.current
-    val theme = remember { AppTheme.fromPrefs(context) }
+    val theme = ThemeController.current()
     val isDark = theme != AppTheme.LIGHT
     // IMPORTANT: content() must stay at ONE composition position regardless of
     // seedColor. Branching (e.g. early-returning content() when the seed is null)

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ContentSniffer.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ContentSniffer.kt
@@ -19,6 +19,18 @@ private const val TAG = "ContentSniffer"
  */
 class ContentSniffer {
 
+    companion object {
+        /** Shared base client — pool/dispatcher reused by every derived per-request client. */
+        private val baseClient: okhttp3.OkHttpClient by lazy {
+            okhttp3.OkHttpClient.Builder()
+                .connectTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
+                .readTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
+                .followRedirects(true)
+                .followSslRedirects(true)
+                .build()
+        }
+    }
+
     /**
      * Returns true if the URL is on a local/private network address where
      * self-signed certificates are common and acceptable.
@@ -28,12 +40,16 @@ class ContentSniffer {
      * thread. Non-numeric hostnames are matched only by name (.local, localhost).
      */
     fun isLocalUrl(url: String): Boolean {
-        val host = Uri.parse(url).host ?: return false
+        val rawHost = Uri.parse(url).host ?: return false
+        val host = rawHost.removePrefix("[").removeSuffix("]")
 
         if (host == "localhost" || host.endsWith(".local")) return true
 
-        // Avoid DNS: only attempt InetAddress parsing for numeric IPs.
-        val looksLikeIp = host.all { it.isDigit() || it == '.' || it == ':' || it in 'a'..'f' || it in 'A'..'F' }
+        // Avoid DNS — and never grant the trust-all path to a resolvable NAME: only a
+        // literal IPv4 dotted-quad or an IPv6 literal (contains ':') qualifies. The old
+        // hex-char heuristic accepted hostnames like "beef.dead", silently resolving
+        // them via DNS and letting a DNS-controlled name earn the local trust bypass.
+        val looksLikeIp = host.contains(':') || host.matches(Regex("""\d{1,3}(\.\d{1,3}){3}"""))
         if (!looksLikeIp) return false
 
         return try {
@@ -62,11 +78,10 @@ class ContentSniffer {
      */
     fun getOkHttpClient(headers: Map<String, String>? = null, trustAllCerts: Boolean = false): okhttp3.OkHttpClient {
         try {
-            val builder = okhttp3.OkHttpClient.Builder()
-                .connectTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
-                .readTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
-                .followRedirects(true)
-                .followSslRedirects(true)
+            // Derive from a shared base client: newBuilder() shares the connection pool
+            // and dispatcher threads, so per-sniff clients no longer each spin up their
+            // own pool/executor.
+            val builder = baseClient.newBuilder()
 
             if (trustAllCerts) {
                 val trustManagers = arrayOf<javax.net.ssl.TrustManager>(object : javax.net.ssl.X509TrustManager {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
@@ -887,7 +887,7 @@ class ExoPlayerActivity : PlayerActivity() {
                     else -> FileLogger.w(TAG, "Fatal decoder error with all compatibility flags already set")
                 }
                 FileLogger.w(TAG, "Fatal Decoder Error — failing over to MPV")
-                switchPlayer("mpv")
+                switchPlayer("mpv", automatic = true)
                 return
             }
             // Live stream fell behind the available DVR window — seek back to the live edge and resume.

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
@@ -680,7 +680,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
                         // If it ended very quickly without playing anything, it might be a load error
                         if (positionMs == 0L && durationMs == 0L) {
                             FileLogger.w(TAG, "MPV ended file immediately — likely a load error. Failing over to ExoPlayer.")
-                            switchPlayer("exo")
+                            switchPlayer("exo", automatic = true)
                         } else {
                             finish()
                         }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerActivity.kt
@@ -45,7 +45,7 @@ abstract class PlayerActivity : ComponentActivity() {
             if (!isFinishing) {
                 FileLogger.w("PlayerActivity", "Watchdog: Playback failed to start within 30s. Swapping engine.")
                 val alternative = if (currentEngineId == "mpv") "exo" else "mpv"
-                switchPlayer(alternative)
+                switchPlayer(alternative, automatic = true)
             }
         }
     }
@@ -576,7 +576,31 @@ abstract class PlayerActivity : ComponentActivity() {
     protected open fun playlistSnapshot(): Pair<List<playbridge.PlayPayload>, Int> =
         emptyList<playbridge.PlayPayload>() to 0
 
-    protected fun switchPlayer(newMode: String) {
+    /**
+     * Relaunch playback in [newMode]'s engine activity.
+     *
+     * [automatic] marks failover switches (watchdog timeout, fatal decoder/load errors) as
+     * opposed to an explicit user/phone request. Automatic switches carry a counter across
+     * the relaunch intent and stop after [MAX_AUTO_ENGINE_SWITCHES]: without the cap, a
+     * stream that fails on BOTH engines ping-pongs exo↔mpv forever (each bounce relaunches
+     * an Activity, re-sniffs and re-buffers, flashing the screen indefinitely). A manual
+     * switch resets the budget.
+     */
+    protected fun switchPlayer(newMode: String, automatic: Boolean = false) {
+        val autoSwitchCount = intent.getIntExtra(EXTRA_AUTO_SWITCH_COUNT, 0)
+        if (automatic && autoSwitchCount >= MAX_AUTO_ENGINE_SWITCHES) {
+            FileLogger.e(
+                "PlayerActivity",
+                "Auto engine switch budget exhausted ($autoSwitchCount) — giving up instead of ping-ponging"
+            )
+            android.widget.Toast.makeText(
+                this,
+                "Playback failed in both players",
+                android.widget.Toast.LENGTH_LONG
+            ).show()
+            finish()
+            return
+        }
         val currentPosition = getCurrentPosition()
         val pm = getPlayerProgressManager()
         val url = pm?.url ?: intent.getStringExtra(ServerService.EXTRA_URL)
@@ -648,6 +672,9 @@ abstract class PlayerActivity : ComponentActivity() {
         }
 
         newIntent.putExtra("extra_start_position", currentPosition)
+        // Failover bookkeeping: count automatic switches across relaunches; a manual
+        // switch is a fresh user intent and resets the budget.
+        newIntent.putExtra(EXTRA_AUTO_SWITCH_COUNT, if (automatic) autoSwitchCount + 1 else 0)
         newIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
 
         // Clear the explicit package/component if it was set by the original intent
@@ -662,5 +689,11 @@ abstract class PlayerActivity : ComponentActivity() {
     companion object {
         @Volatile
         private var current: java.lang.ref.WeakReference<PlayerActivity>? = null
+
+        /** Intent extra carrying how many automatic engine failovers this session has done. */
+        private const val EXTRA_AUTO_SWITCH_COUNT = "extra_auto_engine_switch_count"
+
+        /** exo→mpv→exo (2 automatic switches) is the most a failing stream gets. */
+        private const val MAX_AUTO_ENGINE_SWITCHES = 2
     }
 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
@@ -44,7 +44,10 @@ class ServerService : Service() {
     private lateinit var pairingStore: PairingStore
     private lateinit var overlayWindow: OverlayWindowHelper
 
-    // Track what is currently active on the TV
+    // Track what is currently active on the TV. @Volatile: written by main-thread
+    // lifecycle setters and the broadcast receiver, read by the IO-dispatcher command
+    // collector (handleMessage routes Remote/Mouse/BrowserControl on it).
+    @Volatile
     private var activeContext: String = "idle" // "player", "browser", or "idle"
 
     private val _serverInfo = MutableStateFlow<ServerInfo?>(null)
@@ -870,6 +873,10 @@ class ServerService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onDestroy() {
+        // Drop the static reference so the dead service (cancelled scope, stopped server)
+        // stops receiving routed calls and doesn't leak as a retained Context. Identity
+        // check: a replacement instance may already have registered itself in onCreate.
+        if (_staticInstance === this) _staticInstance = null
         try { unregisterReceiver(contextIdleReceiver) } catch (_: Exception) {}
         if (registrationListener != null) {
             try {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/WebSocketServer.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/WebSocketServer.kt
@@ -164,8 +164,18 @@ class WebSocketServer(
                             call.respondText(combined, ContentType.Text.Plain)
                         }
 
-                        // HTTP endpoint: clear log files
+                        // HTTP endpoint: clear log files. Gated like GET: this listener is
+                        // reachable by anyone on the LAN, so honour the on-TV logging
+                        // opt-in rather than letting arbitrary peers wipe diagnostics.
                         delete("/logs") {
+                            if (!FileLogger.isEnabled()) {
+                                call.respondText(
+                                    "Logging is disabled on the TV.",
+                                    ContentType.Text.Plain,
+                                    HttpStatusCode.Forbidden
+                                )
+                                return@delete
+                            }
                             FileLogger.clearLogs()
                             call.respondText("Logs cleared.", ContentType.Text.Plain)
                         }
@@ -195,20 +205,26 @@ class WebSocketServer(
 // ... (handleConnection remains same)
 
     fun stop() {
-        try {
-            runBlocking {
-                server?.stop(500, 1000)
-                server = null
-                try { wssServer?.stop(500) } catch (e: Exception) { FileLogger.e(TAG, "Error stopping wss", e) }
-                wssServer = null
-                wssClients.clear()
-                boundWssPort = null
-                certFingerprint = null
+        // Detach references and flip state synchronously; do the (blocking) engine
+        // teardown off the caller's thread. This is invoked from ServerService.onDestroy
+        // on the main thread — the previous runBlocking teardown could stall it for
+        // 1.5s+ (ANR territory).
+        val ktor = server
+        val wss = wssServer
+        server = null
+        wssServer = null
+        wssClients.clear()
+        boundWssPort = null
+        certFingerprint = null
+        _connectionState.value = ConnectionState.Stopped
+        scope.launch {
+            try {
+                ktor?.stop(500, 1000)
+                try { wss?.stop(500) } catch (e: Exception) { FileLogger.e(TAG, "Error stopping wss", e) }
                 FileLogger.i(TAG, "Server stopped")
+            } catch (e: Exception) {
+                FileLogger.e(TAG, "Error stopping server", e)
             }
-            _connectionState.value = ConnectionState.Stopped
-        } catch (e: Exception) {
-            FileLogger.e(TAG, "Error stopping server", e)
         }
     }
 

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/SettingsScreen.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/SettingsScreen.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.launch
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.*
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -63,6 +64,7 @@ fun SettingsScreen(
     var loudnessEnhancer by remember { mutableStateOf(prefs.getBoolean("loudness_enhancer", false)) }
     var enableHistory by remember { mutableStateOf(prefs.getBoolean("enable_history", true)) }
     var isRestarting by remember { mutableStateOf(false) }
+    var showExitDialog by remember { mutableStateOf(false) }
     var themeStr by remember { mutableStateOf(prefs.getString("app_theme", "DARK") ?: "DARK") }
 
     // GeckoView Plugin states
@@ -107,6 +109,18 @@ fun SettingsScreen(
         }
     }
 
+    fun exitApp() {
+        scope.launch {
+            // Stop the FGS first so the WS server closes cleanly and NSD unregisters.
+            ServerService.stop(context)
+            delay(300)
+            (context as? Activity)?.finishAffinity()
+            // Kill the process so nothing (started-sticky service, retained singletons)
+            // lingers. BootReceiver will bring the server back on next boot/app launch.
+            kotlin.system.exitProcess(0)
+        }
+    }
+
     Row(modifier = Modifier.fillMaxSize()) {
         // --- Sidebar ---
         Column(
@@ -124,7 +138,10 @@ fun SettingsScreen(
                 modifier = Modifier.padding(start = 16.dp, bottom = 12.dp)
             )
 
-            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.weight(1f)
+            ) {
                 items(SettingsCategory.entries) { category ->
                     val isSelected = selectedCategory == category
                     ListItem(
@@ -144,8 +161,28 @@ fun SettingsScreen(
                         scale = ListItemDefaults.scale(focusedScale = 1.05f)
                     )
                 }
-                
+
             }
+
+            // Pinned below the category list: fully quit the app and shut down the server.
+            ListItem(
+                selected = false,
+                onClick = { showExitDialog = true },
+                leadingContent = {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ExitToApp,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp)
+                    )
+                },
+                headlineContent = { Text("Exit") },
+                supportingContent = { Text("Quit app & stop server") },
+                colors = ListItemDefaults.colors(
+                    contentColor = MaterialTheme.colorScheme.onSurface
+                ),
+                scale = ListItemDefaults.scale(focusedScale = 1.05f),
+                modifier = Modifier.padding(bottom = 24.dp)
+            )
         }
 
         // --- Content Area ---
@@ -467,6 +504,42 @@ fun SettingsScreen(
                                     }
                                 }
                             )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showExitDialog) {
+        com.playbridge.player.ui.theme.ThemedDialog(onDismissRequest = { showExitDialog = false }) {
+            Surface(
+                shape = MaterialTheme.shapes.medium,
+                modifier = Modifier.width(400.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(32.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Text("Exit PlayBridge?", style = MaterialTheme.typography.headlineSmall)
+                    Text(
+                        "This stops the server — the phone won't be able to cast until you open the app again.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Button(onClick = { showExitDialog = false }, modifier = Modifier.padding(end = 8.dp)) {
+                            Text("Cancel")
+                        }
+                        Button(onClick = {
+                            showExitDialog = false
+                            exitApp()
+                        }) {
+                            Text("Exit")
                         }
                     }
                 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/SettingsScreen.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/SettingsScreen.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.launch
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.*
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -138,10 +137,7 @@ fun SettingsScreen(
                 modifier = Modifier.padding(start = 16.dp, bottom = 12.dp)
             )
 
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.weight(1f)
-            ) {
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 items(SettingsCategory.entries) { category ->
                     val isSelected = selectedCategory == category
                     ListItem(
@@ -163,26 +159,6 @@ fun SettingsScreen(
                 }
 
             }
-
-            // Pinned below the category list: fully quit the app and shut down the server.
-            ListItem(
-                selected = false,
-                onClick = { showExitDialog = true },
-                leadingContent = {
-                    Icon(
-                        Icons.AutoMirrored.Filled.ExitToApp,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp)
-                    )
-                },
-                headlineContent = { Text("Exit") },
-                supportingContent = { Text("Quit app & stop server") },
-                colors = ListItemDefaults.colors(
-                    contentColor = MaterialTheme.colorScheme.onSurface
-                ),
-                scale = ListItemDefaults.scale(focusedScale = 1.05f),
-                modifier = Modifier.padding(bottom = 24.dp)
-            )
         }
 
         // --- Content Area ---
@@ -503,6 +479,13 @@ fun SettingsScreen(
                                         showGeckoDialog = true
                                     }
                                 }
+                            )
+                        }
+                        item {
+                            SettingClickableItem(
+                                label = "Exit PlayBridge",
+                                description = "Quit the app and stop the server.",
+                                onClick = { showExitDialog = true }
                             )
                         }
                     }


### PR DESCRIPTION
Bug/race/perf fixes from a code audit, plus media-notification rework, in-app player background playback + orientation, cast-sheet pause, connection/reconnection UX, navigation restore on Back, and a reactive theme fix. See individual commits for details.