### PR TITLE
FOSS/Play flavors, TheIntroDB skip segments, watch-progress fixes

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -68,42 +68,42 @@ jobs:
       if: steps.check_tag.outputs.skipped == 'false'
       run: chmod +x gradlew
 
-    - name: Build Release APK
+    # Distribution flavors: GitHub sideload releases ship the `foss` APKs
+    # (self-update + all features); the Play Store gets the `play` AAB
+    # (REQUEST_INSTALL_PACKAGES and self-update code stripped via the flavor —
+    # no manifest sed hacks needed anymore).
+    - name: Build Release APK (foss — GitHub sideload)
       if: steps.check_tag.outputs.skipped == 'false'
       env:
         PLAYBRIDGE_STORE_PASSWORD: ${{ secrets.PLAYBRIDGE_STORE_PASSWORD }}
         PLAYBRIDGE_KEY_ALIAS: ${{ secrets.PLAYBRIDGE_KEY_ALIAS }}
         PLAYBRIDGE_KEY_PASSWORD: ${{ secrets.PLAYBRIDGE_KEY_PASSWORD }}
-      run: ./gradlew assembleRelease
+      run: ./gradlew assembleFossRelease
 
-    - name: Strip restricted permissions for Play Store build
-      if: steps.check_tag.outputs.skipped == 'false'
-      run: sed -i '/REQUEST_INSTALL_PACKAGES/d' app/src/main/AndroidManifest.xml
-
-    - name: Build Release AAB
+    - name: Build Release AAB (play — Play Store)
       if: steps.check_tag.outputs.skipped == 'false'
       env:
         PLAYBRIDGE_STORE_PASSWORD: ${{ secrets.PLAYBRIDGE_STORE_PASSWORD }}
         PLAYBRIDGE_KEY_ALIAS: ${{ secrets.PLAYBRIDGE_KEY_ALIAS }}
         PLAYBRIDGE_KEY_PASSWORD: ${{ secrets.PLAYBRIDGE_KEY_PASSWORD }}
-      run: ./gradlew bundleRelease
+      run: ./gradlew bundlePlayRelease
 
     - name: Rename outputs
       if: steps.check_tag.outputs.skipped == 'false'
       run: |
-        find app/build/outputs/apk/release -name "*.apk" -type f | while read f; do
+        find app/build/outputs/apk/foss/release -name "*.apk" -type f | while read f; do
           mv "$f" "$(dirname "$f")/playbridge-phone-${{ steps.version.outputs.version }}-$(basename "$f")"
         done
-        mv app/build/outputs/bundle/release/app-release.aab \
-           app/build/outputs/bundle/release/playbridge-phone-${{ steps.version.outputs.version }}.aab
+        mv app/build/outputs/bundle/playRelease/app-play-release.aab \
+           app/build/outputs/bundle/playRelease/playbridge-phone-${{ steps.version.outputs.version }}.aab
 
     - name: List outputs (Debug)
       if: steps.check_tag.outputs.skipped == 'false'
       run: |
         echo "APK outputs:"
-        find app/build/outputs/apk/release -maxdepth 2
+        find app/build/outputs/apk/foss/release -maxdepth 2
         echo "Bundle outputs:"
-        find app/build/outputs/bundle/release -maxdepth 2
+        find app/build/outputs/bundle/playRelease -maxdepth 2
 
     - name: Upload to R2
       if: steps.check_tag.outputs.skipped == 'false'
@@ -112,10 +112,10 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
       run: |
-        aws s3 cp app/build/outputs/apk/release/ \
+        aws s3 cp app/build/outputs/apk/foss/release/ \
           s3://${{ secrets.R2_BUCKET }}/phone-release-apk/ \
           --recursive --exclude "*" --include "*.apk"
-        aws s3 cp app/build/outputs/bundle/release/ \
+        aws s3 cp app/build/outputs/bundle/playRelease/ \
           s3://${{ secrets.R2_BUCKET }}/phone-release-aab/ \
           --recursive --exclude "*" --include "*.aab"
 
@@ -172,42 +172,39 @@ jobs:
       if: steps.check_tag.outputs.skipped == 'false'
       run: chmod +x gradlew
 
-    - name: Build Release APK
+    # Same flavor split as the phone job: foss APKs → GitHub, play AAB → Play Store.
+    - name: Build Release APK (foss — GitHub sideload)
       if: steps.check_tag.outputs.skipped == 'false'
       env:
         PLAYBRIDGE_STORE_PASSWORD: ${{ secrets.PLAYBRIDGE_STORE_PASSWORD }}
         PLAYBRIDGE_KEY_ALIAS: ${{ secrets.PLAYBRIDGE_KEY_ALIAS }}
         PLAYBRIDGE_KEY_PASSWORD: ${{ secrets.PLAYBRIDGE_KEY_PASSWORD }}
-      run: ./gradlew :player:app:assembleRelease
+      run: ./gradlew :player:app:assembleFossRelease
 
-    - name: Strip restricted permissions for Play Store build
-      if: steps.check_tag.outputs.skipped == 'false'
-      run: sed -i '/REQUEST_INSTALL_PACKAGES/d' app/src/main/AndroidManifest.xml
-
-    - name: Build Release AAB
+    - name: Build Release AAB (play — Play Store)
       if: steps.check_tag.outputs.skipped == 'false'
       env:
         PLAYBRIDGE_STORE_PASSWORD: ${{ secrets.PLAYBRIDGE_STORE_PASSWORD }}
         PLAYBRIDGE_KEY_ALIAS: ${{ secrets.PLAYBRIDGE_KEY_ALIAS }}
         PLAYBRIDGE_KEY_PASSWORD: ${{ secrets.PLAYBRIDGE_KEY_PASSWORD }}
-      run: ./gradlew :player:app:bundleRelease
+      run: ./gradlew :player:app:bundlePlayRelease
 
     - name: Rename outputs
       if: steps.check_tag.outputs.skipped == 'false'
       run: |
-        find app/build/outputs/apk/release -name "*.apk" -type f | while read f; do
+        find app/build/outputs/apk/foss/release -name "*.apk" -type f | while read f; do
           mv "$f" "$(dirname "$f")/playbridge-tv-player-${{ steps.version.outputs.version }}-$(basename "$f")"
         done
-        mv app/build/outputs/bundle/release/app-release.aab \
-           app/build/outputs/bundle/release/playbridge-tv-player-${{ steps.version.outputs.version }}.aab
+        mv app/build/outputs/bundle/playRelease/app-play-release.aab \
+           app/build/outputs/bundle/playRelease/playbridge-tv-player-${{ steps.version.outputs.version }}.aab
 
     - name: List outputs (Debug)
       if: steps.check_tag.outputs.skipped == 'false'
       run: |
         echo "APK outputs:"
-        find app/build/outputs/apk/release -maxdepth 2
+        find app/build/outputs/apk/foss/release -maxdepth 2
         echo "Bundle outputs:"
-        find app/build/outputs/bundle/release -maxdepth 2
+        find app/build/outputs/bundle/playRelease -maxdepth 2
 
     - name: Upload to R2
       if: steps.check_tag.outputs.skipped == 'false'
@@ -216,10 +213,10 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
       run: |
-        aws s3 cp app/build/outputs/apk/release/ \
+        aws s3 cp app/build/outputs/apk/foss/release/ \
           s3://${{ secrets.R2_BUCKET }}/tv-player-release-apk/ \
           --recursive --exclude "*" --include "*.apk"
-        aws s3 cp app/build/outputs/bundle/release/ \
+        aws s3 cp app/build/outputs/bundle/playRelease/ \
           s3://${{ secrets.R2_BUCKET }}/tv-player-release-aab/ \
           --recursive --exclude "*" --include "*.aab"
 

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -61,6 +61,20 @@ android {
             )
         }
     }
+    // Distribution flavors: `foss` (GitHub/sideload; includes APK self-update) vs
+    // `play` (Google Play; self-update code and REQUEST_INSTALL_PACKAGES stripped -
+    // Play policy prohibits apps updating themselves outside the Store).
+    flavorDimensions += "distribution"
+    productFlavors {
+        create("foss") {
+            dimension = "distribution"
+            isDefault = true
+        }
+        create("play") {
+            dimension = "distribution"
+        }
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11

--- a/mobile/android/app/src/foss/java/com/playbridge/sender/FlavorConfig.kt
+++ b/mobile/android/app/src/foss/java/com/playbridge/sender/FlavorConfig.kt
@@ -1,0 +1,17 @@
+package com.playbridge.sender
+
+/**
+ * Capabilities of the FOSS (GitHub/sideload) distribution flavor.
+ * The Play flavor ships a counterpart with restricted features
+ * (Google Play content-policy compliance).
+ */
+object FlavorConfig {
+    /** Debrid services (Real-Debrid, All-Debrid, Premiumize, TorBox) are FOSS-only. */
+    const val DEBRID_SUPPORTED = true
+
+    /**
+     * Nuvio-style local scraper plugins (downloaded JS run in QuickJS) are FOSS-only,
+     * matching Nuvio's own Play posture (their Play flavor sets pluginsEnabled=false).
+     */
+    const val SCRAPER_PLUGINS_SUPPORTED = true
+}

--- a/mobile/android/app/src/foss/java/com/playbridge/sender/update/ApkInstaller.kt
+++ b/mobile/android/app/src/foss/java/com/playbridge/sender/update/ApkInstaller.kt
@@ -20,6 +20,9 @@ import java.util.concurrent.TimeUnit
  */
 class ApkInstaller(private val appContext: Context) {
 
+    /** FOSS builds may download and install release APKs directly. */
+    val selfUpdateSupported: Boolean get() = true
+
     private val http: OkHttpClient by lazy {
         OkHttpClient.Builder()
             .connectTimeout(15, TimeUnit.SECONDS)

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -16,9 +16,10 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <!-- One-time user-approved exemption so Doze/OEM app-sleep can't freeze the
-         local proxy while casting phone files with the app backgrounded. -->
-    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <!-- NOTE: deliberately NO REQUEST_IGNORE_BATTERY_OPTIMIZATIONS permission — Play
+         restricts it heavily. Doze protection for the cast proxy instead guides the
+         user to the system battery-optimization settings page (no permission needed);
+         see CastSessionManager.maybeRequestBatteryExemption(). -->
     <!-- Self-update: install a downloaded APK when the app was sideloaded (not from Play). -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <!-- Explicitly remove QUERY_ALL_PACKAGES permission potentially merged from dependencies -->

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -1316,7 +1316,9 @@ fun AppNavHost(
                                 if (connectionViewModel.webSocketClient.send(com.playbridge.shared.protocol.createPlaylistCommandJson(finalPlaylist))) {
                                     connectionCoordinator.startLocalPlaybackSession(
                                         tmdbId = screenNumericId,
-                                        season = playlist.items.getOrNull(playlist.start_index)?.visual_metadata?.season ?: 1,
+                                        // No fabricated fallback: a metadata-less start item must
+                                        // stay unidentified rather than be attributed to season 1.
+                                        season = playlist.items.getOrNull(playlist.start_index)?.visual_metadata?.season,
                                         episodeStart = playlist.items.getOrNull(playlist.start_index)?.visual_metadata?.episode,
                                     )
                                     if (autoSwitchToRemote) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
@@ -211,6 +211,9 @@ class BrowserActivity : ComponentActivity() {
     private val connectionCoordinator: ConnectionCoordinator by inject()
     private val addonRepository: com.playbridge.sender.data.library.AddonRepository by inject()
     private val downloadRepository: com.playbridge.sender.downloads.engine.DownloadRepository by inject()
+    private val historyDao: com.playbridge.sender.data.history.HistoryDao by inject()
+    private val searchHistoryDao: com.playbridge.sender.data.history.SearchHistoryDao by inject()
+    private val downloadDao: com.playbridge.sender.data.downloads.DownloadDao by inject()
     private val browserViewModel: com.playbridge.sender.browser.BrowserViewModel by viewModel()
     private val updateChecker: com.playbridge.sender.update.UpdateChecker by inject()
 
@@ -247,6 +250,81 @@ class BrowserActivity : ComponentActivity() {
         lifecycleScope.launch { downloadRepository.enqueue(request) }
         Toast.makeText(this, "Download started", Toast.LENGTH_SHORT).show()
     }
+
+    /**
+     * Executes the Clear Data sheet's selection (Firefox-style "Delete browsing
+     * data"). Gecko-side data (cookies, caches, permissions) is cleared through
+     * the supported StorageController API — never by deleting cache dirs, which
+     * could corrupt Gecko's open files and would also nuke the compiled
+     * ad-block rulesets. App-side data (tabs, history, downloads) lives in Room.
+     */
+    private fun performClearData(selection: ClearDataSelection) {
+        // Open tabs first: GeckoView recommends closing sessions before clearing
+        // so live pages don't immediately re-accumulate the data being deleted.
+        if (selection.openTabs) {
+            val store = Components.store
+            store.state.tabs.map { it.id }.forEach { Components.tabManager.closeTab(it, store) }
+            // Land on a fresh tab (Fenix-style) instead of a dead browser view.
+            Components.tabManager.createTab("about:blank", store)
+        }
+
+        var flags = 0L
+        if (selection.cookiesAndSiteData) {
+            flags = flags or org.mozilla.geckoview.StorageController.ClearFlags.COOKIES or
+                org.mozilla.geckoview.StorageController.ClearFlags.DOM_STORAGES or
+                org.mozilla.geckoview.StorageController.ClearFlags.AUTH_SESSIONS
+        }
+        if (selection.cachedImagesAndFiles) {
+            flags = flags or org.mozilla.geckoview.StorageController.ClearFlags.ALL_CACHES
+        }
+        if (selection.sitePermissions) {
+            flags = flags or org.mozilla.geckoview.StorageController.ClearFlags.PERMISSIONS
+        }
+        // clearData is async (returns a GeckoResult) — kick it off now, await below so
+        // the confirmation toast doesn't fire before the data is actually gone.
+        val geckoClear = if (flags != 0L) {
+            Components.runtime.storageController.clearData(flags)
+        } else null
+
+        lifecycleScope.launch {
+            if (selection.browsingHistory) {
+                historyDao.clear()
+                searchHistoryDao.deleteAll()
+            }
+            if (selection.downloads) {
+                withContext(Dispatchers.IO) {
+                    // cancel() stops any running worker, wipes the temp dir, and
+                    // drops the Room row. Files already published to MediaStore
+                    // (the user's saved videos) are intentionally left alone.
+                    downloadDao.observeAll().first().forEach {
+                        downloadRepository.cancel(it.id, removeFiles = true)
+                    }
+                }
+            }
+            val geckoOk = geckoClear?.awaitSuccess("clearData") ?: true
+            Toast.makeText(
+                this@BrowserActivity,
+                if (geckoOk) "Browsing data deleted" else "Some site data could not be cleared",
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
+
+    /**
+     * Suspends until this GeckoResult completes; true on success, false (never throws)
+     * on failure. Must be called from a Looper thread (Main here) — GeckoResult
+     * dispatches its callbacks via the calling thread's Handler.
+     */
+    private suspend fun <T> org.mozilla.geckoview.GeckoResult<T>.awaitSuccess(what: String): Boolean =
+        kotlinx.coroutines.suspendCancellableCoroutine { cont ->
+            accept(
+                { if (cont.isActive) cont.resume(true) {} },
+                { e ->
+                    android.util.Log.w("BrowserActivity", "Gecko $what failed", e)
+                    if (cont.isActive) cont.resume(false) {}
+                }
+            )
+        }
 
     /**
      * Best filename we can get: an explicit download filename, else a filename embedded in the
@@ -410,7 +488,9 @@ class BrowserActivity : ComponentActivity() {
                     if (!sp.contains("last_main_screen")) Screen.Dashboard
                     else when (sp.getString("last_main_screen", "browser")) {
                         "library" -> Screen.Library
-                        "debrid" -> Screen.DebridLibrary
+                        "debrid" ->
+                            if (com.playbridge.sender.FlavorConfig.DEBRID_SUPPORTED) Screen.DebridLibrary
+                            else Screen.Library
                         else -> Screen.Browser
                     }
                 )
@@ -729,6 +809,7 @@ class BrowserActivity : ComponentActivity() {
             val sheetState = rememberModalBottomSheetState()
             var showUserAgentSheet by remember { mutableStateOf(false) }
             val userAgentSheetState = rememberModalBottomSheetState()
+            var showClearDataSheet by remember { mutableStateOf(false) }
 
             val composeScope = rememberCoroutineScope()
             // User preferences via SettingsRepository
@@ -1707,6 +1788,21 @@ class BrowserActivity : ComponentActivity() {
                         }
                     },
 
+                    // Clear Data Sheet States
+                    onClearDataClick = {
+                        scope.launch { sheetState.hide() }.invokeOnCompletion {
+                            showMenuSheet = false
+                            showClearDataSheet = true
+                        }
+                    },
+                    showClearDataSheet = showClearDataSheet,
+                    onClearDataDismiss = { showClearDataSheet = false },
+                    openTabsCount = store.state.tabs.size,
+                    onClearDataConfirm = { selection ->
+                        showClearDataSheet = false
+                        performClearData(selection)
+                    },
+
                     // User Agent Sheet States
                     showUserAgentSheet = showUserAgentSheet,
                     onUserAgentDismiss = { showUserAgentSheet = false },
@@ -2091,9 +2187,9 @@ class BrowserActivity : ComponentActivity() {
                     )
                 }
 
-                // Pairing/Connection Dialog Popup. Also shown across the reconnect retry
-                // cycle (linear, 3 attempts) so the user sees progress and can bail out —
-                // Cancel routes playback to This Device instead of silently retrying.
+                // Pairing/Connection Dialog Popup — the single connection popup. Also shown
+                // across the reconnect retry cycle so the user sees progress and can bail
+                // out: the primary action plays on this device; staying keeps trying.
                 val state = connectionState
                 val reconnect by connectionViewModel.reconnectStatus.collectAsState()
                 val isPairingState = state is WebSocketClient.ConnectionState.WaitingForCodeInput ||
@@ -2208,7 +2304,7 @@ class BrowserActivity : ComponentActivity() {
                                     )
                                     if (rc != null || state is WebSocketClient.ConnectionState.Connecting) {
                                         Text(
-                                            text = "Play on this device instead, or keep waiting for the TV.",
+                                            text = "Stay on this screen to keep trying, or play on this device instead.",
                                             style = MaterialTheme.typography.bodySmall,
                                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                                             textAlign = TextAlign.Center,
@@ -2228,25 +2324,24 @@ class BrowserActivity : ComponentActivity() {
                                         Text("Verify")
                                     }
                                 }
-                                // Reconnect cycle: let the user extend the retry window.
-                                reconnect != null -> {
-                                    Button(onClick = { connectionViewModel.keepTryingReconnect() }) {
-                                        Text("Keep trying")
+                                // Connecting/reconnecting: the primary (default) action is to
+                                // stop chasing the TV and play here. Simply staying on the dialog
+                                // keeps the connection attempts running — so there's no separate
+                                // "keep trying" button.
+                                !isPairingState -> {
+                                    Button(onClick = { connectionViewModel.cancelConnectingToThisDevice() }) {
+                                        Text("Play on this device")
                                     }
                                 }
                             }
                         },
                         dismissButton = {
-                            TextButton(onClick = {
-                                if (isPairingState) {
-                                    connectionViewModel.disconnect()
-                                } else {
-                                    // Connecting/reconnecting: bail out to phone-local playback.
-                                    connectionViewModel.cancelConnectingToThisDevice()
+                            // Only pairing dialogs get a Cancel; the connecting/reconnecting
+                            // dialog's single action lives in confirmButton above.
+                            if (isPairingState) {
+                                TextButton(onClick = { connectionViewModel.disconnect() }) {
+                                    Text("Cancel")
                                 }
-                            }) {
-                                // The dismiss action means "play here" everywhere except pairing.
-                                Text(if (isPairingState) "Cancel" else "Play on this device")
                             }
                         }
                     )

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/ClearDataSheet.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/ClearDataSheet.kt
@@ -1,0 +1,154 @@
+package com.playbridge.sender.browser
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * What the user picked in the Clear Data sheet. Mirrors Firefox's
+ * "Delete browsing data" categories.
+ */
+data class ClearDataSelection(
+    val openTabs: Boolean,
+    val browsingHistory: Boolean,
+    val cookiesAndSiteData: Boolean,
+    val cachedImagesAndFiles: Boolean,
+    val sitePermissions: Boolean,
+    val downloads: Boolean,
+) {
+    val isEmpty: Boolean
+        get() = !openTabs && !browsingHistory && !cookiesAndSiteData &&
+            !cachedImagesAndFiles && !sitePermissions && !downloads
+}
+
+/**
+ * Firefox-style "Delete browsing data" bottom sheet: one checkbox per data
+ * category plus a destructive confirm button. Owns its own sheet state; the
+ * caller controls visibility via [onDismissRequest].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ClearDataSheet(
+    openTabsCount: Int,
+    onDismissRequest: () -> Unit,
+    onConfirm: (ClearDataSelection) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    var openTabs by remember { mutableStateOf(false) }
+    var browsingHistory by remember { mutableStateOf(true) }
+    var cookies by remember { mutableStateOf(true) }
+    var caches by remember { mutableStateOf(true) }
+    var permissions by remember { mutableStateOf(false) }
+    var downloads by remember { mutableStateOf(false) }
+
+    val selection = ClearDataSelection(
+        openTabs = openTabs,
+        browsingHistory = browsingHistory,
+        cookiesAndSiteData = cookies,
+        cachedImagesAndFiles = caches,
+        sitePermissions = permissions,
+        downloads = downloads,
+    )
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        dragHandle = { BottomSheetDefaults.DragHandle() },
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 16.dp, bottom = 24.dp)
+        ) {
+            Text(
+                text = "Delete browsing data",
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+
+            ClearDataRow(
+                label = "Open tabs",
+                subtitle = if (openTabsCount == 1) "1 tab" else "$openTabsCount tabs",
+                checked = openTabs,
+                onCheckedChange = { openTabs = it },
+            )
+            ClearDataRow(
+                label = "Browsing history",
+                subtitle = "Includes search history",
+                checked = browsingHistory,
+                onCheckedChange = { browsingHistory = it },
+            )
+            ClearDataRow(
+                label = "Cookies and site data",
+                subtitle = "You'll be logged out of most sites",
+                checked = cookies,
+                onCheckedChange = { cookies = it },
+            )
+            ClearDataRow(
+                label = "Cached images and files",
+                subtitle = "Frees up storage space",
+                checked = caches,
+                onCheckedChange = { caches = it },
+            )
+            ClearDataRow(
+                label = "Site permissions",
+                subtitle = "Camera, location, notifications, etc.",
+                checked = permissions,
+                onCheckedChange = { permissions = it },
+            )
+            ClearDataRow(
+                label = "Downloads",
+                subtitle = "Clears the download list and temporary files; saved videos stay on your device",
+                checked = downloads,
+                onCheckedChange = { downloads = it },
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = { onConfirm(selection) },
+                enabled = !selection.isEmpty,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                    contentColor = MaterialTheme.colorScheme.onError,
+                ),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Delete browsing data")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ClearDataRow(
+    label: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!checked) }
+            .padding(vertical = 4.dp)
+    ) {
+        Checkbox(checked = checked, onCheckedChange = onCheckedChange)
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = label, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/Components.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/Components.kt
@@ -116,6 +116,29 @@ object Components {
     val applicationContext: Context
         get() = appContext
     
+    /**
+     * Writes a GeckoView startup config (read via configFilePath, which works in
+     * release builds too — see Mozilla's automation docs) that caps the HTTP disk
+     * cache. By default Gecko "smart sizes" the cache off free disk space, which
+     * on a roomy phone lets it balloon to 600+ MB of media fragments and web
+     * assets. Capping at 200 MB (the ceiling Firefox itself uses on Android)
+     * with LRU eviction keeps hot assets fast without unbounded growth.
+     */
+    private fun writeGeckoConfig(): String? = try {
+        val file = java.io.File(appContext.filesDir, "geckoview-config.yaml")
+        val yaml = """
+            |prefs:
+            |  browser.cache.disk.smart_size.enabled: false
+            |  browser.cache.disk.capacity: 204800
+            |""".trimMargin() // capacity is in KB → 200 MB
+        // Avoid rewriting on every start; only touch the file when content changes.
+        if (!file.exists() || file.readText() != yaml) file.writeText(yaml)
+        file.absolutePath
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to write gecko config; cache cap disabled", e)
+        null
+    }
+
     // GeckoRuntime - the core Gecko engine
     val runtime: GeckoRuntime by lazy {
         // BuildConfig generation is disabled by default on AGP 8+; the
@@ -124,6 +147,7 @@ object Components {
                 android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0
         val settings = GeckoRuntimeSettings.Builder()
             .aboutConfigEnabled(true)
+            .apply { writeGeckoConfig()?.let { configFilePath(it) } }
             .webManifest(true)
             .javaScriptEnabled(true)
             // Remote debugging only in debug builds — it was previously

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/MenuSheet.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/MenuSheet.kt
@@ -1,16 +1,25 @@
 package com.playbridge.sender.browser
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -18,7 +27,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
-@OptIn(ExperimentalMaterial3Api::class)
+/**
+ * Hamburger menu as a horizontally paged bottom sheet (Firefox-style).
+ * Page 1: everyday browsing actions. Page 2: app-level tools and the
+ * destructive Clear Data action, kept off the first page so it can't be
+ * fat-fingered. Swipe between pages; dots below indicate position.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun MenuSheet(
     sheetState: SheetState,
@@ -36,8 +51,17 @@ fun MenuSheet(
     onSettingsClick: () -> Unit,
     onToggleDesktopMode: () -> Unit,
     onToggleVideoDetect: () -> Unit,
-    onUserAgentClick: () -> Unit = {}
+    onUserAgentClick: () -> Unit = {},
+    onClearDataClick: () -> Unit = {}
 ) {
+    val pagerState = rememberPagerState(pageCount = { 2 })
+    // Page 1's measured height, applied as a min height to page 2 so the sheet
+    // keeps a stable size when swiping (page 2 has fewer rows). Page 1 is always
+    // composed first (the sheet opens on it), so the height is known by the time
+    // page 2 becomes visible.
+    var firstPageHeightPx by remember { mutableIntStateOf(0) }
+    val density = LocalDensity.current
+
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
@@ -50,75 +74,128 @@ fun MenuSheet(
                 .fillMaxWidth()
                 .padding(start = 16.dp, end = 16.dp, top = 0.dp, bottom = 16.dp)
         ) {
-            // Row 1: Bookmarks, History, Downloads, Add Bookmark, Find in Page
-            Row(modifier = Modifier.fillMaxWidth()) {
-                MenuGridItem(
-                    icon = Icons.Default.Bookmarks,
-                    label = "Bookmarks",
-                    modifier = Modifier.weight(1f),
-                    onClick = onBookmarksClick
-                )
-                MenuGridItem(
-                    icon = Icons.Default.History,
-                    label = "History",
-                    modifier = Modifier.weight(1f),
-                    onClick = onHistoryClick
-                )
-                MenuGridItem(
-                    icon = Icons.Default.Download,
-                    label = "Downloads",
-                    modifier = Modifier.weight(1f),
-                    onClick = onDownloadsClick
-                )
-                MenuGridItem(
-                    icon = Icons.Default.Star,
-                    label = "Add Bookmark",
-                    modifier = Modifier.weight(1f),
-                    onClick = onAddBookmarkClick
-                )
-                MenuGridItem(
-                    icon = Icons.Default.Search,
-                    label = "Find in Page",
-                    modifier = Modifier.weight(1f),
-                    onClick = onFindInPageClick
-                )
+            HorizontalPager(
+                state = pagerState,
+                verticalAlignment = Alignment.Top,
+                modifier = Modifier.fillMaxWidth()
+            ) { page ->
+                when (page) {
+                    0 -> Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .onSizeChanged { firstPageHeightPx = it.height }
+                    ) {
+                        // Row 1: bookmark pair first, then the other destinations
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            MenuGridItem(
+                                icon = Icons.Default.Bookmarks,
+                                label = "Bookmarks",
+                                modifier = Modifier.weight(1f),
+                                onClick = onBookmarksClick
+                            )
+                            MenuGridItem(
+                                icon = Icons.Default.Star,
+                                label = "Add Bookmark",
+                                modifier = Modifier.weight(1f),
+                                onClick = onAddBookmarkClick
+                            )
+                            MenuGridItem(
+                                icon = Icons.Default.History,
+                                label = "History",
+                                modifier = Modifier.weight(1f),
+                                onClick = onHistoryClick
+                            )
+                            MenuGridItem(
+                                icon = Icons.Default.Download,
+                                label = "Downloads",
+                                modifier = Modifier.weight(1f),
+                                onClick = onDownloadsClick
+                            )
+                            MenuGridItem(
+                                icon = Icons.Default.Search,
+                                label = "Find in Page",
+                                modifier = Modifier.weight(1f),
+                                onClick = onFindInPageClick
+                            )
+                        }
+                        // Row 2: per-page toggles together, then app destinations
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            MenuGridItem(
+                                icon = Icons.Default.Devices,
+                                label = "Desktop Site",
+                                selected = isDesktopMode,
+                                modifier = Modifier.weight(1f),
+                                onClick = onToggleDesktopMode
+                            )
+                            MenuGridItem(
+                                icon = Icons.Default.PlayCircle,
+                                label = "Video Detect",
+                                selected = detectVideosEnabled,
+                                modifier = Modifier.weight(1f),
+                                onClick = onToggleVideoDetect
+                            )
+                            MenuGridItem(
+                                icon = Icons.Default.Language,
+                                label = "User Agent",
+                                selected = userAgentActive,
+                                modifier = Modifier.weight(1f),
+                                onClick = onUserAgentClick
+                            )
+                            MenuGridItem(
+                                icon = Icons.Default.Extension,
+                                label = "Extensions",
+                                modifier = Modifier.weight(1f),
+                                onClick = onExtensionsClick
+                            )
+                            MenuGridItem(
+                                icon = Icons.Default.Settings,
+                                label = "Settings",
+                                selected = currentScreen == Screen.Settings,
+                                modifier = Modifier.weight(1f),
+                                onClick = onSettingsClick
+                            )
+                        }
+                    }
+                    1 -> Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = with(density) { firstPageHeightPx.toDp() })
+                    ) {
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            MenuGridItem(
+                                icon = Icons.Default.DeleteSweep,
+                                label = "Clear Data",
+                                tint = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.weight(1f),
+                                onClick = onClearDataClick
+                            )
+                            Spacer(modifier = Modifier.weight(4f))
+                        }
+                    }
+                }
             }
-            // Row 2: Extensions, Settings, Desktop Site, Video Detect
-            Row(modifier = Modifier.fillMaxWidth()) {
-                MenuGridItem(
-                    icon = Icons.Default.Extension,
-                    label = "Extensions",
-                    modifier = Modifier.weight(1f),
-                    onClick = onExtensionsClick
-                )
-                MenuGridItem(
-                    icon = Icons.Default.Settings,
-                    label = "Settings",
-                    selected = currentScreen == Screen.Settings,
-                    modifier = Modifier.weight(1f),
-                    onClick = onSettingsClick
-                )
-                MenuGridItem(
-                    icon = Icons.Default.Devices,
-                    label = "Desktop Site",
-                    selected = isDesktopMode,
-                    modifier = Modifier.weight(1f),
-                    onClick = onToggleDesktopMode
-                )
-                MenuGridItem(
-                    icon = Icons.Default.PlayCircle,
-                    label = "Video Detect",
-                    selected = detectVideosEnabled,
-                    modifier = Modifier.weight(1f),
-                    onClick = onToggleVideoDetect
-                )
-                MenuGridItem(
-                    icon = Icons.Default.Language,
-                    label = "User Agent",
-                    selected = userAgentActive,
-                    modifier = Modifier.weight(1f),
-                    onClick = onUserAgentClick
-                )
+
+            // Page indicator dots
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp)
+            ) {
+                repeat(2) { index ->
+                    Box(
+                        modifier = Modifier
+                            .padding(horizontal = 4.dp)
+                            .size(8.dp)
+                            .clip(CircleShape)
+                            .background(
+                                if (pagerState.currentPage == index)
+                                    MaterialTheme.colorScheme.primary
+                                else
+                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
+                            )
+                    )
+                }
             }
         }
     }
@@ -147,7 +224,7 @@ private fun MenuGridItem(
                 .size(48.dp)
                 .clip(CircleShape)
                 .background(
-                    if (selected) MaterialTheme.colorScheme.primaryContainer 
+                    if (selected) MaterialTheme.colorScheme.primaryContainer
                     else Color.Transparent
                 )
         ) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/Screen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/Screen.kt
@@ -78,7 +78,8 @@ sealed class Screen {
                         "home" -> Home
                         "remote" -> Remote
                         "library" -> Library
-                        "debridlibrary" -> DebridLibrary
+                        "debridlibrary" ->
+                            if (com.playbridge.sender.FlavorConfig.DEBRID_SUPPORTED) DebridLibrary else Library
                         "addonsettings" -> AddonSettings
                         "dashboard" -> Dashboard
                         "phonefiles" -> PhoneFiles

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/SheetOverlayContainer.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/SheetOverlayContainer.kt
@@ -45,6 +45,13 @@ fun SheetOverlayContainer(
     onUserAgentClick: () -> Unit = {},
     userAgentActive: Boolean = false,
 
+    // Clear Data Sheet States
+    onClearDataClick: () -> Unit = {},
+    showClearDataSheet: Boolean = false,
+    onClearDataDismiss: () -> Unit = {},
+    openTabsCount: Int = 0,
+    onClearDataConfirm: (ClearDataSelection) -> Unit = {},
+
     // User Agent Sheet States
     showUserAgentSheet: Boolean = false,
     onUserAgentDismiss: () -> Unit = {},
@@ -115,7 +122,17 @@ fun SheetOverlayContainer(
                 onToggleDesktopMode = onToggleDesktopMode,
                 onToggleVideoDetect = onToggleVideoDetect,
                 userAgentActive = userAgentActive,
-                onUserAgentClick = onUserAgentClick
+                onUserAgentClick = onUserAgentClick,
+                onClearDataClick = onClearDataClick
+            )
+        }
+
+        // 1a. Clear Data Sheet
+        if (showClearDataSheet) {
+            ClearDataSheet(
+                openTabsCount = openTabsCount,
+                onDismissRequest = onClearDataDismiss,
+                onConfirm = onClearDataConfirm
             )
         }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
@@ -360,7 +360,14 @@ class CastSessionManager(
                     }
                     is WebSocketClient.ConnectionState.Error,
                     is WebSocketClient.ConnectionState.Disconnected -> {
-                        if (_route.value is Route.NativeTv && hasConnectedThisSession) {
+                        // A deliberate disconnect (Disconnect button / route change) must NOT
+                        // trigger the reconnect cycle — only an *unexpected* drop does. Without
+                        // this guard, hitting Disconnect immediately popped a "Reconnecting…"
+                        // dialog and fought the user's action.
+                        if (_route.value is Route.NativeTv &&
+                            hasConnectedThisSession &&
+                            !webSocketClient.wasUserDisconnect
+                        ) {
                             scheduleReconnect()
                         }
                     }
@@ -398,28 +405,12 @@ class CastSessionManager(
         selectThisDevice() // also stands the supervisor down
     }
 
-    /**
-     * User pressed "Keep trying" on the reconnect popup: refresh the retry budget and,
-     * if the supervisor had stood down, kick off a new cycle.
-     */
-    fun keepTryingReconnect() {
-        scope.launch {
-            reconnectAttempt = 0
-            if (reconnectJob?.isActive != true &&
-                _route.value is Route.NativeTv &&
-                hasConnectedThisSession
-            ) {
-                scheduleReconnect()
-            }
-        }
-    }
-
     private fun scheduleReconnect() {
         if (reconnectJob?.isActive == true) return
         // Budget exhausted: how we stand down depends on whether the user is watching.
         //  - Foreground (interactive): the user was actively using the TV; a route left
         //    pointing at a dead receiver makes every play action fail, so fall back to
-        //    this phone and tell them (they can re-pick the TV, or hit "Keep trying").
+        //    this phone and tell them (they can re-pick the TV to try again).
         //  - Background: never silently change the route — a screen-off session (episode
         //    queue topping up) must resume on the TV when it returns. Just stand down and
         //    notify; the foreground-return / Wi-Fi hooks re-arm and reconnect later.
@@ -653,27 +644,42 @@ class CastSessionManager(
     }
 
     /**
-     * Ask (once, on the first cast session) to be exempted from battery optimization.
-     * Casting phone files means this app IS the media server: Doze and OEM "app sleep"
-     * managers freeze a backgrounded app's network — and eventually the process — even
-     * with the cast FGS running, killing the local proxy mid-stream. Prompted here
-     * rather than at app launch so a fresh install isn't greeted by a stack of system
-     * dialogs; a session always starts from a foreground user action, so launching
-     * the settings dialog is permitted.
+     * Guide the user (once, on the first cast session) to whitelist the app from
+     * battery optimization. Casting phone files means this app IS the media server:
+     * Doze and OEM "app sleep" managers freeze a backgrounded app's network — and
+     * eventually the process — even with the cast FGS running, killing the local
+     * proxy mid-stream.
+     *
+     * Deliberately does NOT use ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS: the
+     * direct-exemption dialog requires the REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+     * permission, which Google Play restricts to a narrow allowlist. Instead we open
+     * the system battery-optimization settings page (no permission needed) with an
+     * explanatory toast, and the user flips the switch manually. Prompted here rather
+     * than at app launch so a fresh install isn't greeted by a stack of system
+     * screens; a session always starts from a foreground user action, so launching
+     * the settings screen is permitted.
      */
     private fun maybeRequestBatteryExemption() {
         val pm = context.getSystemService(android.content.Context.POWER_SERVICE) as android.os.PowerManager
         if (pm.isIgnoringBatteryOptimizations(context.packageName)) return
         val prefs = context.getSharedPreferences("browser_prefs", android.content.Context.MODE_PRIVATE)
         if (prefs.getBoolean("battery_exemption_prompted", false)) return
-        prefs.edit().putBoolean("battery_exemption_prompted", true).apply()
         runCatching {
+            android.widget.Toast.makeText(
+                context,
+                "To keep casting stable with the screen off, find PlayBridge in this list " +
+                    "and set battery usage to “Unrestricted” / “Don’t optimize”.",
+                android.widget.Toast.LENGTH_LONG
+            ).show()
             context.startActivity(
-                android.content.Intent(android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
-                    .setData(android.net.Uri.parse("package:${context.packageName}"))
+                android.content.Intent(android.provider.Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
                     .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
             )
-        }.onFailure { Log.w(TAG, "Battery-optimization exemption request failed", it) }
+        }.onSuccess {
+            // Only burn the one-shot AFTER the settings screen actually launched — if the
+            // intent fails (odd OEM builds), the next cast session gets another chance.
+            prefs.edit().putBoolean("battery_exemption_prompted", true).apply()
+        }.onFailure { Log.w(TAG, "Couldn't open battery-optimization settings", it) }
     }
 
     /**

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/DevicePicker.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/DevicePicker.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.LaunchedEffect
 import com.playbridge.sender.ui.UnifiedDevice
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -296,12 +295,18 @@ fun DeviceConnectionSheet(
                         icon = Icons.Default.Tv,
                         badge = null,
                         onDisconnect = {
+                            // A manual disconnect is a deliberate "stop watching on TV":
+                            // route back to this phone so nothing tries to reconnect.
+                            viewModel.selectThisDevice()
                             viewModel.disconnect()
                             onDismiss()
                         }
                     )
                 }
-                isConnecting -> ConnectingCard(onCancel = { viewModel.disconnect() })
+                // While connecting/reconnecting, the global connection popup (in
+                // BrowserActivity) is the single source of truth — don't also show an
+                // inline card here, which produced two overlays saying the same thing.
+                isConnecting -> Unit
             }
 
             // Player-engine picker, shown with the connected TV it configures (native
@@ -453,24 +458,6 @@ private fun ActiveDeviceCard(
             TextButton(onClick = onDisconnect) {
                 Text("Disconnect", color = MaterialTheme.colorScheme.error)
             }
-        }
-    }
-}
-
-@Composable
-private fun ConnectingCard(onCancel: () -> Unit) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
-            Text("Connecting to TV…", style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
-            TextButton(onClick = onCancel) { Text("Cancel") }
         }
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/StreamPickerSheet.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/StreamPickerSheet.kt
@@ -468,7 +468,7 @@ fun StreamPickerSheet(
                             color = contentColor
                         )
                         Text(
-                            "Make sure you have addons installed with Real-Debrid configured",
+                            "Make sure you have streaming addons installed and configured",
                             style = MaterialTheme.typography.bodySmall,
                             color = subTextColor,
                             modifier = Modifier.padding(horizontal = 32.dp)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
@@ -441,10 +441,6 @@ class ConnectionViewModel(
         castSessionManager.cancelReconnect() // clears retry state + selects This Device
     }
 
-    /** "Keep trying" on the reconnect popup: refresh the retry budget and continue. */
-    fun keepTryingReconnect() {
-        castSessionManager.keepTryingReconnect()
-    }
 
     fun removeDeviceFromHistory(device: TvDevice) {
         viewModelScope.launch {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/PlaybackProgressTracker.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/PlaybackProgressTracker.kt
@@ -228,7 +228,15 @@ class PlaybackProgressTracker(
         }
 
         // Playback is reporting → user started watching: ensure a Watching row exists.
-        ensureTracked(item)
+        // Skip-ahead catch-up may only fire for the episode the user explicitly sent
+        // (it matches the send-time pointer) — NEVER for items the playlist advanced to
+        // mid-session (those are judged by the advance rules above; catching up "past"
+        // a manually-skipped episode would mark it watched and delete its resume point),
+        // and never for a stale echo of the previous content.
+        val userStartedThis = item.mediaType != "tv" ||
+            (item.season == t.nowPlayingSeason &&
+                item.episode == connectionCoordinator.nowPlayingEpisodeStart.value)
+        ensureTracked(item, allowCatchUp = userStartedThis)
 
         if (ProgressRules.isWatched(pb.positionMs, pb.durationMs)) {
             if (!thresholdArmed) return // stale near-end status from before this session
@@ -249,6 +257,15 @@ class PlaybackProgressTracker(
     ) {
         if (!enabled.value) return
         if (!targetActive || meta == null) {
+            // Session over (explicit stop / target lost) — flush a final resume point for
+            // whatever was playing, mirroring the in-app player's close flush.
+            val last = dlnaItem
+            if (last != null &&
+                dlnaLastObservedPosMs >= MIN_RESUME_POSITION_MS && dlnaLastObservedDurMs > 0 &&
+                !ProgressRules.isWatched(dlnaLastObservedPosMs, dlnaLastObservedDurMs)
+            ) {
+                saveResume(last, dlnaLastObservedPosMs, dlnaLastObservedDurMs, dlnaThrottle)
+            }
             if (!targetActive && dlnaItem != null) resetSession()
             dlnaItem = null
             dlnaLastObservedPosMs = 0L
@@ -267,7 +284,7 @@ class PlaybackProgressTracker(
         // like the native playlist-advance rule.
         val prevItem = dlnaItem
         if (prevItem != null && prevItem.key != item.key) {
-            if (prevItem.mediaType == "tv" &&
+            if (advancedForward(prevItem, item) &&
                 ProgressRules.finishedOnAdvance(dlnaLastObservedPosMs, dlnaLastObservedDurMs)
             ) {
                 markEpisodeWatched(prevItem.tmdbId, prevItem.season!!, prevItem.episode!!)
@@ -285,7 +302,13 @@ class PlaybackProgressTracker(
         if (st.positionMs > 0) dlnaLastObservedPosMs = st.positionMs
         if (st.durationMs > 0) dlnaLastObservedDurMs = st.durationMs
 
-        ensureTracked(item)
+        // Catch-up only for the item the user cast (fresh session or a show switch) —
+        // queue advances within a show must not imply earlier episodes were seen.
+        // NOTE: deliberately more conservative than the native path (which matches the
+        // send-time pointer): on DLNA a manual cast of a LATER episode of the same show
+        // mid-session is indistinguishable from a queue advance, so it won't catch up.
+        // Missing a catch-up is recoverable; marking a skipped episode watched is not.
+        ensureTracked(item, allowCatchUp = prevItem == null || prevItem.tmdbId != item.tmdbId)
 
         if (ProgressRules.isWatched(st.positionMs, st.durationMs)) {
             if (!dlnaThresholdArmed) return // stale poll from the previous item
@@ -352,7 +375,7 @@ class PlaybackProgressTracker(
         // like the native playlist-advance / DLNA item-change rule.
         val prevItem = inAppItem
         if (prevItem != null && prevItem.key != item.key) {
-            if (prevItem.mediaType == "tv" &&
+            if (advancedForward(prevItem, item) &&
                 ProgressRules.finishedOnAdvance(inAppLastObservedPosMs, inAppLastObservedDurMs)
             ) {
                 markEpisodeWatched(prevItem.tmdbId, prevItem.season!!, prevItem.episode!!)
@@ -368,7 +391,11 @@ class PlaybackProgressTracker(
         if (positionMs > 0) inAppLastObservedPosMs = positionMs
         if (durationMs > 0) inAppLastObservedDurMs = durationMs
 
-        ensureTracked(item)
+        // Catch-up only for the episode this player session was launched on — episode
+        // advances inside the player must not imply earlier episodes were seen.
+        // NOTE: same conservative trade-off as the DLNA call site above — jumping to a
+        // later episode of the same show within one player session won't catch up.
+        ensureTracked(item, allowCatchUp = prevItem == null || prevItem.tmdbId != item.tmdbId)
 
         if (ProgressRules.isWatched(positionMs, durationMs)) {
             if (!inAppThresholdArmed) return // stale near-end position before this session armed
@@ -447,6 +474,19 @@ class PlaybackProgressTracker(
         return season to connectionCoordinator.nowPlayingEpisodeStart.value
     }
 
+    /**
+     * True when [next] is a later episode of the same show as [prev] — the only kind of
+     * item change that can mean "the previous episode finished and playback advanced".
+     * Backward jumps, show switches and tv↔movie changes are user navigation: the
+     * previous item keeps a resume point instead of being marked watched.
+     */
+    private fun advancedForward(prev: PlayingItem, next: PlayingItem): Boolean =
+        prev.mediaType == "tv" && next.mediaType == "tv" &&
+            prev.tmdbId == next.tmdbId &&
+            prev.season != null && prev.episode != null &&
+            next.season != null && next.episode != null &&
+            ProgressRules.isForwardProgress(next.season, next.episode, prev.season, prev.episode)
+
     private fun resetSession() {
         markedKeys.clear()
         ensuredKeys.clear()
@@ -466,12 +506,16 @@ class PlaybackProgressTracker(
      * promotion from Plan-to-Watch/On-Hold/Dropped. Watching/Completed rows are left
      * alone (rewatches must not demote Completed).
      *
-     * Skip-ahead catch-up: starting S/E implies everything before it has been seen —
-     * the progress pointer moves (forward-only) to the episode *before* the one being
-     * started, so starting S1E3 marks E1/E2 watched and starting S3E1 marks seasons
-     * 1–2 watched. Rewatching an earlier episode never regresses the pointer.
+     * Skip-ahead catch-up ([allowCatchUp]): *deliberately starting* S/E implies
+     * everything before it has been seen — the progress pointer moves (forward-only) to
+     * the episode *before* the one being started, so starting S1E3 marks E1/E2 watched
+     * and starting S3E1 marks seasons 1–2 watched. Rewatching an earlier episode never
+     * regresses the pointer. Callers pass allowCatchUp=true ONLY for the episode the
+     * user explicitly chose to play — never for items playback advanced to mid-session,
+     * where catching up would mark a manually-skipped episode watched and delete the
+     * resume point the advance rules just saved for it.
      */
-    private suspend fun ensureTracked(item: PlayingItem) {
+    private suspend fun ensureTracked(item: PlayingItem, allowCatchUp: Boolean) {
         if (!ensuredKeys.add(item.key)) return
         writeMutex.withLock {
             val now = System.currentTimeMillis()
@@ -490,7 +534,7 @@ class PlaybackProgressTracker(
             // Skip-ahead catch-up (series only; no-op when starting S1E1).
             val season = item.season
             val episode = item.episode
-            if (item.mediaType == "tv" && season != null && episode != null &&
+            if (allowCatchUp && item.mediaType == "tv" && season != null && episode != null &&
                 (episode > 1 || season > 1)
             ) {
                 val catchUpEpisode = episode - 1 // (s, 0) = previous seasons done, this one untouched
@@ -505,9 +549,10 @@ class PlaybackProgressTracker(
     }
 
     private suspend fun markEpisodeWatched(tmdbId: Int, season: Int, episode: Int) {
-        if (!markedKeys.add("$tmdbId:$season:$episode")) return
-        // Watched → never offer to resume it again.
+        // Watched → never offer to resume it again. Runs BEFORE the dedup: a rewatch in
+        // the same session re-creates resume points that still need cleaning at 90%.
         runCatching { resumeDao.deleteByKey("tmdb:$tmdbId:$season:$episode") }
+        if (!markedKeys.add("$tmdbId:$season:$episode")) return
         writeMutex.withLock {
             val existing = watchlistDao.getByIdSync(tmdbId)
                 ?: autoAddEntity(tmdbId, mediaType = "tv")
@@ -563,9 +608,10 @@ class PlaybackProgressTracker(
     }
 
     private suspend fun markMovieWatched(tmdbId: Int) {
-        if (!markedKeys.add("movie:$tmdbId")) return
-        // Watched → never offer to resume it again.
+        // Watched → never offer to resume it again. Runs BEFORE the dedup: a rewatch in
+        // the same session re-creates resume points that still need cleaning at 90%.
         runCatching { resumeDao.deleteByKey("tmdb:$tmdbId") }
+        if (!markedKeys.add("movie:$tmdbId")) return
         writeMutex.withLock {
             val existing = watchlistDao.getByIdSync(tmdbId)
                 ?: autoAddEntity(tmdbId, mediaType = "movie")

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/debrid/DebridRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/debrid/DebridRepository.kt
@@ -46,6 +46,7 @@ class DebridRepository(
     private fun prefs() = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
     fun isConfigured(): Boolean {
+        if (!com.playbridge.sender.FlavorConfig.DEBRID_SUPPORTED) return false
         return getActiveProvider() != null
     }
 
@@ -93,7 +94,8 @@ class DebridRepository(
 
     /** Providers that have a non-blank API key configured, in display order. */
     fun getConfiguredProviders(): List<String> =
-        ALL_PROVIDERS.filter { getApiKeyFor(it).isNotBlank() }
+        if (!com.playbridge.sender.FlavorConfig.DEBRID_SUPPORTED) emptyList()
+        else ALL_PROVIDERS.filter { getApiKeyFor(it).isNotBlank() }
 
     fun saveConfiguration(provider: String, apiKey: String) {
         prefs().edit { putString(KEY_DEBRID_PROVIDER, provider) }
@@ -101,6 +103,8 @@ class DebridRepository(
     }
 
     fun getActiveProvider(): DebridProvider? {
+        // Play flavor: debrid is disabled entirely (Play content-policy compliance).
+        if (!com.playbridge.sender.FlavorConfig.DEBRID_SUPPORTED) return null
         val providerName = getConfiguredProviderName()
         val apiKey = getApiKeyFor(providerName)
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/nuvio/NuvioRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/nuvio/NuvioRepository.kt
@@ -88,7 +88,13 @@ class NuvioRepository(
      * @param preFetchedBody Optional manifest JSON already downloaded by the caller
      *   (avoids a second network round-trip during install detection).
      */
-    suspend fun installRepo(manifestUrl: String, preFetchedBody: String? = null): Boolean =
+    suspend fun installRepo(manifestUrl: String, preFetchedBody: String? = null): Boolean {
+        // Play flavor: scraper plugins are disabled entirely (see FlavorConfig).
+        if (!com.playbridge.sender.FlavorConfig.SCRAPER_PLUGINS_SUPPORTED) return false
+        return installRepoInternal(manifestUrl, preFetchedBody)
+    }
+
+    private suspend fun installRepoInternal(manifestUrl: String, preFetchedBody: String? = null): Boolean =
         withContext(Dispatchers.IO) {
             try {
                 val body = preFetchedBody ?: fetchText(manifestUrl) ?: run {
@@ -170,6 +176,9 @@ class NuvioRepository(
      * null so the caller can fall back to the standard Stremio addon install.
      */
     suspend fun tryInstall(url: String): Boolean? = withContext(Dispatchers.IO) {
+        // Play flavor: never recognize scraper manifests; the URL falls through to the
+        // regular addon installer (no scraper-plugin branding surfaces in this build).
+        if (!com.playbridge.sender.FlavorConfig.SCRAPER_PLUGINS_SUPPORTED) return@withContext null
         val body = fetchText(url) ?: return@withContext null
         if (!looksLikeNuvioManifest(body)) return@withContext null
         installRepo(url, preFetchedBody = body)
@@ -221,6 +230,8 @@ class NuvioRepository(
         season: Int?,
         episode: Int?
     ): List<ResolvedStream> {
+        // Play flavor: scraper plugins are disabled entirely (see FlavorConfig).
+        if (!com.playbridge.sender.FlavorConfig.SCRAPER_PLUGINS_SUPPORTED) return emptyList()
         // Master opt-in gate — scrapers run third-party JS, so they stay off by default.
         if (!settingsRepository.enableLocalScrapers.first()) return emptyList()
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/library/AddonSettingsScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/library/AddonSettingsScreen.kt
@@ -151,7 +151,7 @@ fun AddonSettingsScreen(
                             fontWeight = FontWeight.Bold
                         )
                         Text(
-                            text = "Paste a Stremio addon URL, or a Nuvio plugin manifest URL to add local scrapers. For Torrentio with Real-Debrid, configure it at torrentio.strem.fun and copy the install URL.",
+                            text = "Paste an addon manifest URL. Addons can provide catalogs, streams, or subtitles.",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -160,7 +160,7 @@ fun AddonSettingsScreen(
                             value = addonUrl,
                             onValueChange = { addonUrl = it },
                             label = { Text("Addon URL") },
-                            placeholder = { Text("https://torrentio.strem.fun/.../manifest.json") },
+                            placeholder = { Text("https://example.com/addon/manifest.json") },
                             singleLine = true,
                             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                             keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
@@ -227,8 +227,8 @@ fun AddonSettingsScreen(
                 }
             }
 
-            // ── Nuvio scraper plugins (per-scraper toggles) ──────────────
-            val nuvioRepos = installedAddons.filter {
+            // ── Nuvio scraper plugins (per-scraper toggles; FOSS flavor only) ──
+            val nuvioRepos = if (!com.playbridge.sender.FlavorConfig.SCRAPER_PLUGINS_SUPPORTED) emptyList() else installedAddons.filter {
                 it.resources.contains(com.playbridge.sender.data.nuvio.NuvioRepository.NUVIO_RESOURCE)
             }
             if (nuvioRepos.isNotEmpty()) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/player/PlayerActivity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/player/PlayerActivity.kt
@@ -388,7 +388,13 @@ class PlayerActivity : ComponentActivity() {
                     val season = plSeasons?.getOrNull(idx)?.takeIf { it > 0 } ?: singleSeason
                     val episode = plEpisodes?.getOrNull(idx)?.takeIf { it > 0 } ?: singleEpisode
                     val dur = exo.duration
-                    if (dur > 0) {
+                    // Lazy mode: currentIndex flips as soon as goTo() is called, but the
+                    // player keeps holding the PREVIOUS episode until its stream resolves
+                    // (or fails). Reporting during that window would pair the new episode's
+                    // identity with the old episode's position — a bogus resume point.
+                    val identityStale = controller != null &&
+                        (controller.isLoading.value || controller.errorMessage.value != null)
+                    if (dur > 0 && !identityStale) {
                         progressTracker.reportInAppProgress(
                             com.playbridge.sender.connection.InAppContent(
                                 tmdbId = tmdbId,

--- a/mobile/android/app/src/main/java/com/playbridge/sender/settings/SettingsScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/settings/SettingsScreen.kt
@@ -173,15 +173,17 @@ private fun SettingsHubContent(
                         )
                     }
 
-                    // 3. Debrid (Shared)
-                    add(
-                        SettingsItemData(
-                            icon = Icons.Default.Cloud,
-                            title = "Debrid",
-                            subtitle = "Real-Debrid, All-Debrid, Premiumize, TorBox",
-                            onClick = onDebrid
+                    // 3. Debrid (Shared; FOSS flavor only)
+                    if (com.playbridge.sender.FlavorConfig.DEBRID_SUPPORTED) {
+                        add(
+                            SettingsItemData(
+                                icon = Icons.Default.Cloud,
+                                title = "Debrid",
+                                subtitle = "Real-Debrid, All-Debrid, Premiumize, TorBox",
+                                onClick = onDebrid
+                            )
                         )
-                    )
+                    }
 
                     // 4. Proxy (Shared)
                     add(

--- a/mobile/android/app/src/main/java/com/playbridge/sender/ui/DashboardScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/ui/DashboardScreen.kt
@@ -377,7 +377,10 @@ fun DashboardScreen(
                     screen = Screen.CastHistory,
                     gradientColors = listOf(Color(0xFFE65100), Color(0xFFFB8C00))
                 )
-            )
+            ).filter {
+                // Debrid is FOSS-only; the Play flavor hides the tile entirely.
+                com.playbridge.sender.FlavorConfig.DEBRID_SUPPORTED || it.screen != Screen.DebridLibrary
+            }
 
             // Top row: 2 large cards (Browser + Library)
             Row(

--- a/mobile/android/app/src/main/java/com/playbridge/sender/update/UpdateChecker.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/update/UpdateChecker.kt
@@ -222,6 +222,8 @@ class UpdateChecker(
     }.getOrNull()
 
     private fun installSource(): InstallSource {
+        // Play flavor: no sideload/install path exists in this binary - always Play.
+        if (!this.installer.selfUpdateSupported) return InstallSource.PLAY_STORE
         val pm = appContext.packageManager
         val installer = runCatching {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/mobile/android/app/src/play/AndroidManifest.xml
+++ b/mobile/android/app/src/play/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Play-flavor manifest overlay: strip permissions Google Play prohibits or
+     restricts. Self-update installs are FOSS-only (see update/ApkInstaller stub). -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission
+        android:name="android.permission.REQUEST_INSTALL_PACKAGES"
+        tools:node="remove" />
+
+</manifest>

--- a/mobile/android/app/src/play/java/com/playbridge/sender/FlavorConfig.kt
+++ b/mobile/android/app/src/play/java/com/playbridge/sender/FlavorConfig.kt
@@ -1,0 +1,18 @@
+package com.playbridge.sender
+
+/**
+ * Capabilities of the Google Play distribution flavor.
+ * Debrid integration is disabled for Play content-policy compliance:
+ * [com.playbridge.sender.data.debrid.DebridRepository] reports no providers and the
+ * Debrid dashboard/settings entry points are hidden.
+ */
+object FlavorConfig {
+    /** Debrid services (Real-Debrid, All-Debrid, Premiumize, TorBox) are FOSS-only. */
+    const val DEBRID_SUPPORTED = false
+
+    /**
+     * Nuvio-style local scraper plugins (downloaded JS run in QuickJS) are FOSS-only,
+     * matching Nuvio's own Play posture (their Play flavor sets pluginsEnabled=false).
+     */
+    const val SCRAPER_PLUGINS_SUPPORTED = false
+}

--- a/mobile/android/app/src/play/java/com/playbridge/sender/update/ApkInstaller.kt
+++ b/mobile/android/app/src/play/java/com/playbridge/sender/update/ApkInstaller.kt
@@ -1,0 +1,28 @@
+package com.playbridge.sender.update
+
+import android.content.Context
+import java.io.File
+
+/**
+ * Play-flavor stub. Google Play's Device and Network Abuse policy prohibits apps
+ * distributed through Play from downloading and installing APKs themselves, so the
+ * Play build contains no self-update code at all — [UpdateChecker] sees
+ * [selfUpdateSupported] = false and routes users to the Play listing instead.
+ */
+class ApkInstaller(@Suppress("UNUSED_PARAMETER") appContext: Context) {
+
+    /** Play builds never sideload — UpdateChecker treats every install as Play-sourced. */
+    val selfUpdateSupported: Boolean get() = false
+
+    suspend fun download(url: String, onProgress: (Float?) -> Unit): File =
+        throw UnsupportedOperationException("Self-update is not available in Play builds")
+
+    fun launchInstall(apk: File) {
+        throw UnsupportedOperationException("Self-update is not available in Play builds")
+    }
+
+    companion object {
+        /** No downloaded APKs can exist in Play builds — nothing to clean. */
+        fun cleanupStaleApks(context: Context, maxAgeMillis: Long = 0L) = Unit
+    }
+}

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,11 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [Unreleased]
+
+### Added
+- **TheIntroDB Skip Segments** (https://theintrodb.org): second skip-segments provider alongside IntroDB. Keyless, works with TMDB or IMDb ids, and covers **movies** (credits) as well as episodes — including multiple ranges per type and open-ended credits that run to the end of the file. New "Skip Segments Provider" setting (IntroDB / TheIntroDB / Both — default Both, where IntroDB wins per segment type and TheIntroDB fills the gaps) plus a configurable TheIntroDB API URL in Settings → Integrations.
+
 ## Player [0.8.0] — 2026-07-04 (versionCode 219)
 
 ### Added

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -63,6 +63,20 @@ android {
             )
         }
     }
+    // Distribution flavors: `foss` (GitHub/sideload; includes APK self-update) vs
+    // `play` (Google Play; self-update code and REQUEST_INSTALL_PACKAGES stripped -
+    // Play policy prohibits apps updating themselves outside the Store).
+    flavorDimensions += "distribution"
+    productFlavors {
+        create("foss") {
+            dimension = "distribution"
+            isDefault = true
+        }
+        create("play") {
+            dimension = "distribution"
+        }
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11

--- a/tv/android/player/app/src/foss/java/com/playbridge/player/FlavorConfig.kt
+++ b/tv/android/player/app/src/foss/java/com/playbridge/player/FlavorConfig.kt
@@ -1,0 +1,15 @@
+package com.playbridge.player
+
+/**
+ * Capabilities of the FOSS (GitHub/sideload) distribution flavor.
+ * The Play flavor ships a counterpart with restricted features
+ * (Google Play policy compliance).
+ */
+object FlavorConfig {
+    /**
+     * Whether the app may point users at APK downloads outside an app store
+     * (e.g. the optional GeckoView browser-plugin APK on GitHub releases).
+     * Prohibited for Play-distributed builds (Device and Network Abuse policy).
+     */
+    const val SIDELOAD_LINKS_SUPPORTED = true
+}

--- a/tv/android/player/app/src/foss/java/com/playbridge/player/update/ApkInstaller.kt
+++ b/tv/android/player/app/src/foss/java/com/playbridge/player/update/ApkInstaller.kt
@@ -20,6 +20,9 @@ import java.util.concurrent.TimeUnit
  */
 class ApkInstaller(private val appContext: Context) {
 
+    /** FOSS builds may download and install release APKs directly. */
+    val selfUpdateSupported: Boolean get() = true
+
     private val http: OkHttpClient by lazy {
         OkHttpClient.Builder()
             .connectTimeout(15, TimeUnit.SECONDS)

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ContentSniffer.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ContentSniffer.kt
@@ -13,9 +13,10 @@ private const val TAG = "ContentSniffer"
  * Handles HTTP client creation and pre-flight content-type sniffing
  * (reads the first few bytes of a URL to detect HLS streams).
  *
- * SSL certificate validation is bypassed only for local-network URLs
- * (RFC 1918 private IPs, loopback, and .local hostnames) to support
- * self-signed certs on local servers (Plex, Jellyfin, etc.).
+ * For local-network URLs (RFC 1918 private IPs, loopback, and .local hostnames)
+ * a relaxed-but-validating trust path ([LocalSelfSignedTrustManager]) accepts
+ * single self-signed certificates so local servers (Plex, Jellyfin, etc.) work.
+ * Public URLs always use standard system certificate validation.
  */
 class ContentSniffer {
 
@@ -41,6 +42,11 @@ class ContentSniffer {
      */
     fun isLocalUrl(url: String): Boolean {
         val rawHost = Uri.parse(url).host ?: return false
+        return isLocalHost(rawHost)
+    }
+
+    /** Same as [isLocalUrl] but takes a bare hostname/IP (as seen by a HostnameVerifier). */
+    fun isLocalHost(rawHost: String): Boolean {
         val host = rawHost.removePrefix("[").removeSuffix("]")
 
         if (host == "localhost" || host.endsWith(".local")) return true
@@ -72,27 +78,24 @@ class ContentSniffer {
     }
 
     /**
-     * Creates an OkHttpClient. For local-network URLs, SSL certificate
-     * validation is disabled to support self-signed certificates.
-     * Public URLs always use standard certificate validation.
+     * Creates an OkHttpClient. When [allowLocalSelfSigned] is set (callers gate this
+     * on [isLocalUrl]), a single self-signed certificate is accepted after system
+     * validation fails — see [LocalSelfSignedTrustManager]. Public URLs always use
+     * standard certificate validation and strict hostname verification.
      */
-    fun getOkHttpClient(headers: Map<String, String>? = null, trustAllCerts: Boolean = false): okhttp3.OkHttpClient {
+    fun getOkHttpClient(headers: Map<String, String>? = null, allowLocalSelfSigned: Boolean = false): okhttp3.OkHttpClient {
         try {
             // Derive from a shared base client: newBuilder() shares the connection pool
             // and dispatcher threads, so per-sniff clients no longer each spin up their
             // own pool/executor.
             val builder = baseClient.newBuilder()
 
-            if (trustAllCerts) {
-                val trustManagers = arrayOf<javax.net.ssl.TrustManager>(object : javax.net.ssl.X509TrustManager {
-                    override fun checkClientTrusted(chain: Array<out java.security.cert.X509Certificate>?, authType: String?) {}
-                    override fun checkServerTrusted(chain: Array<out java.security.cert.X509Certificate>?, authType: String?) {}
-                    override fun getAcceptedIssuers(): Array<java.security.cert.X509Certificate> = arrayOf()
-                })
+            if (allowLocalSelfSigned) {
+                val trustManager = LocalSelfSignedTrustManager()
                 val sslContext = javax.net.ssl.SSLContext.getInstance("TLS")
-                sslContext.init(null, trustManagers, java.security.SecureRandom())
-                builder.sslSocketFactory(sslContext.socketFactory, trustManagers[0] as javax.net.ssl.X509TrustManager)
-                       .hostnameVerifier { _, _ -> true }
+                sslContext.init(null, arrayOf<javax.net.ssl.TrustManager>(trustManager), null)
+                builder.sslSocketFactory(sslContext.socketFactory, trustManager)
+                       .hostnameVerifier(LocalHostnameVerifier(::isLocalHost))
             }
 
             if (headers != null && headers.isNotEmpty()) {
@@ -135,7 +138,7 @@ class ContentSniffer {
             try {
                 // Pass headers to the client so the interceptor applies them
                 // This ensures cookies and auth headers are sent during the sniff
-                val client = getOkHttpClient(headers, trustAllCerts = isLocalUrl(url))
+                val client = getOkHttpClient(headers, allowLocalSelfSigned = isLocalUrl(url))
                 val requestBuilder = okhttp3.Request.Builder()
                     .url(url)
                     .header("Range", "bytes=0-50")

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/LocalTrust.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/LocalTrust.kt
@@ -1,0 +1,96 @@
+package com.playbridge.player.player
+
+import java.security.KeyStore
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLSession
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+/**
+ * TLS trust helpers for local-network media servers (Plex, Jellyfin, etc.) that
+ * commonly serve self-signed certificates.
+ *
+ * Unlike a trust-all TrustManager, [LocalSelfSignedTrustManager] validates against
+ * the system trust store FIRST and only then accepts a single, self-signed,
+ * currently-valid, correctly-signed certificate. Untrusted CA chains, expired
+ * certs, and tampered certs are still rejected with [CertificateException], so
+ * this does not grant blanket trust (and does not trip Play's
+ * unsafe-X509TrustManager scan, which flags implementations that never throw).
+ */
+object LocalTrust {
+
+    /** The platform default trust manager (system CA store). */
+    val systemTrustManager: X509TrustManager by lazy {
+        val factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        factory.init(null as KeyStore?)
+        factory.trustManagers.filterIsInstance<X509TrustManager>().first()
+    }
+}
+
+class LocalSelfSignedTrustManager(
+    private val delegate: X509TrustManager = LocalTrust.systemTrustManager,
+) : X509TrustManager {
+
+    @Throws(CertificateException::class)
+    override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) {
+        delegate.checkClientTrusted(chain, authType)
+    }
+
+    @Throws(CertificateException::class)
+    override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) {
+        try {
+            delegate.checkServerTrusted(chain, authType)
+        } catch (systemFailure: CertificateException) {
+            // System trust failed — accept only a lone self-signed cert that is
+            // currently valid and actually signed by its own key.
+            if (chain.size != 1) throw systemFailure
+            val cert = chain[0]
+            if (cert.subjectX500Principal != cert.issuerX500Principal) throw systemFailure
+            try {
+                cert.checkValidity()
+                cert.verify(cert.publicKey)
+            } catch (e: Exception) {
+                throw CertificateException("Self-signed certificate failed validation", e)
+            }
+        }
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> = delegate.acceptedIssuers
+}
+
+/**
+ * Hostname verification for clients built with [LocalSelfSignedTrustManager].
+ *
+ * Local-network hosts skip name matching (self-signed LAN certs rarely carry a
+ * SAN matching a private IP). Public hosts must pass BOTH the platform default
+ * name check AND a system-trust re-validation of the peer chain. The re-check
+ * closes a redirect hole: the relaxed trust manager applies connection-wide, so
+ * when a local URL redirects to a public host, name matching alone would accept
+ * an attacker's self-signed cert whose SAN matches that public hostname.
+ */
+class LocalHostnameVerifier(
+    private val isLocalHost: (String) -> Boolean,
+) : HostnameVerifier {
+
+    private val default: HostnameVerifier = HttpsURLConnection.getDefaultHostnameVerifier()
+
+    override fun verify(hostname: String, session: SSLSession): Boolean {
+        if (isLocalHost(hostname)) return true
+        if (!default.verify(hostname, session)) return false
+        // Public host: the self-signed leniency must not apply — require the
+        // presented chain to validate against the system trust store.
+        return try {
+            val chain = session.peerCertificates
+                .filterIsInstance<X509Certificate>()
+                .toTypedArray()
+            if (chain.isEmpty()) return false
+            LocalTrust.systemTrustManager.checkServerTrusted(chain, chain[0].publicKey.algorithm)
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+}

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/SkipSegment.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/SkipSegment.kt
@@ -1,7 +1,7 @@
 package com.playbridge.player.player
 
 data class SkipSegment(
-    val type: String, // "intro", "recap", "outro"
+    val type: String, // "intro", "recap", "outro", "preview"
     val startMs: Long,
     val endMs: Long
 )

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/SkipSegmentFetcher.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/SkipSegmentFetcher.kt
@@ -8,22 +8,79 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
 
+/**
+ * Fetches skip segments (intro/recap/outro/preview) from up to two providers:
+ *
+ *  - **IntroDB** (https://introdb.app) — the original integration. IMDb-keyed,
+ *    episodes only, optional API key. Response: `{ "intro": {start_ms, end_ms}, … }`.
+ *  - **TheIntroDB** (https://theintrodb.org) — keyless, community-verified. Works with
+ *    TMDB/IMDb ids and covers movies too. `GET /v3/media?tmdb_id=…[&season=…&episode=…]`
+ *    → `{ "type": "tv", "recap": [{start_ms, end_ms|null}], "credits": […], … }` —
+ *    each segment type is an ARRAY, and `end_ms` may be null (runs to the end of file).
+ *
+ * The `skip_segments_provider` pref picks the source: "introdb", "theintrodb", or
+ * "both" (default — IntroDB first, TheIntroDB fills in any segment types it didn't
+ * return, plus everything IntroDB can't cover, like movies).
+ */
 object SkipSegmentFetcher {
     private const val TAG = "SkipSegmentFetcher"
     private val client = OkHttpClient()
 
+    private const val DEFAULT_INTRODB_URL = "https://api.introdb.app"
+    private const val DEFAULT_THEINTRODB_URL = "https://api.theintrodb.org"
+
+    /**
+     * Sentinel end for open-ended segments (TheIntroDB reports `end_ms: null` for
+     * credits that run to the end of the file). Far past any real duration so the
+     * containment check keeps the segment active; engines clamp seeks to the duration,
+     * so skipping such a segment jumps to the end of playback.
+     */
+    const val OPEN_ENDED_MS = Long.MAX_VALUE / 2
+
     suspend fun fetchSegments(
         context: Context,
-        imdbId: String,
-        season: Int,
-        episode: Int
+        imdbId: String?,
+        tmdbId: String?,
+        season: Int?,
+        episode: Int?,
     ): List<SkipSegment> = withContext(Dispatchers.IO) {
         val prefs = context.getSharedPreferences("browser_prefs", Context.MODE_PRIVATE)
-        val baseUrl = prefs.getString("introdb_api_url", "https://api.introdb.app")?.trim()?.removeSuffix("/") ?: "https://api.introdb.app"
+        val provider = prefs.getString("skip_segments_provider", "both") ?: "both"
+
+        val fromIntroDb =
+            if (provider != "theintrodb" && !imdbId.isNullOrBlank() && season != null && episode != null) {
+                fetchIntroDb(prefs, imdbId, season, episode)
+            } else {
+                emptyList()
+            }
+
+        val fromTheIntroDb =
+            if (provider != "introdb" && (!imdbId.isNullOrBlank() || !tmdbId.isNullOrBlank())) {
+                // In "both" mode IntroDB wins per segment type; TheIntroDB fills the gaps.
+                val covered = fromIntroDb.map { it.type }.toSet()
+                fetchTheIntroDb(prefs, imdbId, tmdbId, season, episode)
+                    .filter { it.type !in covered }
+            } else {
+                emptyList()
+            }
+
+        (fromIntroDb + fromTheIntroDb).sortedBy { it.startMs }
+    }
+
+    // ── IntroDB (introdb.app) ───────────────────────────────────────────────
+
+    private fun fetchIntroDb(
+        prefs: android.content.SharedPreferences,
+        imdbId: String,
+        season: Int,
+        episode: Int,
+    ): List<SkipSegment> {
+        val baseUrl = prefs.getString("introdb_api_url", DEFAULT_INTRODB_URL)
+            ?.trim()?.removeSuffix("/") ?: DEFAULT_INTRODB_URL
         val apiKey = prefs.getString("introdb_api_key", "") ?: ""
 
         val url = "$baseUrl/segments?imdb_id=$imdbId&season=$season&episode=$episode"
-        Log.i(TAG, "Fetching skip segments from: $url")
+        Log.i(TAG, "Fetching skip segments from IntroDB: $url")
 
         val requestBuilder = Request.Builder()
             .url(url)
@@ -38,13 +95,13 @@ object SkipSegmentFetcher {
             }
         }
 
-        try {
+        return try {
             client.newCall(requestBuilder.build()).execute().use { response ->
                 if (!response.isSuccessful) {
-                    Log.w(TAG, "Failed to fetch skip segments: HTTP ${response.code}")
-                    return@withContext emptyList()
+                    Log.w(TAG, "IntroDB fetch failed: HTTP ${response.code}")
+                    return emptyList()
                 }
-                val bodyText = response.body?.string() ?: return@withContext emptyList()
+                val bodyText = response.body?.string() ?: return emptyList()
                 val json = JSONObject(bodyText)
                 val segments = mutableListOf<SkipSegment>()
 
@@ -62,11 +119,84 @@ object SkipSegmentFetcher {
                         }
                     }
                 }
-                Log.i(TAG, "Successfully fetched ${segments.size} segments: $segments")
+                Log.i(TAG, "IntroDB returned ${segments.size} segments: $segments")
                 segments
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Error fetching skip segments", e)
+            Log.e(TAG, "Error fetching from IntroDB", e)
+            emptyList()
+        }
+    }
+
+    // ── TheIntroDB (theintrodb.org) ─────────────────────────────────────────
+
+    private fun fetchTheIntroDb(
+        prefs: android.content.SharedPreferences,
+        imdbId: String?,
+        tmdbId: String?,
+        season: Int?,
+        episode: Int?,
+    ): List<SkipSegment> {
+        val baseUrl = prefs.getString("theintrodb_api_url", DEFAULT_THEINTRODB_URL)
+            ?.trim()?.removeSuffix("/") ?: DEFAULT_THEINTRODB_URL
+
+        val idQuery = when {
+            !tmdbId.isNullOrBlank() -> "tmdb_id=$tmdbId"
+            !imdbId.isNullOrBlank() -> "imdb_id=$imdbId"
+            else -> return emptyList()
+        }
+        // TV needs season+episode; without them the same endpoint is a movie lookup.
+        val episodeQuery =
+            if (season != null && episode != null) "&season=$season&episode=$episode" else ""
+        val url = "$baseUrl/v3/media?$idQuery$episodeQuery"
+        Log.i(TAG, "Fetching skip segments from TheIntroDB: $url")
+
+        val request = Request.Builder()
+            .url(url)
+            .header("User-Agent", "PlayBridgeTV/1.0")
+            .build()
+
+        return try {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    Log.w(TAG, "TheIntroDB fetch failed: HTTP ${response.code}")
+                    return emptyList()
+                }
+                val bodyText = response.body?.string() ?: return emptyList()
+                val json = JSONObject(bodyText)
+                val segments = mutableListOf<SkipSegment>()
+
+                // TheIntroDB types → the app's segment types ("credits" feeds the same
+                // UI/auto-skip pref as "outro"). Each value is an array of ranges.
+                val typeMap = listOf(
+                    "intro" to "intro",
+                    "recap" to "recap",
+                    "outro" to "outro",
+                    "credits" to "outro",
+                    "preview" to "preview",
+                )
+                val seenTypes = mutableSetOf<String>()
+                for ((apiType, uiType) in typeMap) {
+                    if (!json.has(apiType) || json.isNull(apiType)) continue
+                    if (!seenTypes.add(uiType)) continue // e.g. both "outro" and "credits"
+                    val arr = json.optJSONArray(apiType) ?: continue
+                    for (i in 0 until arr.length()) {
+                        val segObj = arr.optJSONObject(i) ?: continue
+                        val startMs = segObj.optLong("start_ms", -1L)
+                        if (startMs < 0) continue
+                        val endMs = if (segObj.isNull("end_ms")) {
+                            OPEN_ENDED_MS // runs to the end of the file
+                        } else {
+                            segObj.optLong("end_ms", -1L).takeIf { it > startMs } ?: continue
+                        }
+                        segments.add(SkipSegment(uiType, startMs, endMs))
+                    }
+                }
+                Log.i(TAG, "TheIntroDB returned ${segments.size} segments: $segments")
+                segments
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error fetching from TheIntroDB", e)
             emptyList()
         }
     }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/SubtitleManager.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/SubtitleManager.kt
@@ -100,7 +100,7 @@ class SubtitleManager(
 
     private fun downloadUrlBytes(urlString: String, headers: Map<String, String>? = null): ByteArray {
         val sniffer = ContentSniffer()
-        val client = sniffer.getOkHttpClient(trustAllCerts = sniffer.isLocalUrl(urlString))
+        val client = sniffer.getOkHttpClient(allowLocalSelfSigned = sniffer.isLocalUrl(urlString))
         val requestBuilder = Request.Builder()
             .url(urlString)
             .header("User-Agent", "Mozilla/5.0")

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/SubtitlePreview.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/SubtitlePreview.kt
@@ -158,7 +158,7 @@ object SubtitleCueLoader {
 
     private fun download(url: String, headers: Map<String, String>?): ByteArray {
         val sniffer = ContentSniffer()
-        val client = sniffer.getOkHttpClient(trustAllCerts = sniffer.isLocalUrl(url))
+        val client = sniffer.getOkHttpClient(allowLocalSelfSigned = sniffer.isLocalUrl(url))
         val builder = Request.Builder().url(url).header("User-Agent", "Mozilla/5.0")
         headers?.forEach { (k, v) -> if (!k.equals("Host", true)) builder.header(k, v) }
         client.newCall(builder.build()).execute().use { resp ->

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/SettingsScreen.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/SettingsScreen.kt
@@ -71,13 +71,16 @@ fun SettingsScreen(
     var showGeckoDialog by remember { mutableStateOf(false) }
 
     // Skip segments states
+    var skipProvider by remember { mutableStateOf(prefs.getString("skip_segments_provider", "both") ?: "both") }
     var introDbApiKey by remember { mutableStateOf(prefs.getString("introdb_api_key", "") ?: "") }
     var introDbApiUrl by remember { mutableStateOf(prefs.getString("introdb_api_url", "https://api.introdb.app") ?: "https://api.introdb.app") }
+    var theIntroDbApiUrl by remember { mutableStateOf(prefs.getString("theintrodb_api_url", "https://api.theintrodb.org") ?: "https://api.theintrodb.org") }
     var autoSkipIntro by remember { mutableStateOf(prefs.getBoolean("auto_skip_intro", false)) }
     var autoSkipRecap by remember { mutableStateOf(prefs.getBoolean("auto_skip_recap", false)) }
     var autoSkipOutro by remember { mutableStateOf(prefs.getBoolean("auto_skip_outro", false)) }
     var showApiKeyDialog by remember { mutableStateOf(false) }
     var showApiUrlDialog by remember { mutableStateOf(false) }
+    var showTheIntroDbUrlDialog by remember { mutableStateOf(false) }
 
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
@@ -292,6 +295,24 @@ fun SettingsScreen(
                     SettingsCategory.INTEGRATIONS -> {
                         item {
                             SettingClickableItem(
+                                label = "Skip Segments Provider",
+                                description = when (skipProvider) {
+                                    "introdb" -> "IntroDB only"
+                                    "theintrodb" -> "TheIntroDB only"
+                                    else -> "Both — IntroDB first, TheIntroDB fills gaps (movies too)"
+                                },
+                                onClick = {
+                                    skipProvider = when (skipProvider) {
+                                        "both" -> "introdb"
+                                        "introdb" -> "theintrodb"
+                                        else -> "both"
+                                    }
+                                    prefs.edit().putString("skip_segments_provider", skipProvider).apply()
+                                }
+                            )
+                        }
+                        item {
+                            SettingClickableItem(
                                 label = "IntroDB API Key",
                                 description = if (introDbApiKey.isEmpty()) "Not Configured" else "••••••••",
                                 onClick = { showApiKeyDialog = true }
@@ -302,6 +323,13 @@ fun SettingsScreen(
                                 label = "IntroDB API URL",
                                 description = introDbApiUrl,
                                 onClick = { showApiUrlDialog = true }
+                            )
+                        }
+                        item {
+                            SettingClickableItem(
+                                label = "TheIntroDB API URL",
+                                description = theIntroDbApiUrl,
+                                onClick = { showTheIntroDbUrlDialog = true }
                             )
                         }
                         item {
@@ -468,18 +496,22 @@ fun SettingsScreen(
                                 onClick = { updateChecker.check(manual = true) }
                             )
                         }
-                        item {
-                            SettingClickableItem(
-                                label = "GeckoView Engine (Optional Plugin)",
-                                description = if (isGeckoInstalled) "Installed" else "Not Installed (click to learn more/sideload)",
-                                onClick = {
-                                    if (isGeckoInstalled) {
-                                        Toast.makeText(context, "GeckoView Plugin is ready to use", Toast.LENGTH_SHORT).show()
-                                    } else {
-                                        showGeckoDialog = true
+                        // Play flavor: never advertise the sideloaded plugin APK; only show
+                        // the row when the plugin is already present (informational).
+                        if (isGeckoInstalled || com.playbridge.player.FlavorConfig.SIDELOAD_LINKS_SUPPORTED) {
+                            item {
+                                SettingClickableItem(
+                                    label = "GeckoView Engine (Optional Plugin)",
+                                    description = if (isGeckoInstalled) "Installed" else "Not Installed (click to learn more/sideload)",
+                                    onClick = {
+                                        if (isGeckoInstalled) {
+                                            Toast.makeText(context, "GeckoView Plugin is ready to use", Toast.LENGTH_SHORT).show()
+                                        } else {
+                                            showGeckoDialog = true
+                                        }
                                     }
-                                }
-                            )
+                                )
+                            }
                         }
                         item {
                             SettingClickableItem(
@@ -721,6 +753,56 @@ fun SettingsScreen(
                             introDbApiUrl = finalUrl
                             prefs.edit().putString("introdb_api_url", finalUrl).apply()
                             showApiUrlDialog = false
+                        }) {
+                            Text("Save")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showTheIntroDbUrlDialog) {
+        var tempUrl by remember { mutableStateOf(theIntroDbApiUrl) }
+        com.playbridge.player.ui.theme.ThemedDialog(onDismissRequest = { showTheIntroDbUrlDialog = false }) {
+            Surface(
+                shape = MaterialTheme.shapes.medium,
+                modifier = Modifier.width(400.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(32.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Text("TheIntroDB API URL", style = MaterialTheme.typography.headlineSmall)
+                    Text(
+                        "Set custom API url for TheIntroDB skip segments. Default is https://api.theintrodb.org",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    androidx.compose.foundation.text.BasicTextField(
+                        value = tempUrl,
+                        onValueChange = { tempUrl = it },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(MaterialTheme.colorScheme.surfaceVariant, MaterialTheme.shapes.small)
+                            .padding(16.dp),
+                        textStyle = androidx.compose.ui.text.TextStyle(color = MaterialTheme.colorScheme.onSurface, fontSize = 16.sp)
+                    )
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Button(onClick = { showTheIntroDbUrlDialog = false }, modifier = Modifier.padding(end = 8.dp)) {
+                            Text("Cancel")
+                        }
+                        Button(onClick = {
+                            val finalUrl = tempUrl.trim().ifEmpty { "https://api.theintrodb.org" }
+                            theIntroDbApiUrl = finalUrl
+                            prefs.edit().putString("theintrodb_api_url", finalUrl).apply()
+                            showTheIntroDbUrlDialog = false
                         }) {
                             Text("Save")
                         }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsViewModel.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsViewModel.kt
@@ -214,12 +214,16 @@ class PlayerControlsViewModel : ViewModel() {
 
         val season = metadata?.season
         val episode = metadata?.episode
-        if (imdbId != null && context != null && season != null && episode != null) {
+        val tmdbId = metadata?.tmdb_id?.takeIf { it.isNotBlank() }
+        // Episodes need season+episode; when both are absent this is a movie lookup
+        // (TheIntroDB covers movies). A half-specified episode is skipped.
+        val validShape = (season != null && episode != null) || (season == null && episode == null)
+        if ((imdbId != null || tmdbId != null) && context != null && validShape) {
             val appCtx = context.applicationContext
             skipSegmentsJob = viewModelScope.launch {
                 try {
                     val segments = com.playbridge.player.player.SkipSegmentFetcher.fetchSegments(
-                        appCtx, imdbId, season, episode
+                        appCtx, imdbId = imdbId, tmdbId = tmdbId, season = season, episode = episode
                     )
                     com.playbridge.player.logging.FileLogger.i("PlayerControlsViewModel", "Set skipSegments in state: $segments")
                     _controlsState.update { it.copy(skipSegments = segments) }
@@ -313,7 +317,7 @@ class PlayerControlsViewModel : ViewModel() {
                         if (shouldAutoSkip) {
                             lastSkippedSegment = activeSegment
                             isAutoSkipTriggered = true
-                            engine?.seekTo(activeSegment.endMs + 1000)
+                            engine?.seekTo(skipTargetMs(activeSegment, duration))
                             viewModelScope.launch(kotlinx.coroutines.Dispatchers.Main) {
                                 android.widget.Toast.makeText(context, "Auto-skipped ${activeSegment.type}", android.widget.Toast.LENGTH_SHORT).show()
                             }
@@ -478,9 +482,25 @@ class PlayerControlsViewModel : ViewModel() {
     fun skipCurrentSegment() {
         val segment = _controlsState.value.activeSkipSegment ?: return
         lastSkippedSegment = segment
-        engine?.seekTo(segment.endMs + 1000)
+        engine?.seekTo(skipTargetMs(segment, _controlsState.value.duration))
         _controlsState.update { it.copy(activeSkipSegment = null) }
         resetAutoHideTimer()
+    }
+
+    /**
+     * Seek target for skipping [segment]. Clamped to the known duration: open-ended
+     * segments carry [com.playbridge.player.player.SkipSegmentFetcher.OPEN_ENDED_MS]
+     * as their end, and while ExoPlayer clamps out-of-range seeks internally, MPV
+     * passes the raw value straight to `seek` — an unclamped Long.MAX_VALUE/2 target
+     * is undefined behavior there. Clamping to duration means "jump to the end",
+     * which is the intent for credits that run to the end of the file.
+     */
+    private fun skipTargetMs(
+        segment: com.playbridge.player.player.SkipSegment,
+        durationMs: Long,
+    ): Long {
+        val target = segment.endMs + 1000
+        return if (durationMs > 0) target.coerceAtMost(durationMs) else target
     }
 
     fun setSkipButtonFocused(focused: Boolean) {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/update/UpdateChecker.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/update/UpdateChecker.kt
@@ -223,6 +223,8 @@ class UpdateChecker private constructor(
     }.getOrNull()
 
     private fun installSource(): InstallSource {
+        // Play flavor: no sideload/install path exists in this binary - always Play.
+        if (!this.installer.selfUpdateSupported) return InstallSource.PLAY_STORE
         val pm = appContext.packageManager
         val installer = runCatching {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/tv/android/player/app/src/main/res/xml/network_security_config.xml
+++ b/tv/android/player/app/src/main/res/xml/network_security_config.xml
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-    <!-- Allow cleartext HTTP traffic for local network addresses -->
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">localhost</domain>
-        <domain includeSubdomains="true">127.0.0.1</domain>
-        <domain includeSubdomains="true">192.168.0.0/16</domain>
-        <domain includeSubdomains="true">10.0.0.0/8</domain>
-    </domain-config>
-    
-    <!-- For development/testing, you can also enable all cleartext -->
-    <!-- Remove this in production builds -->
-    <base-config cleartextTrafficPermitted="true">
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+    <!-- Cleartext HTTP must stay permitted app-wide: the TV plays streams proxied
+         over plain HTTP from the phone's LAN proxy and from arbitrary local media
+         servers (DLNA, Plex, Jellyfin). Network Security Config cannot express
+         IP ranges (CIDR entries in <domain> are silently ignored), so scoping
+         cleartext to RFC 1918 addresses via domain-config is not possible. -->
+    <base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>

--- a/tv/android/player/app/src/play/AndroidManifest.xml
+++ b/tv/android/player/app/src/play/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Play-flavor manifest overlay: strip permissions Google Play prohibits or
+     restricts. Self-update installs are FOSS-only (see update/ApkInstaller stub). -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission
+        android:name="android.permission.REQUEST_INSTALL_PACKAGES"
+        tools:node="remove" />
+
+</manifest>

--- a/tv/android/player/app/src/play/java/com/playbridge/player/FlavorConfig.kt
+++ b/tv/android/player/app/src/play/java/com/playbridge/player/FlavorConfig.kt
@@ -1,0 +1,12 @@
+package com.playbridge.player
+
+/**
+ * Capabilities of the Google Play distribution flavor.
+ * Pointing users at APK downloads outside Play violates the Device and Network
+ * Abuse policy, so the GeckoView plugin install prompt is hidden. If the plugin
+ * is already installed (sideloaded), it is still detected and used.
+ */
+object FlavorConfig {
+    /** See the FOSS counterpart. */
+    const val SIDELOAD_LINKS_SUPPORTED = false
+}

--- a/tv/android/player/app/src/play/java/com/playbridge/player/update/ApkInstaller.kt
+++ b/tv/android/player/app/src/play/java/com/playbridge/player/update/ApkInstaller.kt
@@ -1,0 +1,28 @@
+package com.playbridge.player.update
+
+import android.content.Context
+import java.io.File
+
+/**
+ * Play-flavor stub. Google Play's Device and Network Abuse policy prohibits apps
+ * distributed through Play from downloading and installing APKs themselves, so the
+ * Play build contains no self-update code at all — [UpdateChecker] sees
+ * [selfUpdateSupported] = false and routes users to the Play listing instead.
+ */
+class ApkInstaller(@Suppress("UNUSED_PARAMETER") appContext: Context) {
+
+    /** Play builds never sideload — UpdateChecker treats every install as Play-sourced. */
+    val selfUpdateSupported: Boolean get() = false
+
+    suspend fun download(url: String, onProgress: (Float?) -> Unit): File =
+        throw UnsupportedOperationException("Self-update is not available in Play builds")
+
+    fun launchInstall(apk: File) {
+        throw UnsupportedOperationException("Self-update is not available in Play builds")
+    }
+
+    companion object {
+        /** No downloaded APKs can exist in Play builds — nothing to clean. */
+        fun cleanupStaleApks(context: Context, maxAgeMillis: Long = 0L) = Unit
+    }
+}


### PR DESCRIPTION
## Summary

Four themes in this PR:

### 1. FOSS/Play distribution flavors (phone + TV player)
Clears the Play Store blockers. Both Android trees gain a `distribution` flavor dimension: `foss` (GitHub sideload, default) keeps everything; `play` strips what Play policy prohibits.
- `REQUEST_INSTALL_PACKAGES` removed via play-manifest overlay (`tools:node="remove"`) — replaces the fragile `sed` hack in CI
- Self-update: `ApkInstaller` moved to the foss source set; play ships a stub (`selfUpdateSupported=false`) so `UpdateChecker` routes to the Play listing
- Phone play flavor: Debrid (RD/AD/Premiumize/TorBox) and Nuvio scraper plugins fully disabled via `FlavorConfig` — repository gates, hidden settings/dashboard entries, saved-screen fallbacks
- TV play flavor: GeckoView plugin sideload prompt hidden (still detected if already installed)
- CI builds `assembleFossRelease` (GitHub APKs) + `bundlePlayRelease` (Play AAB)
- `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` dropped entirely; cast sessions now guide the user to the system battery settings page instead

### 2. TLS hardening (TV player — Play blocker)
`ContentSniffer`'s trust-all SSL replaced with `LocalSelfSignedTrustManager`: system trust store first, then accept only a lone, currently-valid, self-verified self-signed cert (for LAN Plex/Jellyfin). Hostname verifier relaxes name-matching only for local hosts and re-validates public hosts against system trust — closes the redirect-to-public-host hole. `network_security_config` documented (NSC can't express CIDR ranges, so cleartext stays base-config with `tools:ignore`).

### 3. TheIntroDB skip-segments provider (TV player)
Second provider alongside IntroDB: keyless, TMDB or IMDb ids, covers movies (credits), multiple ranges per type, open-ended credits (`end_ms: null` → clamped jump-to-end; safe on both ExoPlayer and MPV). New "Skip Segments Provider" setting (IntroDB / TheIntroDB / Both — default Both, IntroDB wins per segment type) + custom API URL.

### 4. Watch-progress correctness (phone)
- Skip-ahead catch-up now fires ONLY for the episode the user deliberately started — queue/playlist advances can no longer mark manually-skipped episodes watched or delete their resume points
- Advance-finished marking requires forward progress within the same show (backward jumps / show switches save a resume point instead)
- DLNA session end flushes a final resume point (parity with the in-app player)
- Resume-point deletion happens before the watched-dedup so same-session rewatches get cleaned at 90%
- In-app player no longer reports progress while the lazy queue is resolving (prevented bogus resume points pairing new identity with old position)
- Removed fabricated season-1 fallback when sending metadata-less playlists

### Also
- Browser: Firefox-style "Delete browsing data" sheet (Gecko StorageController API + Room; toast awaits the async Gecko result), menu sheet split into two swipeable pages with Clear Data on page 2
- Gecko HTTP disk cache capped at 200 MB (was smart-sizing to 600+ MB)
- Connection UX: one connection popup (removed duplicate inline card), deliberate disconnects no longer trigger the reconnect cycle, "Keep trying" button removed (staying on the dialog keeps trying)

## Testing

Both `assembleFossDebug` builds verified. Please exercise:

**Flavor split**
- [ ] `play` builds: no Debrid tile/settings, no scraper-plugin UI, addon install of a Nuvio manifest falls through to regular addon flow, Check-for-Updates points at Play, no GeckoView sideload prompt on TV
- [ ] `foss` builds: self-update download + install still works on phone and TV
- [ ] Play AAB: verify final manifest has no `REQUEST_INSTALL_PACKAGES` (`aapt dump permissions`)
- [ ] Tag-triggered CI run produces renamed foss APKs + play AAB and uploads to R2

**TLS**
- [ ] Cast from a LAN server with a self-signed cert (Plex/Jellyfin) — sniff, subtitles, playback all work
- [ ] Public HTTPS streams still play (system validation unchanged)

**Skip segments**
- [ ] Episode with IntroDB coverage: unchanged behavior in "Both" and "IntroDB only"
- [ ] Movie with TheIntroDB credits: skip button appears; open-ended credits skip jumps to end **on MPV as well as ExoPlayer**
- [ ] Provider cycle + custom TheIntroDB URL persist across restarts

**Watch progress**
- [ ] Binge 2+ episodes via native queue: each marks watched at threshold, none of the skipped-past episodes get falsely marked
- [ ] Start S1E3 fresh → E1/E2 marked watched (catch-up still works for deliberate starts)
- [ ] Manually skip an episode mid-queue → it keeps its resume point, NOT marked watched
- [ ] Stop a DLNA session mid-episode → resume point saved
- [ ] `:app:testDebugUnitTest` (ProgressRulesTest) passes

**Browser**
- [ ] Clear Data: each category individually; cookies actually gone after toast; downloads clear leaves MediaStore videos intact
- [ ] Disconnect button on the device sheet does NOT pop the reconnect dialog; killing the TV app mid-session DOES