### PR TITLE
chore: uprev project versions and changelogs for v0.10.0 phone / v0.9.0 TV releases

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.4+22] — 2026-07-07
+
+### Fixed
+- **Theme Consistency**: Bundled the Poppins font and aligned the desktop theme with the refreshed cross-app styling. (#85)
+
 ## [0.6.3+21] — 2026-07-03
 
 ### Added

--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -4,8 +4,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.6.4+22] — 2026-07-07
 
+### Added
+- **Self-Update**: In-place self-update, mirroring the Android apps' update flow. Checks `playbridge.app/download/<os>` silently on launch (and manually from Settings), downloads the release archive, swaps the install via a detached helper script, and relaunches. Falls back to opening the downloads page when the install location isn't writable.
+
 ### Fixed
 - **Theme Consistency**: Bundled the Poppins font and aligned the desktop theme with the refreshed cross-app styling. (#85)
+- **About Version**: The Settings About tile showed a hardcoded `v1.0.0`; it now shows the real app version.
 
 ## [0.6.3+21] — 2026-07-03
 

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: playbridge_desktop
 description: "PlayBridge desktop receiver — accepts cast commands from the phone and plays via libmpv."
 publish_to: 'none'
-version: 0.6.3+21
+version: 0.6.4+22
 
 environment:
   sdk: ^3.6.0

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.1] — 2026-07-07
+
+### Fixed
+- **XSS in Popup**: Replaced unsafe `innerHTML` assignment with safe DOM methods (`createElement`/`textContent`) in `renderSavedConnections` to prevent Cross-Site Scripting when rendering user-supplied connection data (IP and PIN). (#89)
+
 ## [0.4.0] — 2026-06-21
 
 ### Added

--- a/extension/manifests/chrome.json
+++ b/extension/manifests/chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PlayBridge Video Detector",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Detects video URLs for PlayBridge casting",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtZQGgGin2mHxxXXJOQzUD9RHd5Fv19263KYRWrc5W7l2j8zggs4DXiWp5yqe56klCln3+ZNjNO0uUrU33dbkIQKRfj8hPhibBcCc7E+/+ZTFC1VZ+hry29LlDOLruMA+N7dg0EkdPD5qsHoYq6mhVelG7gpUDwnI/GPQOWezyAvYHFTfuP32cBcrW2lEMG7EZAcpds6rnFrYbGsBs/KACgYcvVGEy653tvGKBb4A2rU2bUv+5ph01sok/HDqVwwMFHHGD+U/LTy5ZGX85mRgmNhKLr/WE8IOdFFxIWzdC7hLtgRDxDiYaj2EOAFWE8v+VHmYvl++X1cDVpzxbV/MvQIDAQAB",
   "icons": {

--- a/extension/manifests/firefox.json
+++ b/extension/manifests/firefox.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "PlayBridge Video Detector",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Detects video URLs for PlayBridge casting",
     "icons": {
         "48": "icon.png",

--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.10.0] — 2026-07-07 (versionCode 218)
+
+### Added
+- **FOSS/Play Distribution Flavors**: Play builds strip `REQUEST_INSTALL_PACKAGES` via a manifest overlay, stub out the APK installer, disable Debrid + Nuvio scraper plugins, and hide sideload links. (#90)
+- **Clear Data Sheet**: Firefox-style Clear Data sheet (Gecko StorageController + Room), paged menu sheet, and a 200 MB Gecko disk-cache cap. (#90)
+- **Battery Exemption Guidance**: Settings-page guidance replaces the restricted `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` permission. (#90)
+
+### Fixed
+- **Watch-Progress Tracking**: Gated skip-ahead catch-up to deliberately-started episodes only, forward-only advance detection, DLNA final resume flush, resume cleanup before rewatch dedup, and dropped the fabricated season-1 fallback. (#90)
+- **Media Notification & Background Playback**: Reworked the media notification and in-app player background playback; page/tab playback now stops when the cast sheet opens. (#87)
+- **Connection UX**: Single connection popup, no reconnect after a deliberate disconnect, removed the Keep-trying button, and restored navigation on return to shell. (#87, #90)
+- **Reactive Theme Switching**: Theme changes apply without `Activity.recreate`, plus theme/UI styling consistency fixes. (#85, #87)
+- **Touchpad Click Tracking**: Improved touchpad click tracking in the remote control and cast sheet. (#86)
+
 ## [0.9.0] — 2026-07-04 (versionCode 217)
 
 ### Added

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 217
-        versionName = "0.9.0"
+        versionCode = 218
+        versionName = "0.10.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,10 +3,23 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## Player [Unreleased]
+## Player [0.9.0] — 2026-07-07 (versionCode 220)
 
 ### Added
-- **TheIntroDB Skip Segments** (https://theintrodb.org): second skip-segments provider alongside IntroDB. Keyless, works with TMDB or IMDb ids, and covers **movies** (credits) as well as episodes — including multiple ranges per type and open-ended credits that run to the end of the file. New "Skip Segments Provider" setting (IntroDB / TheIntroDB / Both — default Both, where IntroDB wins per segment type and TheIntroDB fills the gaps) plus a configurable TheIntroDB API URL in Settings → Integrations.
+- **TheIntroDB Skip Segments** (https://theintrodb.org): second skip-segments provider alongside IntroDB. Keyless, works with TMDB or IMDb ids, and covers **movies** (credits) as well as episodes — including multiple ranges per type and open-ended credits that run to the end of the file. New "Skip Segments Provider" setting (IntroDB / TheIntroDB / Both — default Both, where IntroDB wins per segment type and TheIntroDB fills the gaps) plus a configurable TheIntroDB API URL in Settings → Integrations. (#90)
+- **FOSS/Play Distribution Flavors**: Play builds strip `REQUEST_INSTALL_PACKAGES` via a manifest overlay, stub out the APK installer, and hide sideload links (GeckoView plugin prompt). (#90)
+- **Exit-App Action**: New exit-app action in Settings. (#87)
+
+### Fixed
+- **Local TLS Trust**: Replaced the `ContentSniffer` trust-all SSL with `LocalSelfSignedTrustManager` — system trust first, then a single valid self-signed cert for LAN hosts; the hostname verifier re-validates public hosts against system trust. (#90)
+- **MPV Skip Clamping**: Clamped open-ended skip seeks to media duration for MPV. (#90)
+- **Injected Input Events**: Set `SOURCE_TOUCHSCREEN` on injected events so remote touchpad input behaves like real touches. (#86)
+- **Theme & UI Styling**: Resolved theme and UI styling inconsistencies, removed `StaticAuroraBackground`, and fixed playback/connection races from a code audit. (#85, #87)
+
+## GeckoView Plugin [0.3.3] — 2026-07-07 (versionCode 211)
+
+### Fixed
+- **Injected Input Events**: Set `SOURCE_TOUCHSCREEN` on injected events and improved touchpad click tracking in the browser engine. (#86)
 
 ## Player [0.8.0] — 2026-07-04 (versionCode 219)
 

--- a/tv/android/geckoview-plugin/app/build.gradle.kts
+++ b/tv/android/geckoview-plugin/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "com.playbridge.geckoview.plugin"
         minSdk = 26
         targetSdk = 36
-        versionCode = 210
-        versionName = "0.3.2"
+        versionCode = 211
+        versionName = "0.3.3"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 219
-        versionName = "0.8.0"
+        versionCode = 220
+        versionName = "0.9.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
## Summary
Uprev versions and changelogs for all projects modified since #83 (covering #85, #86, #87, #89, #90).

| Project | Version | Build |
|---|---|---|
| Android Phone | 0.9.0 → 0.10.0 | 217 → 218 |
| Android TV Player | 0.8.0 → 0.9.0 | 219 → 220 |
| GeckoView Plugin | 0.3.2 → 0.3.3 | 210 → 211 |
| Desktop | 0.6.3+21 → 0.6.4+22 | — |
| Extension (Chrome + Firefox) | 0.4.0 → 0.4.1 | — |

TV changelog `Player [Unreleased]` section rolled into 0.9.0. No code changes.
