### PR TITLE
chore: uprev project versions and changelogs for v0.11.0 phone / v0.9.1 TV releases

### DIFF
--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11.0] — 2026-07-08 (versionCode 219)
+
+### Added
+- **Nuvio DOM & Crypto Support**: Integrated JSoup `1.18.1` and implemented DOM parsing (`DomBridge`) and cryptographic helpers (`CryptoBridge`/`PluginCrypto`) inside sandboxed QuickJS scraper plugin runner.
+
+### Changed
+- **Concurrent Stream Resolution**: Refactored stream resolution to fetch from multiple Stremio/Nuvio sources concurrently using Kotlin coroutines and `channelFlow` for immediate and progressive UI updates.
+
+### Fixed
+- **Addon Loading & Navigation**: Gated addon navigation by keying on `addonBaseUrl` instead of name, mapped request types to Stremio-supported types, and made `seasonPosters` nullable to prevent deserialization crashes.
+
 ## [0.10.0] — 2026-07-07 (versionCode 218)
 
 ### Added

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 218
-        versionName = "0.10.0"
+        versionCode = 219
+        versionName = "0.11.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,16 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [0.9.1] — 2026-07-08 (versionCode 221)
+
+### Changed
+- **Gradle Wrapper**: Upgraded gradle wrapper version to 9.5.1 in player.
+
+## GeckoView Plugin [0.3.4] — 2026-07-08 (versionCode 212)
+
+### Changed
+- **Gradle Wrapper**: Upgraded gradle wrapper version to 9.5.1 in geckoview plugin.
+
 ## Player [0.9.0] — 2026-07-07 (versionCode 220)
 
 ### Added

--- a/tv/android/geckoview-plugin/app/build.gradle.kts
+++ b/tv/android/geckoview-plugin/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "com.playbridge.geckoview.plugin"
         minSdk = 26
         targetSdk = 36
-        versionCode = 211
-        versionName = "0.3.3"
+        versionCode = 212
+        versionName = "0.3.4"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 220
-        versionName = "0.9.0"
+        versionCode = 221
+        versionName = "0.9.1"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
## Summary of Changes

Uprevved app versions and documented recent changes in the project changelogs.

### 📦 Version Bumps

* **Android Phone**: `0.10.0` (218) ➔ `0.11.0` (219)
  * Features QuickJS DOM/Crypto bridge additions, concurrent Stremio + Nuvio stream resolution, and navigation/addon loading fixes.
* **Android TV Player**: `0.9.0` (220) ➔ `0.9.1` (221)
  * Includes Gradle wrapper upgrade to 9.5.1.
* **Android TV GeckoView Plugin**: `0.3.3` (211) ➔ `0.3.4` (212)
  * Includes Gradle wrapper upgrade to 9.5.1.