### PR TITLE
fix: restore Windows build with MSVC 14.51

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.8+26] — 2026-07-11
+
+### Fixed
+- **Windows MSVC compatibility**: Allow the `flutter_media_session` plugin's legacy experimental coroutine header to compile with Visual Studio 18 / MSVC 14.51 while the dependency migrates to standard C++ coroutines.
+
 ## [0.6.7+25] — 2026-07-11
 
 ### Fixed

--- a/desktop/lib/update/app_version.dart
+++ b/desktop/lib/update/app_version.dart
@@ -2,7 +2,7 @@
 ///
 /// MUST match `version:` in pubspec.yaml (build-metadata part excluded) —
 /// guarded by `test/update_test.dart` so CI fails if they drift.
-const String kAppVersion = '0.6.7';
+const String kAppVersion = '0.6.8';
 
 /// Dotted numeric version (`0.6.4`, `1.10.2`) with sane comparison semantics.
 ///

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: playbridge_desktop
 description: "PlayBridge desktop receiver — accepts cast commands from the phone and plays via libmpv."
 publish_to: 'none'
-version: 0.6.7+25
+version: 0.6.8+26
 
 environment:
   sdk: ^3.6.0

--- a/desktop/windows/CMakeLists.txt
+++ b/desktop/windows/CMakeLists.txt
@@ -32,6 +32,14 @@ set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
 # Use Unicode for all projects.
 add_definitions(-DUNICODE -D_UNICODE)
 
+# Visual Studio 18 / MSVC 14.51 rejects flutter_media_session's legacy
+# <experimental/coroutine> include unless this compatibility warning is
+# explicitly silenced. Apply it directory-wide so generated plugin targets
+# inherit the definition as well as the app runner.
+if(MSVC)
+  add_compile_definitions(_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+endif()
+
 # Compilation settings that should be applied to most targets.
 #
 # Be cautious about adding new options here, as plugins use this function by


### PR DESCRIPTION
## Summary

Fix the Windows release build on Visual Studio 18 / MSVC 14.51 by defining `_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS` for Windows CMake targets.

The definition is directory-wide so generated plugin targets, including `flutter_media_session_plugin.vcxproj`, inherit it. This addresses the hard failure caused by the plugin's current `<experimental/coroutine>` include without changing runtime behavior.

Failure: https://github.com/playbridgeapp/playbridge/actions/runs/29158561461/job/86559644493

## Version

- Desktop: `0.6.7+25` → `0.6.8+26`
- Updated `kAppVersion` to `0.6.8`
- Added the `0.6.8+26` changelog entry

## Test plan

- [x] `flutter test test/update_test.dart`
- [x] `flutter analyze`
- [ ] Windows release build passes in GitHub Actions

