### PR TITLE
ci: implement Release Candidate (RC) gating and promotion workflow

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -378,6 +378,11 @@ jobs:
             output/phone-release-aab/*.aab
           generate_release_notes: false
           draft: false
+          # RC gating: every CI build lands as a pre-release. The website
+          # download endpoint (and therefore the in-app updaters) ignores
+          # pre-releases; promote via the promote-release workflow or the
+          # GitHub UI to go live.
+          prerelease: true
 
       - name: Create TV Player release
         if: needs.build-tv-player.outputs.skipped == 'false'
@@ -399,6 +404,11 @@ jobs:
             output/tv-player-release-aab/*.aab
           generate_release_notes: false
           draft: false
+          # RC gating: every CI build lands as a pre-release. The website
+          # download endpoint (and therefore the in-app updaters) ignores
+          # pre-releases; promote via the promote-release workflow or the
+          # GitHub UI to go live.
+          prerelease: true
 
       - name: Create TV GeckoView Plugin release
         if: needs.build-tv-geckoview-plugin.outputs.skipped == 'false'
@@ -418,6 +428,11 @@ jobs:
             output/tv-geckoview-plugin-release-aab/*.aab
           generate_release_notes: false
           draft: false
+          # RC gating: every CI build lands as a pre-release. The website
+          # download endpoint (and therefore the in-app updaters) ignores
+          # pre-releases; promote via the promote-release workflow or the
+          # GitHub UI to go live.
+          prerelease: true
 
       # Play Store publishes are independent: one failing must not block the
       # others (continue-on-error), but any failure is re-surfaced at the end.

--- a/.github/workflows/desktop_build.yml
+++ b/.github/workflows/desktop_build.yml
@@ -303,6 +303,11 @@ jobs:
           **macOS:** unsigned build — Gatekeeper will warn on first launch. Right-click → Open to bypass, or run `xattr -dr com.apple.quarantine PlayBridge\ Desktop.app`.
         files: output/*
         generate_release_notes: false
+        # RC gating: every CI build lands as a pre-release. The website
+        # download endpoint (and therefore the desktop self-updater) ignores
+        # pre-releases; promote via the promote-release workflow or the
+        # GitHub UI to go live.
+        prerelease: true
 
     - name: Clean up R2 after release
       if: always()

--- a/.github/workflows/promote_release.yml
+++ b/.github/workflows/promote_release.yml
@@ -1,0 +1,174 @@
+# Promote a release candidate to "released".
+#
+# Every CI build lands as a GitHub *pre-release* (an RC) and — for the phone /
+# TV-player apps — on the Play Store *alpha* track. Nothing is served to end
+# users until it is promoted:
+#
+#   * The website `/download/<platform>` endpoint (which the FOSS APK updater
+#     and the desktop self-updater both read) ignores pre-releases, so clearing
+#     the pre-release flag on a GitHub release is what makes it "live" for
+#     sideload + desktop self-update.
+#   * Play Store users get it when the alpha release is promoted to the target
+#     track (production by default).
+#
+# This workflow does both in one shot. Run it from the Actions tab (or `gh
+# workflow run promote_release.yml -f tag=phone-v0.10.0`) once you're happy with
+# an RC.
+name: Promote release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to promote (e.g. phone-v0.10.0, tv-player-v0.9.0, desktop-v0.6.4)"
+        required: true
+        type: string
+      play_track:
+        description: "Play Store track to promote the alpha release into (phone / tv-player only)"
+        required: false
+        default: production
+        type: choice
+        options:
+          - production
+          - beta
+      promote_play:
+        description: "Also promote the Play Store alpha release (ignored for tags with no Play listing)"
+        required: false
+        default: true
+        type: boolean
+
+# The tag prefix decides which app we're promoting and whether it has a Play
+# Store listing. Keep in sync with the tag_name values in android_build.yml /
+# desktop_build.yml.
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag -> Play package
+        id: resolve
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          case "$TAG" in
+            phone-v*)          pkg="com.playbridge.sender" ;;
+            tv-player-v*)      pkg="com.playbridge.player" ;;
+            tv-geckoview-plugin-v*|desktop-v*)
+                               pkg="" ;;  # GitHub-only, no Play listing
+            *)
+              echo "::error::Unrecognised tag prefix '$TAG'. Expected one of: phone-v*, tv-player-v*, tv-geckoview-plugin-v*, desktop-v*." >&2
+              exit 1
+              ;;
+          esac
+          echo "package=$pkg" >> "$GITHUB_OUTPUT"
+          echo "Resolved '$TAG' -> Play package: '${pkg:-<none>}'"
+
+      - name: Clear GitHub pre-release flag (unblocks website / FOSS / desktop updaters)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          # Fail loudly if the release/tag doesn't exist.
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::error::No GitHub release found for tag '$TAG'." >&2
+            exit 1
+          fi
+          gh release edit "$TAG" --prerelease=false
+          echo "Cleared pre-release flag on $TAG; the /download endpoint will now serve it."
+
+      # Promote by *reassigning the already-uploaded version* from alpha to the
+      # target track — NOT by re-uploading the AAB (Play rejects a duplicate
+      # versionCode). This is a pure Edits.tracks operation on the Play
+      # Developer API, so no bundle bytes are needed here.
+      - name: Set up Python
+        if: steps.resolve.outputs.package != '' && inputs.promote_play
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Promote alpha -> ${{ inputs.play_track }} on Play Store
+        if: steps.resolve.outputs.package != '' && inputs.promote_play
+        env:
+          PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+          PACKAGE: ${{ steps.resolve.outputs.package }}
+          TARGET_TRACK: ${{ inputs.play_track }}
+          SOURCE_TRACK: alpha
+        run: |
+          set -euo pipefail
+          pip install --quiet google-api-python-client google-auth
+          python - <<'PY'
+          import json
+          import os
+
+          from google.oauth2 import service_account
+          from googleapiclient.discovery import build
+
+          pkg = os.environ["PACKAGE"]
+          source = os.environ["SOURCE_TRACK"]
+          target = os.environ["TARGET_TRACK"]
+
+          creds = service_account.Credentials.from_service_account_info(
+              json.loads(os.environ["PLAY_STORE_SERVICE_ACCOUNT_JSON"]),
+              scopes=["https://www.googleapis.com/auth/androidpublisher"],
+          )
+          service = build("androidpublisher", "v3", credentials=creds, cache_discovery=False)
+          edits = service.edits()
+
+          edit_id = edits.insert(packageName=pkg, body={}).execute()["id"]
+
+          src = edits.tracks().get(packageName=pkg, editId=edit_id, track=source).execute()
+          releases = src.get("releases") or []
+          if not releases:
+              raise SystemExit(f"No releases on the '{source}' track for {pkg}; nothing to promote.")
+
+          # The RC we just built is the highest versionCode currently on alpha.
+          def max_vc(rel):
+              return max(int(v) for v in rel.get("versionCodes", []) or [0])
+
+          rc = max(releases, key=max_vc)
+          version_codes = [str(v) for v in rc.get("versionCodes", [])]
+          print(f"Promoting {pkg} versionCodes {version_codes} from '{source}' -> '{target}'")
+
+          promoted = {"status": "completed", "versionCodes": version_codes}
+          if rc.get("name"):
+              promoted["name"] = rc["name"]
+          if rc.get("releaseNotes"):
+              promoted["releaseNotes"] = rc["releaseNotes"]
+
+          edits.tracks().update(
+              packageName=pkg,
+              editId=edit_id,
+              track=target,
+              body={"track": target, "releases": [promoted]},
+          ).execute()
+
+          edits.commit(packageName=pkg, editId=edit_id).execute()
+          print(f"Committed: {pkg} is now live on '{target}'.")
+          PY
+
+      - name: Summary
+        if: always()
+        env:
+          TAG: ${{ inputs.tag }}
+          PKG: ${{ steps.resolve.outputs.package }}
+          TRACK: ${{ inputs.play_track }}
+          PLAY: ${{ inputs.promote_play }}
+        run: |
+          {
+            echo "### Promotion summary"
+            echo ""
+            echo "- **Tag:** \`$TAG\`"
+            echo "- **GitHub release:** pre-release flag cleared -> now served by \`/download\` (FOSS APK + desktop self-update)."
+            if [ -n "$PKG" ] && [ "$PLAY" = "true" ]; then
+              echo "- **Play Store:** alpha AAB promoted to \`$TRACK\` for \`$PKG\`."
+            elif [ -n "$PKG" ]; then
+              echo "- **Play Store:** skipped (promote_play=false)."
+            else
+              echo "- **Play Store:** n/a (no listing for this tag)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/tv/android/geckoview-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/tv/android/geckoview-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,7 +2,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tv/android/player/gradle/wrapper/gradle-wrapper.properties
+++ b/tv/android/player/gradle/wrapper/gradle-wrapper.properties
@@ -2,7 +2,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/web/site/functions/download/[platform].ts
+++ b/web/site/functions/download/[platform].ts
@@ -79,11 +79,18 @@ export const onRequestGet: PagesFunction<unknown, 'platform'> = async (context) 
 
     const releases = (await apiResponse.json()) as Array<{
       tag_name: string;
+      draft?: boolean;
+      prerelease?: boolean;
       assets?: Array<{ name: string; browser_download_url: string }>;
     }>;
 
-    // Find the latest release matching the tag prefix
-    const release = releases.find((r) => r.tag_name && r.tag_name.startsWith(tagPrefix));
+    // Find the latest *promoted* release matching the tag prefix. CI publishes
+    // every build as a pre-release (an RC); nothing is served here — to the
+    // website or to the in-app updaters — until the pre-release flag is
+    // cleared (GitHub UI or the promote-release workflow).
+    const release = releases.find(
+      (r) => r.tag_name && r.tag_name.startsWith(tagPrefix) && !r.draft && !r.prerelease
+    );
     if (!release) {
       throw new Error(`No release found for prefix: ${tagPrefix}`);
     }


### PR DESCRIPTION
This PR introduces a Release Candidate (RC) gating and promotion system to manage releases for FOSS sideloading, desktop self-updates, and Play Store tracks.

### Changes Summary

* **RC Gating in CI Build Workflows (`android_build.yml`, `desktop_build.yml`)**:
  * Configured GitHub release tasks to create releases as **pre-releases** (`prerelease: true`) by default.
* **Release Promotion Workflow (`.github/workflows/promote_release.yml`)**:
  * Added a new `workflow_dispatch` action to clear the pre-release flag on GitHub releases (allowing updates to go live for FOSS/desktop users).
  * Automatically handles Google Play Developer API promotion from `alpha` to `production` or `beta` track for phone and TV apps without re-uploading the bundles.
* **Website Download Endpoint (`web/site/functions/download/[platform].ts`)**:
  * Filtered out draft and pre-release releases so that end users and in-app updaters are not served RC builds until they are promoted.
* **Gradle Upgrades**:
  * Updated gradle wrappers in the TV subprojects.

### Verification
* Verified syntax and parameters matching in promote_release workflow.
