### PR TITLE
fix: add macOS codesigning to installers and throttle native bridge reconnection attempts

### DIFF
--- a/desktop/lib/context_menu_installer.dart
+++ b/desktop/lib/context_menu_installer.dart
@@ -58,7 +58,13 @@ class ContextMenuInstaller {
         data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
         flush: true,
       );
-      if (!Platform.isWindows) await Process.run('chmod', ['+x', out.path]);
+      if (!Platform.isWindows) {
+        await Process.run('chmod', ['+x', out.path]);
+        if (Platform.isMacOS) {
+          await Process.run('xattr', ['-c', out.path]);
+          await Process.run('codesign', ['-s', '-', '--force', out.path]);
+        }
+      }
       return out.absolute.path;
     } catch (_) {
       return null;

--- a/desktop/lib/native_host_installer.dart
+++ b/desktop/lib/native_host_installer.dart
@@ -77,6 +77,10 @@ class NativeHostInstaller {
       );
       if (!Platform.isWindows) {
         await Process.run('chmod', ['+x', out.path]);
+        if (Platform.isMacOS) {
+          await Process.run('xattr', ['-c', out.path]);
+          await Process.run('codesign', ['-s', '-', '--force', out.path]);
+        }
       }
       return out.absolute.path;
     } catch (_) {

--- a/extension/src/native-bridge.ts
+++ b/extension/src/native-bridge.ts
@@ -24,9 +24,11 @@ type StateListener = (s: BridgeState) => void;
 
 const HOST_NAME = "com.playbridge.host";
 const RECONNECT_MS = 5_000;
+const MAX_RECONNECT_ATTEMPTS = 3;
 
 let port: ReturnType<typeof browser.runtime.connectNative> | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnectAttempts = 0;
 const listeners = new Set<StateListener>();
 // Bridge results arrive in order; correlate them to in-flight requests by FIFO.
 const pendingResults: Array<(ok: boolean, error?: string) => void> = [];
@@ -63,15 +65,29 @@ export function connect(): void {
   }
   port.onMessage.addListener(onMessage);
   port.onDisconnect.addListener(() => {
+    const err = browser.runtime.lastError;
+    if (err) {
+      console.error("[PB Bridge] Native host disconnected with error:", err.message);
+    }
     port = null;
     failPending("disconnected");
+    const wasConnected = state.desktopConnected;
     setDisconnected();
-    scheduleReconnect();
+    if (wasConnected) {
+      reconnectAttempts = 0;
+      scheduleReconnect();
+    } else if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
+      reconnectAttempts++;
+      scheduleReconnect();
+    } else {
+      console.warn(`[PB Bridge] Reached max reconnect attempts (${MAX_RECONNECT_ATTEMPTS}). Stopping retries.`);
+    }
   });
   send({ cmd: "list_devices" });
 }
 
 export function refresh(): void {
+  reconnectAttempts = 0;
   if (!port) {
     connect();
     return;
@@ -96,6 +112,7 @@ function request(
 ): Promise<{ ok: boolean; error?: string }> {
   return new Promise((resolve) => {
     if (!port) {
+      reconnectAttempts = 0;
       connect();
       resolve({ ok: false, error: "PlayBridge desktop is not running" });
       return;
@@ -114,6 +131,7 @@ function onMessage(raw: unknown): void {
   switch (msg.type) {
     case "hello":
       state = { ...state, desktopConnected: true };
+      reconnectAttempts = 0;
       emit();
       break;
     case "state":
@@ -123,6 +141,7 @@ function onMessage(raw: unknown): void {
         activeTv: (msg.activeTv as string | null) ?? null,
         devices: Array.isArray(msg.devices) ? (msg.devices as BridgeDevice[]) : [],
       };
+      reconnectAttempts = 0;
       emit();
       break;
     case "result": {


### PR DESCRIPTION
## Summary of Changes

This Pull Request addresses macOS security gating for spawned installer binaries and prevents infinite reconnection attempts to the native bridge in the extension.

### 🛠 Fixes & Enhancements

1. **macOS Executable Code Signing Fallback**:
   - In `context_menu_installer.dart` and `native_host_installer.dart`, added a fallback sequence for macOS that runs `xattr -c` to remove the quarantine attributes from the extracted binaries and runs `codesign -s - --force` to apply ad-hoc signatures. This prevents macOS from blocking the execution of the helper scripts/installers.

2. **Extension Native Bridge Reconnect Throttling**:
   - In `native-bridge.ts`, added a limit to reconnection retries (`MAX_RECONNECT_ATTEMPTS = 3`).
   - Limits retries to prevent continuous loops when connection fails initially, and resets the attempt counter upon successful communication (via `hello` or `state` messages) or manual interaction (`refresh` / `request`).