### PR TITLE
fix: phone addon priority + desktop cast/local play and player UX

### DIFF
--- a/desktop/lib/engines/mpv_engine.dart
+++ b/desktop/lib/engines/mpv_engine.dart
@@ -108,8 +108,7 @@ class MpvEngine extends PlayerEngine {
     if (cur.name.isEmpty || cur.name == 'auto') return;
     final stillThere = devices.any((d) => d.name == cur.name);
     if (stillThere) return;
-    debugPrint(
-        '[mpv] audio device removed (${cur.name}); pausing');
+    debugPrint('[mpv] audio device removed (${cur.name}); pausing');
     unawaited(player.pause());
   }
 

--- a/desktop/lib/engines/mpv_engine.dart
+++ b/desktop/lib/engines/mpv_engine.dart
@@ -250,7 +250,7 @@ class MpvEngine extends PlayerEngine {
     // Drop the previous item's last decoded frame before demuxing the next
     // one. Without this, stop→wait→play B briefly shows A's final frame
     // (media_kit / mpv leave the VO texture intact across stop/open).
-    await _clearVideoSurface();
+    await clearVideoSurface();
 
     // Resolve any HLS *master* playlist to a single H.264 variant first — see
     // hls_master_resolver.dart for why mpv chokes on multi-rendition masters.
@@ -293,12 +293,13 @@ class MpvEngine extends PlayerEngine {
   @override
   Future<void> stop() async {
     await player.stop();
-    await _clearVideoSurface();
+    await clearVideoSurface();
   }
 
   /// Disable video output so the last frame is not held on the texture.
   /// [open] re-selects the default video track for the next item.
-  Future<void> _clearVideoSurface() async {
+  @override
+  Future<void> clearVideoSurface() async {
     try {
       await player.setVideoTrack(VideoTrack.no());
     } catch (e) {

--- a/desktop/lib/engines/mpv_engine.dart
+++ b/desktop/lib/engines/mpv_engine.dart
@@ -247,11 +247,6 @@ class MpvEngine extends PlayerEngine {
     // Ensure demuxer/network tuning is live before the first open (race fix).
     await _configured;
 
-    // Drop the previous item's last decoded frame before demuxing the next
-    // one. Without this, stop→wait→play B briefly shows A's final frame
-    // (media_kit / mpv leave the VO texture intact across stop/open).
-    await clearVideoSurface();
-
     // Resolve any HLS *master* playlist to a single H.264 variant first — see
     // hls_master_resolver.dart for why mpv chokes on multi-rendition masters.
     final medias = await Future.wait(items.map((i) async {
@@ -278,6 +273,11 @@ class MpvEngine extends PlayerEngine {
         }
       }
     }
+    // Ensure video is on — never leave a prior "no" selection sticky (that
+    // produced a permanent black picture after the stale-frame experiments).
+    try {
+      await player.setVideoTrack(VideoTrack.auto());
+    } catch (_) {}
     await player.play();
     unawaited(_reapplyTrackPrefs());
   }
@@ -291,21 +291,7 @@ class MpvEngine extends PlayerEngine {
   @override
   Future<void> setVolume(double volume) => player.setVolume(volume * 100.0);
   @override
-  Future<void> stop() async {
-    await player.stop();
-    await clearVideoSurface();
-  }
-
-  /// Disable video output so the last frame is not held on the texture.
-  /// [open] re-selects the default video track for the next item.
-  @override
-  Future<void> clearVideoSurface() async {
-    try {
-      await player.setVideoTrack(VideoTrack.no());
-    } catch (e) {
-      debugPrint('[mpv] clear video surface failed: $e');
-    }
-  }
+  Future<void> stop() => player.stop();
 
   @override
   Future<void> dispose() async {

--- a/desktop/lib/engines/mpv_engine.dart
+++ b/desktop/lib/engines/mpv_engine.dart
@@ -43,7 +43,10 @@ Map<String, String>? sanitizePlayerHeaders(Map<String, String>? headers) {
 class MpvEngine extends PlayerEngine {
   MpvEngine() {
     _subs.addAll([
-      player.stream.playing.listen((_) => notifyListeners()),
+      player.stream.playing.listen((playing) {
+        if (playing) _audioRouteArmed = true;
+        notifyListeners();
+      }),
       player.stream.position.listen((_) => _emitThrottled()),
       player.stream.duration.listen((_) => notifyListeners()),
       player.stream.buffering.listen((_) => notifyListeners()),
@@ -58,12 +61,20 @@ class MpvEngine extends PlayerEngine {
         debugPrint('[mpv] error: $e');
         notifyListeners();
       }),
+      // Headphone unplug / output route change: pause so audio doesn't jump to
+      // speakers at full volume (same idea as phone media apps).
+      player.stream.audioDevice.listen(_onAudioDevice),
+      player.stream.audioDevices.listen(_onAudioDevices),
     ]);
   }
 
   final Player player = Player();
   final List<StreamSubscription> _subs = [];
   VoidCallback? onCompleted;
+
+  /// Ignore the first device enumeration until something has actually played.
+  bool _audioRouteArmed = false;
+  String? _lastAudioDeviceName;
 
   /// mpv tuning is applied asynchronously; opens must await it so the very first
   /// stream gets the same demuxer/network config as every later one (otherwise a
@@ -78,6 +89,28 @@ class MpvEngine extends PlayerEngine {
     if (now.difference(_lastPositionEmit) < _positionEmitInterval) return;
     _lastPositionEmit = now;
     notifyListeners();
+  }
+
+  void _onAudioDevice(AudioDevice device) {
+    final prev = _lastAudioDeviceName;
+    _lastAudioDeviceName = device.name;
+    if (!_audioRouteArmed || !player.state.playing) return;
+    if (prev == null || prev == device.name) return;
+    // "auto" ↔ concrete name can flap on open; only react to real switches.
+    if (prev == 'auto' || device.name == 'auto') return;
+    debugPrint('[mpv] audio output changed ($prev → ${device.name}); pausing');
+    unawaited(player.pause());
+  }
+
+  void _onAudioDevices(List<AudioDevice> devices) {
+    if (!_audioRouteArmed || !player.state.playing) return;
+    final cur = player.state.audioDevice;
+    if (cur.name.isEmpty || cur.name == 'auto') return;
+    final stillThere = devices.any((d) => d.name == cur.name);
+    if (stillThere) return;
+    debugPrint(
+        '[mpv] audio device removed (${cur.name}); pausing');
+    unawaited(player.pause());
   }
 
   @override

--- a/desktop/lib/engines/mpv_engine.dart
+++ b/desktop/lib/engines/mpv_engine.dart
@@ -247,6 +247,11 @@ class MpvEngine extends PlayerEngine {
     // Ensure demuxer/network tuning is live before the first open (race fix).
     await _configured;
 
+    // Drop the previous item's last decoded frame before demuxing the next
+    // one. Without this, stop→wait→play B briefly shows A's final frame
+    // (media_kit / mpv leave the VO texture intact across stop/open).
+    await _clearVideoSurface();
+
     // Resolve any HLS *master* playlist to a single H.264 variant first — see
     // hls_master_resolver.dart for why mpv chokes on multi-rendition masters.
     final medias = await Future.wait(items.map((i) async {
@@ -286,7 +291,20 @@ class MpvEngine extends PlayerEngine {
   @override
   Future<void> setVolume(double volume) => player.setVolume(volume * 100.0);
   @override
-  Future<void> stop() => player.stop();
+  Future<void> stop() async {
+    await player.stop();
+    await _clearVideoSurface();
+  }
+
+  /// Disable video output so the last frame is not held on the texture.
+  /// [open] re-selects the default video track for the next item.
+  Future<void> _clearVideoSurface() async {
+    try {
+      await player.setVideoTrack(VideoTrack.no());
+    } catch (e) {
+      debugPrint('[mpv] clear video surface failed: $e');
+    }
+  }
 
   @override
   Future<void> dispose() async {

--- a/desktop/lib/extension_bridge.dart
+++ b/desktop/lib/extension_bridge.dart
@@ -163,8 +163,7 @@ class ExtensionBridge {
             return;
           }
           if (_sender.isConnected) {
-            final ok =
-                await _sender.castLocalFile(file, title: fileTitle);
+            final ok = await _sender.castLocalFile(file, title: fileTitle);
             _send(socket, {
               'type': 'result',
               'ok': ok,
@@ -231,17 +230,15 @@ class ExtensionBridge {
           unawaited(_player.pause());
           return true;
         case 'toggle':
-          unawaited(_player.state == 'playing'
-              ? _player.pause()
-              : _player.resume());
+          unawaited(
+              _player.state == 'playing' ? _player.pause() : _player.resume());
           return true;
         case 'stop':
           unawaited(_player.stop());
           return true;
         case 'seek_back':
           final pos = _player.positionMs - 10000;
-          unawaited(
-              _player.seek(Duration(milliseconds: pos < 0 ? 0 : pos)));
+          unawaited(_player.seek(Duration(milliseconds: pos < 0 ? 0 : pos)));
           return true;
         case 'seek_forward':
           final dur = _player.durationMs;
@@ -277,9 +274,7 @@ class ExtensionBridge {
       'connected': true,
       'target': tvLinked ? 'tv' : 'local',
       'state': tvLinked ? _sender.state.name : _player.state,
-      'activeTv': tvLinked
-          ? _sender.activeTv?.name
-          : 'This computer',
+      'activeTv': tvLinked ? _sender.activeTv?.name : 'This computer',
       'devices': [
         for (final d in _sender.discovered)
           {

--- a/desktop/lib/extension_bridge.dart
+++ b/desktop/lib/extension_bridge.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 
 import 'bridge_paths.dart';
+import 'player_controller.dart';
 import 'tv_sender_controller.dart';
 
 /// Local IPC endpoint the browser extension reaches **via the native-messaging
@@ -18,13 +19,19 @@ import 'tv_sender_controller.dart';
 /// the host (browser-enforced allowlist) nor read the token file, so it can't
 /// drive the bridge even though there is a loopback port.
 ///
+/// Routing: when a TV/device is linked ([TvSenderController.isConnected]), cast
+/// and control go to that receiver. When nothing is connected, the same
+/// commands play on **this** desktop ([PlayerController]) so the extension
+/// always has a working target.
+///
 /// Wire format: newline-delimited JSON, one object per line.
 /// - client → app: `{"token":"…"}` (first line), then `{"cmd":…}`.
 /// - app → client: `{"type":"hello"|"state"|"result", …}`.
 class ExtensionBridge {
-  ExtensionBridge(this._controller);
+  ExtensionBridge(this._sender, this._player);
 
-  final TvSenderController _controller;
+  final TvSenderController _sender;
+  final PlayerController _player;
 
   ServerSocket? _server;
   final Set<Socket> _authed = {};
@@ -37,7 +44,8 @@ class ExtensionBridge {
     _server = server;
     await _writeBridgeInfo(server.port, _token);
     server.listen(_onClient);
-    _controller.addListener(_pushState);
+    _sender.addListener(_pushState);
+    _player.addListener(_pushState);
     debugPrint('[ext-bridge] listening on 127.0.0.1:${server.port}');
   }
 
@@ -107,19 +115,36 @@ class ExtensionBridge {
         }
         final headers =
             (obj['headers'] as Map?)?.map((k, v) => MapEntry('$k', '$v'));
-        final ok = _controller.castUrl(url,
-            headers: headers, title: obj['title'] as String?);
-        _send(socket, {
-          'type': 'result',
-          'ok': ok,
-          if (!ok) 'error': 'no TV connected',
-        });
+        final title = obj['title'] as String?;
+        if (_sender.isConnected) {
+          final ok = _sender.castUrl(url, headers: headers, title: title);
+          _send(socket, {
+            'type': 'result',
+            'ok': ok,
+            'target': 'tv',
+            if (!ok) 'error': 'send failed',
+          });
+        } else {
+          // No cast target — play on this machine (extension → desktop).
+          unawaited(_player.playUrl(
+            url,
+            headers: headers,
+            title: title,
+            isRemote: true,
+          ));
+          debugPrint('[ext-bridge] cast → local player: $url');
+          _send(socket, {
+            'type': 'result',
+            'ok': true,
+            'target': 'local',
+          });
+        }
         break;
       case 'cast_file':
         // Cast a local file by absolute path — used by the OS "Play on TV"
         // context-menu entry, which shells `playbridge_cast <path>` and relays
-        // it here. castLocalFile is async (it spins up the LAN file server), so
-        // reply once it resolves.
+        // it here. When a TV is linked, serve over LAN; otherwise open in the
+        // local player.
         final path = obj['path'] as String?;
         if (path == null || path.isEmpty) {
           _send(
@@ -128,22 +153,109 @@ class ExtensionBridge {
         }
         final fileTitle = obj['title'] as String?;
         unawaited(() async {
-          final ok =
-              await _controller.castLocalFile(File(path), title: fileTitle);
+          final file = File(path);
+          if (!file.existsSync()) {
+            _send(socket, {
+              'type': 'result',
+              'ok': false,
+              'error': 'file not found',
+            });
+            return;
+          }
+          if (_sender.isConnected) {
+            final ok =
+                await _sender.castLocalFile(file, title: fileTitle);
+            _send(socket, {
+              'type': 'result',
+              'ok': ok,
+              'target': 'tv',
+              if (!ok) 'error': 'send failed',
+            });
+            return;
+          }
+          final name = fileTitle ??
+              (file.uri.pathSegments.isNotEmpty
+                  ? file.uri.pathSegments.last
+                  : path);
+          await _player.playUrl(
+            file.uri.toString(),
+            title: name,
+            isRemote: true,
+          );
+          debugPrint('[ext-bridge] cast_file → local player: $path');
           _send(socket, {
             'type': 'result',
-            'ok': ok,
-            if (!ok) 'error': 'no TV connected or file not found',
+            'ok': true,
+            'target': 'local',
           });
         }());
         break;
       case 'control':
         final action = obj['action'] as String?;
-        final ok = action != null && _controller.sendControl(action);
-        _send(socket, {'type': 'result', 'ok': ok});
+        if (action == null || action.isEmpty) {
+          _send(socket, {'type': 'result', 'ok': false});
+          break;
+        }
+        final ok = _sender.isConnected
+            ? _sender.sendControl(action)
+            : _localControl(action);
+        _send(socket, {
+          'type': 'result',
+          'ok': ok,
+          'target': _sender.isConnected ? 'tv' : 'local',
+        });
         break;
       default:
         _send(socket, {'type': 'result', 'ok': false, 'error': 'unknown cmd'});
+    }
+  }
+
+  /// Apply a control action to the local [PlayerController] (same vocabulary
+  /// as the TV receiver / [TvSenderController.sendControl]).
+  bool _localControl(String action) {
+    try {
+      if (action.startsWith('seek_to:')) {
+        final ms = int.tryParse(action.substring('seek_to:'.length));
+        if (ms == null) return false;
+        final dur = _player.durationMs;
+        var target = ms < 0 ? 0 : ms;
+        if (dur > 0 && target > dur) target = dur;
+        unawaited(_player.seek(Duration(milliseconds: target)));
+        return true;
+      }
+      switch (action) {
+        case 'play':
+          unawaited(_player.resume());
+          return true;
+        case 'pause':
+          unawaited(_player.pause());
+          return true;
+        case 'toggle':
+          unawaited(_player.state == 'playing'
+              ? _player.pause()
+              : _player.resume());
+          return true;
+        case 'stop':
+          unawaited(_player.stop());
+          return true;
+        case 'seek_back':
+          final pos = _player.positionMs - 10000;
+          unawaited(
+              _player.seek(Duration(milliseconds: pos < 0 ? 0 : pos)));
+          return true;
+        case 'seek_forward':
+          final dur = _player.durationMs;
+          var target = _player.positionMs + 10000;
+          if (dur > 0 && target > dur) target = dur;
+          unawaited(_player.seek(Duration(milliseconds: target)));
+          return true;
+        default:
+          debugPrint('[ext-bridge] local control ignored: $action');
+          return false;
+      }
+    } catch (e) {
+      debugPrint('[ext-bridge] local control failed: $e');
+      return false;
     }
   }
 
@@ -157,20 +269,27 @@ class ExtensionBridge {
 
   void _sendStateTo(Socket socket) => _send(socket, _stateFrame());
 
-  Map<String, dynamic> _stateFrame() => {
-        'type': 'state',
-        'connected': _controller.isConnected,
-        'state': _controller.state.name,
-        'activeTv': _controller.activeTv?.name,
-        'devices': [
-          for (final d in _controller.discovered)
-            {
-              'uuid': d.uuid,
-              'name': d.name,
-              'paired': _controller.pairedTvs.any((p) => p.uuid == d.uuid),
-            },
-        ],
-      };
+  Map<String, dynamic> _stateFrame() {
+    final tvLinked = _sender.isConnected;
+    return {
+      'type': 'state',
+      // Always ready to accept cast — either a TV or this desktop.
+      'connected': true,
+      'target': tvLinked ? 'tv' : 'local',
+      'state': tvLinked ? _sender.state.name : _player.state,
+      'activeTv': tvLinked
+          ? _sender.activeTv?.name
+          : 'This computer',
+      'devices': [
+        for (final d in _sender.discovered)
+          {
+            'uuid': d.uuid,
+            'name': d.name,
+            'paired': _sender.pairedTvs.any((p) => p.uuid == d.uuid),
+          },
+      ],
+    };
+  }
 
   void _send(Socket socket, Map<String, dynamic> obj) {
     try {
@@ -203,7 +322,8 @@ class ExtensionBridge {
   }
 
   Future<void> stop() async {
-    _controller.removeListener(_pushState);
+    _sender.removeListener(_pushState);
+    _player.removeListener(_pushState);
     for (final s in _authed) {
       try {
         await s.close();

--- a/desktop/lib/keyboard_shortcuts_sheet.dart
+++ b/desktop/lib/keyboard_shortcuts_sheet.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+/// Modal cheat sheet for desktop player shortcuts.
+Future<void> showKeyboardShortcutsSheet(BuildContext context) {
+  return showDialog<void>(
+    context: context,
+    barrierColor: Colors.black54,
+    builder: (ctx) => const _KeyboardShortcutsDialog(),
+  );
+}
+
+class _KeyboardShortcutsDialog extends StatelessWidget {
+  const _KeyboardShortcutsDialog();
+
+  static const _rows = <(String, String)>[
+    ('Space', 'Play / pause'),
+    ('← / →', 'Seek −10s / +10s'),
+    ('↑ / ↓', 'Volume up / down'),
+    ('F', 'Toggle fullscreen'),
+    ('I', 'Playback stats overlay'),
+    ('?', 'This shortcuts list'),
+    ('Click video', 'Play / pause'),
+    ('Double-click video', 'Fullscreen'),
+    ('Drop files / URLs', 'Play here (or cast if TV linked)'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: const Color(0xFF1A1A1A),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 420),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 20, 16, 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  const Icon(Icons.keyboard, size: 20, color: Colors.white54),
+                  const SizedBox(width: 10),
+                  const Expanded(
+                    child: Text(
+                      'Keyboard & gestures',
+                      style: TextStyle(
+                        fontSize: 17,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: 'Close',
+                    onPressed: () => Navigator.of(context).pop(),
+                    icon: const Icon(Icons.close, size: 18),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              for (final row in _rows)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 6),
+                  child: Row(
+                    children: [
+                      SizedBox(
+                        width: 150,
+                        child: Text(
+                          row.$1,
+                          style: TextStyle(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.tealAccent.withValues(alpha: 0.9),
+                            fontFeatures: const [FontFeature.tabularFigures()],
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: Text(
+                          row.$2,
+                          style: const TextStyle(
+                            fontSize: 13,
+                            color: Colors.white70,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Got it'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Intent for the `?` / help shortcut.
+class ShowShortcutsIntent extends Intent {
+  const ShowShortcutsIntent();
+}
+
+/// Intent for the `F` fullscreen shortcut.
+class ToggleFullScreenIntent extends Intent {
+  const ToggleFullScreenIntent();
+}

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -207,7 +207,7 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     _tray =
         TrayController(player: _player, server: _server, store: widget.store);
     _sender = TvSenderController(identity: widget.store, store: widget.tvStore);
-    _extBridge = ExtensionBridge(_sender);
+    _extBridge = ExtensionBridge(_sender, _player);
 
     windowManager.addListener(this);
     _player.addListener(_handlePlayerChange);
@@ -234,10 +234,16 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     // video here). Tracks the rising edge so it doesn't fight tab navigation.
     _sender.addListener(_handleSenderChange);
 
-    // Cold-start "Play on TV": cast the launched file once a TV is connected.
+    // Cold-start file open (`playbridge_cast` launched the app): cast to a TV
+    // if already linked, otherwise play on this desktop (same as extension
+    // bridge when disconnected).
     if (widget.initialCastFile != null) {
       _pendingCastFile = widget.initialCastFile;
       _sender.addListener(_maybeCastPendingFile);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _resolvePendingCastFile();
+      });
     }
   }
 
@@ -260,14 +266,37 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
 
   String? _pendingCastFile;
 
-  /// When launched with `--cast-file`, wait for a TV connection then cast once.
+  /// Rising edge: TV connected while a cold-start file is still pending → TV.
   void _maybeCastPendingFile() {
+    if (_pendingCastFile == null || !_sender.isConnected) return;
+    _resolvePendingCastFile();
+  }
+
+  /// One-shot: send [initialCastFile] to the TV if linked, else play locally.
+  void _resolvePendingCastFile() {
     final path = _pendingCastFile;
-    if (path == null || !_sender.isConnected) return;
-    _pendingCastFile = null; // one-shot
+    if (path == null) return;
+    _pendingCastFile = null;
     _sender.removeListener(_maybeCastPendingFile);
-    unawaited(
-        _sender.castLocalFile(File(path), title: widget.initialCastTitle));
+    final file = File(path);
+    if (!file.existsSync()) {
+      debugPrint('[main] pending cast file missing: $path');
+      return;
+    }
+    final title = widget.initialCastTitle;
+    if (_sender.isConnected) {
+      unawaited(_sender.castLocalFile(file, title: title));
+      return;
+    }
+    final name = title ??
+        (file.uri.pathSegments.isNotEmpty
+            ? file.uri.pathSegments.last
+            : path);
+    unawaited(_player.playUrl(
+      file.uri.toString(),
+      title: name,
+      isRemote: true,
+    ));
   }
 
   Future<void> _initTrayAndWindow() async {

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -185,6 +185,7 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   /// Center OSD (pause / seek / volume); cleared by [_osdTimer].
   String? _osdMessage;
   Timer? _osdTimer;
+
   /// Debounces single-tap play/pause so double-tap fullscreen isn't stolen.
   Timer? _tapTimer;
   bool _mainDragging = false;
@@ -323,9 +324,7 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
       return;
     }
     final name = title ??
-        (file.uri.pathSegments.isNotEmpty
-            ? file.uri.pathSegments.last
-            : path);
+        (file.uri.pathSegments.isNotEmpty ? file.uri.pathSegments.last : path);
     unawaited(_player.playUrl(
       file.uri.toString(),
       title: name,
@@ -623,9 +622,8 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
       for (final f in files)
         QueueItem(
           url: f.uri.toString(),
-          title: f.uri.pathSegments.isNotEmpty
-              ? f.uri.pathSegments.last
-              : f.path,
+          title:
+              f.uri.pathSegments.isNotEmpty ? f.uri.pathSegments.last : f.path,
         ),
     ];
     if (items.isEmpty) return;
@@ -852,153 +850,158 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
                                         setState(() => _mainDragging = false),
                                     onDragDone: _onMainDrop,
                                     child: MouseRegion(
-                                    onEnter: (_) => _markActive(),
-                                    onExit: (_) => _markInactive(),
-                                    onHover: (_) => _markActive(),
-                                    child: Stack(
-                                      fit: StackFit.expand,
-                                      children: [
-                                        // Video is always in the tree (Offstage) so
-                                        // mpv is never torn down on screen switch.
-                                        Positioned.fill(
-                                          child: Offstage(
-                                            offstage:
-                                                !_showingVideo || !hasMedia,
-                                            child: Container(
-                                              color: Colors.black,
-                                              child: PlaybackSurface(
-                                                controller: _player,
-                                                controlsVisible:
-                                                    _videoHovered ||
-                                                        _playlistDrawerOpen ||
-                                                        _menusOpen > 0,
-                                              ),
-                                            ),
-                                          ),
-                                        ),
-                                        // Tap / double-tap video (not controls).
-                                        // Below overlays so buttons/menus keep hits.
-                                        if (_showingVideo && hasMedia)
+                                      onEnter: (_) => _markActive(),
+                                      onExit: (_) => _markInactive(),
+                                      onHover: (_) => _markActive(),
+                                      child: Stack(
+                                        fit: StackFit.expand,
+                                        children: [
+                                          // Video is always in the tree (Offstage) so
+                                          // mpv is never torn down on screen switch.
                                           Positioned.fill(
-                                            child: GestureDetector(
-                                              behavior:
-                                                  HitTestBehavior.translucent,
-                                              onTap: () {
-                                                _markActive();
-                                                // Wait out a possible double-tap.
-                                                _tapTimer?.cancel();
-                                                _tapTimer = Timer(
-                                                  const Duration(
-                                                      milliseconds: 220),
-                                                  () => _togglePlayPause(),
-                                                );
-                                              },
-                                              onDoubleTap: () {
-                                                _tapTimer?.cancel();
-                                                _markActive();
-                                                final entering = !_isFullScreen;
-                                                unawaited(_toggleFullScreen());
-                                                _showOsd(entering
-                                                    ? 'Fullscreen'
-                                                    : 'Windowed');
-                                              },
-                                            ),
-                                          ),
-                                        if (!_showingVideo)
-                                          Positioned.fill(
-                                              child: _buildScreen()),
-                                        if (_showingVideo &&
-                                            hasMedia &&
-                                            _showStats.value &&
-                                            _player.engine is MpvEngine)
-                                          Positioned(
-                                            top: 16,
-                                            left: 16,
-                                            child: StatsOverlay(
-                                              engine:
-                                                  _player.engine as MpvEngine,
-                                            ),
-                                          ),
-                                        if (_showingVideo && hasMedia)
-                                          Positioned(
-                                            left: 0,
-                                            right: 0,
-                                            bottom: 0,
-                                            child: _PlayerControlsBar(
-                                              player: _player,
-                                              store: widget.store,
-                                              visible: _videoHovered ||
-                                                  _playlistDrawerOpen ||
-                                                  _menusOpen > 0,
-                                              showQueueControls: hasQueue,
-                                              onTogglePlaylist: () => setState(
-                                                () => _playlistDrawerOpen =
-                                                    !_playlistDrawerOpen,
-                                              ),
-                                              playlistOpen: _playlistDrawerOpen,
-                                              onMenuOpened: () =>
-                                                  setState(() => _menusOpen++),
-                                              onMenuClosed: () => setState(
-                                                () => _menusOpen =
-                                                    (_menusOpen - 1)
-                                                        .clamp(0, 99),
-                                              ),
-                                              isFullScreen: _isFullScreen,
-                                              onToggleFullScreen:
-                                                  _toggleFullScreen,
-                                            ),
-                                          ),
-                                        if (_showingVideo &&
-                                            hasQueue &&
-                                            _playlistDrawerOpen)
-                                          Positioned(
-                                            right: 0,
-                                            top: 0,
-                                            bottom: 0,
-                                            width: 360,
-                                            child: _PlaylistDrawer(
-                                              player: _player,
-                                              onClose: () => setState(
-                                                () =>
-                                                    _playlistDrawerOpen = false,
+                                            child: Offstage(
+                                              offstage:
+                                                  !_showingVideo || !hasMedia,
+                                              child: Container(
+                                                color: Colors.black,
+                                                child: PlaybackSurface(
+                                                  controller: _player,
+                                                  controlsVisible:
+                                                      _videoHovered ||
+                                                          _playlistDrawerOpen ||
+                                                          _menusOpen > 0,
+                                                ),
                                               ),
                                             ),
                                           ),
-                                        // Title scrim along the top — same
-                                        // visibility as the controls bar, so
-                                        // the title is reachable in fullscreen.
-                                        if (_showingVideo && hasMedia)
-                                          Positioned(
-                                            left: 0,
-                                            right: 0,
-                                            top: 0,
-                                            child: _TitleOverlay(
-                                              player: _player,
-                                              visible: _videoHovered ||
-                                                  _playlistDrawerOpen ||
-                                                  _menusOpen > 0,
+                                          // Tap / double-tap video (not controls).
+                                          // Below overlays so buttons/menus keep hits.
+                                          if (_showingVideo && hasMedia)
+                                            Positioned.fill(
+                                              child: GestureDetector(
+                                                behavior:
+                                                    HitTestBehavior.translucent,
+                                                onTap: () {
+                                                  _markActive();
+                                                  // Wait out a possible double-tap.
+                                                  _tapTimer?.cancel();
+                                                  _tapTimer = Timer(
+                                                    const Duration(
+                                                        milliseconds: 220),
+                                                    () => _togglePlayPause(),
+                                                  );
+                                                },
+                                                onDoubleTap: () {
+                                                  _tapTimer?.cancel();
+                                                  _markActive();
+                                                  final entering =
+                                                      !_isFullScreen;
+                                                  unawaited(
+                                                      _toggleFullScreen());
+                                                  _showOsd(entering
+                                                      ? 'Fullscreen'
+                                                      : 'Windowed');
+                                                },
+                                              ),
                                             ),
-                                          ),
-                                        // Pre-play screen for casts with
-                                        // metadata; sits above everything.
-                                        if (_showingVideo &&
-                                            _prePlayItem != null)
-                                          Positioned.fill(
-                                            child: PrePlayOverlay(
-                                              key: ValueKey(_prePlayItem!.url),
-                                              item: _prePlayItem!,
-                                              onStart: _dismissPrePlay,
+                                          if (!_showingVideo)
+                                            Positioned.fill(
+                                                child: _buildScreen()),
+                                          if (_showingVideo &&
+                                              hasMedia &&
+                                              _showStats.value &&
+                                              _player.engine is MpvEngine)
+                                            Positioned(
+                                              top: 16,
+                                              left: 16,
+                                              child: StatsOverlay(
+                                                engine:
+                                                    _player.engine as MpvEngine,
+                                              ),
                                             ),
-                                          ),
-                                        if (_osdMessage != null)
-                                          PlaybackOsd(message: _osdMessage!),
-                                        if (_mainDragging)
-                                          const Positioned.fill(
-                                            child: _MainDropOverlay(),
-                                          ),
-                                      ],
+                                          if (_showingVideo && hasMedia)
+                                            Positioned(
+                                              left: 0,
+                                              right: 0,
+                                              bottom: 0,
+                                              child: _PlayerControlsBar(
+                                                player: _player,
+                                                store: widget.store,
+                                                visible: _videoHovered ||
+                                                    _playlistDrawerOpen ||
+                                                    _menusOpen > 0,
+                                                showQueueControls: hasQueue,
+                                                onTogglePlaylist: () =>
+                                                    setState(
+                                                  () => _playlistDrawerOpen =
+                                                      !_playlistDrawerOpen,
+                                                ),
+                                                playlistOpen:
+                                                    _playlistDrawerOpen,
+                                                onMenuOpened: () => setState(
+                                                    () => _menusOpen++),
+                                                onMenuClosed: () => setState(
+                                                  () => _menusOpen =
+                                                      (_menusOpen - 1)
+                                                          .clamp(0, 99),
+                                                ),
+                                                isFullScreen: _isFullScreen,
+                                                onToggleFullScreen:
+                                                    _toggleFullScreen,
+                                              ),
+                                            ),
+                                          if (_showingVideo &&
+                                              hasQueue &&
+                                              _playlistDrawerOpen)
+                                            Positioned(
+                                              right: 0,
+                                              top: 0,
+                                              bottom: 0,
+                                              width: 360,
+                                              child: _PlaylistDrawer(
+                                                player: _player,
+                                                onClose: () => setState(
+                                                  () => _playlistDrawerOpen =
+                                                      false,
+                                                ),
+                                              ),
+                                            ),
+                                          // Title scrim along the top — same
+                                          // visibility as the controls bar, so
+                                          // the title is reachable in fullscreen.
+                                          if (_showingVideo && hasMedia)
+                                            Positioned(
+                                              left: 0,
+                                              right: 0,
+                                              top: 0,
+                                              child: _TitleOverlay(
+                                                player: _player,
+                                                visible: _videoHovered ||
+                                                    _playlistDrawerOpen ||
+                                                    _menusOpen > 0,
+                                              ),
+                                            ),
+                                          // Pre-play screen for casts with
+                                          // metadata; sits above everything.
+                                          if (_showingVideo &&
+                                              _prePlayItem != null)
+                                            Positioned.fill(
+                                              child: PrePlayOverlay(
+                                                key:
+                                                    ValueKey(_prePlayItem!.url),
+                                                item: _prePlayItem!,
+                                                onStart: _dismissPrePlay,
+                                              ),
+                                            ),
+                                          if (_osdMessage != null)
+                                            PlaybackOsd(message: _osdMessage!),
+                                          if (_mainDragging)
+                                            const Positioned.fill(
+                                              child: _MainDropOverlay(),
+                                            ),
+                                        ],
+                                      ),
                                     ),
-                                  ),
                                   ),
                                 ),
                               ],

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -15,6 +15,7 @@ import 'extension_bridge.dart';
 import 'favorites_screen.dart';
 import 'history_screen.dart';
 import 'history_store.dart';
+import 'media_session_bridge.dart';
 import 'native_host_installer.dart';
 import 'now_casting_screen.dart';
 import 'pairing_store.dart';
@@ -142,6 +143,7 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   late final TrayController _tray;
   late final TvSenderController _sender;
   late final ExtensionBridge _extBridge;
+  late final MediaSessionBridge _mediaSession;
   final UpdateChecker _updateChecker = UpdateChecker();
 
   bool _hadMedia = false;
@@ -208,16 +210,20 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
         TrayController(player: _player, server: _server, store: widget.store);
     _sender = TvSenderController(identity: widget.store, store: widget.tvStore);
     _extBridge = ExtensionBridge(_sender, _player);
+    _mediaSession = MediaSessionBridge(_player);
 
     windowManager.addListener(this);
     _player.addListener(_handlePlayerChange);
     _player.playRequests.addListener(_handlePlayRequest);
+    _server.addListener(_handlePairingPrompt);
 
     _bootServerThenDiscovery();
     _resolveHost();
     _initTrayAndWindow();
     unawaited(_sender.start());
     unawaited(_extBridge.start());
+    // Now Playing / SMTC so Bluetooth headset play-pause reaches this player.
+    unawaited(_mediaSession.start());
     // Register the browser native-messaging host + the OS "Play on TV" context
     // menu so the extension and file manager can reach us without the user
     // editing files by hand (idempotent, best-effort).
@@ -395,6 +401,29 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     }
   }
 
+  /// Rising edge into a pairing UI phase: bring the window forward (no
+  /// fullscreen) so the user can enter the code even if the app was hidden
+  /// or another app was focused — same idea as cast playback reveal.
+  PairingPhase _lastPairingPhase = PairingPhase.idle;
+  void _handlePairingPrompt() {
+    final phase = _server.phase;
+    final pairing = phase == PairingPhase.awaitingCode ||
+        phase == PairingPhase.awaitingApproval;
+    final wasPairing = _lastPairingPhase == PairingPhase.awaitingCode ||
+        _lastPairingPhase == PairingPhase.awaitingApproval;
+    _lastPairingPhase = phase;
+    if (!pairing || wasPairing) return;
+
+    unawaited(_revealWindow(fullScreen: false));
+    if (!mounted) return;
+    setState(() {
+      // Pair UI lives on the Cast tab; leave the video view so the code is
+      // visible even if something was playing.
+      _dest = _Dest.cast;
+      _showingVideo = false;
+    });
+  }
+
   @override
   void onWindowClose() async {
     final prevented = await windowManager.isPreventClose();
@@ -476,9 +505,11 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     windowManager.removeListener(this);
     _player.removeListener(_handlePlayerChange);
     _player.playRequests.removeListener(_handlePlayRequest);
+    _server.removeListener(_handlePairingPrompt);
     _tray.dispose();
     _sender.removeListener(_handleSenderChange);
     if (_pendingCastFile != null) _sender.removeListener(_maybeCastPendingFile);
+    unawaited(_mediaSession.dispose());
     _extBridge.stop();
     _sender.dispose();
     _discovery.stop();
@@ -683,6 +714,26 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
                                             ),
                                           ),
                                         ),
+                                        // Tap video (not controls/drawer) to play/pause.
+                                        // Below overlays so buttons/menus keep their hits.
+                                        if (_showingVideo && hasMedia)
+                                          Positioned.fill(
+                                            child: GestureDetector(
+                                              behavior:
+                                                  HitTestBehavior.translucent,
+                                              onTap: () {
+                                                _markActive();
+                                                if (_player.state == 'playing') {
+                                                  unawaited(_player.pause());
+                                                } else if (_player.state ==
+                                                        'paused' ||
+                                                    _player.state ==
+                                                        'buffering') {
+                                                  unawaited(_player.resume());
+                                                }
+                                              },
+                                            ),
+                                          ),
                                         if (!_showingVideo)
                                           Positioned.fill(
                                               child: _buildScreen()),

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -7,6 +7,8 @@ import 'package:flutter/services.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:window_manager/window_manager.dart';
 
+import 'package:desktop_drop/desktop_drop.dart';
+
 import 'logging/log_store.dart';
 import 'context_menu_installer.dart';
 import 'discovery.dart';
@@ -15,11 +17,13 @@ import 'extension_bridge.dart';
 import 'favorites_screen.dart';
 import 'history_screen.dart';
 import 'history_store.dart';
+import 'keyboard_shortcuts_sheet.dart';
 import 'media_session_bridge.dart';
 import 'native_host_installer.dart';
 import 'now_casting_screen.dart';
 import 'pairing_store.dart';
 import 'pair_screen.dart';
+import 'playback_osd.dart';
 import 'player_controller.dart';
 import 'player_engine.dart';
 import 'playback_surface.dart';
@@ -177,6 +181,30 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   bool _playlistDrawerOpen = false;
   Timer? _hideTimer;
   static const _autoHide = Duration(seconds: 2);
+
+  /// Center OSD (pause / seek / volume); cleared by [_osdTimer].
+  String? _osdMessage;
+  Timer? _osdTimer;
+  /// Debounces single-tap play/pause so double-tap fullscreen isn't stolen.
+  Timer? _tapTimer;
+  bool _mainDragging = false;
+
+  static const _mediaExts = {
+    'mp4',
+    'm4v',
+    'mkv',
+    'webm',
+    'avi',
+    'mov',
+    'wmv',
+    'flv',
+    'mp3',
+    'flac',
+    'm4a',
+    'aac',
+    'ogg',
+    'wav',
+  };
 
   void _markActive() {
     if (!_videoHovered) setState(() => _videoHovered = true);
@@ -427,7 +455,23 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   @override
   void onWindowClose() async {
     final prevented = await windowManager.isPreventClose();
-    if (prevented) await windowManager.hide();
+    if (!prevented) return;
+    // Fullscreen red X = leave immersive mode only (stay visible), same end
+    // state as the green full-screen control. Windowed red X = hide to tray.
+    // Quit is tray / Settings only.
+    //
+    // Green vs red in fullscreen both end windowed+visible; they differ after
+    // that: green is “back to a normal window”, red is the first step of close
+    // (second red X then hides). Matching Safari-style progressive close.
+    if (await windowManager.isFullScreen()) {
+      await windowManager.setFullScreen(false);
+      return;
+    }
+    if (widget.store.pauseOnWindowHide &&
+        (_player.state == 'playing' || _player.state == 'buffering')) {
+      await _player.pause();
+    }
+    await windowManager.hide();
   }
 
   @override
@@ -499,9 +543,106 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     }
   }
 
+  void _showOsd(String message) {
+    _osdTimer?.cancel();
+    if (!mounted) return;
+    setState(() => _osdMessage = message);
+    _osdTimer = Timer(const Duration(milliseconds: 1100), () {
+      if (mounted) setState(() => _osdMessage = null);
+    });
+  }
+
+  void _togglePlayPause({bool withOsd = true}) {
+    if (_player.state == 'playing') {
+      unawaited(_player.pause());
+      if (withOsd) _showOsd('Paused');
+    } else if (_player.state == 'paused' || _player.state == 'buffering') {
+      unawaited(_player.resume());
+      if (withOsd) _showOsd('Play');
+    }
+  }
+
+  void _seekBy(int deltaMs, {required String osd}) {
+    final dur = _player.durationMs;
+    var target = _player.positionMs + deltaMs;
+    if (target < 0) target = 0;
+    if (dur > 0 && target > dur) target = dur;
+    unawaited(_player.seek(Duration(milliseconds: target)));
+    _showOsd(osd);
+  }
+
+  void _nudgeVolume(double delta) {
+    final next = (_player.volume + delta).clamp(0.0, 1.0);
+    unawaited(_player.setVolume(next));
+    _showOsd('Volume ${(next * 100).round()}%');
+  }
+
+  /// Drop files/URLs onto the main surface: cast if a TV is linked, else play here.
+  void _onMainDrop(DropDoneDetails detail) {
+    setState(() => _mainDragging = false);
+    final files = <File>[];
+    final urls = <String>[];
+    for (final f in detail.files) {
+      final path = f.path;
+      if (path.startsWith('http://') || path.startsWith('https://')) {
+        urls.add(path);
+        continue;
+      }
+      final ext = _fileExt(path);
+      if (_mediaExts.contains(ext)) files.add(File(path));
+    }
+    if (files.isEmpty && urls.isEmpty) {
+      _showOsd('No media in drop');
+      return;
+    }
+
+    final tvLinked = _sender.isConnected;
+    if (tvLinked) {
+      if (files.isNotEmpty) {
+        unawaited(_sender.castLocalFiles(files).then((ok) {
+          if (!ok) _showOsd('Cast failed');
+        }));
+      }
+      for (final u in urls) {
+        _sender.castUrl(u);
+      }
+      if (files.isNotEmpty || urls.isNotEmpty) {
+        _showOsd('Casting…');
+        setState(() {
+          _dest = _Dest.nowCasting;
+          _showingVideo = false;
+        });
+      }
+      return;
+    }
+
+    // Local play: URLs + files as a playlist.
+    final items = <QueueItem>[
+      for (final u in urls)
+        QueueItem(url: u, title: u.split('/').last.split('?').first),
+      for (final f in files)
+        QueueItem(
+          url: f.uri.toString(),
+          title: f.uri.pathSegments.isNotEmpty
+              ? f.uri.pathSegments.last
+              : f.path,
+        ),
+    ];
+    if (items.isEmpty) return;
+    unawaited(_player.playPlaylist(items, 0, isRemote: true));
+    _showOsd(items.length == 1 ? 'Playing' : '${items.length} items');
+  }
+
+  static String _fileExt(String path) {
+    final dot = path.lastIndexOf('.');
+    return dot >= 0 ? path.substring(dot + 1).toLowerCase() : '';
+  }
+
   @override
   void dispose() {
     _hideTimer?.cancel();
+    _osdTimer?.cancel();
+    _tapTimer?.cancel();
     windowManager.removeListener(this);
     _player.removeListener(_handlePlayerChange);
     _player.playRequests.removeListener(_handlePlayRequest);
@@ -551,46 +692,61 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
               const VolumeDownIntent(),
           const SingleActivator(LogicalKeyboardKey.keyI):
               const StatsToggleIntent(),
+          const SingleActivator(LogicalKeyboardKey.keyF):
+              const ToggleFullScreenIntent(),
+          // `?` is Shift+/ on US keyboards.
+          const SingleActivator(LogicalKeyboardKey.slash, shift: true):
+              const ShowShortcutsIntent(),
+          const SingleActivator(LogicalKeyboardKey.slash):
+              const ShowShortcutsIntent(),
         },
         child: Actions(
           actions: {
             PlayPauseIntent: CallbackAction<PlayPauseIntent>(
-              onInvoke: (_) => _player.state == 'playing'
-                  ? _player.pause()
-                  : _player.resume(),
+              onInvoke: (_) {
+                _togglePlayPause();
+                return null;
+              },
             ),
             SeekForwardIntent: CallbackAction<SeekForwardIntent>(
               onInvoke: (_) {
-                final dur = _player.durationMs;
-                var target = _player.positionMs + 10000;
-                if (dur > 0 && target > dur) target = dur;
-                _player.seek(Duration(milliseconds: target));
+                _seekBy(10000, osd: '≫ 10s');
                 return null;
               },
             ),
             SeekBackwardIntent: CallbackAction<SeekBackwardIntent>(
               onInvoke: (_) {
-                // Clamp to 0 — a negative absolute seek makes mpv jump to EOF.
-                final target = _player.positionMs - 10000;
-                _player.seek(Duration(milliseconds: target < 0 ? 0 : target));
+                _seekBy(-10000, osd: '≪ 10s');
                 return null;
               },
             ),
             VolumeUpIntent: CallbackAction<VolumeUpIntent>(
               onInvoke: (_) {
-                _player.setVolume((_player.volume + 0.05).clamp(0.0, 1.0));
+                _nudgeVolume(0.05);
                 return null;
               },
             ),
             VolumeDownIntent: CallbackAction<VolumeDownIntent>(
               onInvoke: (_) {
-                _player.setVolume((_player.volume - 0.05).clamp(0.0, 1.0));
+                _nudgeVolume(-0.05);
                 return null;
               },
             ),
             StatsToggleIntent: CallbackAction<StatsToggleIntent>(
               onInvoke: (_) {
                 _showStats.value = !_showStats.value;
+                return null;
+              },
+            ),
+            ToggleFullScreenIntent: CallbackAction<ToggleFullScreenIntent>(
+              onInvoke: (_) {
+                unawaited(_toggleFullScreen());
+                return null;
+              },
+            ),
+            ShowShortcutsIntent: CallbackAction<ShowShortcutsIntent>(
+              onInvoke: (_) {
+                unawaited(showKeyboardShortcutsSheet(context));
                 return null;
               },
             ),
@@ -689,7 +845,13 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
                                         setState(() => _showingVideo = true),
                                   ),
                                 Expanded(
-                                  child: MouseRegion(
+                                  child: DropTarget(
+                                    onDragEntered: (_) =>
+                                        setState(() => _mainDragging = true),
+                                    onDragExited: (_) =>
+                                        setState(() => _mainDragging = false),
+                                    onDragDone: _onMainDrop,
+                                    child: MouseRegion(
                                     onEnter: (_) => _markActive(),
                                     onExit: (_) => _markInactive(),
                                     onHover: (_) => _markActive(),
@@ -714,8 +876,8 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
                                             ),
                                           ),
                                         ),
-                                        // Tap video (not controls/drawer) to play/pause.
-                                        // Below overlays so buttons/menus keep their hits.
+                                        // Tap / double-tap video (not controls).
+                                        // Below overlays so buttons/menus keep hits.
                                         if (_showingVideo && hasMedia)
                                           Positioned.fill(
                                             child: GestureDetector(
@@ -723,14 +885,22 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
                                                   HitTestBehavior.translucent,
                                               onTap: () {
                                                 _markActive();
-                                                if (_player.state == 'playing') {
-                                                  unawaited(_player.pause());
-                                                } else if (_player.state ==
-                                                        'paused' ||
-                                                    _player.state ==
-                                                        'buffering') {
-                                                  unawaited(_player.resume());
-                                                }
+                                                // Wait out a possible double-tap.
+                                                _tapTimer?.cancel();
+                                                _tapTimer = Timer(
+                                                  const Duration(
+                                                      milliseconds: 220),
+                                                  () => _togglePlayPause(),
+                                                );
+                                              },
+                                              onDoubleTap: () {
+                                                _tapTimer?.cancel();
+                                                _markActive();
+                                                final entering = !_isFullScreen;
+                                                unawaited(_toggleFullScreen());
+                                                _showOsd(entering
+                                                    ? 'Fullscreen'
+                                                    : 'Windowed');
                                               },
                                             ),
                                           ),
@@ -820,8 +990,15 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
                                               onStart: _dismissPrePlay,
                                             ),
                                           ),
+                                        if (_osdMessage != null)
+                                          PlaybackOsd(message: _osdMessage!),
+                                        if (_mainDragging)
+                                          const Positioned.fill(
+                                            child: _MainDropOverlay(),
+                                          ),
                                       ],
                                     ),
+                                  ),
                                   ),
                                 ),
                               ],
@@ -887,6 +1064,7 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
               _dest = _Dest.cast;
             }
           }),
+          onQuit: () => unawaited(_tray.quit()),
         ),
     };
   }
@@ -1533,6 +1711,50 @@ class _AudioMenuButton extends StatelessWidget {
       if (title != null && title.isNotEmpty) title,
     ];
     return parts.isEmpty ? fallback : parts.join(' · ');
+  }
+}
+
+/// Full-surface hint while media is dragged onto the main player.
+class _MainDropOverlay extends StatelessWidget {
+  const _MainDropOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.black.withValues(alpha: 0.55),
+      alignment: Alignment.center,
+      child: Container(
+        padding: const EdgeInsets.all(28),
+        decoration: BoxDecoration(
+          color: Colors.tealAccent.withValues(alpha: 0.10),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: Colors.tealAccent.withValues(alpha: 0.6),
+            width: 2,
+          ),
+        ),
+        child: const Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.file_download, size: 40, color: Colors.tealAccent),
+            SizedBox(height: 12),
+            Text(
+              'Drop to play',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w700,
+                color: Colors.white,
+              ),
+            ),
+            SizedBox(height: 4),
+            Text(
+              'TV linked → cast · otherwise plays here',
+              style: TextStyle(fontSize: 13, color: Colors.white70),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/desktop/lib/media_session_bridge.dart
+++ b/desktop/lib/media_session_bridge.dart
@@ -1,0 +1,324 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_media_session/flutter_media_session.dart';
+import 'package:flutter_media_session/flutter_media_session_platform_interface.dart';
+
+import 'engines/mpv_engine.dart';
+import 'player_controller.dart';
+
+/// Hooks [PlayerController] into OS media controls so Bluetooth headsets and
+/// keyboard media keys can play/pause/skip/seek.
+///
+/// * **macOS** — native [MediaRemoteHandler] (Now Playing +
+///   `togglePlayPauseCommand` + `playbackState`). The pub plugin alone is not
+///   enough on macOS for headset buttons.
+/// * **Windows** — `flutter_media_session` SMTC.
+/// * **Linux** — no-op (no MPRIS backend yet).
+class MediaSessionBridge {
+  MediaSessionBridge(this._player);
+
+  final PlayerController _player;
+  final FlutterMediaSession _pluginSession = FlutterMediaSession();
+  _PluginAdapter? _pluginAdapter;
+  StreamSubscription? _macEvents;
+  bool _started = false;
+
+  static const _macMethod =
+      MethodChannel('com.playbridge.desktop/media_remote');
+  static const _macEventsCh =
+      EventChannel('com.playbridge.desktop/media_remote_events');
+
+  Future<void> start() async {
+    if (_started) return;
+    if (Platform.isLinux) {
+      debugPrint('[media-session] skipped on Linux');
+      return;
+    }
+    try {
+      if (Platform.isMacOS) {
+        await _startMac();
+      } else {
+        await _startPlugin();
+      }
+      _started = true;
+      debugPrint(
+          '[media-session] activated (${Platform.isMacOS ? "native-mac" : "plugin"})');
+    } catch (e, st) {
+      debugPrint('[media-session] failed to start: $e\n$st');
+    }
+  }
+
+  Future<void> _startMac() async {
+    await _macMethod.invokeMethod('activate');
+    _macEvents = _macEventsCh.receiveBroadcastStream().listen(
+      _onMacEvent,
+      onError: (e) => debugPrint('[media-session] event error: $e'),
+    );
+    _player.addListener(_pushMacState);
+    // Prefer mpv streams for timely playing/paused updates.
+    final engine = _player.engine;
+    if (engine is MpvEngine) {
+      _macMpvSubs.add(engine.player.stream.playing.listen((_) => _pushMacState()));
+      _macMpvSubs.add(engine.player.stream.completed.listen((_) => _pushMacState()));
+      _macMpvSubs.add(engine.player.stream.duration.listen((_) => _pushMacState()));
+      _macMpvSubs.add(engine.player.stream.position.listen((_) {
+        // Throttle position pushes to Now Playing.
+        final now = DateTime.now();
+        if (now.difference(_lastMacPosPush) < const Duration(milliseconds: 800)) {
+          return;
+        }
+        _lastMacPosPush = now;
+        _pushMacState();
+      }));
+    }
+    _pushMacState();
+  }
+
+  final List<StreamSubscription> _macMpvSubs = [];
+  DateTime _lastMacPosPush = DateTime.fromMillisecondsSinceEpoch(0);
+
+  void _pushMacState() {
+    final title = _player.currentTitle;
+    final idle = _player.queue.isEmpty || _player.currentIndex < 0;
+    final status = idle
+        ? 'idle'
+        : switch (_player.state) {
+            'playing' => 'playing',
+            'buffering' => 'buffering',
+            'ended' => 'ended',
+            _ => 'paused',
+          };
+    unawaited(
+      _macMethod.invokeMethod('update', {
+        'title': (title != null && title.isNotEmpty) ? title : 'PlayBridge',
+        'artist': 'PlayBridge',
+        'status': status,
+        'positionMs': _player.positionMs.clamp(0, 1 << 30),
+        'durationMs': _player.durationMs.clamp(0, 1 << 30),
+        'speed': 1.0,
+      }).catchError((e) {
+        debugPrint('[media-session] mac update: $e');
+      }),
+    );
+  }
+
+  void _onMacEvent(dynamic raw) {
+    if (raw is! Map) return;
+    final action = raw['action'] as String?;
+    if (action == null) return;
+    debugPrint('[media-session] mac action: $action');
+    switch (action) {
+      case 'toggle':
+        if (_player.state == 'playing') {
+          unawaited(_player.pause());
+        } else {
+          unawaited(_player.resume());
+        }
+      case 'play':
+        unawaited(_player.resume());
+      case 'pause':
+        unawaited(_player.pause());
+      case 'stop':
+        unawaited(_player.stop());
+      case 'skipToNext':
+        unawaited(_player.next());
+      case 'skipToPrevious':
+        unawaited(_player.previous());
+      case 'fastForward':
+        final dur = _player.durationMs;
+        var t = _player.positionMs + 10000;
+        if (dur > 0 && t > dur) t = dur;
+        unawaited(_player.seek(Duration(milliseconds: t)));
+      case 'rewind':
+        final t = _player.positionMs - 10000;
+        unawaited(_player.seek(Duration(milliseconds: t < 0 ? 0 : t)));
+      case 'seekTo':
+        final ms = raw['positionMs'];
+        if (ms is int) {
+          unawaited(_player.seek(Duration(milliseconds: ms)));
+        } else if (ms is num) {
+          unawaited(_player.seek(Duration(milliseconds: ms.toInt())));
+        }
+      default:
+        break;
+    }
+  }
+
+  Future<void> _startPlugin() async {
+    if (Platform.isWindows) {
+      await _pluginSession.setWindowsAppUserModelId(
+        'com.playbridge.playbridgeDesktop',
+        displayName: 'PlayBridge',
+      );
+    }
+    await _pluginSession.setSkipIntervals(
+        forwardSeconds: 10, backwardSeconds: 10);
+    await _pluginSession.setAutoHandleInterruptions(false);
+    await _pluginSession.activate();
+    _pluginAdapter = _PluginAdapter(_player);
+    _pluginSession.bind(_pluginAdapter!);
+  }
+
+  Future<void> dispose() async {
+    if (!_started) return;
+    try {
+      if (Platform.isMacOS) {
+        _player.removeListener(_pushMacState);
+        for (final s in _macMpvSubs) {
+          await s.cancel();
+        }
+        _macMpvSubs.clear();
+        await _macEvents?.cancel();
+        _macEvents = null;
+        await _macMethod.invokeMethod('deactivate');
+      } else {
+        _pluginSession.unbind();
+        await _pluginSession.deactivate();
+      }
+    } catch (e) {
+      debugPrint('[media-session] dispose: $e');
+    }
+    _pluginAdapter = null;
+    _started = false;
+  }
+}
+
+/// Windows (and future non-mac) adapter via flutter_media_session.
+class _PluginAdapter implements MediaSessionAdapter {
+  _PluginAdapter(this._player);
+
+  final PlayerController _player;
+  final List<StreamSubscription<dynamic>> _subs = [];
+  FlutterMediaSession? _session;
+
+  @override
+  void bind(FlutterMediaSession session) {
+    unbind();
+    _session = session;
+    _player.addListener(_sync);
+    final engine = _player.engine;
+    if (engine is MpvEngine) {
+      _subs.add(engine.player.stream.playing.listen((_) => _sync()));
+      _subs.add(engine.player.stream.duration.listen((_) => _sync()));
+      _subs.add(engine.player.stream.position.listen((_) => _syncPos()));
+    }
+    _subs.add(
+      FlutterMediaSessionPlatform.instance.onMediaAction.listen(_onAction),
+    );
+    _sync();
+  }
+
+  DateTime _lastPos = DateTime.fromMillisecondsSinceEpoch(0);
+  void _syncPos() {
+    final now = DateTime.now();
+    if (now.difference(_lastPos) < const Duration(milliseconds: 800)) return;
+    _lastPos = now;
+    _sync();
+  }
+
+  @override
+  void unbind() {
+    _player.removeListener(_sync);
+    for (final s in _subs) {
+      s.cancel();
+    }
+    _subs.clear();
+    _session = null;
+  }
+
+  void _sync() {
+    if (_session == null) return;
+    final title = _player.currentTitle;
+    final idle = _player.queue.isEmpty ||
+        _player.currentIndex < 0 ||
+        _player.currentIndex >= _player.queue.length;
+    final item = idle ? null : _player.queue[_player.currentIndex];
+    unawaited(
+      FlutterMediaSessionPlatform.instance
+          .updateMetadata(
+            MediaMetadata(
+              title: (title != null && title.isNotEmpty) ? title : 'PlayBridge',
+              artist: 'PlayBridge',
+              artworkUri: item?.posterUrl ?? item?.backdropUrl,
+              duration:
+                  Duration(milliseconds: _player.durationMs.clamp(0, 1 << 30)),
+            ),
+          )
+          .catchError((Object e) {
+        debugPrint('[media-session] metadata: $e');
+      }),
+    );
+
+    final PlaybackStatus status;
+    if (idle) {
+      status = PlaybackStatus.idle;
+    } else {
+      status = switch (_player.state) {
+        'playing' => PlaybackStatus.playing,
+        'buffering' => PlaybackStatus.buffering,
+        'ended' => PlaybackStatus.ended,
+        _ => PlaybackStatus.paused,
+      };
+    }
+    unawaited(
+      FlutterMediaSessionPlatform.instance
+          .updatePlaybackState(
+            PlaybackState(
+              status: status,
+              position: Duration(
+                  milliseconds: _player.positionMs.clamp(0, 1 << 30)),
+            ),
+          )
+          .catchError((Object e) {
+        debugPrint('[media-session] state: $e');
+      }),
+    );
+
+    unawaited(
+      FlutterMediaSessionPlatform.instance
+          .updateAvailableActions({
+            MediaAction.play,
+            MediaAction.pause,
+            MediaAction.stop,
+            MediaAction.seekTo,
+            MediaAction.rewind,
+            MediaAction.fastForward,
+            if (_player.hasNext) MediaAction.skipToNext,
+            if (_player.hasPrevious) MediaAction.skipToPrevious,
+          })
+          .catchError((Object e) {
+        debugPrint('[media-session] actions: $e');
+      }),
+    );
+  }
+
+  void _onAction(MediaAction action) {
+    debugPrint('[media-session] plugin action: ${action.name}');
+    switch (action.name) {
+      case 'play':
+        unawaited(_player.resume());
+      case 'pause':
+        unawaited(_player.pause());
+      case 'stop':
+        unawaited(_player.stop());
+      case 'skipToNext':
+        unawaited(_player.next());
+      case 'skipToPrevious':
+        unawaited(_player.previous());
+      case 'seekTo':
+        final pos = action.seekPosition;
+        if (pos != null) unawaited(_player.seek(pos));
+      case 'rewind':
+        final t = _player.positionMs - 10000;
+        unawaited(_player.seek(Duration(milliseconds: t < 0 ? 0 : t)));
+      case 'fastForward':
+        final dur = _player.durationMs;
+        var t = _player.positionMs + 10000;
+        if (dur > 0 && t > dur) t = dur;
+        unawaited(_player.seek(Duration(milliseconds: t)));
+    }
+  }
+}

--- a/desktop/lib/media_session_bridge.dart
+++ b/desktop/lib/media_session_bridge.dart
@@ -54,20 +54,24 @@ class MediaSessionBridge {
   Future<void> _startMac() async {
     await _macMethod.invokeMethod('activate');
     _macEvents = _macEventsCh.receiveBroadcastStream().listen(
-      _onMacEvent,
-      onError: (e) => debugPrint('[media-session] event error: $e'),
-    );
+          _onMacEvent,
+          onError: (e) => debugPrint('[media-session] event error: $e'),
+        );
     _player.addListener(_pushMacState);
     // Prefer mpv streams for timely playing/paused updates.
     final engine = _player.engine;
     if (engine is MpvEngine) {
-      _macMpvSubs.add(engine.player.stream.playing.listen((_) => _pushMacState()));
-      _macMpvSubs.add(engine.player.stream.completed.listen((_) => _pushMacState()));
-      _macMpvSubs.add(engine.player.stream.duration.listen((_) => _pushMacState()));
+      _macMpvSubs
+          .add(engine.player.stream.playing.listen((_) => _pushMacState()));
+      _macMpvSubs
+          .add(engine.player.stream.completed.listen((_) => _pushMacState()));
+      _macMpvSubs
+          .add(engine.player.stream.duration.listen((_) => _pushMacState()));
       _macMpvSubs.add(engine.player.stream.position.listen((_) {
         // Throttle position pushes to Now Playing.
         final now = DateTime.now();
-        if (now.difference(_lastMacPosPush) < const Duration(milliseconds: 800)) {
+        if (now.difference(_lastMacPosPush) <
+            const Duration(milliseconds: 800)) {
           return;
         }
         _lastMacPosPush = now;
@@ -239,14 +243,14 @@ class _PluginAdapter implements MediaSessionAdapter {
     unawaited(
       FlutterMediaSessionPlatform.instance
           .updateMetadata(
-            MediaMetadata(
-              title: (title != null && title.isNotEmpty) ? title : 'PlayBridge',
-              artist: 'PlayBridge',
-              artworkUri: item?.posterUrl ?? item?.backdropUrl,
-              duration:
-                  Duration(milliseconds: _player.durationMs.clamp(0, 1 << 30)),
-            ),
-          )
+        MediaMetadata(
+          title: (title != null && title.isNotEmpty) ? title : 'PlayBridge',
+          artist: 'PlayBridge',
+          artworkUri: item?.posterUrl ?? item?.backdropUrl,
+          duration:
+              Duration(milliseconds: _player.durationMs.clamp(0, 1 << 30)),
+        ),
+      )
           .catchError((Object e) {
         debugPrint('[media-session] metadata: $e');
       }),
@@ -266,30 +270,28 @@ class _PluginAdapter implements MediaSessionAdapter {
     unawaited(
       FlutterMediaSessionPlatform.instance
           .updatePlaybackState(
-            PlaybackState(
-              status: status,
-              position: Duration(
-                  milliseconds: _player.positionMs.clamp(0, 1 << 30)),
-            ),
-          )
+        PlaybackState(
+          status: status,
+          position:
+              Duration(milliseconds: _player.positionMs.clamp(0, 1 << 30)),
+        ),
+      )
           .catchError((Object e) {
         debugPrint('[media-session] state: $e');
       }),
     );
 
     unawaited(
-      FlutterMediaSessionPlatform.instance
-          .updateAvailableActions({
-            MediaAction.play,
-            MediaAction.pause,
-            MediaAction.stop,
-            MediaAction.seekTo,
-            MediaAction.rewind,
-            MediaAction.fastForward,
-            if (_player.hasNext) MediaAction.skipToNext,
-            if (_player.hasPrevious) MediaAction.skipToPrevious,
-          })
-          .catchError((Object e) {
+      FlutterMediaSessionPlatform.instance.updateAvailableActions({
+        MediaAction.play,
+        MediaAction.pause,
+        MediaAction.stop,
+        MediaAction.seekTo,
+        MediaAction.rewind,
+        MediaAction.fastForward,
+        if (_player.hasNext) MediaAction.skipToNext,
+        if (_player.hasPrevious) MediaAction.skipToPrevious,
+      }).catchError((Object e) {
         debugPrint('[media-session] actions: $e');
       }),
     );

--- a/desktop/lib/pairing_store.dart
+++ b/desktop/lib/pairing_store.dart
@@ -46,6 +46,7 @@ class PairingStore {
   static const _kPairedDevices = 'pb.paired_devices';
   static const _kShowStats = 'pb.show_stats';
   static const _kAutoFullScreen = 'pb.auto_fullscreen';
+  static const _kPauseOnWindowHide = 'pb.pause_on_window_hide';
   static const _kEnableHistory = 'pb.enable_history';
 
   final SharedPreferences _prefs;
@@ -92,6 +93,13 @@ class PairingStore {
 
   Future<void> setAutoFullScreen(bool value) =>
       _prefs.setBool(_kAutoFullScreen, value);
+
+  /// When true, the red close button (hide to tray) also pauses local playback.
+  /// Default false: keep playing in the background like a cast receiver.
+  bool get pauseOnWindowHide => _prefs.getBool(_kPauseOnWindowHide) ?? false;
+
+  Future<void> setPauseOnWindowHide(bool value) =>
+      _prefs.setBool(_kPauseOnWindowHide, value);
 
   bool get enableHistory => _prefs.getBool(_kEnableHistory) ?? true;
 

--- a/desktop/lib/playback_osd.dart
+++ b/desktop/lib/playback_osd.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+/// Centered, auto-fading on-screen display for pause / seek / volume cues.
+class PlaybackOsd extends StatelessWidget {
+  const PlaybackOsd({super.key, required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: Center(
+        child: AnimatedOpacity(
+          opacity: message.isEmpty ? 0 : 1,
+          duration: const Duration(milliseconds: 120),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 14),
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.72),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
+            ),
+            child: Text(
+              message,
+              style: const TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                color: Colors.white,
+                letterSpacing: 0.3,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/desktop/lib/playback_surface.dart
+++ b/desktop/lib/playback_surface.dart
@@ -56,7 +56,11 @@ class _PlaybackSurfaceState extends State<PlaybackSurface> {
 
   @override
   Widget build(BuildContext context) {
-    if (_mpvVideo != null) {
+    // While the queue is empty the previous item's last frame can still sit on
+    // the media_kit texture. Paint black and skip [Video] so stop → later play
+    // never flashes the old thumbnail.
+    final hasMedia = widget.controller.queue.isNotEmpty;
+    if (_mpvVideo != null && hasMedia) {
       return TweenAnimationBuilder<double>(
         tween: Tween(
           end: widget.controlsVisible

--- a/desktop/lib/playback_surface.dart
+++ b/desktop/lib/playback_surface.dart
@@ -21,35 +21,31 @@ class PlaybackSurface extends StatefulWidget {
 
 class _PlaybackSurfaceState extends State<PlaybackSurface> {
   VideoController? _mpvVideo;
-  int _boundGeneration = -1;
 
   @override
   void initState() {
     super.initState();
-    _syncVideoController();
+    _initMpv();
     widget.controller.addListener(_onControllerChange);
   }
 
   void _onControllerChange() {
-    _syncVideoController();
+    // Rebuild for isOpening / queue changes (black mask).
+    if (mounted) setState(() {});
+    if (_mpvVideo == null) _initMpv();
   }
 
-  /// Keep a live [VideoController], recreating it after each stop so a GPU
-  /// texture frozen while the window was unfocused cannot flash video A when
-  /// video B starts.
-  void _syncVideoController() {
+  void _initMpv() {
     final engine = widget.controller.engine;
-    if (engine is! MpvEngine) return;
-    final gen = widget.controller.surfaceGeneration;
-    if (_mpvVideo != null && gen == _boundGeneration) return;
-    _boundGeneration = gen;
-    _mpvVideo = VideoController(
-      engine.player,
-      configuration: VideoControllerConfiguration(
-        enableHardwareAcceleration: !Platform.isLinux,
-      ),
-    );
-    if (mounted) setState(() {});
+    if (engine is MpvEngine) {
+      _mpvVideo = VideoController(
+        engine.player,
+        configuration: VideoControllerConfiguration(
+          enableHardwareAcceleration: !Platform.isLinux,
+        ),
+      );
+      if (mounted) setState(() {});
+    }
   }
 
   @override
@@ -61,30 +57,33 @@ class _PlaybackSurfaceState extends State<PlaybackSurface> {
   @override
   Widget build(BuildContext context) {
     final hasMedia = widget.controller.queue.isNotEmpty;
+    // Cover the VO while idle or while the next item is still opening so a
+    // frozen last-frame of the previous title cannot flash (esp. after unfocus).
     final mask = !hasMedia || widget.controller.isOpening;
 
-    // Keep [Video] mounted under a black mask so stop/clear can update the VO
-    // while idle; only the mask hides stale pixels (unmounting alone left the
-    // old texture intact when the window was unfocused).
+    if (_mpvVideo == null) {
+      return const ColoredBox(color: Colors.black);
+    }
+
     return Stack(
       fit: StackFit.expand,
       children: [
-        if (_mpvVideo != null)
-          TweenAnimationBuilder<double>(
-            tween: Tween(
-              end: widget.controlsVisible
-                  ? _kSubtitleBottomWithControls
-                  : _kSubtitleBottomDefault,
-            ),
-            duration: const Duration(milliseconds: 150),
-            builder: (context, bottomPad, _) => Video(
-              controller: _mpvVideo!,
-              controls: NoVideoControls,
-              subtitleViewConfiguration: SubtitleViewConfiguration(
-                padding: EdgeInsets.fromLTRB(16, 0, 16, bottomPad),
-              ),
+        // Keep Video mounted so the texture stays bound; mask hides stale pixels.
+        TweenAnimationBuilder<double>(
+          tween: Tween(
+            end: widget.controlsVisible
+                ? _kSubtitleBottomWithControls
+                : _kSubtitleBottomDefault,
+          ),
+          duration: const Duration(milliseconds: 150),
+          builder: (context, bottomPad, _) => Video(
+            controller: _mpvVideo!,
+            controls: NoVideoControls,
+            subtitleViewConfiguration: SubtitleViewConfiguration(
+              padding: EdgeInsets.fromLTRB(16, 0, 16, bottomPad),
             ),
           ),
+        ),
         if (mask) const ColoredBox(color: Colors.black),
       ],
     );

--- a/desktop/lib/playback_surface.dart
+++ b/desktop/lib/playback_surface.dart
@@ -21,31 +21,35 @@ class PlaybackSurface extends StatefulWidget {
 
 class _PlaybackSurfaceState extends State<PlaybackSurface> {
   VideoController? _mpvVideo;
+  int _boundGeneration = -1;
 
   @override
   void initState() {
     super.initState();
-    _initMpv();
+    _syncVideoController();
     widget.controller.addListener(_onControllerChange);
   }
 
   void _onControllerChange() {
-    if (_mpvVideo == null) {
-      _initMpv();
-    }
+    _syncVideoController();
   }
 
-  void _initMpv() {
+  /// Keep a live [VideoController], recreating it after each stop so a GPU
+  /// texture frozen while the window was unfocused cannot flash video A when
+  /// video B starts.
+  void _syncVideoController() {
     final engine = widget.controller.engine;
-    if (engine is MpvEngine) {
-      _mpvVideo = VideoController(
-        engine.player,
-        configuration: VideoControllerConfiguration(
-          enableHardwareAcceleration: !Platform.isLinux,
-        ),
-      );
-      setState(() {});
-    }
+    if (engine is! MpvEngine) return;
+    final gen = widget.controller.surfaceGeneration;
+    if (_mpvVideo != null && gen == _boundGeneration) return;
+    _boundGeneration = gen;
+    _mpvVideo = VideoController(
+      engine.player,
+      configuration: VideoControllerConfiguration(
+        enableHardwareAcceleration: !Platform.isLinux,
+      ),
+    );
+    if (mounted) setState(() {});
   }
 
   @override
@@ -56,28 +60,33 @@ class _PlaybackSurfaceState extends State<PlaybackSurface> {
 
   @override
   Widget build(BuildContext context) {
-    // While the queue is empty the previous item's last frame can still sit on
-    // the media_kit texture. Paint black and skip [Video] so stop → later play
-    // never flashes the old thumbnail.
     final hasMedia = widget.controller.queue.isNotEmpty;
-    if (_mpvVideo != null && hasMedia) {
-      return TweenAnimationBuilder<double>(
-        tween: Tween(
-          end: widget.controlsVisible
-              ? _kSubtitleBottomWithControls
-              : _kSubtitleBottomDefault,
-        ),
-        duration: const Duration(milliseconds: 150),
-        builder: (context, bottomPad, _) => Video(
-          controller: _mpvVideo!,
-          controls: NoVideoControls,
-          subtitleViewConfiguration: SubtitleViewConfiguration(
-            padding: EdgeInsets.fromLTRB(16, 0, 16, bottomPad),
-          ),
-        ),
-      );
-    }
+    final mask = !hasMedia || widget.controller.isOpening;
 
-    return const ColoredBox(color: Colors.black);
+    // Keep [Video] mounted under a black mask so stop/clear can update the VO
+    // while idle; only the mask hides stale pixels (unmounting alone left the
+    // old texture intact when the window was unfocused).
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        if (_mpvVideo != null)
+          TweenAnimationBuilder<double>(
+            tween: Tween(
+              end: widget.controlsVisible
+                  ? _kSubtitleBottomWithControls
+                  : _kSubtitleBottomDefault,
+            ),
+            duration: const Duration(milliseconds: 150),
+            builder: (context, bottomPad, _) => Video(
+              controller: _mpvVideo!,
+              controls: NoVideoControls,
+              subtitleViewConfiguration: SubtitleViewConfiguration(
+                padding: EdgeInsets.fromLTRB(16, 0, 16, bottomPad),
+              ),
+            ),
+          ),
+        if (mask) const ColoredBox(color: Colors.black),
+      ],
+    );
   }
 }

--- a/desktop/lib/player_controller.dart
+++ b/desktop/lib/player_controller.dart
@@ -107,6 +107,16 @@ class PlayerController extends ChangeNotifier {
   final List<QueueItem> _queue = [];
   int _currentIndex = -1;
 
+  /// True while a new playlist is being opened — UI paints black over the VO
+  /// so a stale frame can't flash (especially after the window was unfocused).
+  bool _opening = false;
+  bool get isOpening => _opening;
+
+  /// Bumped on every [stop] so [PlaybackSurface] can rebuild the media_kit
+  /// [VideoController] and drop a GPU texture frozen while the window was idle.
+  int _surfaceGeneration = 0;
+  int get surfaceGeneration => _surfaceGeneration;
+
   String? get currentTitle =>
       _currentIndex >= 0 && _currentIndex < _queue.length
           ? _queue[_currentIndex].title
@@ -172,6 +182,12 @@ class PlayerController extends ChangeNotifier {
     bool isRemote = false,
   }) async {
     if (items.isEmpty) return;
+    // Mask first so focus/reveal never paints the previous item's last frame
+    // (repro: stop A → unfocus window → cast B).
+    _opening = true;
+    notifyListeners();
+    await _engine.clearVideoSurface();
+
     _queue
       ..clear()
       ..addAll(items);
@@ -179,11 +195,14 @@ class PlayerController extends ChangeNotifier {
     if (isRemote) {
       playRequests.value++;
     }
-    // So PlaybackSurface rebuilds with the new queue before frames arrive
-    // (pairs with mpv surface clear in openPlaylist).
     notifyListeners();
-    await _engine.openPlaylist(_queue, _currentIndex);
-    unawaited(_applyStartPosition());
+    try {
+      await _engine.openPlaylist(_queue, _currentIndex);
+      unawaited(_applyStartPosition());
+    } finally {
+      _opening = false;
+      notifyListeners();
+    }
   }
 
   /// Append an item to the live queue (`queue_add`). If nothing is playing,
@@ -271,6 +290,10 @@ class PlayerController extends ChangeNotifier {
     await _engine.stop();
     _queue.clear();
     _setIndex(-1);
+    // New VO binding on next play — unfocused windows can freeze the old
+    // Metal/OpenGL texture so clear alone is not enough.
+    _surfaceGeneration++;
+    _opening = false;
     queueChanges.value++;
     notifyListeners();
   }

--- a/desktop/lib/player_controller.dart
+++ b/desktop/lib/player_controller.dart
@@ -107,15 +107,11 @@ class PlayerController extends ChangeNotifier {
   final List<QueueItem> _queue = [];
   int _currentIndex = -1;
 
-  /// True while a new playlist is being opened — UI paints black over the VO
-  /// so a stale frame can't flash (especially after the window was unfocused).
+  /// True while a new item is opening — [PlaybackSurface] paints black over the
+  /// VO so a frozen last-frame of the previous item cannot flash (esp. after
+  /// the window was unfocused). Lifted only after the engine has real media.
   bool _opening = false;
   bool get isOpening => _opening;
-
-  /// Bumped on every [stop] so [PlaybackSurface] can rebuild the media_kit
-  /// [VideoController] and drop a GPU texture frozen while the window was idle.
-  int _surfaceGeneration = 0;
-  int get surfaceGeneration => _surfaceGeneration;
 
   String? get currentTitle =>
       _currentIndex >= 0 && _currentIndex < _queue.length
@@ -182,11 +178,10 @@ class PlayerController extends ChangeNotifier {
     bool isRemote = false,
   }) async {
     if (items.isEmpty) return;
-    // Mask first so focus/reveal never paints the previous item's last frame
-    // (repro: stop A → unfocus window → cast B).
+    // Mask before queue/reveal so stop→unfocus→play B never flashes video A.
+    // Do not disable the mpv video track — that left a permanent black picture.
     _opening = true;
     notifyListeners();
-    await _engine.clearVideoSurface();
 
     _queue
       ..clear()
@@ -199,6 +194,12 @@ class PlayerController extends ChangeNotifier {
     try {
       await _engine.openPlaylist(_queue, _currentIndex);
       unawaited(_applyStartPosition());
+      // Keep the mask until the demuxer has real media so the first paint is B.
+      var retries = 0;
+      while (_engine.durationMs <= 0 && retries < 40) {
+        await Future.delayed(const Duration(milliseconds: 50));
+        retries++;
+      }
     } finally {
       _opening = false;
       notifyListeners();
@@ -290,9 +291,6 @@ class PlayerController extends ChangeNotifier {
     await _engine.stop();
     _queue.clear();
     _setIndex(-1);
-    // New VO binding on next play — unfocused windows can freeze the old
-    // Metal/OpenGL texture so clear alone is not enough.
-    _surfaceGeneration++;
     _opening = false;
     queueChanges.value++;
     notifyListeners();

--- a/desktop/lib/player_controller.dart
+++ b/desktop/lib/player_controller.dart
@@ -179,6 +179,9 @@ class PlayerController extends ChangeNotifier {
     if (isRemote) {
       playRequests.value++;
     }
+    // So PlaybackSurface rebuilds with the new queue before frames arrive
+    // (pairs with mpv surface clear in openPlaylist).
+    notifyListeners();
     await _engine.openPlaylist(_queue, _currentIndex);
     unawaited(_applyStartPosition());
   }

--- a/desktop/lib/player_engine.dart
+++ b/desktop/lib/player_engine.dart
@@ -136,6 +136,12 @@ abstract class PlayerEngine extends ChangeNotifier {
   Future<void> seek(Duration position);
   Future<void> setVolume(double volume) async {}
   Future<void> stop();
+
+  /// Best-effort blank of the last decoded frame (mpv VO texture). No-op by
+  /// default. Call before a new open when the window may have been unfocused
+  /// since the previous stop — otherwise the GPU can still show video A.
+  Future<void> clearVideoSurface() async {}
+
   @override
   Future<void> dispose();
 }

--- a/desktop/lib/player_engine.dart
+++ b/desktop/lib/player_engine.dart
@@ -136,12 +136,6 @@ abstract class PlayerEngine extends ChangeNotifier {
   Future<void> seek(Duration position);
   Future<void> setVolume(double volume) async {}
   Future<void> stop();
-
-  /// Best-effort blank of the last decoded frame (mpv VO texture). No-op by
-  /// default. Call before a new open when the window may have been unfocused
-  /// since the previous stop — otherwise the GPU can still show video A.
-  Future<void> clearVideoSurface() async {}
-
   @override
   Future<void> dispose();
 }

--- a/desktop/lib/send_to_tv_screen.dart
+++ b/desktop/lib/send_to_tv_screen.dart
@@ -199,11 +199,6 @@ class _SendToTvScreenState extends State<SendToTvScreen> {
             label: const Text('Set up browser casting'),
           ),
         ),
-        const SizedBox(height: 24),
-        _SelfCastToggle(
-          value: controller.allowSelfCast,
-          onChanged: (v) => controller.allowSelfCast = v,
-        ),
       ],
     );
   }
@@ -336,29 +331,6 @@ class _DropOverlay extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-class _SelfCastToggle extends StatelessWidget {
-  const _SelfCastToggle({required this.value, required this.onChanged});
-
-  final bool value;
-  final ValueChanged<bool> onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Expanded(
-          child: Text(
-            'Show this device (for testing on one machine)',
-            style: TextStyle(
-                fontSize: 12, color: Colors.white.withValues(alpha: 0.5)),
-          ),
-        ),
-        Switch(value: value, onChanged: onChanged),
-      ],
     );
   }
 }

--- a/desktop/lib/settings_screen.dart
+++ b/desktop/lib/settings_screen.dart
@@ -32,6 +32,7 @@ class SettingsScreen extends StatefulWidget {
   final UpdateChecker updateChecker;
   final VoidCallback onNavigateToCast;
   final VoidCallback? onSettingsChanged;
+
   /// Fully quit the app (same as tray → Quit). Red window X only hides.
   final VoidCallback? onQuit;
 

--- a/desktop/lib/settings_screen.dart
+++ b/desktop/lib/settings_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import 'auto_launch.dart';
+import 'keyboard_shortcuts_sheet.dart';
 import 'logging/log_store.dart';
 import 'logs_screen.dart';
 import 'pairing_store.dart';
@@ -21,6 +22,7 @@ class SettingsScreen extends StatefulWidget {
     required this.updateChecker,
     required this.onNavigateToCast,
     this.onSettingsChanged,
+    this.onQuit,
   });
 
   final ReceiverServer server;
@@ -30,6 +32,8 @@ class SettingsScreen extends StatefulWidget {
   final UpdateChecker updateChecker;
   final VoidCallback onNavigateToCast;
   final VoidCallback? onSettingsChanged;
+  /// Fully quit the app (same as tray → Quit). Red window X only hides.
+  final VoidCallback? onQuit;
 
   @override
   State<SettingsScreen> createState() => _SettingsScreenState();
@@ -106,6 +110,26 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   if (mounted) setState(() {});
                 },
               ),
+            ),
+            _Tile(
+              icon: Icons.visibility_off_outlined,
+              title: 'Pause when window is hidden',
+              subtitle:
+                  'Red close button hides to the menu bar. On: pause playback. '
+                  'Off: keep playing in the background (default).',
+              trailing: Switch(
+                value: widget.store.pauseOnWindowHide,
+                onChanged: (v) async {
+                  await widget.store.setPauseOnWindowHide(v);
+                  if (mounted) setState(() {});
+                },
+              ),
+            ),
+            _Tile(
+              icon: Icons.keyboard,
+              title: 'Keyboard shortcuts',
+              subtitle: 'Space, arrows, F, I, and gestures — press ? anytime.',
+              onTap: () => showKeyboardShortcutsSheet(context),
             ),
             _Tile(
               icon: Icons.insights,
@@ -253,10 +277,46 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 );
               },
             ),
+            if (widget.onQuit != null) ...[
+              const SizedBox(height: 12),
+              _Tile(
+                icon: Icons.power_settings_new,
+                title: 'Quit PlayBridge',
+                subtitle:
+                    'Stop the receiver and exit. The red window button only '
+                    'hides to the menu bar.',
+                danger: true,
+                onTap: () => _confirmQuit(context),
+              ),
+            ],
           ],
         );
       },
     );
+  }
+
+  Future<void> _confirmQuit(BuildContext context) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Quit PlayBridge?'),
+        content: const Text(
+          'The desktop receiver will stop. Phones won’t be able to cast here '
+          'until you open PlayBridge again.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Quit'),
+          ),
+        ],
+      ),
+    );
+    if (ok == true) widget.onQuit?.call();
   }
 }
 

--- a/desktop/lib/tray_controller.dart
+++ b/desktop/lib/tray_controller.dart
@@ -137,7 +137,7 @@ class TrayController with TrayListener {
       case 'launch_at_login':
         _toggleLaunchAtLogin();
       case 'quit':
-        _quit();
+        unawaited(quit());
     }
   }
 
@@ -162,7 +162,9 @@ class TrayController with TrayListener {
     }
   }
 
-  Future<void> _quit() async {
+  /// Fully exit the app (window + tray + process). Used by the tray menu and
+  /// Settings → Quit.
+  Future<void> quit() async {
     await windowManager.destroy();
     exit(0);
   }

--- a/desktop/lib/tv_sender_controller.dart
+++ b/desktop/lib/tv_sender_controller.dart
@@ -38,7 +38,6 @@ class TvSenderController extends ChangeNotifier {
   StreamSubscription<String>? _sasSub;
 
   List<DiscoveredTv> _discoveredRaw = const [];
-  bool _allowSelfCast = false;
   SenderConnectionState _state = SenderConnectionState.disconnected;
   DiscoveredTv? _pending; // target of the in-flight / most recent connect
   TvRecord? _activeTv;
@@ -55,22 +54,12 @@ class TvSenderController extends ChangeNotifier {
   List<({int index, String title})> _castPlaylist = const [];
   int _castIndex = -1;
 
-  /// Discovered TVs, excluding this device's own receiver advertisement unless
-  /// [allowSelfCast] is enabled (single-machine testing).
-  List<DiscoveredTv> get discovered => _allowSelfCast
-      ? _discoveredRaw
-      : _discoveredRaw
-          .where((t) => t.uuid != _identity.deviceId)
-          .toList(growable: false);
-
-  /// Whether to show this device's own receiver as a cast target (off in normal
-  /// use; on for testing the sender and receiver on one machine).
-  bool get allowSelfCast => _allowSelfCast;
-  set allowSelfCast(bool value) {
-    if (_allowSelfCast == value) return;
-    _allowSelfCast = value;
-    notifyListeners();
-  }
+  /// Discovered TVs on the LAN, always excluding this app's own receiver
+  /// advertisement. Local playback is the default when nothing is linked
+  /// (extension bridge / cold-start file); self-cast is not offered.
+  List<DiscoveredTv> get discovered => _discoveredRaw
+      .where((t) => t.uuid != _identity.deviceId)
+      .toList(growable: false);
 
   List<TvRecord> get pairedTvs => _store.tvs;
   SenderConnectionState get state => _state;

--- a/desktop/lib/update/update_gate.dart
+++ b/desktop/lib/update/update_gate.dart
@@ -54,7 +54,8 @@ class _UpdateGateState extends State<UpdateGate> {
   @override
   Widget build(BuildContext context) {
     return switch (widget.checker.state) {
-      UpdateAvailable(:final info) => _barrier(_availableCard(info)),
+      // Quiet non-blocking strip — background checks shouldn't interrupt video.
+      UpdateAvailable(:final info) => _availableBanner(info),
       UpdateDownloading(:final info, :final fraction) => _barrier(_progressCard(
           'Downloading v${info.version}…',
           fraction: fraction,
@@ -69,6 +70,67 @@ class _UpdateGateState extends State<UpdateGate> {
       _ => const SizedBox.shrink(),
     };
   }
+
+  /// Persistent bottom strip with one-tap restart (not a modal barrier).
+  Widget _availableBanner(UpdateInfo info) => Positioned(
+        left: 0,
+        right: 0,
+        bottom: 48,
+        child: Center(
+          child: Material(
+            color: Colors.transparent,
+            child: Container(
+              constraints: const BoxConstraints(maxWidth: 560),
+              margin: const EdgeInsets.symmetric(horizontal: 16),
+              padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
+              decoration: BoxDecoration(
+                color: const Color(0xFF1E1E24),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: Colors.tealAccent.withValues(alpha: 0.35),
+                ),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.4),
+                    blurRadius: 16,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.system_update_alt,
+                      size: 20, color: Colors.tealAccent),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      'v${info.version} is ready',
+                      style: const TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: widget.checker.dismiss,
+                    child: const Text('Later'),
+                  ),
+                  const SizedBox(width: 4),
+                  FilledButton(
+                    onPressed: () => widget.checker.accept(info),
+                    child: const Text('Restart & update'),
+                  ),
+                  IconButton(
+                    tooltip: 'Dismiss',
+                    icon: const Icon(Icons.close, size: 16),
+                    onPressed: widget.checker.dismiss,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
 
   Widget _barrier(Widget child) => Positioned.fill(
         child: Container(
@@ -92,32 +154,6 @@ class _UpdateGateState extends State<UpdateGate> {
           children: children,
         ),
       );
-
-  Widget _availableCard(UpdateInfo info) => _card(children: [
-        const Text('Update available',
-            style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
-        const SizedBox(height: 12),
-        Text(
-          'PlayBridge Desktop v${info.version} is available. The app will '
-          'download it, restart, and update itself in place.',
-          style: const TextStyle(color: Colors.white70, fontSize: 13),
-        ),
-        const SizedBox(height: 20),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: [
-            TextButton(
-              onPressed: widget.checker.dismiss,
-              child: const Text('Later'),
-            ),
-            const SizedBox(width: 8),
-            FilledButton(
-              onPressed: () => widget.checker.accept(info),
-              child: const Text('Restart & update'),
-            ),
-          ],
-        ),
-      ]);
 
   Widget _progressCard(String title, {required double? fraction}) =>
       _card(children: [

--- a/desktop/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/desktop/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import bonsoir_darwin
 import desktop_drop
 import file_selector_macos
+import flutter_media_session
 import media_kit_libs_macos_video
 import media_kit_video
 import package_info_plus
@@ -24,6 +25,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SwiftBonsoirPlugin.register(with: registry.registrar(forPlugin: "SwiftBonsoirPlugin"))
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  FlutterMediaSessionPlugin.register(with: registry.registrar(forPlugin: "FlutterMediaSessionPlugin"))
   MediaKitLibsMacosVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosVideoPlugin"))
   MediaKitVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitVideoPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/desktop/macos/Runner.xcodeproj/project.pbxproj
+++ b/desktop/macos/Runner.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		A1B2C3D4E5F60718293A4B5D /* MediaRemoteHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5C /* MediaRemoteHandler.swift */; };
 		129B0BC1764C753C66B06FE9 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D44112AA135796FBC7CBDD5 /* Pods_Runner.framework */; };
 		331C80D8294CF71000263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C80D7294CF71000263BE5 /* RunnerTests.swift */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
@@ -73,6 +74,7 @@
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		33CC10F72044A3C60003C045 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Runner/Info.plist; sourceTree = "<group>"; };
 		33CC11122044BFA00003C045 /* MainFlutterWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFlutterWindow.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B5C /* MediaRemoteHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaRemoteHandler.swift; sourceTree = "<group>"; };
 		33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Debug.xcconfig"; sourceTree = "<group>"; };
 		33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Release.xcconfig"; sourceTree = "<group>"; };
 		33CEB47722A0578A004F2AC0 /* Flutter-Generated.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Flutter-Generated.xcconfig"; path = "ephemeral/Flutter-Generated.xcconfig"; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 			children = (
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
+				A1B2C3D4E5F60718293A4B5C /* MediaRemoteHandler.swift */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
 				33E51914231749380026EE4D /* Release.entitlements */,
 				33CC11242044D66E0003C045 /* Resources */,
@@ -438,6 +441,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5D /* MediaRemoteHandler.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,
 			);

--- a/desktop/macos/Runner/MainFlutterWindow.swift
+++ b/desktop/macos/Runner/MainFlutterWindow.swift
@@ -2,6 +2,9 @@ import Cocoa
 import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
+  /// Observers for fullscreen enter/exit (menu-bar / Control Center access).
+  private var fullscreenObservers: [NSObjectProtocol] = []
+
   override func awakeFromNib() {
     let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
@@ -46,6 +49,55 @@ class MainFlutterWindow: NSWindow {
 
     RegisterGeneratedPlugins(registry: flutterViewController)
 
+    // Bluetooth headset / media-key remote control (Now Playing + togglePlayPause).
+    MediaRemoteHandler.shared.register(
+      with: flutterViewController.engine.binaryMessenger
+    )
+
+    // Agent apps (LSUIElement) run as .accessory and permanently suppress the
+    // menu bar in fullscreen. Promote to .regular while fullscreen so the
+    // system menu bar / Control Center / Notification Center can auto-show
+    // when the cursor hits the top of the screen (like Safari, IINA, etc.).
+    registerFullscreenMenuBarFix()
+
     super.awakeFromNib()
+  }
+
+  deinit {
+    for o in fullscreenObservers {
+      NotificationCenter.default.removeObserver(o)
+    }
+  }
+
+  private func registerFullscreenMenuBarFix() {
+    let nc = NotificationCenter.default
+    fullscreenObservers.append(
+      nc.addObserver(
+        forName: NSWindow.willEnterFullScreenNotification,
+        object: self,
+        queue: .main
+      ) { _ in
+        // Become a normal app for this Space so macOS auto-hides/shows the
+        // menu bar on the top edge (and unlocks Control Center / NC).
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate(ignoringOtherApps: true)
+      }
+    )
+    fullscreenObservers.append(
+      nc.addObserver(
+        forName: NSWindow.didExitFullScreenNotification,
+        object: self,
+        queue: .main
+      ) { [weak self] _ in
+        // Back to tray/agent behavior (no Dock icon) matching LSUIElement.
+        // setActivationPolicy(.accessory) can re-key the previously front app;
+        // re-assert focus after the policy settles so playback keeps the window.
+        NSApp.setActivationPolicy(.accessory)
+        DispatchQueue.main.async {
+          NSApp.activate(ignoringOtherApps: true)
+          self?.makeKeyAndOrderFront(nil)
+        }
+      }
+    )
   }
 }

--- a/desktop/macos/Runner/MediaRemoteHandler.swift
+++ b/desktop/macos/Runner/MediaRemoteHandler.swift
@@ -1,0 +1,173 @@
+import Cocoa
+import FlutterMacOS
+import MediaPlayer
+
+/// Native Now Playing + remote command center for Bluetooth / keyboard media keys.
+///
+/// The pub `flutter_media_session` plugin registers play/pause but never sets
+/// `MPNowPlayingInfoCenter.playbackState` on macOS, and it skips
+/// `togglePlayPauseCommand` — which is what most BT headsets actually send.
+/// Without those, macOS routes headset buttons elsewhere.
+final class MediaRemoteHandler: NSObject {
+  static let shared = MediaRemoteHandler()
+
+  private var eventSink: FlutterEventSink?
+  private var commandTargets: [Any] = []
+  private var registered = false
+
+  private override init() {
+    super.init()
+  }
+
+  func register(with messenger: FlutterBinaryMessenger) {
+    let method = FlutterMethodChannel(
+      name: "com.playbridge.desktop/media_remote",
+      binaryMessenger: messenger
+    )
+    method.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call, result: result)
+    }
+
+    let events = FlutterEventChannel(
+      name: "com.playbridge.desktop/media_remote_events",
+      binaryMessenger: messenger
+    )
+    events.setStreamHandler(self)
+  }
+
+  private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "activate":
+      activate()
+      result(nil)
+    case "deactivate":
+      deactivate()
+      result(nil)
+    case "update":
+      if let args = call.arguments as? [String: Any] {
+        update(args)
+      }
+      result(nil)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func activate() {
+    guard !registered else { return }
+    registered = true
+    let center = MPRemoteCommandCenter.shared()
+
+    // Most Bluetooth headsets send toggle, not separate play/pause.
+    register(center.togglePlayPauseCommand, action: "toggle")
+    register(center.playCommand, action: "play")
+    register(center.pauseCommand, action: "pause")
+    register(center.stopCommand, action: "stop")
+    register(center.nextTrackCommand, action: "skipToNext")
+    register(center.previousTrackCommand, action: "skipToPrevious")
+    register(center.skipForwardCommand, action: "fastForward")
+    register(center.skipBackwardCommand, action: "rewind")
+    center.skipForwardCommand.preferredIntervals = [10]
+    center.skipBackwardCommand.preferredIntervals = [10]
+
+    let seekTarget = center.changePlaybackPositionCommand.addTarget { [weak self] event in
+      guard let e = event as? MPChangePlaybackPositionCommandEvent else {
+        return .commandFailed
+      }
+      self?.emit(["action": "seekTo", "positionMs": Int(e.positionTime * 1000)])
+      return .success
+    }
+    commandTargets.append(seekTarget)
+    center.changePlaybackPositionCommand.isEnabled = true
+
+    // Begin as paused idle so the system knows we own the remote center.
+    if #available(macOS 10.12.2, *) {
+      MPNowPlayingInfoCenter.default().playbackState = .paused
+    }
+  }
+
+  private func deactivate() {
+    let center = MPRemoteCommandCenter.shared()
+    for t in commandTargets {
+      center.togglePlayPauseCommand.removeTarget(t)
+      center.playCommand.removeTarget(t)
+      center.pauseCommand.removeTarget(t)
+      center.stopCommand.removeTarget(t)
+      center.nextTrackCommand.removeTarget(t)
+      center.previousTrackCommand.removeTarget(t)
+      center.skipForwardCommand.removeTarget(t)
+      center.skipBackwardCommand.removeTarget(t)
+      center.changePlaybackPositionCommand.removeTarget(t)
+    }
+    commandTargets.removeAll()
+    registered = false
+    MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+    if #available(macOS 10.12.2, *) {
+      MPNowPlayingInfoCenter.default().playbackState = .stopped
+    }
+  }
+
+  private func register(_ command: MPRemoteCommand, action: String) {
+    command.isEnabled = true
+    let target = command.addTarget { [weak self] _ in
+      self?.emit(["action": action])
+      return .success
+    }
+    commandTargets.append(target)
+  }
+
+  private func update(_ args: [String: Any]) {
+    let title = args["title"] as? String ?? "PlayBridge"
+    let artist = args["artist"] as? String ?? "PlayBridge"
+    let status = args["status"] as? String ?? "paused"
+    let positionMs = (args["positionMs"] as? NSNumber)?.intValue ?? 0
+    let durationMs = (args["durationMs"] as? NSNumber)?.intValue ?? 0
+    let speed = (args["speed"] as? NSNumber)?.doubleValue ?? 1.0
+
+    var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
+    info[MPMediaItemPropertyTitle] = title
+    info[MPMediaItemPropertyArtist] = artist
+    info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.video.rawValue
+    if durationMs > 0 {
+      info[MPMediaItemPropertyPlaybackDuration] = Double(durationMs) / 1000.0
+    }
+    info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = Double(positionMs) / 1000.0
+    info[MPNowPlayingInfoPropertyPlaybackRate] = status == "playing" ? speed : 0.0
+    info[MPNowPlayingInfoPropertyDefaultPlaybackRate] = speed
+    MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+
+    // Critical on macOS: without playbackState, remote events are not delivered.
+    if #available(macOS 10.12.2, *) {
+      switch status {
+      case "playing":
+        MPNowPlayingInfoCenter.default().playbackState = .playing
+      case "buffering":
+        MPNowPlayingInfoCenter.default().playbackState = .playing
+      case "ended", "idle":
+        MPNowPlayingInfoCenter.default().playbackState = .stopped
+      default:
+        MPNowPlayingInfoCenter.default().playbackState = .paused
+      }
+    }
+  }
+
+  private func emit(_ event: [String: Any]) {
+    DispatchQueue.main.async { [weak self] in
+      self?.eventSink?(event)
+    }
+  }
+}
+
+extension MediaRemoteHandler: FlutterStreamHandler {
+  func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink)
+    -> FlutterError?
+  {
+    eventSink = events
+    return nil
+  }
+
+  func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    eventSink = nil
+    return nil
+  }
+}

--- a/desktop/pubspec.lock
+++ b/desktop/pubspec.lock
@@ -286,6 +286,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_media_session:
+    dependency: "direct main"
+    description:
+      name: flutter_media_session
+      sha256: "147c2ac8ddcbaf8caed231b21083bac9d1e36cccb7782a0fde974961e8e8e5c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   # Drag-and-drop of local files onto the Send to TV screen (→ playlist).
   desktop_drop: ^0.5.0
   x25519: ^0.1.1
+  flutter_media_session: ^3.0.0
 
 dev_dependencies:
   flutter_test:

--- a/desktop/windows/flutter/generated_plugin_registrant.cc
+++ b/desktop/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <bonsoir_windows/bonsoir_windows_plugin_c_api.h>
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
+#include <flutter_media_session/flutter_media_session_plugin_c_api.h>
 #include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
 #include <media_kit_video/media_kit_video_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
@@ -23,6 +24,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("DesktopDropPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
+  FlutterMediaSessionPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterMediaSessionPluginCApi"));
   MediaKitLibsWindowsVideoPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("MediaKitLibsWindowsVideoPluginCApi"));
   MediaKitVideoPluginCApiRegisterWithRegistrar(

--- a/desktop/windows/flutter/generated_plugins.cmake
+++ b/desktop/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   bonsoir_windows
   desktop_drop
   file_selector_windows
+  flutter_media_session
   media_kit_libs_windows_video
   media_kit_video
   screen_retriever_windows

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/library/AddonRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/library/AddonRepository.kt
@@ -215,6 +215,13 @@ class AddonRepository(
                 val resourceDetailsJson = json.encodeToString(manifest.resources)
                 val catalogsJson = json.encodeToString(manifest.catalogs)
 
+                // New installs go last (lowest priority). sortOrder defaults to 0, which is
+                // highest priority and would jump ahead of every existing addon.
+                val existing = addonDao.getAllSync()
+                val existingMatch = existing.find { it.manifestUrl == manifestUrl }
+                val sortOrder = existingMatch?.sortOrder
+                    ?: ((existing.maxOfOrNull { it.sortOrder } ?: -1) + 1)
+
                 val entity = InstalledAddonEntity(
                     manifestUrl = manifestUrl,
                     name = manifest.name.ifBlank { "Unknown Addon" },
@@ -226,11 +233,16 @@ class AddonRepository(
                     resourceDetailsJson = resourceDetailsJson,
                     catalogsJson = catalogsJson,
                     playEndpoint = manifest.behaviorHints?.playEndpoint ?: "",
-                    isConfigurable = manifest.behaviorHints?.configurable ?: false
+                    isConfigurable = manifest.behaviorHints?.configurable ?: false,
+                    // Re-install of the same URL (REPLACE) keeps order; brand-new → end of list.
+                    sortOrder = sortOrder,
+                    isEnabled = existingMatch?.isEnabled ?: true,
+                    disabledFeatures = existingMatch?.disabledFeatures ?: "",
+                    installedAt = existingMatch?.installedAt ?: System.currentTimeMillis(),
                 )
 
                 addonDao.insert(entity)
-                Log.d(TAG, "Installed addon: ${entity.name} from $manifestUrl")
+                Log.d(TAG, "Installed addon: ${entity.name} sortOrder=$sortOrder from $manifestUrl")
                 entity
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to install addon", e)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/nuvio/NuvioRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/nuvio/NuvioRepository.kt
@@ -108,6 +108,11 @@ class NuvioRepository(
                 val previous = scraperDao.getForRepo(manifestUrl).associateBy { it.scraperId }
 
                 // Repo row in installed_addons — reuses addon enable/remove UI.
+                // New repos go last (lowest priority); refresh preserves order/settings.
+                val existingAddons = addonDao.getAllSync()
+                val existingMatch = existingAddons.find { it.manifestUrl == manifestUrl }
+                val sortOrder = existingMatch?.sortOrder
+                    ?: ((existingAddons.maxOfOrNull { it.sortOrder } ?: -1) + 1)
                 addonDao.insert(
                     InstalledAddonEntity(
                         manifestUrl = manifestUrl,
@@ -117,7 +122,11 @@ class NuvioRepository(
                         version = manifest.version,
                         types = "movie,series",
                         resources = json.encodeToString(listOf(NUVIO_RESOURCE)),
-                        resourceDetailsJson = ""
+                        resourceDetailsJson = "",
+                        sortOrder = sortOrder,
+                        isEnabled = existingMatch?.isEnabled ?: true,
+                        disabledFeatures = existingMatch?.disabledFeatures ?: "",
+                        installedAt = existingMatch?.installedAt ?: System.currentTimeMillis(),
                     )
                 )
 


### PR DESCRIPTION
## Summary

Phone + desktop improvements: new library addons install last, desktop plays extension casts locally when no TV is linked, and a substantial desktop player/window UX pass (media keys, focus, close behavior, gestures).

### Phone
- **Addon install order:** new Stremio addons and Nuvio repos get `sortOrder` at the end of the list (lowest priority). Re-install/refresh of the same URL keeps order and enable flags.

### Desktop — cast routing
- **Extension / context-menu cast:** when no TV is connected, `cast` / `cast_file` / `control` go to the local player; when linked, still to the TV.
- **Cold-start `--cast-file`:** plays locally if nothing is linked.
- **Remove self-cast** from Send to TV (“show this device”) — redundant with local default.

### Desktop — playback correctness
- **Stale-frame flash:** UI black mask while idle/opening + `VideoTrack.auto` after open (no sticky `VideoTrack.no()`).
- **Headphone unplug:** pause on audio device route change.
- **Bluetooth / media keys (macOS):** native Now Playing + `togglePlayPause` + `playbackState` (`MediaRemoteHandler.swift`). Windows via `flutter_media_session`.

### Desktop — player UX
- Click video → play/pause; **double-click → fullscreen**.
- **OSD** toasts for pause / seek / volume / drop.
- **Drag-and-drop** on main surface: TV linked → cast; else play here.
- Keyboard: **F** fullscreen, **?** / **/** shortcuts sheet; Settings entry for the same.
- **Quiet update banner:** non-blocking “Restart & update” when a release is ready.

### Desktop — window / tray
- **Fullscreen:** agent app promotes to regular activation so menu bar / Control Center auto-show; restore accessory on exit; re-focus after exit.
- **Red X:** fullscreen → exit fullscreen only; windowed → hide to tray.
- **Settings:** Quit PlayBridge (confirm); **Pause when window is hidden** (default off = keep playing).

## Test plan
- [x] **Phone:** install a new addon → appears last in order; re-install same URL keeps position
- [x] **Desktop no TV:** extension cast / file open → plays locally
- [x] **Desktop + TV:** extension cast → TV; self-device not listed in Send to TV
- [x] Stop A, unfocus, play B → no flash of A; video not blank
- [x] Unplug headphones while playing → pauses
- [x] BT headset play/pause → controls app (macOS: Now Playing shows PlayBridge)
- [x] Click / double-click video; Space / arrows / F / ? 
- [x] Drop media files with and without TV linked
- [x] Fullscreen: menu bar on top edge; exit FS keeps focus; red X then windowed X hides
- [x] Settings: pause-when-hidden; Quit
- [x] Update available → bottom banner, not full modal
- [x] Pairing while backgrounded → window focuses, Cast tab shows code

## Commits (high level)
1. Addon last priority + local extension cast  
2. Drop self-cast  
3–5. Stale-frame / blank-screen fixes  
6. Media keys, click pause, window focus  
7. Player UX polish + close options  