### PR TITLE
fix(security): harden pairing and secret handling

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,15 +17,33 @@ We take the security of PlayBridge seriously. If you have discovered a security 
 
 ## Security Considerations
 
-As PlayBridge is a casting solution for the local network, there are several architectural choices users should be aware of:
+The normative sender/receiver requirements are defined in
+[`docs/SECURITY_STANDARD.md`](docs/SECURITY_STANDARD.md). The wire-format details
+are documented in [`protocol/README.md`](protocol/README.md). Known implementation
+gaps and their remediation order are tracked in
+[`docs/SECURITY_GAPS.md`](docs/SECURITY_GAPS.md).
 
-### Local Network Assumption
-PlayBridge assumes a trusted local network. Communication between the phone and TV apps via WebSocket is unencrypted over HTTP (`ws://`), which is standard for local device-to-device casting (similar to early Chromecast/DIAL protocols).
+### Local Network
 
-### SSL Bypass Option
-The TV app's `PlayerActivity` includes an option to bypass SSL verification for media streams. This is intended for local media servers or self-signed HLS streams. Users should use this with caution as it facilitates Man-In-The-Middle (MITM) attacks if used on hostile networks.
+PlayBridge does not treat the local network, mDNS discovery, IP addresses, or
+device names as trusted identities. The control channel uses `wss://`. Previously
+paired senders authenticate receivers by their saved TLS SPKI pin before sending
+credentials or commands.
 
-### Authentication
-Pairing between phone and TV is secured via a PIN and token flow. Only authenticated devices can send commands to the TV receiver.
+### Pairing and Authentication
+
+First pairing uses an ephemeral X25519 exchange, a user-compared short
+authentication string (SAS), cryptographic key confirmation, and AEAD-protected
+delivery of the receiver token and certificate pin. Later connections use the
+saved pin and token. A pin mismatch requires explicit re-pairing; plaintext
+pairing and control-channel downgrade fallbacks are prohibited.
+
+### Media Transport
+
+Some media sources intentionally use plain HTTP or self-signed TLS, especially
+local servers and direct/torrent streams. This media compatibility exception is
+separate from the PlayBridge control channel. Authenticated headers and cookies
+must remain bound to their intended origin across redirects and derived playlist,
+segment, subtitle, artwork, and proxy requests.
 
 Thank you for helping keep PlayBridge safe!

--- a/desktop/lib/cert_manager.dart
+++ b/desktop/lib/cert_manager.dart
@@ -32,6 +32,7 @@ class CertManager {
     final tlsDir = dir ??
         Directory('${(await getApplicationSupportDirectory()).path}/tls');
     if (!tlsDir.existsSync()) tlsDir.createSync(recursive: true);
+    await _restrictPermissions(tlsDir.path, directory: true);
 
     final cert = File('${tlsDir.path}/$_certFile');
     final key = File('${tlsDir.path}/$_keyFile');
@@ -61,6 +62,9 @@ class CertManager {
       await key.writeAsString(keyPem, flush: true);
       await pin.writeAsString(fingerprint, flush: true);
     }
+    await _restrictPermissions(cert.path);
+    await _restrictPermissions(key.path);
+    await _restrictPermissions(pin.path);
 
     final ctx = SecurityContext()
       ..useCertificateChainBytes(utf8.encode(certPem))
@@ -80,5 +84,15 @@ class CertManager {
     final der = base64.decode(b64);
     final digest = crypto.sha256.convert(der).bytes;
     return 'sha256/${base64.encode(digest)}';
+  }
+
+  static Future<void> _restrictPermissions(String path,
+      {bool directory = false}) async {
+    if (Platform.isWindows) return;
+    try {
+      await Process.run('chmod', [directory ? '700' : '600', path]);
+    } catch (_) {
+      // Best effort on filesystems without POSIX permissions.
+    }
   }
 }

--- a/desktop/lib/logging/log_store.dart
+++ b/desktop/lib/logging/log_store.dart
@@ -6,6 +6,38 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 enum LogLevel { verbose, debug, info, warn, error, unknown }
 
+@visibleForTesting
+String redactSensitiveLogData(String input) {
+  var value = input;
+  value = value.replaceAllMapped(
+    RegExp(
+      r'("?(?:authorization|proxy-authorization)"?\s*[:=]\s*)("[^"]*"|[^,}\]\r\n]+)',
+      caseSensitive: false,
+    ),
+    (m) {
+      final secret = m.group(2)!;
+      final replacement =
+          secret.startsWith('"') ? '"<redacted>"' : '<redacted>';
+      return '${m.group(1)}$replacement';
+    },
+  );
+  value = value.replaceAllMapped(
+    RegExp(
+      r'("?(?:token|cookie|set-cookie)"?\s*[:=]\s*"?)([^",\s}]+)',
+      caseSensitive: false,
+    ),
+    (m) => '${m.group(1)}<redacted>',
+  );
+  value = value.replaceAllMapped(
+    RegExp(
+      r'([?&](?:token|api_key|apikey|auth|signature|sig)=)[^&#\s]+',
+      caseSensitive: false,
+    ),
+    (m) => '${m.group(1)}<redacted>',
+  );
+  return value;
+}
+
 extension LogLevelCode on LogLevel {
   String get code => switch (this) {
         LogLevel.verbose => 'V',
@@ -41,8 +73,8 @@ class LogEntry {
 /// Persistent, opt-in logger for the desktop receiver.
 ///
 /// Logging is OFF by default: persisted logs can contain stream URLs and request
-/// headers (incl. Debrid tokens) and are served over the LAN via `GET /logs`, so
-/// retention is opt-in. Mirrors the TV player's `FileLogger`.
+/// headers (incl. Debrid tokens), so retention is opt-in. Logs are available only
+/// through the local UI and are never served by the LAN receiver.
 class LogStore {
   LogStore._();
   static final LogStore instance = LogStore._();
@@ -148,12 +180,20 @@ class LogStore {
       f.uri.pathSegments.last.startsWith(_logBaseName.split('.').first);
 
   void _record(LogEntry e) {
-    final next = List<LogEntry>.of(entries.value)..add(e);
+    // Redact at the persistence boundary so structured, raw, and crash entries
+    // cannot accidentally bypass secret filtering.
+    final safeEntry = LogEntry(
+      time: e.time,
+      level: e.level,
+      tag: e.tag,
+      message: redactSensitiveLogData(e.message),
+    );
+    final next = List<LogEntry>.of(entries.value)..add(safeEntry);
     if (next.length > _ringCapacity) {
       next.removeRange(0, next.length - _ringCapacity);
     }
     entries.value = next;
-    _writeLine(_format(e));
+    _writeLine(_format(safeEntry));
   }
 
   void _writeLine(String line) {

--- a/desktop/lib/pairing_store.dart
+++ b/desktop/lib/pairing_store.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
+import 'package:crypto/crypto.dart';
 
 import 'player_engine.dart';
 
@@ -126,29 +127,40 @@ class PairingStore {
       _prefs.setString(
           _kPairedDevices, jsonEncode(devices.map((d) => d.toJson()).toList()));
 
-  bool isTokenAuthorized(String token) =>
-      pairedDevices.any((d) => d.token == token);
+  bool isTokenAuthorized(String token) {
+    final digest = _tokenDigest(token);
+    return pairedDevices.any((d) => d.token == token || d.token == digest);
+  }
 
   Future<void> addPairedDevice(PairedDeviceRecord device) async {
     final devices = pairedDevices.toList();
+    final protected = PairedDeviceRecord(
+      deviceUUID: device.deviceUUID,
+      deviceName: device.deviceName,
+      token: _tokenDigest(device.token),
+      lastConnected: device.lastConnected,
+    );
     final idx = devices.indexWhere((d) => d.deviceUUID == device.deviceUUID);
     if (idx >= 0) {
-      devices[idx] = device;
+      devices[idx] = protected;
     } else {
-      devices.add(device);
+      devices.add(protected);
     }
     await _savePairedDevices(devices);
   }
 
   Future<void> updateLastConnected(String token) async {
     final devices = pairedDevices.toList();
-    final idx = devices.indexWhere((d) => d.token == token);
+    final digest = _tokenDigest(token);
+    final idx =
+        devices.indexWhere((d) => d.token == token || d.token == digest);
     if (idx < 0) return;
     final d = devices[idx];
     devices[idx] = PairedDeviceRecord(
       deviceUUID: d.deviceUUID,
       deviceName: d.deviceName,
-      token: d.token,
+      // Transparently migrate legacy plaintext records after successful auth.
+      token: digest,
       lastConnected: DateTime.now(),
     );
     await _savePairedDevices(devices);
@@ -161,6 +173,9 @@ class PairingStore {
   }
 
   Future<void> forgetAllDevices() => _prefs.remove(_kPairedDevices);
+
+  static String _tokenDigest(String token) =>
+      'sha256:${sha256.convert(utf8.encode(token))}';
 
   static String _defaultName() {
     try {

--- a/desktop/lib/protocol.dart
+++ b/desktop/lib/protocol.dart
@@ -239,17 +239,13 @@ Command parseCommand(String json) {
 String pongJson() => jsonEncode({'type': 'pong'});
 
 String pairingApprovedJson(
-  String token, {
-  String? certFingerprint,
-  List<String> players = const [],
-  List<String> browsers = const [],
-}) =>
+  String nonce,
+  String ciphertext,
+) =>
     jsonEncode({
       'type': 'pairing_approved',
-      'token': token,
-      if (certFingerprint != null) 'certFingerprint': certFingerprint,
-      if (players.isNotEmpty) 'players': players,
-      if (browsers.isNotEmpty) 'browsers': browsers,
+      'nonce': nonce,
+      'ciphertext': ciphertext,
     });
 
 String pairingDeniedJson() => jsonEncode({'type': 'pairing_denied'});

--- a/desktop/lib/sas_crypto.dart
+++ b/desktop/lib/sas_crypto.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart' as crypto;
+import 'package:pointycastle/export.dart';
 import 'package:x25519/x25519.dart' as x;
 
 /// Dart port of the shared Kotlin `SasCrypto` object.
@@ -95,6 +96,35 @@ class SasCrypto {
 
   /// Cryptographically secure random bytes.
   static Uint8List generateNonce([int size = 16]) => _platformSeed(size);
+
+  /// AES-256-GCM. The returned bytes are ciphertext followed by the 16-byte tag.
+  static Uint8List aesGcmEncrypt({
+    required Uint8List key,
+    required Uint8List nonce,
+    required Uint8List plaintext,
+    required Uint8List aad,
+  }) {
+    final cipher = GCMBlockCipher(AESEngine())
+      ..init(
+        true,
+        AEADParameters(KeyParameter(key), 128, nonce, aad),
+      );
+    return cipher.process(plaintext);
+  }
+
+  static Uint8List aesGcmDecrypt({
+    required Uint8List key,
+    required Uint8List nonce,
+    required Uint8List ciphertext,
+    required Uint8List aad,
+  }) {
+    final cipher = GCMBlockCipher(AESEngine())
+      ..init(
+        false,
+        AEADParameters(KeyParameter(key), 128, nonce, aad),
+      );
+    return cipher.process(ciphertext);
+  }
 
   // ───────────────────────── Internal ───────────────────────────────────────
 

--- a/desktop/lib/server.dart
+++ b/desktop/lib/server.dart
@@ -10,7 +10,6 @@ import 'package:uuid/uuid.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'cert_manager.dart';
-import 'logging/log_store.dart';
 import 'pairing_store.dart';
 import 'player_controller.dart';
 import 'player_engine.dart';
@@ -114,6 +113,7 @@ class ReceiverServer extends ChangeNotifier {
 
   /// In-progress SAS handshakes keyed by WebSocket channel.
   final Map<WebSocketChannel, _ConnectionHandshake> _inProgressHandshakes = {};
+  final Map<WebSocketChannel, Timer> _handshakeTimers = {};
 
   /// Rate-limiting: failed pairing attempts by IP.
   final Map<String, int> _failedAttempts = {};
@@ -121,14 +121,13 @@ class ReceiverServer extends ChangeNotifier {
   /// Rate-limiting: lockout expiry (epoch ms) by IP.
   final Map<String, int> _lockoutUntil = {};
 
-  /// Remote IPs of pending ws upgrades, consumed in accept order by [_onClient].
-  /// shelf_web_socket's onConnection callback doesn't carry the request, so we
-  /// capture the IP in the route wrapper and hand it off here.
-  final List<String> _pendingClientIps = [];
-
   /// Source IP per connected channel, so pairing rate-limiting/lockout keys on a
   /// real address instead of the (per-connection, trivially-rotated) channel identity.
   final Map<WebSocketChannel, String> _channelIps = {};
+
+  static const int _maxConnections = 32;
+  static const int _maxMessageChars = 1024 * 1024;
+  static const Duration _handshakeTimeout = Duration(seconds: 15);
 
   // Dedupe rapid-fire duplicate play commands from the phone.
   String? _lastPlayUrl;
@@ -164,7 +163,7 @@ class ReceiverServer extends ChangeNotifier {
   /// (Re)binds the wss:// (always) and ws:// (opt-in) listeners. Re-runnable
   /// after [reloadListeners] closes the previous sockets.
   Future<void> _bindListeners() async {
-    final handler = _withLogsRoute(webSocketHandler(_onClient));
+    final handler = _requestHandler();
 
     // Encrypted wss:// on port — the default, preferred transport.
     var wssUp = false;
@@ -194,42 +193,21 @@ class ReceiverServer extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Wraps the WebSocket handler so `GET /logs` (download) and `DELETE /logs`
-  /// (clear) are served as plain HTTP, falling through to the ws upgrade for
-  /// every other request. Gated: returns 403 when logging is disabled so a device
-  /// on the LAN can't pull logs (which may contain stream URLs and headers).
-  Handler _withLogsRoute(Handler wsHandler) {
+  /// Associates the request address directly with its upgraded channel. Logs are
+  /// intentionally unavailable over LAN; use the in-app diagnostics screen.
+  Handler _requestHandler() {
     return (Request request) {
       if (request.url.path == 'logs') {
-        if (request.method == 'GET') {
-          if (!LogStore.instance.enabled) {
-            return Response.forbidden('Logging is disabled on this device.');
-          }
-          final text = LogStore.instance.combinedText();
-          return Response.ok(
-            text.isEmpty ? 'No log entries.' : text,
-            headers: {
-              'content-type': 'text/plain',
-              'content-disposition':
-                  'attachment; filename="playbridge_desktop_logs.txt"',
-            },
-          );
-        }
-        if (request.method == 'DELETE') {
-          LogStore.instance.clear();
-          return Response.ok('Logs cleared.');
-        }
+        return Response.notFound('');
       }
-      // Capture the client IP for the upcoming ws upgrade so pairing rate-limiting
-      // keys on a real address. Only ws-upgrade requests reach here (the /logs HTTP
-      // routes returned above), and upgrades fire onConnection in accept order.
       final ip =
           (request.context['shelf.io.connection_info'] as HttpConnectionInfo?)
                   ?.remoteAddress
                   .address ??
               'unknown';
-      _pendingClientIps.add(ip);
-      return wsHandler(request);
+      return webSocketHandler(
+        (channel, subprotocol) => _onClient(channel, subprotocol, ip),
+      )(request);
     };
   }
 
@@ -248,8 +226,11 @@ class ReceiverServer extends ChangeNotifier {
     _authed.clear();
     _pendingPairingRequest = null;
     _inProgressHandshakes.clear();
+    for (final timer in _handshakeTimers.values) {
+      timer.cancel();
+    }
+    _handshakeTimers.clear();
     _channelIps.clear();
-    _pendingClientIps.clear();
     for (final s in _servers) {
       await s.close(force: true);
     }
@@ -267,11 +248,11 @@ class ReceiverServer extends ChangeNotifier {
     }
   }
 
-  void _onClient(WebSocketChannel channel, String? subprotocol) {
-    // Pair this channel with the IP captured for its upgrade (accept-order FIFO).
-    final ip = _pendingClientIps.isNotEmpty
-        ? _pendingClientIps.removeAt(0)
-        : 'unknown';
+  void _onClient(WebSocketChannel channel, String? subprotocol, String ip) {
+    if (_all.length >= _maxConnections) {
+      unawaited(channel.sink.close(1013, 'Server busy'));
+      return;
+    }
     _channelIps[channel] = ip;
     debugPrint('[server] client connected');
     _all.add(channel);
@@ -279,8 +260,13 @@ class ReceiverServer extends ChangeNotifier {
     channel.stream.listen(
       (raw) {
         if (raw is! String) return;
+        if (raw.length > _maxMessageChars) {
+          unawaited(channel.sink.close(1009, 'Message too large'));
+          return;
+        }
         final isAuthed = _authed.contains(channel);
-        debugPrint('[recv${isAuthed ? '' : ' pre-auth'}] $raw');
+        debugPrint(
+            '[recv${isAuthed ? '' : ' pre-auth'}] ${_safeFrameSummary(raw)}');
         if (isAuthed) {
           _handleAuthed(channel, raw);
         } else {
@@ -297,6 +283,7 @@ class ReceiverServer extends ChangeNotifier {
         _all.remove(channel);
         _authed.remove(channel);
         _inProgressHandshakes.remove(channel);
+        _handshakeTimers.remove(channel)?.cancel();
         _channelIps.remove(channel);
         // Clear pending request if this was the pending channel
         if (_pendingPairingRequest?.channel == channel) {
@@ -311,6 +298,7 @@ class ReceiverServer extends ChangeNotifier {
         _all.remove(channel);
         _authed.remove(channel);
         _inProgressHandshakes.remove(channel);
+        _handshakeTimers.remove(channel)?.cancel();
         _channelIps.remove(channel);
         if (_pendingPairingRequest?.channel == channel) {
           _approvalTimeout?.cancel();
@@ -377,6 +365,13 @@ class ReceiverServer extends ChangeNotifier {
     String deviceName,
     String deviceUUID,
   ) {
+    if (!_validB64Length(commit, 32) ||
+        deviceName.length > 128 ||
+        deviceUUID.length > 128) {
+      channel.sink.add(pairingDeniedJson());
+      _recordPairingFailure(channel);
+      return false;
+    }
     // Rate-limiting: check lockout (keyed on the captured remote IP).
     final ip = _ipFor(channel);
     final lockout = _lockoutUntil[ip];
@@ -404,6 +399,7 @@ class ReceiverServer extends ChangeNotifier {
       tvEphPub: tvKey.publicKey,
       nonceT: nonceT,
     );
+    _resetHandshakeTimer(channel);
 
     // Send challenge.
     channel.sink.add(pairingChallengeJson(
@@ -423,6 +419,11 @@ class ReceiverServer extends ChangeNotifier {
       return;
     }
 
+    if (!_validB64Length(senderEphPubB64, 32) ||
+        !_validB64Length(nonceSB64, 16)) {
+      _denyMalformedHandshake(channel);
+      return;
+    }
     final senderEphPub = Uint8List.fromList(base64.decode(senderEphPubB64));
     final nonceS = Uint8List.fromList(base64.decode(nonceSB64));
 
@@ -468,6 +469,7 @@ class ReceiverServer extends ChangeNotifier {
       channel: channel,
       approval: approval,
     );
+    _handshakeTimers.remove(channel)?.cancel();
 
     // Auto-deny after 60 seconds.
     _approvalTimeout?.cancel();
@@ -493,10 +495,26 @@ class ReceiverServer extends ChangeNotifier {
         );
         unawaited(store.addPairedDevice(device));
 
+        final transcriptHash = SasCrypto.sha256(_transcript(handshake));
+        final prk = SasCrypto.hkdfExtract(ikm: handshake.sharedSecret!);
+        final credentialKey = SasCrypto.hkdfExpand(prk,
+            info: Uint8List.fromList('playbridgeCredentialKey-v1'.codeUnits),
+            length: 32);
+        final nonce = SasCrypto.generateNonce(12);
+        final plaintext = utf8.encode(jsonEncode({
+          'token': token,
+          'certFingerprint': _certFingerprint,
+          'players': _capabilityPlayers,
+        }));
+        final ciphertext = SasCrypto.aesGcmEncrypt(
+          key: credentialKey,
+          nonce: nonce,
+          plaintext: Uint8List.fromList(plaintext),
+          aad: transcriptHash,
+        );
         channel.sink.add(pairingApprovedJson(
-          token,
-          certFingerprint: _certFingerprint,
-          players: _capabilityPlayers,
+          base64.encode(nonce),
+          base64.encode(ciphertext),
         ));
         _authed.add(channel);
       } else {
@@ -505,6 +523,7 @@ class ReceiverServer extends ChangeNotifier {
       }
 
       _inProgressHandshakes.remove(channel);
+      _handshakeTimers.remove(channel)?.cancel();
       _pendingPairingRequest = null;
       notifyListeners();
       if (approved) _sendPlaylistStatusTo(channel);
@@ -520,6 +539,10 @@ class ReceiverServer extends ChangeNotifier {
       return;
     }
     if (pending.approval.isCompleted) return;
+    if (!_validB64Length(mac, 32)) {
+      pending.approval.complete(false);
+      return;
+    }
 
     // Derive confirmation key and expected MAC.
     final commitBytes = Uint8List.fromList(base64.decode(handshake.commit));
@@ -560,6 +583,55 @@ class ReceiverServer extends ChangeNotifier {
       _failedAttempts.remove(ip);
       debugPrint('[server] IP $ip locked out after $count failed pairings');
     }
+  }
+
+  Uint8List _transcript(_ConnectionHandshake h) => Uint8List.fromList(
+        base64.decode(h.commit) +
+            h.tvEphPub +
+            h.nonceT +
+            h.senderEphPub! +
+            h.nonceS!,
+      );
+
+  bool _validB64Length(String value, int expectedBytes) {
+    if (value.length > expectedBytes * 2) return false;
+    try {
+      return base64.decode(value).length == expectedBytes;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  void _resetHandshakeTimer(WebSocketChannel channel) {
+    _handshakeTimers.remove(channel)?.cancel();
+    _handshakeTimers[channel] = Timer(_handshakeTimeout, () {
+      if (_inProgressHandshakes.remove(channel) != null) {
+        channel.sink.add(pairingDeniedJson());
+        unawaited(channel.sink.close(1008, 'Pairing timed out'));
+        notifyListeners();
+      }
+      _handshakeTimers.remove(channel);
+    });
+  }
+
+  void _denyMalformedHandshake(WebSocketChannel channel) {
+    channel.sink.add(pairingDeniedJson());
+    _inProgressHandshakes.remove(channel);
+    _handshakeTimers.remove(channel)?.cancel();
+    _recordPairingFailure(channel);
+    notifyListeners();
+  }
+
+  String _safeFrameSummary(String raw) {
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map) {
+        final type = decoded['type']?.toString() ?? 'unknown';
+        final action = decoded['action']?.toString();
+        return action == null ? 'type=$type' : 'type=$type action=$action';
+      }
+    } catch (_) {}
+    return 'invalid-json (${raw.length} chars)';
   }
 
   // No manual "approve" entry point: approval is driven exclusively by the SAS

--- a/desktop/lib/tv_sender_client.dart
+++ b/desktop/lib/tv_sender_client.dart
@@ -317,8 +317,66 @@ class TvSenderClient {
   }
 
   void _handlePairingApproved(Map<dynamic, dynamic> obj) {
-    final token = obj['token'] as String?;
-    final certFp = (obj['certFingerprint'] as String?)?.trim();
+    try {
+      final nonceB64 = obj['nonce'] as String?;
+      final ciphertextB64 = obj['ciphertext'] as String?;
+      if (nonceB64 == null || ciphertextB64 == null) {
+        throw const FormatException('missing protected credentials');
+      }
+      final nonce = Uint8List.fromList(base64.decode(nonceB64));
+      final ciphertext = Uint8List.fromList(base64.decode(ciphertextB64));
+      if (nonce.length != 12 || ciphertext.length < 16) {
+        throw const FormatException('invalid protected credential lengths');
+      }
+      final transcript = _pairingTranscript();
+      final transcriptHash = SasCrypto.sha256(transcript);
+      final prk = SasCrypto.hkdfExtract(ikm: _sharedSecret!);
+      final credentialKey = SasCrypto.hkdfExpand(
+        prk,
+        info: Uint8List.fromList('playbridgeCredentialKey-v1'.codeUnits),
+        length: 32,
+      );
+      final plaintext = SasCrypto.aesGcmDecrypt(
+        key: credentialKey,
+        nonce: nonce,
+        ciphertext: ciphertext,
+        aad: transcriptHash,
+      );
+      final credentials = jsonDecode(utf8.decode(plaintext));
+      if (credentials is! Map) {
+        throw const FormatException('invalid credential payload');
+      }
+      final token = credentials['token'] as String?;
+      final certFp = (credentials['certFingerprint'] as String?)?.trim();
+      if (token == null || token.isEmpty) {
+        throw const FormatException('missing pairing token');
+      }
+      _acceptPairingCredentials(token, certFp);
+    } catch (_) {
+      debugPrint('[tv-sender] pairing credential verification failed');
+      _clearPairingSecrets();
+      _setState(SenderConnectionState.error);
+      _close();
+    }
+  }
+
+  Uint8List _pairingTranscript() {
+    if (_commitStr == null ||
+        _tvEphPub == null ||
+        _nonceT == null ||
+        _senderPubKey == null ||
+        _nonceS == null ||
+        _sharedSecret == null) {
+      throw StateError('incomplete pairing state');
+    }
+    return Uint8List.fromList(base64.decode(_commitStr!) +
+        _tvEphPub! +
+        _nonceT! +
+        _senderPubKey! +
+        _nonceS!);
+  }
+
+  void _acceptPairingCredentials(String token, String? certFp) {
     // Bind the delivered fingerprint to the cert actually served this handshake.
     if (certFp != null &&
         certFp.isNotEmpty &&
@@ -331,10 +389,22 @@ class TvSenderClient {
       return;
     }
     final pin = (certFp != null && certFp.isNotEmpty) ? certFp : _capturedPin;
-    if (token != null && token.isNotEmpty && !_credentials.isClosed) {
+    if (!_credentials.isClosed) {
       _credentials.add(TvCredentials(token, pin));
     }
+    _clearPairingSecrets();
     _setState(SenderConnectionState.connected);
+  }
+
+  void _clearPairingSecrets() {
+    _senderPrivKey = null;
+    _senderPubKey = null;
+    _nonceS = null;
+    _commitStr = null;
+    _tvEphPub = null;
+    _nonceT = null;
+    _sharedSecret = null;
+    _calculatedSas = null;
   }
 
   void _handleAuthResponse(Map<dynamic, dynamic> obj) {

--- a/desktop/test/log_store_test.dart
+++ b/desktop/test/log_store_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/logging/log_store.dart';
+
+void main() {
+  group('redactSensitiveLogData', () {
+    test('redacts complete bearer and basic authorization values', () {
+      expect(
+        redactSensitiveLogData('Authorization: Bearer secret-token'),
+        'Authorization: <redacted>',
+      );
+      expect(
+        redactSensitiveLogData('Proxy-Authorization=Basic dXNlcjpwYXNz'),
+        'Proxy-Authorization=<redacted>',
+      );
+    });
+
+    test('redacts quoted JSON authorization without consuming other fields',
+        () {
+      expect(
+        redactSensitiveLogData(
+          '{"authorization":"Bearer secret-token","status":"ok"}',
+        ),
+        '{"authorization":"<redacted>","status":"ok"}',
+      );
+    });
+
+    test('continues to redact tokens, cookies, and query credentials', () {
+      expect(
+        redactSensitiveLogData(
+          'token=secret cookie=session-id url=https://example.test/v?api_key=key&quality=hd',
+        ),
+        'token=<redacted> cookie=<redacted> url=https://example.test/v?api_key=<redacted>&quality=hd',
+      );
+    });
+  });
+}

--- a/desktop/test/sas_crypto_test.dart
+++ b/desktop/test/sas_crypto_test.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/sas_crypto.dart';
+
+void main() {
+  test('credential encryption authenticates ciphertext and transcript', () {
+    final key = Uint8List.fromList(List<int>.generate(32, (i) => i));
+    final nonce = Uint8List.fromList(List<int>.generate(12, (i) => i + 32));
+    final aad = SasCrypto.sha256(Uint8List.fromList(utf8.encode('transcript')));
+    final plaintext = Uint8List.fromList(utf8.encode('{"token":"secret"}'));
+
+    final ciphertext = SasCrypto.aesGcmEncrypt(
+      key: key,
+      nonce: nonce,
+      plaintext: plaintext,
+      aad: aad,
+    );
+    expect(
+      SasCrypto.aesGcmDecrypt(
+        key: key,
+        nonce: nonce,
+        ciphertext: ciphertext,
+        aad: aad,
+      ),
+      plaintext,
+    );
+
+    final tampered = Uint8List.fromList(ciphertext)..[0] ^= 1;
+    expect(
+      () => SasCrypto.aesGcmDecrypt(
+        key: key,
+        nonce: nonce,
+        ciphertext: tampered,
+        aad: aad,
+      ),
+      throwsA(anything),
+    );
+  });
+}

--- a/docs/SECURITY_GAPS.md
+++ b/docs/SECURITY_GAPS.md
@@ -1,0 +1,351 @@
+# PlayBridge Remaining Security Gaps
+
+Status: living security backlog
+
+Audit date: 2026-07-12
+
+Standard: [`SECURITY_STANDARD.md`](SECURITY_STANDARD.md)
+
+This document records known gaps between the current PlayBridge implementations
+and the project security standard. It is an engineering backlog, not a claim that
+every listed issue is presently exploitable. Each item must be verified on the
+affected platform when fixed, and the evidence paths should be updated or the
+item removed.
+
+## Severity definitions
+
+| Priority | Meaning |
+| --- | --- |
+| P0 — Critical | Practical compromise of pairing, receiver identity, or arbitrary unauthenticated control; release blocker |
+| P1 — High | Likely disclosure or misuse of credentials, or a meaningful remote attack surface; fix before calling the affected feature secure |
+| P2 — Medium | Important defense-in-depth, local secret exposure, denial of service, or security inconsistency |
+| P3 — Low | Hardening, assurance, or maintainability work with limited direct impact |
+
+## Current posture summary
+
+No P0 issue was identified in this review. First-time pairing is consistently
+protected by X25519, SAS/key confirmation, and AES-256-GCM credential delivery
+across the implemented Android, Apple, and Dart sender/receiver combinations.
+Previously paired senders use certificate-pinned WSS before token authentication,
+and no plaintext pairing fallback is present.
+
+The project is not yet fully compliant with the security standard. The principal
+remaining risks are:
+
+1. credential-bearing media headers can be reused across redirects or derived
+   media requests without a shared origin policy;
+2. receiver history and favorites persist replay credentials without
+   application-level encryption;
+3. some senders and receivers persist bearer tokens in ordinary preferences;
+4. desktop and Apple TV receivers echo bearer tokens during reauthentication;
+5. receiver input and denial-of-service limits are inconsistent;
+6. protocol conformance lacks shared cross-language cryptographic test vectors.
+
+## P1 — High priority
+
+### SEC-001: Origin-bound media credentials are not enforced consistently
+
+**Affected:** Android phone playback, Android TV, Apple TV, desktop playback and
+proxy paths; any shared playback code that applies sender-provided headers.
+
+**Risk:** An `Authorization`, `Cookie`, debrid/API token, or other secret header
+intended for one origin may be attached to a redirect, HLS/DASH child resource,
+subtitle, artwork request, or proxy rewrite at a different origin. A malicious or
+compromised media endpoint could redirect a receiver to an attacker-controlled
+host and collect credentials.
+
+**Evidence:**
+
+- `shared/.../ExoPlayerEngine.kt` applies the complete per-item header map as
+  default request properties while enabling HTTP, HTTPS, and cross-protocol
+  redirects.
+- `shared/.../MpvPlayerEngine.kt` passes the complete map through mpv's global
+  `http-header-fields` option for the loaded item.
+- `tv/apple/.../VLCPlayerView.swift` and `VLCProxyServer.swift` use URLSession and
+  proxy rewriting for redirect and HLS flows without a project-level
+  origin/credential policy.
+- Subtitle and content-sniffing paths accept and reuse the playback header map.
+
+**Required remediation:**
+
+- Introduce one shared conceptual header policy, implemented on every platform.
+- Classify credential-bearing headers and bind them to the initial normalized
+  origin: scheme, host, and effective port.
+- Re-evaluate redirects, manifests, variants, segments, keys, subtitles,
+  artwork, and proxy rewrites independently.
+- Strip credentials on cross-origin transitions unless the sender supplies an
+  explicit bounded origin allowlist.
+- Never retain credentials during HTTPS-to-HTTP downgrade.
+- Add integration tests using two local origins and redirect/playlist chains.
+
+**Done when:** Every HTTP stack has tests proving credential headers reach the
+allowed origin and do not reach a second origin through redirects or child URLs.
+
+### SEC-002: Receiver history and favorites store sensitive replay data unencrypted
+
+**Affected:** Android TV, Apple TV, desktop receiver.
+
+**Risk:** Cast URLs can contain signed query parameters, and authenticated streams
+may include cookies or authorization headers. Local backups, preference files,
+device extraction, another process with access to app data, or diagnostics could
+expose reusable playback credentials. Favorites retain this material longer than
+normal history.
+
+**Evidence:**
+
+- Android TV `HistoryStore.kt` stores the raw playlist payload—including item
+  headers—inside Preferences DataStore as JSON.
+- Apple TV `HistoryStore.swift` encodes URLs and headers directly into
+  `UserDefaults`.
+- Desktop `history_store.dart` stores URLs in `SharedPreferences`; headers are not
+  retained, but signed/authenticated URLs can themselves be secrets.
+
+**Required remediation:**
+
+- Encrypt the sensitive portion of each entry with a platform-backed key.
+- Keep non-sensitive list metadata separate where practical.
+- Preserve the headers needed for replay; do not create broken history entries by
+  silently deleting them.
+- Revalidate URLs and headers under SEC-001 whenever an entry is replayed.
+- Add retention/expiry handling and securely delete encrypted material when an
+  entry or all history is removed.
+- Ensure “clear history” also removes favorites or clearly offers a separate
+  “clear favorites and credentials” action; Android TV currently retains
+  favorites when clearing history.
+
+**Done when:** Raw preference/database files and backups do not reveal full URLs,
+headers, cookies, playlist payloads, or other replay credentials, while valid
+entries still replay successfully.
+
+### SEC-003: URL and header validation is fragmented
+
+**Affected:** All senders and receivers that create or consume playback payloads.
+
+**Risk:** Malformed header names/values, CR/LF injection, hop-by-hop fields,
+userinfo URLs, excessive headers, unsupported schemes, or oversized values may
+reach platform networking libraries and proxies. Results range from credential
+misrouting and request smuggling at protocol boundaries to crashes and resource
+exhaustion.
+
+**Evidence:** Individual paths filter selected fields such as `Host`, `Range`, or
+`Accept-Encoding`, but no common policy enforces header syntax, forbidden fields,
+count/byte limits, URL schemes, userinfo, or redirect revalidation across every
+player, sniffer, subtitle loader, and proxy.
+
+**Required remediation:**
+
+- Define exact maximums and an allow/deny policy in the protocol layer.
+- Validate on the sender for early feedback and again on the receiver as the
+  trust boundary.
+- Reject CR, LF, NUL, invalid names, conflicting duplicates, hop-by-hop headers,
+  proxy credentials, and excessive maps/values.
+- Permit cleartext HTTP media where the TV product requires it, but do not extend
+  that exception to the WSS control channel.
+- Apply validation again after decoding receiver history.
+
+**Done when:** A common malicious-input corpus passes through every platform's
+validator with identical allow/reject results.
+
+## P2 — Medium priority
+
+### SEC-004: Bearer-token storage is inconsistent
+
+**Affected:** Desktop sender, Android TV receiver, Apple TV receiver. Desktop
+receiver is partially compliant because it stores SHA-256 token verifiers.
+
+**Risk:** Theft of an original token permits authentication as the paired sender
+when the attacker can reach the receiver. Ordinary preferences are not a secret
+store and may be exposed through local access or backups.
+
+**Evidence:**
+
+- Desktop `tv_connection_store.dart` serializes the sender token and SPKI pin to
+  `SharedPreferences`.
+- Android TV `PairingStore.kt` stores authorized plaintext token sets and paired
+  device records in Preferences DataStore.
+- Apple TV `WebSocketServer.swift` stores authorized tokens and paired device
+  records, including tokens, in `UserDefaults`.
+- Android phone uses Keystore-backed protection and Apple phone uses Keychain;
+  these are the model for their respective sender platforms.
+
+**Required remediation:**
+
+- Move desktop sender tokens to the OS credential vault/keychain.
+- Store receiver-side token verifiers instead of recoverable tokens where the UI
+  model permits it.
+- If paired-device records need a token association, use a non-secret record ID
+  or verifier, not a second plaintext copy.
+- Migrate legacy records after successful authentication and delete old values.
+
+**Done when:** Preference exports do not contain bearer tokens and legacy values
+are migrated or revoked.
+
+### SEC-005: Desktop and Apple TV echo tokens on successful reauthentication
+
+**Affected:** Desktop receiver and Apple TV receiver; corresponding senders still
+accept optional token refresh fields.
+
+**Risk:** The token is unnecessarily duplicated in response objects and memory,
+increasing exposure to logging, debugging, instrumentation, or future parsing
+mistakes. Pinned WSS prevents passive LAN disclosure, so this is not a control
+channel break, but it violates the minimum-disclosure standard.
+
+**Evidence:**
+
+- Desktop `server.dart` passes the received token to `authResponseJson` after a
+  successful `AuthCmd`.
+- Apple TV `WebSocketServer.swift` inserts `"token": token` into successful
+  reconnect `auth_response` messages.
+- Android TV already returns success, pin, and capabilities without the token.
+
+**Required remediation:** Stop including tokens in reconnect responses and stop
+interpreting `auth_response.token` as a refresh. Token rotation must use a
+separate authenticated protocol operation if introduced later.
+
+**Done when:** Cross-platform reconnect tests assert that `auth_response` never
+contains `token` and existing pairings still reconnect.
+
+### SEC-006: Pre-authentication resource limits are uneven
+
+**Affected:** Primarily Android TV and Apple TV receivers; re-audit desktop when
+limits change.
+
+**Risk:** A LAN peer may hold connections open, create many concurrent sockets,
+send oversized frames/JSON, or repeatedly allocate handshake state, causing UI
+degradation, memory pressure, or receiver unavailability.
+
+**Evidence:** All receivers have some pairing timeout/rate-limit behavior, but
+connection caps, per-IP caps, maximum frame/decoded JSON sizes, auth deadlines,
+and idle deadlines are not defined and enforced uniformly. Desktop has more
+explicit connection/message/handshake bounds than the TV implementations.
+
+**Required remediation:** Define common numeric limits, enforce them before JSON
+allocation where possible, bound pairing maps and lockout maps, and add socket
+tests for slow, oversized, concurrent, and out-of-order clients.
+
+**Done when:** Each receiver passes the same abuse test suite and remains
+responsive under the documented limits.
+
+### SEC-007: Authentication comparisons and token generation need one policy
+
+**Affected:** Receiver implementations.
+
+**Risk:** Direct string/set token comparisons may not be constant-time. UUIDv4
+tokens provide substantial entropy, but the project has no centralized token
+format, entropy, comparison, or verifier migration contract.
+
+**Evidence:** Android TV and Apple TV compare supplied tokens against plaintext
+sets. Desktop computes a SHA-256 verifier, but authorization uses ordinary value
+comparison. Tokens are generally UUIDv4 strings.
+
+**Required remediation:** Define a versioned token format generated from at least
+128 bits of CSPRNG output, store receiver verifiers, compare fixed-length decoded
+verifiers in constant time, and reject malformed lengths before lookup.
+
+**Done when:** All receivers use the same token/verifier rules and unit tests
+cover malformed tokens, revocation, migration, and comparison.
+
+### SEC-008: Security protocol versioning is implicit
+
+**Affected:** All senders and receivers.
+
+**Risk:** Future protocol changes may create ambiguous compatibility behavior or
+pressure developers to add permissive fallbacks. Security properties are harder
+to negotiate and test when support is inferred from missing fields.
+
+**Evidence:** The protected envelope uses a versioned HKDF info string, but the
+pairing/auth message exchange does not provide a single explicit security
+protocol version with minimum-supported-version behavior.
+
+**Required remediation:** Add an authenticated security version/capability,
+define failure behavior for unsupported versions, and prohibit fallback within
+the same connection attempt.
+
+**Done when:** New/new succeeds, unsupported versions fail clearly, and downgrade
+tests prove an attacker cannot select an older security mode.
+
+## P3 — Assurance and hardening
+
+### SEC-009: Shared cryptographic conformance vectors are missing
+
+**Affected:** Android/Kotlin, Apple/Swift, and desktop/Dart implementations.
+
+**Risk:** Each platform can pass isolated tests while disagreeing on transcript
+bytes, base64, HKDF salt semantics, AES-GCM tag layout, SPKI encoding, or JSON
+field handling. Cross-platform drift can cause outages or unsafe compatibility
+patches.
+
+**Required remediation:** Commit language-neutral vectors for X25519 inputs,
+transcript construction, SAS, confirmation MAC, credential key, nonce/AAD,
+ciphertext/tag, decryption, and SPKI pin formatting. Run the same vectors in all
+three language test suites.
+
+**Done when:** Android phone/TV, Apple phone/TV, and desktop sender/receiver tests
+consume the same fixtures in CI.
+
+### SEC-010: Security regression matrix is incomplete
+
+**Affected:** Project-wide CI and release process.
+
+**Risk:** A change can remain internally correct on one platform but break or
+weaken another sender/receiver combination.
+
+**Required remediation:** Add automated or repeatable integration coverage for:
+
+- every supported sender/receiver pairing combination;
+- first pair, reconnect, denial, timeout, malformed envelope, bad MAC, bad AEAD
+  tag, wrong pin, revoked token, and missing token;
+- proof that plaintext `pairing_approved` is rejected;
+- proof that no control-channel `ws://` fallback occurs;
+- SEC-001 cross-origin credential leakage tests;
+- SEC-006 resource-limit tests.
+
+**Done when:** The matrix is a required release check and failures block release.
+
+### SEC-011: Secret logging needs continuous automated checks
+
+**Affected:** All projects.
+
+**Risk:** Existing logging was substantially reduced and redacted, but future
+debugging can reintroduce raw URLs, payloads, tokens, or headers.
+
+**Required remediation:** Add static checks for known unsafe logging patterns and
+runtime tests that inject canary token/cookie/URL values, export diagnostics, and
+assert that the canaries do not appear. Keep logging message type/count rather
+than payload contents.
+
+**Done when:** Canary-secret tests cover receiver logs, sender logs, crash/diagnostic
+exports, and proxy/player logs on every platform.
+
+## Recommended implementation order
+
+1. **SEC-001 and SEC-003 together:** create the shared origin/header policy before
+   adding more replay persistence.
+2. **SEC-002:** encrypt receiver history and favorites while preserving working
+   replay.
+3. **SEC-005:** remove token echo; this is small and independently testable.
+4. **SEC-004 and SEC-007:** migrate token storage and verification consistently.
+5. **SEC-006:** standardize receiver connection, frame, and timeout limits.
+6. **SEC-009 and SEC-010:** establish conformance fixtures and the cross-platform
+   regression matrix.
+7. **SEC-008 and SEC-011:** add explicit versioning and durable logging guardrails.
+
+## Items intentionally not classified as gaps
+
+- Receiver-local history itself is not a vulnerability. The gap is plaintext
+  credential persistence and unsafe replay behavior.
+- TV support for cleartext HTTP media is an explicit product requirement. It
+  must remain isolated from the WSS control channel and must never retain
+  credentials across an HTTPS-to-HTTP downgrade.
+- Sending the bearer token over an already pinned WSS connection is the approved
+  version 1 reauthentication model. An additional application challenge-response
+  exchange is not currently required.
+- Self-signed receiver certificates are acceptable because sender trust is based
+  on the SAS-established SPKI pin, not a public certificate authority.
+
+## Maintenance rule
+
+When a gap is fixed, the implementing change must include tests matching its
+“Done when” condition. Update this file in the same change: remove resolved
+evidence from the active list and record the completion in version control. Do
+not mark an item resolved solely because one platform was fixed.

--- a/docs/SECURITY_STANDARD.md
+++ b/docs/SECURITY_STANDARD.md
@@ -1,0 +1,358 @@
+# PlayBridge Sender and Receiver Security Standard
+
+Status: normative project standard
+
+Version: 1.0
+
+Applies to: Android phone, iOS phone, desktop sender, Android TV, Apple TV,
+desktop receiver, and any future PlayBridge sender or receiver
+
+This document defines the minimum security behavior for PlayBridge control
+connections and media requests. The words **MUST**, **MUST NOT**, **SHOULD**,
+**SHOULD NOT**, and **MAY** are requirements in the sense used by RFC 2119.
+
+Implementation code and the wire-format reference in
+[`protocol/README.md`](../protocol/README.md) remain authoritative for exact
+field names. If an implementation conflicts with this standard, the
+implementation is non-compliant; the conflict must not be resolved by weakening
+this standard or adding an insecure compatibility fallback.
+
+## 1. Security goals and trust boundaries
+
+PlayBridge MUST remain secure on an untrusted local network. Discovery records,
+IP addresses, host names, device display names, QR codes that contain only an
+address, and mDNS TXT fields are untrusted routing hints—not identities.
+
+The design protects against:
+
+- passive LAN monitoring;
+- an active LAN attacker intercepting, changing, replaying, or relaying traffic;
+- an unpaired device sending playback or remote-control commands;
+- credential disclosure through logs, history, favorites, crash reports, or
+  redirects;
+- credentials intended for one media origin being sent to another origin;
+- malformed or oversized pre-authentication input exhausting a receiver.
+
+The design does not claim to protect secrets after the sender or receiver OS is
+fully compromised. A rooted/jailbroken device and a malicious process running as
+the same user are outside the primary threat model.
+
+## 2. Required cryptographic primitives
+
+All implementations MUST use platform cryptographic libraries or a maintained
+cryptographic library. They MUST NOT implement primitives themselves.
+
+| Purpose | Requirement |
+| --- | --- |
+| Control transport | TLS 1.2 or newer; TLS 1.3 preferred |
+| Receiver identity | SHA-256 SPKI pin, encoded as `sha256/<base64>` |
+| Pairing key agreement | X25519 with fresh ephemeral keys |
+| Hash and MAC | SHA-256 and HMAC-SHA-256 |
+| Key derivation | HKDF-SHA-256 (RFC 5869) |
+| Protected pairing credentials | AES-256-GCM with a fresh 96-bit nonce |
+| Random values and tokens | Cryptographically secure random generator |
+
+Cryptographic comparisons of MACs, pins, and token verifiers SHOULD be
+constant-time. Nonces, ephemeral private keys, shared secrets, and derived keys
+MUST be discarded when the handshake ends or times out.
+
+## 3. Receiver discovery and connection
+
+1. A receiver advertises a `wss://` endpoint through local discovery.
+2. A sender treats every discovered address and advertised fingerprint as
+   untrusted until pairing succeeds.
+3. Every control connection MUST use WSS. Plain `ws://` control connections MUST
+   be refused, including fallback after a WSS error.
+4. For a previously paired receiver, the sender MUST validate the TLS
+   certificate against the stored SPKI pin before sending the bearer token or
+   any command.
+5. A pin mismatch MUST terminate the connection and require explicit re-pairing.
+   The sender MUST NOT silently replace the pin with a discovery value or a pin
+   returned by the mismatched peer.
+
+During first pairing, the self-signed TLS connection provides confidentiality
+and basic channel integrity but is not yet the trusted receiver identity. The
+authenticated SAS exchange below establishes that trust.
+
+## 4. First-time pairing
+
+### 4.1 Sender commit
+
+The sender generates a fresh X25519 key pair and 16-byte random `nonceS`, then
+computes:
+
+```text
+commit = SHA-256(senderEphemeralPublicKey || nonceS)
+```
+
+It sends `pairing_commit` containing the base64 commitment and bounded device
+metadata. It MUST retain the private key and nonce only for this handshake.
+
+### 4.2 Receiver challenge
+
+The receiver validates lengths and encoding, applies pairing rate limits, and
+creates a fresh X25519 key pair and 16-byte random `nonceT`. It sends
+`pairing_challenge` containing its public key and nonce.
+
+Only one pending pairing ceremony SHOULD be presented to the receiver user at a
+time. A handshake MUST have a short timeout; 60 seconds is the maximum user
+approval window.
+
+### 4.3 Sender reveal and shared transcript
+
+The sender sends `pairing_reveal` containing its public key and `nonceS`. The
+receiver MUST verify the original commitment before continuing.
+
+Both peers calculate the X25519 shared secret and the byte-exact transcript:
+
+```text
+transcript = commitBytes || receiverEphemeralPublicKey || nonceT
+             || senderEphemeralPublicKey || nonceS
+```
+
+Both peers derive and display the same six-digit SAS from the shared secret and
+transcript. The user MUST confirm that the codes match on the physical sender
+and receiver. A device MUST NOT describe pairing as complete before this user
+confirmation and cryptographic key confirmation succeed.
+
+### 4.4 Key confirmation
+
+Both peers derive:
+
+```text
+prk = HKDF-Extract(salt = empty, IKM = sharedSecret)
+confirmationKey = HKDF-Expand(prk, info = "confirmationKey", length = 32)
+confirmationMac = HMAC-SHA-256(confirmationKey, transcript)
+```
+
+After the user confirms the SAS, the sender sends `pairing_confirmation` with
+`confirmationMac`. The receiver MUST verify it before issuing credentials. A
+denial, mismatch, malformed field, timeout, or disconnect MUST erase handshake
+state and fail closed.
+
+### 4.5 Protected credential delivery
+
+After successful confirmation, the receiver generates a high-entropy,
+receiver-scoped bearer token and derives:
+
+```text
+credentialKey = HKDF-Expand(
+    prk,
+    info = "playbridgeCredentialKey-v1",
+    length = 32
+)
+aad = SHA-256(transcript)
+```
+
+The receiver encrypts a JSON object containing the token, its TLS SPKI pin, and
+capabilities using AES-256-GCM, a fresh 12-byte nonce, and `aad`. It sends only
+the nonce and ciphertext/tag in `pairing_approved`.
+
+The sender MUST authenticate and decrypt this envelope before persisting or
+using any field. A plaintext `token` or `certFingerprint` in
+`pairing_approved` MUST be rejected. There MUST NOT be a plaintext legacy
+fallback, because it creates a downgrade path.
+
+The sender then stores the token and pin as one atomic pairing record. Pairing is
+complete only after that write succeeds. The receiver MUST NOT send the token
+again in any later response.
+
+## 5. Later connections and reauthentication
+
+The following sequence is required for every reconnect:
+
+1. Resolve the receiver address from discovery or saved routing information.
+2. Establish WSS and validate the presented SPKI against the stored pin.
+3. Only after successful pin validation, send `auth` with the saved token.
+4. Until authentication succeeds, the receiver accepts only bounded pairing,
+   authentication, ping, and close traffic. It MUST reject commands and media
+   payloads.
+5. The receiver validates the token and returns `auth_response` with only
+   `success`, current capabilities, and—if retained for consistency checking—the
+   current SPKI pin. It MUST NOT echo the token.
+6. The sender treats the session as authenticated only when `success` is true.
+   A returned pin that differs from the already validated/stored pin is an error,
+   not an automatic rotation instruction.
+
+Sending a high-entropy bearer token inside an already pinned TLS connection is
+the version 1 reauthentication mechanism. Application-level challenge-response
+is not required because it would not replace the need for TLS and pinning. If a
+token is exposed, the pairing MUST be revoked and a new token created.
+
+Tokens MUST be independently generated for each sender/receiver pairing. They
+MUST be revocable individually. Receivers SHOULD store a one-way SHA-256 or
+stronger verifier rather than the plaintext token. Senders require the original
+token and MUST protect it with platform-backed secret storage.
+
+## 6. Certificate and token lifecycle
+
+- A receiver SHOULD retain its TLS key pair across ordinary certificate renewal
+  so the SPKI pin remains stable.
+- Rotating or losing the receiver private key invalidates its identity and MUST
+  require re-pairing. Pin rotation MUST NOT be authorized solely by a message
+  carried over a connection presenting the new, untrusted pin.
+- Unpairing on either device MUST delete the token, pin, device metadata that is
+  no longer needed, and related cached credentials.
+- Receiver reset or “forget all devices” MUST revoke every stored token.
+- Authentication failures SHOULD NOT reveal whether a token, device UUID, or
+  receiver record exists.
+- Tokens MUST never appear in URLs, discovery records, logs, telemetry, crash
+  reports, clipboard contents, or notifications.
+
+Recommended secret storage:
+
+- Android sender: Android Keystore-backed encryption;
+- Apple sender: Keychain with an appropriate device-only accessibility class;
+- desktop sender: the operating system credential vault/keychain;
+- receiver: a platform-protected store; token verifiers are preferred over
+  recoverable tokens.
+
+## 7. Session and receiver hardening
+
+Receivers MUST apply limits before authentication, including:
+
+- maximum concurrent and per-IP connections;
+- maximum WebSocket frame and decoded JSON sizes;
+- bounded strings, arrays, header counts, and playlist sizes;
+- handshake, idle, and authentication timeouts;
+- rate limits and temporary backoff for failed pairing/authentication;
+- one state machine per connection, with no authentication state shared by
+  remote IP or request ordering.
+
+Malformed or out-of-order security messages MUST fail closed. Unknown protocol
+versions MUST NOT trigger a downgrade. Error responses must be generic and must
+not contain secrets or raw attacker-controlled payloads.
+
+Authenticated control does not mean every command is safe. Receivers MUST still
+validate command types, numeric ranges, text lengths, URLs, headers, file paths,
+and resource consumption.
+
+## 8. Media URLs, redirects, headers, and cookies
+
+Media URLs and request headers are sensitive untrusted input even when received
+from an authenticated sender.
+
+### 8.1 Input validation
+
+Senders SHOULD transmit only headers required for playback. Receivers MUST:
+
+- allow only explicitly supported URL schemes (`https` and product-approved
+  `http`; local files only through an explicit local-file feature);
+- reject userinfo in URLs unless a specific feature securely handles it;
+- reject control characters, CR/LF, invalid header names, duplicate conflicting
+  security headers, and excessive header counts or sizes;
+- strip hop-by-hop and transport-controlled fields such as `Host`, `Connection`,
+  `Content-Length`, `Transfer-Encoding`, and proxy authentication fields;
+- keep stream credentials scoped to the individual playback item, never in a
+  global client or host-wide mutable header store.
+
+Android TV's product-approved cleartext media support MAY remain enabled for
+direct and torrent streams. This exception applies to media fetching only, not
+the PlayBridge control channel.
+
+### 8.2 Origin-bound credential forwarding
+
+Credential-bearing headers include at least `Authorization`, `Cookie`,
+`Proxy-Authorization`, API/debrid tokens, and any application-designated secret
+header.
+
+The receiver MUST bind such headers to the original origin: scheme, normalized
+host, and effective port. On every redirect and every derived request—HLS/DASH
+manifests, variants, segments, encryption keys, subtitles, artwork, and proxy
+rewrites—it MUST re-evaluate the destination before attaching credentials.
+
+Credentials MUST NOT cross origins by default. A cross-origin redirect or child
+resource may receive credentials only when the sender supplied an explicit,
+bounded allowlist for that credential set. Redirects MUST have a finite hop
+limit and MUST NOT downgrade HTTPS to HTTP while retaining credentials.
+
+Non-secret compatibility headers such as `User-Agent` or, where required,
+`Referer` MAY follow a separately documented policy; they must not be assumed
+safe merely because they are common.
+
+## 9. Receiver history and favorites
+
+Receiver history is permitted because it enables replay without a sender.
+Authenticated streams may require their original URL, headers, and cookies, so
+silently dropping those fields is not a valid general solution.
+
+If a receiver persists a replayable entry, it MUST:
+
+- encrypt the complete sensitive entry at rest with a non-exportable or
+  platform-protected key;
+- keep display metadata separate where practical so listing history does not
+  decrypt credentials;
+- apply the same URL/header validation and origin policy again on replay;
+- never place decrypted values in logs, UI messages, telemetry, or crash data;
+- delete encrypted credential material when the entry is deleted;
+- provide clear-history and history-disable controls;
+- enforce bounded entry count and retention, and track credential expiry where
+  known;
+- show expired or failed entries as unavailable rather than leaking response
+  details or repeatedly retrying authentication.
+
+Where a provider supports refresh, history and favorites SHOULD store a stable,
+non-secret content identifier and request fresh playback credentials from an
+authorized sender/provider integration. Otherwise, storing encrypted replay
+credentials is acceptable with the limitations above.
+
+Favorites usually live longer than history. Receiver favorites MAY be supported
+only under the same encrypted-storage and credential-lifecycle requirements.
+Until a receiver meets them, favorites containing credentials SHOULD remain
+sender-authoritative.
+
+## 10. Logging, diagnostics, and privacy
+
+Production logs MUST NOT contain:
+
+- pairing or authentication tokens;
+- cookies, authorization values, or complete header maps;
+- complete authenticated/signed media URLs or query strings;
+- shared secrets, keys, nonces combined with secrets, plaintext protected
+  payloads, or raw security frames.
+
+Logs SHOULD record message type, outcome, counts, coarse timing, and a random
+correlation identifier. Redaction is a safety net, not permission to log a
+secret first. Diagnostic export MUST be opt-in, clearly warn the user, and apply
+redaction again at export time.
+
+## 11. Compatibility and protocol evolution
+
+Security-relevant protocol changes MUST have an explicit version or capability
+and must fail closed. A peer that cannot perform protected SAS pairing, WSS pin
+validation, or the required authentication flow is incompatible and must be
+upgraded or re-paired; it must not be accommodated with plaintext fallback.
+
+All cryptographic changes MUST include shared byte-level test vectors for
+transcript construction, HKDF outputs, SAS, confirmation MAC, SPKI formatting,
+and AES-GCM credential envelopes. Android, Apple, and Dart implementations MUST
+pass the same vectors. Cross-version tests SHOULD cover every supported
+sender/receiver combination.
+
+## 12. Compliance checklist
+
+A sender is compliant only if it:
+
+- uses WSS, pins every known receiver before disclosing the token, and fails on
+  pin mismatch;
+- performs the complete SAS and confirmation flow for first pairing;
+- accepts credentials only from the authenticated AEAD envelope;
+- stores the token and pin in platform-protected storage;
+- never sends commands before successful authentication;
+- validates outgoing URL/header data and does not log secrets.
+
+A receiver is compliant only if it:
+
+- exposes the control protocol only over WSS;
+- performs the complete bounded SAS pairing state machine;
+- protects first-pair credentials with the specified AEAD envelope;
+- authenticates every later connection before accepting commands and never
+  echoes tokens;
+- protects token verifiers, TLS keys, history credentials, and favorites at
+  rest;
+- applies pre-authentication resource limits and origin-bound header forwarding;
+- provides revocation and deletion controls and does not log secrets.
+
+Release review MUST verify these requirements separately for every sender and
+receiver project. Passing on one platform does not establish compliance on
+another.

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/VideoDetector.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/VideoDetector.kt
@@ -235,7 +235,7 @@ object VideoDetector {
                     val existing = videos[existingIndex]
                     // If we have new headers, update them
                     if (headers != null && headers.isNotEmpty()) {
-                        Log.i(TAG, "Updating headers for video in tab $kotlinTabId: $url")
+                        Log.i(TAG, "Updating ${headers.size} header(s) for video in tab $kotlinTabId")
                         videos[existingIndex] = existing.copy(
                             headers = headers,
                             originUrl = message["originUrl"]?.jsonPrimitive?.content ?: existing.originUrl,
@@ -257,7 +257,7 @@ object VideoDetector {
                     originalMessage = message.toString()
                 )
 
-                Log.i(TAG, "VIDEO DETECTED in tab $kotlinTabId: ${video.url}")
+                Log.i(TAG, "VIDEO DETECTED in tab $kotlinTabId")
                 Log.i(TAG, "  Type: ${video.contentType ?: "N/A"}")
                 Log.i(TAG, "  Header Count: ${video.headers?.size ?: 0}")
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionStore.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionStore.kt
@@ -1,6 +1,9 @@
 package com.playbridge.sender.connection
 
 import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.*
 import androidx.datastore.preferences.preferencesDataStore
@@ -9,6 +12,11 @@ import com.playbridge.shared.protocol.protocolJson
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "connection_store")
 
@@ -19,7 +27,9 @@ class ConnectionStore(private val context: Context) {
 
     companion object {
         private val TV_DEVICE = stringPreferencesKey("tv_device")
-                private val DEVICE_HISTORY = stringPreferencesKey("device_history")
+        private val DEVICE_HISTORY = stringPreferencesKey("device_history")
+        private const val KEY_ALIAS = "playbridge_connection_tokens_v1"
+        private const val ENCRYPTED_PREFIX = "enc:v1:"
     }
 
     /**
@@ -28,7 +38,7 @@ class ConnectionStore(private val context: Context) {
     val tvDevice: Flow<TvDevice?> = context.dataStore.data.map { prefs ->
         prefs[TV_DEVICE]?.let {
             try {
-                protocolJson.decodeFromString<TvDevice>(it)
+                unprotect(protocolJson.decodeFromString<TvDevice>(it))
             } catch (e: Exception) {
                 null
             }
@@ -41,7 +51,7 @@ class ConnectionStore(private val context: Context) {
     val deviceHistory: Flow<List<TvDevice>> = context.dataStore.data.map { prefs ->
         prefs[DEVICE_HISTORY]?.let {
             try {
-                protocolJson.decodeFromString<List<TvDevice>>(it)
+                decodeHistory(it)
             } catch (e: Exception) {
                 emptyList()
             }
@@ -53,7 +63,7 @@ class ConnectionStore(private val context: Context) {
      */
     suspend fun saveTvDevice(device: TvDevice) {
         context.dataStore.edit { prefs ->
-            prefs[TV_DEVICE] = protocolJson.encodeToString(TvDevice.serializer(), device)
+            prefs[TV_DEVICE] = protocolJson.encodeToString(TvDevice.serializer(), protect(device))
         }
     }
 
@@ -68,7 +78,7 @@ class ConnectionStore(private val context: Context) {
             val historyJson = prefs[DEVICE_HISTORY]
             val currentHistory = if (historyJson != null) {
                 try {
-                    protocolJson.decodeFromString<List<TvDevice>>(historyJson)
+                    decodeHistory(historyJson)
                 } catch (e: Exception) {
                     emptyList()
                 }
@@ -84,7 +94,7 @@ class ConnectionStore(private val context: Context) {
 
             prefs[DEVICE_HISTORY] = protocolJson.encodeToString(
                 kotlinx.serialization.builtins.ListSerializer(TvDevice.serializer()),
-                newHistory
+                newHistory.map(::protect)
             )
         }
     }
@@ -98,7 +108,7 @@ class ConnectionStore(private val context: Context) {
         context.dataStore.edit { prefs ->
             val historyJson = prefs[DEVICE_HISTORY] ?: return@edit
             val currentHistory = try {
-                protocolJson.decodeFromString<List<TvDevice>>(historyJson)
+                decodeHistory(historyJson)
             } catch (e: Exception) {
                 return@edit
             }
@@ -112,7 +122,7 @@ class ConnectionStore(private val context: Context) {
 
             prefs[DEVICE_HISTORY] = protocolJson.encodeToString(
                 kotlinx.serialization.builtins.ListSerializer(TvDevice.serializer()),
-                newHistory
+                newHistory.map(::protect)
             )
         }
     }
@@ -124,7 +134,7 @@ class ConnectionStore(private val context: Context) {
         context.dataStore.edit { prefs ->
             val historyJson = prefs[DEVICE_HISTORY] ?: return@edit
             val currentHistory = try {
-                protocolJson.decodeFromString<List<TvDevice>>(historyJson)
+                decodeHistory(historyJson)
             } catch (e: Exception) {
                 emptyList()
             }
@@ -133,7 +143,7 @@ class ConnectionStore(private val context: Context) {
 
             prefs[DEVICE_HISTORY] = protocolJson.encodeToString(
                 kotlinx.serialization.builtins.ListSerializer(TvDevice.serializer()),
-                newHistory
+                newHistory.map(::protect)
             )
         }
     }
@@ -152,5 +162,55 @@ class ConnectionStore(private val context: Context) {
      */
     suspend fun hasTvDevice(): Boolean {
         return context.dataStore.data.first()[TV_DEVICE] != null
+    }
+
+    private fun decodeHistory(json: String): List<TvDevice> =
+        protocolJson.decodeFromString<List<TvDevice>>(json).map(::unprotect)
+
+    private fun protect(device: TvDevice): TvDevice =
+        if (device.token.isEmpty() || device.token.startsWith(ENCRYPTED_PREFIX)) device
+        else device.copy(token = encryptToken(device.token))
+
+    private fun unprotect(device: TvDevice): TvDevice =
+        if (!device.token.startsWith(ENCRYPTED_PREFIX)) device
+        else device.copy(token = decryptToken(device.token))
+
+    private fun encryptToken(token: String): String {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
+        val packed = cipher.iv + cipher.doFinal(token.toByteArray(Charsets.UTF_8))
+        return ENCRYPTED_PREFIX + Base64.encodeToString(packed, Base64.NO_WRAP)
+    }
+
+    private fun decryptToken(value: String): String = try {
+        val packed = Base64.decode(value.removePrefix(ENCRYPTED_PREFIX), Base64.NO_WRAP)
+        require(packed.size > 12)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(
+            Cipher.DECRYPT_MODE,
+            getOrCreateKey(),
+            GCMParameterSpec(128, packed.copyOfRange(0, 12)),
+        )
+        cipher.doFinal(packed.copyOfRange(12, packed.size)).toString(Charsets.UTF_8)
+    } catch (_: Exception) {
+        // Restored backups cannot use the old device-bound key; require re-pairing.
+        ""
+    }
+
+    private fun getOrCreateKey(): SecretKey {
+        val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        (keyStore.getKey(KEY_ALIAS, null) as? SecretKey)?.let { return it }
+        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+        generator.init(
+            KeyGenParameterSpec.Builder(
+                KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setRandomizedEncryptionRequired(true)
+                .build()
+        )
+        return generator.generateKey()
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
@@ -243,7 +243,7 @@ class WebSocketClient {
                         } else {
                             // Reconnect with saved token.
                             val authJson = createAuthJson(conn!!.token)
-                            Log.d(TAG, "Sending auth: $authJson")
+                            Log.d(TAG, "Sending auth credentials")
                             webSocket.send(authJson)
                             delay(500)
                             sendPing()
@@ -314,9 +314,35 @@ class WebSocketClient {
                     try {
                         val json = kotlinx.serialization.json.Json.parseToJsonElement(text)
                         if (json is JsonObject && json["type"]?.toString()?.replace("\"", "") == "pairing_approved") {
-                            val token = json["token"]?.toString()?.replace("\"", "")
-                            val certFp = json["certFingerprint"]?.toString()?.replace("\"", "")
-                                ?.takeIf { it.isNotEmpty() && it != "null" }
+                            val shared = sharedSecret ?: error("Missing pairing shared secret")
+                            val commit = commitStr ?: error("Missing pairing commitment")
+                            val tvPub = tvEphPub ?: error("Missing receiver public key")
+                            val receiverNonce = nonceT ?: error("Missing receiver nonce")
+                            val keypair = senderKeyPair ?: error("Missing sender keypair")
+                            val senderNonce = nonceS ?: error("Missing sender nonce")
+                            val transcript = Base64.getDecoder().decode(commit) + tvPub + receiverNonce +
+                                keypair.publicKey + senderNonce
+                            val transcriptHash = SasCrypto.sha256(transcript)
+                            val prk = SasCrypto.hkdfExtract(salt = null, ikm = shared)
+                            val credentialKey = SasCrypto.hkdfExpand(
+                                prk,
+                                info = "playbridgeCredentialKey-v1".toByteArray(),
+                                length = 32,
+                            )
+                            val nonce = Base64.getDecoder().decode(
+                                json["nonce"]?.jsonPrimitive?.contentOrNull ?: error("Missing credential nonce")
+                            )
+                            val ciphertext = Base64.getDecoder().decode(
+                                json["ciphertext"]?.jsonPrimitive?.contentOrNull ?: error("Missing credentials")
+                            )
+                            val credentialsJson = Json.parseToJsonElement(
+                                SasCrypto.aesGcmDecrypt(
+                                    credentialKey, nonce, ciphertext, transcriptHash
+                                ).decodeToString()
+                            ) as? JsonObject ?: error("Invalid credential payload")
+                            val token = credentialsJson["token"]?.jsonPrimitive?.contentOrNull
+                            val certFp = credentialsJson["certFingerprint"]?.jsonPrimitive?.contentOrNull
+                                ?.takeIf { it.isNotEmpty() }
                             Log.i(TAG, "Pairing approved by $serverName")
                             // Bind the delivered pin to the cert actually served this handshake.
                             val served = capturedServerPin
@@ -335,7 +361,7 @@ class WebSocketClient {
                                 targetConnection = targetConnection?.copy(token = token, pin = pin)
                                 scope.launch { _newCredentials.emit(IssuedCredentials(token, pin)) }
                             }
-                            emitCapabilities(json)
+                            emitCapabilities(credentialsJson)
                             clearPairingSecrets() // handshake done — drop key material
                             _connectionState.value = ConnectionState.Connected(serverName, isSecure)
                             // Resync: the TV only broadcasts context on its own activity
@@ -345,7 +371,11 @@ class WebSocketClient {
                             return
                         }
                     } catch (e: Exception) {
-                        Log.e(TAG, "Error parsing pairing_approved", e)
+                        Log.e(TAG, "Invalid or unauthenticated pairing credentials", e)
+                        isUserDisconnect = true
+                        _connectionState.value = ConnectionState.Error("Pairing security verification failed")
+                        webSocket.close(1008, "Invalid pairing credentials")
+                        return
                     }
                 }
 

--- a/mobile/apple/PlayBridge Phone/PlayBridge Phone/Network/SasCrypto.swift
+++ b/mobile/apple/PlayBridge Phone/PlayBridge Phone/Network/SasCrypto.swift
@@ -77,4 +77,16 @@ enum SasCrypto {
         _ = SecRandomCopyBytes(kSecRandomDefault, size, &bytes)
         return Data(bytes)
     }
+
+    static func aesGcmDecrypt(key: Data, nonce: Data, ciphertext: Data, aad: Data) throws -> Data {
+        guard key.count == 32, nonce.count == 12, ciphertext.count >= 16 else {
+            throw CocoaError(.coderInvalidValue)
+        }
+        let box = try AES.GCM.SealedBox(
+            nonce: AES.GCM.Nonce(data: nonce),
+            ciphertext: ciphertext.dropLast(16),
+            tag: ciphertext.suffix(16)
+        )
+        return try AES.GCM.open(box, using: SymmetricKey(data: key), authenticating: aad)
+    }
 }

--- a/mobile/apple/PlayBridge Phone/PlayBridge Phone/Network/WebSocketClient.swift
+++ b/mobile/apple/PlayBridge Phone/PlayBridge Phone/Network/WebSocketClient.swift
@@ -337,8 +337,36 @@ final class WebSocketClient: NSObject, ObservableObject {
 
     private func handlePairingApproved(_ json: [String: Any]) {
         let serverName = target?.serverName ?? ""
-        let token = (json["token"] as? String) ?? ""
-        let certFp = (json["certFingerprint"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        guard let keyPair = senderKeyPair, let senderNonce = nonceS,
+              let commit = commitStr, let commitBytes = Data(base64Encoded: commit),
+              let tvPub = tvEphPub, let receiverNonce = nonceT, let shared = sharedSecret,
+              let nonceB64 = json["nonce"] as? String, let nonce = Data(base64Encoded: nonceB64),
+              let ciphertextB64 = json["ciphertext"] as? String,
+              let ciphertext = Data(base64Encoded: ciphertextB64) else {
+            failPairingSecurity(serverName)
+            return
+        }
+        let transcript = pairingTranscript(
+            commitBytes: commitBytes, tvEphPub: tvPub, nonceT: receiverNonce,
+            senderEphPub: keyPair.publicKeyBytes, nonceS: senderNonce
+        )
+        let transcriptHash = SasCrypto.sha256(transcript)
+        let prk = SasCrypto.hkdfExtract(salt: nil, ikm: shared)
+        let credentialKey = SasCrypto.hkdfExpand(
+            prk: prk, info: "playbridgeCredentialKey-v1".data(using: .utf8), length: 32
+        )
+        guard let plaintext = try? SasCrypto.aesGcmDecrypt(
+                  key: credentialKey, nonce: nonce, ciphertext: ciphertext, aad: transcriptHash),
+              let object = try? JSONSerialization.jsonObject(with: plaintext),
+              let credentials = object as? [String: Any] else {
+            failPairingSecurity(serverName)
+            return
+        }
+        guard let token = credentials["token"] as? String, !token.isEmpty else {
+            failPairingSecurity(serverName)
+            return
+        }
+        let certFp = (credentials["certFingerprint"] as? String).flatMap { $0.isEmpty ? nil : $0 }
 
         // Bind the delivered pin to the cert actually served this handshake.
         if let certFp, let served = capturedServerPin, certFp != served {
@@ -348,15 +376,31 @@ final class WebSocketClient: NSObject, ObservableObject {
             task?.cancel(with: .normalClosure, reason: nil)
             return
         }
-        if !token.isEmpty {
-            let pin = certFp ?? capturedServerPin
-            target?.token = token
-            target?.pin = pin
-            onCredentials?(IssuedCredentials(token: token, certFingerprint: pin))
-        }
-        emitCapabilities(json)
+        let pin = certFp ?? capturedServerPin
+        target?.token = token
+        target?.pin = pin
+        onCredentials?(IssuedCredentials(token: token, certFingerprint: pin))
+        emitCapabilities(credentials)
+        clearPairingSecrets()
         setState(.connected(serverName: serverName, secure: isSecure))
         startPing()
+    }
+
+    private func failPairingSecurity(_ serverName: String) {
+        isUserDisconnect = true
+        clearPairingSecrets()
+        setState(.error(message: "Pairing security verification failed"))
+        task?.cancel(with: .policyViolation, reason: nil)
+    }
+
+    private func clearPairingSecrets() {
+        senderKeyPair = nil
+        nonceS = nil
+        commitStr = nil
+        tvEphPub = nil
+        nonceT = nil
+        sharedSecret = nil
+        calculatedSas = nil
     }
 
     private func handleAuthResponse(_ json: [String: Any]) {

--- a/shared/src/androidMain/kotlin/com/playbridge/shared/crypto/SasCrypto.kt
+++ b/shared/src/androidMain/kotlin/com/playbridge/shared/crypto/SasCrypto.kt
@@ -3,6 +3,8 @@ package com.playbridge.shared.crypto
 import java.security.MessageDigest
 import java.security.SecureRandom
 import javax.crypto.Mac
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
 import org.bouncycastle.crypto.generators.X25519KeyPairGenerator
 import org.bouncycastle.crypto.params.X25519KeyGenerationParameters
@@ -114,5 +116,24 @@ object SasCrypto {
         val nonce = ByteArray(size)
         SecureRandom().nextBytes(nonce)
         return nonce
+    }
+
+    /** Decrypt AES-256-GCM ciphertext whose final 16 bytes are the authentication tag. */
+    fun aesGcmDecrypt(key: ByteArray, nonce: ByteArray, ciphertext: ByteArray, aad: ByteArray): ByteArray {
+        require(key.size == 32) { "AES-256 key must be 32 bytes" }
+        require(nonce.size == 12) { "GCM nonce must be 12 bytes" }
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "AES"), GCMParameterSpec(128, nonce))
+        cipher.updateAAD(aad)
+        return cipher.doFinal(ciphertext)
+    }
+
+    fun aesGcmEncrypt(key: ByteArray, nonce: ByteArray, plaintext: ByteArray, aad: ByteArray): ByteArray {
+        require(key.size == 32) { "AES-256 key must be 32 bytes" }
+        require(nonce.size == 12) { "GCM nonce must be 12 bytes" }
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"), GCMParameterSpec(128, nonce))
+        cipher.updateAAD(aad)
+        return cipher.doFinal(plaintext)
     }
 }

--- a/shared/src/androidMain/kotlin/com/playbridge/shared/player/ExoPlayerEngine.kt
+++ b/shared/src/androidMain/kotlin/com/playbridge/shared/player/ExoPlayerEngine.kt
@@ -156,7 +156,7 @@ class ExoPlayerEngine(private val context: Context) : PlaybackEngine {
             ?: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, ignoreCase = true) Chrome/120.0.0.0 Safari/537.36"
         requestProperties["User-Agent"] = userAgent
 
-        logger.i(TAG, "Final Request Headers: $requestProperties")
+        logger.i(TAG, "Prepared ${requestProperties.size} request header(s)")
 
         // Network stack:
         // 1. Browser-captured streams (detectedBy is not null) use the legacy DefaultHttpDataSource for live stream compatibility.

--- a/shared/src/androidMain/kotlin/com/playbridge/shared/player/MpvPlayerEngine.kt
+++ b/shared/src/androidMain/kotlin/com/playbridge/shared/player/MpvPlayerEngine.kt
@@ -270,7 +270,7 @@ class MpvPlayerEngine(private val context: Context) : PlaybackEngine, MPVLib.Eve
             .entries
             .joinToString(",") { "${it.key}: ${it.value.replace("\\", "\\\\").replace(",", "\\,")}" }
         if (headerString.isNotEmpty()) {
-            logger.d(TAG, "Setting http-header-fields: $headerString")
+            logger.d(TAG, "Setting ${payload.headers.size} HTTP header field(s)")
             MPVLib.setOptionString("http-header-fields", headerString)
         }
 

--- a/shared/src/androidMain/kotlin/com/playbridge/shared/protocol/IncomingMessage.kt
+++ b/shared/src/androidMain/kotlin/com/playbridge/shared/protocol/IncomingMessage.kt
@@ -274,18 +274,11 @@ fun createPairingConfirmationJson(mac: String): String =
         PairingConfirmationMessage(type = "pairing_confirmation", mac = mac)
     )
 
-fun createPairingApprovedJson(
-    token: String,
-    certFingerprint: String? = null,
-    players: List<String> = emptyList(),
-    browsers: List<String> = emptyList(),
-): String =
+fun createProtectedPairingApprovedJson(nonce: String, ciphertext: String): String =
     buildJsonObject {
         put("type", "pairing_approved")
-        put("token", token)
-        if (certFingerprint != null) put("certFingerprint", certFingerprint)
-        if (players.isNotEmpty()) put("players", buildJsonArray { players.forEach { add(it) } })
-        if (browsers.isNotEmpty()) put("browsers", buildJsonArray { browsers.forEach { add(it) } })
+        put("nonce", nonce)
+        put("ciphertext", ciphertext)
     }.toString()
 
 fun createPairingDeniedJson(): String = """{"type":"pairing_denied"}"""

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ContentSniffer.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ContentSniffer.kt
@@ -108,7 +108,7 @@ class ContentSniffer {
                         requestBuilder.header(key, value)
                     }
                     val finalRequest = requestBuilder.build()
-                    Log.d("OkHttpInterceptor", "Intercepted request to $url with headers: ${finalRequest.headers}")
+                    Log.d("OkHttpInterceptor", "Prepared request with ${finalRequest.headers.size} header(s)")
                     chain.proceed(finalRequest)
                 }
             }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
@@ -845,7 +845,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
         FileLogger.i(TAG, "========== PLAY COMMAND RECEIVED ==========")
         FileLogger.i(TAG, "URL: $url")
         FileLogger.i(TAG, "Title: ${controlsViewModel.getTitle()}")
-        FileLogger.i(TAG, "Headers: $headers")
+        FileLogger.i(TAG, "Request headers: ${headers?.size ?: 0} field(s)")
         FileLogger.i(TAG, "Start Paused: $startPaused")
         FileLogger.i(TAG, "===========================================")
 

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/WebSocketServer.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/WebSocketServer.kt
@@ -3,7 +3,7 @@ package com.playbridge.player.server
 import android.util.Log
 import com.playbridge.shared.protocol.IncomingMessage
 import com.playbridge.shared.protocol.createAuthResponseJson
-import com.playbridge.shared.protocol.createPairingApprovedJson
+import com.playbridge.shared.protocol.createProtectedPairingApprovedJson
 import com.playbridge.shared.protocol.createPairingDeniedJson
 import com.playbridge.shared.protocol.createPairingChallengeJson
 import com.playbridge.shared.protocol.createPongJson
@@ -26,6 +26,10 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.put
 
 private const val TAG = "WebSocketServer"
 
@@ -462,7 +466,25 @@ class WebSocketServer(
                         val token = onPairingApproved(handshake.deviceName, handshake.deviceUUID)
                         val caps = capabilities()
                         if (conn.isOpen) {
-                            conn.send(createPairingApprovedJson(token, certFingerprint, caps.players, caps.browsers))
+                            val transcriptHash = SasCrypto.sha256(transcript)
+                            val prk = SasCrypto.hkdfExtract(salt = null, ikm = sharedSecret)
+                            val credentialKey = SasCrypto.hkdfExpand(
+                                prk, info = "playbridgeCredentialKey-v1".toByteArray(), length = 32
+                            )
+                            val credentialNonce = SasCrypto.generateNonce(12)
+                            val plaintext = buildJsonObject {
+                                put("token", token)
+                                certFingerprint?.let { put("certFingerprint", it) }
+                                put("players", buildJsonArray { caps.players.forEach { add(it) } })
+                                put("browsers", buildJsonArray { caps.browsers.forEach { add(it) } })
+                            }.toString().toByteArray()
+                            val ciphertext = SasCrypto.aesGcmEncrypt(
+                                credentialKey, credentialNonce, plaintext, transcriptHash
+                            )
+                            conn.send(createProtectedPairingApprovedJson(
+                                Base64.getEncoder().encodeToString(credentialNonce),
+                                Base64.getEncoder().encodeToString(ciphertext),
+                            ))
                         }
                         registerAuthed(conn)
                         inProgressHandshakes.remove(conn)

--- a/tv/android/player/app/src/test/java/com/playbridge/player/protocol/ProtocolJsonTest.kt
+++ b/tv/android/player/app/src/test/java/com/playbridge/player/protocol/ProtocolJsonTest.kt
@@ -1,7 +1,7 @@
 package com.playbridge.player.protocol
 
 import com.playbridge.shared.protocol.createAuthResponseJson
-import com.playbridge.shared.protocol.createPairingApprovedJson
+import com.playbridge.shared.protocol.createProtectedPairingApprovedJson
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -17,17 +17,12 @@ class ProtocolJsonTest {
     private fun obj(json: String) = Json.parseToJsonElement(json).jsonObject
 
     @Test
-    fun pairingApprovedIncludesCertFingerprintWhenPresent() {
-        val o = obj(createPairingApprovedJson("tok", "sha256/abc"))
+    fun pairingApprovedContainsOnlyProtectedCredentialEnvelope() {
+        val o = obj(createProtectedPairingApprovedJson("nonce-b64", "ciphertext-b64"))
         assertEquals("pairing_approved", o["type"]?.jsonPrimitive?.content)
-        assertEquals("tok", o["token"]?.jsonPrimitive?.content)
-        assertEquals("sha256/abc", o["certFingerprint"]?.jsonPrimitive?.content)
-    }
-
-    @Test
-    fun pairingApprovedOmitsCertFingerprintWhenNull() {
-        val o = obj(createPairingApprovedJson("tok"))
-        assertEquals("tok", o["token"]?.jsonPrimitive?.content)
+        assertEquals("nonce-b64", o["nonce"]?.jsonPrimitive?.content)
+        assertEquals("ciphertext-b64", o["ciphertext"]?.jsonPrimitive?.content)
+        assertNull(o["token"])
         assertNull(o["certFingerprint"])
     }
 
@@ -68,22 +63,6 @@ class ProtocolJsonTest {
         val o = obj(createAuthResponseJson(success = true))
         assertNull(o["players"])
         assertNull(o["browsers"])
-    }
-
-    @Test
-    fun pairingApprovedIncludesCapabilitiesAndOmitsGeckoWhenNotInstalled() {
-        // The browsers list models a TV without the GeckoView plugin: webview only.
-        val o = obj(createPairingApprovedJson(
-            token = "tok",
-            players = listOf("exo", "mpv"),
-            browsers = listOf("webview"),
-        ))
-        assertEquals("tok", o["token"]?.jsonPrimitive?.content)
-        assertEquals(
-            listOf("exo", "mpv"),
-            o["players"]?.jsonArray?.map { it.jsonPrimitive.content }
-        )
-        assertEquals(listOf("webview"), o["browsers"]?.jsonArray?.map { it.jsonPrimitive.content })
     }
 
     @Test

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/SasCrypto.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/SasCrypto.swift
@@ -85,4 +85,20 @@ enum SasCrypto {
         _ = SecRandomCopyBytes(kSecRandomDefault, size, &bytes)
         return Data(bytes)
     }
+
+    /// AES-256-GCM ciphertext followed by the 16-byte authentication tag.
+    static func aesGcmEncrypt(key: Data, nonce: Data, plaintext: Data, aad: Data) throws -> Data {
+        guard key.count == 32, nonce.count == 12 else {
+            throw CocoaError(.coderInvalidValue)
+        }
+        let sealed = try AES.GCM.seal(
+            plaintext,
+            using: SymmetricKey(data: key),
+            nonce: AES.GCM.Nonce(data: nonce),
+            authenticating: aad
+        )
+        var result = sealed.ciphertext
+        result.append(sealed.tag)
+        return result
+    }
 }

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/VLCProxyServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/VLCProxyServer.swift
@@ -66,7 +66,7 @@ class ProxySessionManager: NSObject, URLSessionDataDelegate {
 
         print("[Proxy] T\(task.taskIdentifier) upstream request: \(request.httpMethod ?? "GET") \(request.url?.absoluteString ?? "?")")
         if let headers = request.allHTTPHeaderFields, !headers.isEmpty {
-            print("[Proxy] T\(task.taskIdentifier) request headers: \(headers)")
+            print("[Proxy] T\(task.taskIdentifier) request headers: \(headers.count) field(s)")
         }
 
         // Watch for VLC closing its end of the connection. Capture only the
@@ -555,7 +555,7 @@ class VLCProxyServer {
                 switch k.lowercased() {
                 case "range", "accept-encoding", "accept":
                     urlRequest.setValue(v, forHTTPHeaderField: k)
-                    print("[Proxy] Forwarding VLC header: \(k): \(v)")
+                    print("[Proxy] Forwarding VLC header: \(k)")
                 default: break
                 }
             }

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
@@ -608,17 +608,60 @@ class WebSocketServer: ObservableObject {
         )
         savePairedDevice(device)
 
-        var approved: [String: Any] = ["type": "pairing_approved", "token": token]
-        if let fp = certFingerprint { approved["certFingerprint"] = fp }
-        approved["players"] = Self.capabilityPlayers
-        send(json: approved, to: connection)
+        guard let commitBytes = Data(base64Encoded: handshake.commit),
+              let senderEphPub = handshake.senderEphPub,
+              let nonceS = handshake.nonceS,
+              let sharedSecret = handshake.sharedSecret else {
+            send(json: ["type": "pairing_denied"], to: connection)
+            removeConnection(connection)
+            return
+        }
+        var transcript = Data()
+        transcript.append(commitBytes)
+        transcript.append(handshake.tvEphPub)
+        transcript.append(handshake.nonceT)
+        transcript.append(senderEphPub)
+        transcript.append(nonceS)
+
+        do {
+            let transcriptHash = SasCrypto.sha256(transcript)
+            let prk = SasCrypto.hkdfExtract(salt: nil, ikm: sharedSecret)
+            let credentialKey = SasCrypto.hkdfExpand(
+                prk: prk,
+                info: "playbridgeCredentialKey-v1".data(using: .utf8),
+                length: 32
+            )
+            let credentialNonce = SasCrypto.generateNonce(size: 12)
+            var credentials: [String: Any] = [
+                "token": token,
+                "players": Self.capabilityPlayers,
+            ]
+            if let fp = certFingerprint { credentials["certFingerprint"] = fp }
+            let plaintext = try JSONSerialization.data(withJSONObject: credentials)
+            let ciphertext = try SasCrypto.aesGcmEncrypt(
+                key: credentialKey,
+                nonce: credentialNonce,
+                plaintext: plaintext,
+                aad: transcriptHash
+            )
+            send(json: [
+                "type": "pairing_approved",
+                "nonce": credentialNonce.base64EncodedString(),
+                "ciphertext": ciphertext.base64EncodedString(),
+            ], to: connection)
+        } catch {
+            print("[server] Failed to protect pairing credentials")
+            send(json: ["type": "pairing_denied"], to: connection)
+            removeConnection(connection)
+            return
+        }
         
         let ip = getIPAddress(from: connection)
         failedAttempts.removeValue(forKey: ip)
         lockoutUntil.removeValue(forKey: ip)
         
         inProgressHandshakes.removeValue(forKey: ObjectIdentifier(connection))
-        completeAuth(from: connection, token: token)
+        completeAuth(from: connection, token: token, sendAuthResponse: false)
         pendingPairingRequest = nil
     }
 
@@ -702,15 +745,22 @@ class WebSocketServer: ObservableObject {
         }
     }
 
-    private func completeAuth(from connection: NWConnection, token: String) {
+    private func completeAuth(
+        from connection: NWConnection,
+        token: String,
+        sendAuthResponse: Bool = true
+    ) {
         DispatchQueue.main.async {
             self.isAuthenticated = true
             self.connectedConnections.append(connection)
             self.connectedCount = self.connectedConnections.count
-            var response: [String: Any] = ["type": "auth_response", "success": true, "token": token]
-            if let fp = self.certFingerprint { response["certFingerprint"] = fp }
-            response["players"] = Self.capabilityPlayers
-            self.send(json: response, to: connection)
+            if sendAuthResponse {
+                // Safe on reconnect: the sender has already pinned this TLS identity.
+                var response: [String: Any] = ["type": "auth_response", "success": true, "token": token]
+                if let fp = self.certFingerprint { response["certFingerprint"] = fp }
+                response["players"] = Self.capabilityPlayers
+                self.send(json: response, to: connection)
+            }
             // Re-sync now-playing for a client that connected mid-playback: context + a nudge
             // for the active player to re-broadcast its status/tracks.
             self.broadcast(["type": "context", "active": self.currentPlayRequest != nil ? "player" : "idle"])


### PR DESCRIPTION
## Summary

- protect first-pairing credentials with transcript-bound AES-256-GCM across Android, Apple, and desktop
- harden token storage, receiver limits, certificate permissions, and secret-safe logging
- document the security standard and remaining security backlog
- add crypto and log-redaction coverage

## Verification

- `flutter test`
- `flutter analyze`
- `zsh -c "source ~/.zshrc && ./gradlew :app:testFossDebugUnitTest"` from `mobile/android`
- `zsh -c "source ~/.zshrc && ./gradlew test"` from `tv/android`
- `npm run build` from `extension` (extension changes are not included in this PR)

## Manual verification

- Apple projects were reviewed but not compiled in this environment
- cross-platform pairing should be exercised between each sender/receiver combination
