### PR TITLE
chore: uprev versions and changelogs for v0.6.6 desktop / v0.4.2 extension releases

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.6+24] — 2026-07-08
+
+### Fixed
+- **macOS Installer Security**: Clear quarantine flag (`xattr -c`) and apply ad-hoc signatures (`codesign -s - --force`) when preparing the context menu and native host installation scripts to bypass macOS security blocks.
+
 ## [0.6.4+22] — 2026-07-07
 
 ### Added

--- a/desktop/lib/update/app_version.dart
+++ b/desktop/lib/update/app_version.dart
@@ -2,7 +2,7 @@
 ///
 /// MUST match `version:` in pubspec.yaml (build-metadata part excluded) —
 /// guarded by `test/update_test.dart` so CI fails if they drift.
-const String kAppVersion = '0.6.5';
+const String kAppVersion = '0.6.6';
 
 /// Dotted numeric version (`0.6.4`, `1.10.2`) with sane comparison semantics.
 ///

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: playbridge_desktop
 description: "PlayBridge desktop receiver — accepts cast commands from the phone and plays via libmpv."
 publish_to: 'none'
-version: 0.6.5+23
+version: 0.6.6+24
 
 environment:
   sdk: ^3.6.0

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.2] — 2026-07-08
+
+### Fixed
+- **Native Bridge Reconnection**: Throttled the native messaging port's reconnection routine to at most 3 failed retries upon disconnecting without establishing a valid session. Resets on successful message events.
+
 ## [0.4.1] — 2026-07-07
 
 ### Fixed

--- a/extension/manifests/chrome.json
+++ b/extension/manifests/chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PlayBridge Video Detector",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Detects video URLs for PlayBridge casting",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtZQGgGin2mHxxXXJOQzUD9RHd5Fv19263KYRWrc5W7l2j8zggs4DXiWp5yqe56klCln3+ZNjNO0uUrU33dbkIQKRfj8hPhibBcCc7E+/+ZTFC1VZ+hry29LlDOLruMA+N7dg0EkdPD5qsHoYq6mhVelG7gpUDwnI/GPQOWezyAvYHFTfuP32cBcrW2lEMG7EZAcpds6rnFrYbGsBs/KACgYcvVGEy653tvGKBb4A2rU2bUv+5ph01sok/HDqVwwMFHHGD+U/LTy5ZGX85mRgmNhKLr/WE8IOdFFxIWzdC7hLtgRDxDiYaj2EOAFWE8v+VHmYvl++X1cDVpzxbV/MvQIDAQAB",
   "icons": {

--- a/extension/manifests/firefox.json
+++ b/extension/manifests/firefox.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "PlayBridge Video Detector",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "description": "Detects video URLs for PlayBridge casting",
     "icons": {
         "48": "icon.png",


### PR DESCRIPTION
## Summary of Changes

This Pull Request uprevs the version configurations and writes release changelogs for Desktop and Extension to cover the fixes introduced in PR #99.

### 📦 Version Bumps

* **Desktop Receiver**: `0.6.5+23` ➔ `0.6.6+24`
  * Documents the macOS installer security bypass (quarantine clearance + ad-hoc code signing).
* **Browser Extension**: `0.4.1` ➔ `0.4.2`
  * Documents native bridge port reconnection attempts throttling.