### PR TITLE
chore: uprev phone 0.11.1 / TV 0.9.2 / desktop 0.6.7

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.7+25] — 2026-07-11
+
+### Fixed
+- **Cast / local open stability**: Delay mpv audio-route arming until playback is stable (~2s) so open-time device flaps no longer pause casts mid-buffer; only re-enable video when the track is stuck on `"no"` (forcing `VideoTrack.auto()` mid-open could disrupt demux on token CDNs). (#103)
+- **False end-of-file**: Ignore early `completed` while still near position 0 so progressive HTTP streams that emit demuxer EOF during buffer do not tear down the session. (#103)
+
 ## [0.6.6+24] — 2026-07-08
 
 ### Fixed

--- a/desktop/lib/update/app_version.dart
+++ b/desktop/lib/update/app_version.dart
@@ -2,7 +2,7 @@
 ///
 /// MUST match `version:` in pubspec.yaml (build-metadata part excluded) —
 /// guarded by `test/update_test.dart` so CI fails if they drift.
-const String kAppVersion = '0.6.6';
+const String kAppVersion = '0.6.7';
 
 /// Dotted numeric version (`0.6.4`, `1.10.2`) with sane comparison semantics.
 ///

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: playbridge_desktop
 description: "PlayBridge desktop receiver — accepts cast commands from the phone and plays via libmpv."
 publish_to: 'none'
-version: 0.6.6+24
+version: 0.6.7+25
 
 environment:
   sdk: ^3.6.0

--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11.1] — 2026-07-11 (versionCode 220)
+
+### Fixed
+- **In-app player (no video / silent video)**: TV-aligned ExoPlayer factory with Media3 **FFmpeg audio PREFER** (`prebuilt/media3/lib-decoder-ffmpeg-release.aar`), hardware-first video, decoder fallback, and memory-aware load control. TextureView + deferred `prepare()` until the surface is attached (Compose SurfaceView left permanent buffering). Stuck recovery only after first frame and does not mute audio when FFmpeg is loaded. (#103)
+- **Library Watch**: No longer auto-reconnects to the TV from the detail screen; pairing stays on the Connection sheet. (#103)
+
+### Changed
+- **FFmpeg packaging**: Phone depends on the shared repo prebuilt FFmpeg decoder AAR (same artifact as TV). (#103)
+
 ## [0.11.0] — 2026-07-08 (versionCode 219)
 
 ### Added

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 219
-        versionName = "0.11.0"
+        versionCode = 220
+        versionName = "0.11.1"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,11 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [0.9.2] — 2026-07-11 (versionCode 222)
+
+### Changed
+- **FFmpeg decoder AAR**: Moved to shared `prebuilt/media3/lib-decoder-ffmpeg-release.aar` (single copy with phone). Gradle path updated; runtime behavior unchanged. (#103)
+
 ## Player [0.9.1] — 2026-07-08 (versionCode 221)
 
 ### Changed

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 221
-        versionName = "0.9.1"
+        versionCode = 222
+        versionName = "0.9.2"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
## Summary

Version bumps and changelogs for the #103 player/cast reliability work.

| Project | Previous | New |
| :--- | :--- | :--- |
| **Android Phone** | `0.11.0` (versionCode 219) | **`0.11.1` (versionCode 220)** |
| **Android TV Player** | `0.9.1` (versionCode 221) | **`0.9.2` (versionCode 222)** |
| **Desktop** | `0.6.6+24` | **`0.6.7+25`** |

### Included in these releases (#103)

**Phone**
- In-app ExoPlayer: FFmpeg audio PREFER, TextureView + deferred prepare, memory-aware buffers
- Shared `prebuilt/media3` FFmpeg AAR dependency
- Library Watch no longer auto-reconnects to TV

**TV**
- FFmpeg AAR path → `prebuilt/media3/` (shared with phone; packaging only)

**Desktop**
- MPV audio-route arm delay; safer video track re-enable
- Ignore false early `completed` while still buffering

## Test plan

- [ ] Confirm version fields:
  - Phone `build.gradle.kts`: `versionName = "0.11.1"`, `versionCode = 220`
  - TV player `build.gradle.kts`: `versionName = "0.9.2"`, `versionCode = 222`
  - Desktop `pubspec.yaml`: `version: 0.6.7+25`
- [ ] Changelogs list #103 under each project with date 2026-07-11
- [ ] No app logic changes in this PR (versions + changelogs only)
- [ ] After merge: tag/release pipelines (if any) pick up the new codes