### PR TITLE
chore(tv): upgrade gradle wrapper to 9.5.1 in player and geckoview plugin

### DIFF
--- a/tv/android/geckoview-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/tv/android/geckoview-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,7 +2,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tv/android/player/gradle/wrapper/gradle-wrapper.properties
+++ b/tv/android/player/gradle/wrapper/gradle-wrapper.properties
@@ -2,7 +2,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR upgrades the Gradle wrapper properties in the TV player and GeckoView plugin subprojects.

### Changes Summary

* **Gradle Wrappers**:
  * Upgraded `gradle-wrapper.properties` to use Gradle version `9.5.1` in both `tv/android/player` and `tv/android/geckoview-plugin`.
