### PR TITLE
feat(extension): add on-video cast overlay

### DIFF
--- a/extension/build.mjs
+++ b/extension/build.mjs
@@ -10,7 +10,7 @@ const TARGETS = [
   { name: "chrome", manifest: "manifests/chrome.json", outDir: "dist/chrome" },
 ];
 
-const entryPoints = ["src/background.ts", "src/ui/popup.ts"];
+const entryPoints = ["src/background.ts", "src/content.ts", "src/ui/popup.ts"];
 
 const sharedOpts = {
   bundle: true,

--- a/extension/manifests/chrome.json
+++ b/extension/manifests/chrome.json
@@ -15,6 +15,15 @@
     "default_popup": "ui/popup.html",
     "default_icon": "icon.png"
   },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "all_frames": true,
+      "match_about_blank": true,
+      "run_at": "document_idle"
+    }
+  ],
   "permissions": [
     "webRequest",
     "webRequestExtraHeaders",

--- a/extension/manifests/firefox.json
+++ b/extension/manifests/firefox.json
@@ -15,6 +15,15 @@
         "default_popup": "ui/popup.html",
         "default_icon": "icon.png"
     },
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "js": ["content.js"],
+            "all_frames": true,
+            "match_about_blank": true,
+            "run_at": "document_idle"
+        }
+    ],
     "permissions": [
         "webRequest",
         "webRequestBlocking",

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -41,6 +41,8 @@ interface VideoData {
   detectedBy: string;
   originUrl: string;
   timestamp: number;
+  /** webRequest frame id when known; older session records may omit this. */
+  frameId?: number;
   headers?: Record<string, string>;
   subtitles?: string[];
   subtitlePreview?: string;
@@ -187,6 +189,7 @@ browser.tabs.onRemoved.addListener((tabId) => cleanupTab(tabId));
 function handleNavigation(details: { frameId: number; tabId: number; url: string }) {
   if (details.frameId !== 0) return;
   cleanupTab(details.tabId);
+  browser.tabs.sendMessage(details.tabId, { type: "overlay_navigation" }).catch(() => {});
 }
 
 if (browser.webNavigation) {
@@ -224,7 +227,14 @@ function notifyContentScript(video: VideoData, tabId: number, headers: Record<st
   persistVideos(tabId);
 
   // Notify an open popup (if any) so it can refresh its list live.
-  browser.runtime.sendMessage({ type: "video_detected", ...video }).catch(() => {});
+  browser.runtime.sendMessage({ type: "video_detected" }).catch(() => {});
+  // runtime.sendMessage is not a reliable way to target content scripts.
+  // Notify the owning frame directly without exposing captured request headers.
+  if (tabId >= 0) {
+    const message = { type: "video_detected", video: publicVideoView(video) };
+    const options = typeof video.frameId === "number" ? { frameId: video.frameId } : undefined;
+    browser.tabs.sendMessage(tabId, message, options).catch(() => {});
+  }
 }
 
 function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
@@ -241,7 +251,12 @@ function updateStoredVideo(video: VideoData, tabId: number) {
   const idx = videos.findIndex((v) => v.url === video.url);
   if (idx !== -1) videos[idx] = { ...videos[idx], ...video };
   persistVideos(tabId);
-  browser.runtime.sendMessage({ type: "video_detected", ...video }).catch(() => {});
+  browser.runtime.sendMessage({ type: "video_detected" }).catch(() => {});
+  if (tabId >= 0) {
+    const message = { type: "video_detected", video: publicVideoView(video) };
+    const options = typeof video.frameId === "number" ? { frameId: video.frameId } : undefined;
+    browser.tabs.sendMessage(tabId, message, options).catch(() => {});
+  }
 }
 
 function processAndNotifyVideo(videoData: VideoData, tabId: number, headers: Record<string, string> | null) {
@@ -317,9 +332,39 @@ function broadcastStatus() {
 
 bridge.onState(() => broadcastStatus());
 
-function castVideo(video: VideoData): Promise<{ ok: boolean; error?: string }> {
-  const title = video.url.split("/").pop() || video.url;
-  return bridge.cast(video.url, video.headers ?? {}, title);
+/**
+ * Stream title for the TV: prefer the website/tab title, never the raw URL
+ * basename unless the tab title is unavailable.
+ */
+async function resolveStreamTitle(
+  tabId: number | undefined,
+  fallbackUrl: string,
+  preferred?: string | null,
+): Promise<string> {
+  const fromPreferred = preferred?.trim();
+  if (fromPreferred) return fromPreferred;
+
+  if (tabId != null && tabId >= 0) {
+    try {
+      const tab = await browser.tabs.get(tabId);
+      const fromTab = tab?.title?.trim();
+      if (fromTab) return fromTab;
+    } catch {
+      /* tab may already be closed */
+    }
+  }
+
+  // Last resort only — better than an empty title on the TV.
+  return fallbackUrl.split("/").pop() || fallbackUrl;
+}
+
+function castVideo(
+  video: VideoData,
+  titleHint?: string | null,
+): Promise<{ ok: boolean; error?: string }> {
+  return resolveStreamTitle(video.tabId, video.url, titleHint).then((title) =>
+    bridge.cast(video.url, video.headers ?? {}, title),
+  );
 }
 
 // ==================== Request header capture ====================
@@ -411,10 +456,26 @@ browser.webRequest.onHeadersReceived.addListener(
     else if (isVideoExtMatch || hasVideoExt) { isVideo = true; detectedBy = "url_extension"; }
     else if (hasSubExt) { isVideo = true; detectedBy = "subtitle_extension"; }
 
+    // Prefer the request's frameId when the browser provided a real tab; for
+    // tabId:-1 recoveries we still record frameId when present so content
+    // scripts in that frame can associate detections later.
+    const frameId =
+      typeof details.frameId === "number" && details.frameId >= 0
+        ? details.frameId
+        : undefined;
+
     if (isVideo) {
-      plog("  ✓ DETECTED:", detectedBy, "| ct:", contentType || "(none)", "| tabId:", tabId, "|", short(details.url));
+      plog("  ✓ DETECTED:", detectedBy, "| ct:", contentType || "(none)", "| tabId:", tabId, "| frameId:", frameId, "|", short(details.url));
       processAndNotifyVideo(
-        { url: details.url, tabId, contentType, detectedBy, originUrl: details.originUrl ?? "", timestamp: Date.now() },
+        {
+          url: details.url,
+          tabId,
+          contentType,
+          detectedBy,
+          originUrl: details.originUrl ?? "",
+          timestamp: Date.now(),
+          frameId,
+        },
         tabId,
         stored?.headers ?? null,
       );
@@ -440,7 +501,15 @@ browser.webRequest.onHeadersReceived.addListener(
               if (acc.trim().startsWith("#EXTM3U")) {
                 plog("  ✓ DETECTED via body sniff (#EXTM3U):", short(details.url));
                 processAndNotifyVideo(
-                  { url: details.url, tabId, contentType, detectedBy: "body_content_m3u8", originUrl: details.originUrl ?? "", timestamp: Date.now() },
+                  {
+                    url: details.url,
+                    tabId,
+                    contentType,
+                    detectedBy: "body_content_m3u8",
+                    originUrl: details.originUrl ?? "",
+                    timestamp: Date.now(),
+                    frameId,
+                  },
                   tabId,
                   stored?.headers ?? null,
                 );
@@ -463,18 +532,58 @@ browser.webRequest.onHeadersReceived.addListener(
 
 // ==================== Runtime message handler ====================
 
+/** Strip sensitive fields before sending detection records to content scripts. */
+function publicVideoView(v: VideoData): Omit<VideoData, "headers"> {
+  const { headers: _headers, ...rest } = v;
+  return rest;
+}
+
+function videosForSender(
+  sender: browser.Runtime.MessageSender,
+  options: { preferFrame?: boolean } = {},
+): VideoData[] {
+  const tabId = sender.tab?.id;
+  if (tabId == null || tabId < 0) return [];
+  const all = tabVideos.get(tabId) ?? [];
+  if (!options.preferFrame) return all;
+  const frameId = sender.frameId;
+  if (typeof frameId !== "number" || frameId < 0) return all;
+  const sameFrame = all.filter((v) => v.frameId === frameId);
+  // Legacy/session records without frame metadata are safe fallback candidates.
+  // Never expose a record explicitly owned by a different frame.
+  const unframed = all.filter((v) => typeof v.frameId !== "number");
+  return [...sameFrame, ...unframed];
+}
+
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
   const msg = message as Record<string, unknown>;
 
   if (msg.action === "getVideos") {
-    const tabId = (msg.tabId ?? sender.tab?.id) as number | undefined;
+    // Content scripts must not choose arbitrary tab/frame IDs. Popup/extension
+    // pages have no sender.tab and may pass an explicit tabId for the active tab.
+    const fromContent = sender.tab?.id != null;
+    const tabId = fromContent
+      ? sender.tab!.id!
+      : ((msg.tabId ?? sender.tab?.id) as number | undefined);
     // Await rehydration so a freshly-woken MV3 service worker doesn't reply with
     // an empty list before storage.session has been merged back in.
     hydrated.then(() => {
-      const videos = tabId ? (tabVideos.get(tabId) ?? []) : [];
-      plog("getVideos query for tabId", tabId, "→", videos.length, "videos.",
-        "All tabs with videos:", [...tabVideos.entries()].map(([t, v]) => `${t}:${v.length}`).join(", ") || "(none)");
-      sendResponse({ videos, count: videos.length });
+      let videos: VideoData[];
+      if (fromContent) {
+        videos = videosForSender(sender, { preferFrame: true });
+        // Never expose captured auth headers to page-isolated content scripts.
+        sendResponse({
+          videos: videos.map(publicVideoView),
+          count: videos.length,
+          frameId: sender.frameId,
+          tabId,
+        });
+      } else {
+        videos = tabId != null ? (tabVideos.get(tabId) ?? []) : [];
+        plog("getVideos query for tabId", tabId, "→", videos.length, "videos.",
+          "All tabs with videos:", [...tabVideos.entries()].map(([t, v]) => `${t}:${v.length}`).join(", ") || "(none)");
+        sendResponse({ videos, count: videos.length });
+      }
     });
     return true; // async response
   }
@@ -524,15 +633,101 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 
   if (msg.action === "wsPlayOnTv") {
+    // Popup path: may pass a full video object (including quality-selected URL).
+    // Content-script path: only accept a URL identifier; headers always come
+    // from the stored detection record for the sender's tab.
+    const fromContent = sender.tab?.id != null;
+    if (fromContent) {
+      const url = typeof msg.url === "string" ? msg.url : (msg.video as VideoData | undefined)?.url;
+      if (!url || typeof url !== "string") {
+        sendResponse({ success: false, reason: "Video not found" });
+        return true;
+      }
+      const tabVideosList = getTabVideos(sender.tab!.id!);
+      const stored = tabVideosList.find((v) => v.url === url);
+      if (!stored) {
+        sendResponse({ success: false, reason: "Video not found" });
+        return true;
+      }
+      // Prefer the live tab title from sender (website title).
+      const titleHint = sender.tab?.title;
+      castVideo(stored, titleHint).then((r) =>
+        sendResponse({ success: r.ok, reason: r.ok ? null : (r.error ?? "Not connected") }),
+      );
+      return true;
+    }
+
     const tabId = (sender.tab?.id ?? msg.tabId) as number | undefined;
-    const videos = tabId ? getTabVideos(tabId) : [];
-    const video = videos.find((v) => v.url === msg.url) ?? (msg.video as VideoData | undefined);
+    const videos = tabId != null ? getTabVideos(tabId) : [];
+    const video =
+      (typeof msg.url === "string" ? videos.find((v) => v.url === msg.url) : undefined) ??
+      (msg.video as VideoData | undefined);
     if (!video) {
       sendResponse({ success: false, reason: "Video not found" });
       return true;
     }
-    if (msg.subtitleUrl) video.subtitles = [msg.subtitleUrl as string];
-    castVideo(video).then((r) =>
+    // Prefer stored headers for the same URL when available (popup quality pick
+    // may change the URL to a variant that still lacks a stored record).
+    const stored =
+      videos.find((v) => v.url === video.url) ??
+      (video.tabId != null ? getTabVideos(video.tabId).find((v) => v.url === video.url) : undefined);
+    const toCast: VideoData = stored
+      ? { ...stored, ...video, headers: stored.headers ?? video.headers }
+      : { ...video };
+    if (msg.subtitleUrl) toCast.subtitles = [msg.subtitleUrl as string];
+
+    // Popup messages have no sender.tab — use the video's tabId or the active tab
+    // so the stream title is the website title, not a URL basename.
+    const ensureTabId = async (): Promise<number | undefined> => {
+      if (toCast.tabId != null && toCast.tabId >= 0) return toCast.tabId;
+      if (tabId != null && tabId >= 0) {
+        toCast.tabId = tabId;
+        return tabId;
+      }
+      try {
+        const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+        const id = tabs[0]?.id;
+        if (id != null) toCast.tabId = id;
+        return id;
+      } catch {
+        return undefined;
+      }
+    };
+
+    ensureTabId()
+      .then(() => castVideo(toCast))
+      .then((r) =>
+        sendResponse({ success: r.ok, reason: r.ok ? null : (r.error ?? "Not connected") }),
+      );
+    return true;
+  }
+
+  // Content-script cast: URL identifier only; tab/frame from sender; headers from store.
+  if (msg.action === "castDetectedVideo") {
+    const tabId = sender.tab?.id;
+    if (tabId == null || tabId < 0) {
+      sendResponse({ success: false, reason: "Invalid sender" });
+      return true;
+    }
+    const url = msg.url;
+    if (typeof url !== "string" || !url || url.startsWith("blob:") || url.startsWith("data:")) {
+      sendResponse({ success: false, reason: "Invalid media URL" });
+      return true;
+    }
+    const videos = getTabVideos(tabId);
+    const frameId = sender.frameId;
+    const stored = videos.find(
+      (v) =>
+        v.url === url &&
+        (typeof frameId !== "number" ||
+          typeof v.frameId !== "number" ||
+          v.frameId === frameId),
+    );
+    if (!stored) {
+      sendResponse({ success: false, reason: "Video not found" });
+      return true;
+    }
+    castVideo({ ...stored, tabId }, sender.tab?.title).then((r) =>
       sendResponse({ success: r.ok, reason: r.ok ? null : (r.error ?? "Not connected") }),
     );
     return true;
@@ -541,8 +736,19 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (msg.action === "wsSendToTv") {
     if (msg.target === "player") {
       const url = msg.url as string;
-      bridge.cast(url, {}, url.split("/").pop() || url).then((r) =>
-        sendResponse({ success: r.ok, reason: r.ok ? null : (r.error ?? "Not connected") }),
+      const tabId = (sender.tab?.id ?? msg.tabId) as number | undefined;
+      // Popup often has no sender.tab — resolve active tab for the website title.
+      const resolveTabId = tabId != null && tabId >= 0
+        ? Promise.resolve(tabId)
+        : browser.tabs.query({ active: true, currentWindow: true })
+            .then((tabs) => tabs[0]?.id)
+            .catch(() => undefined);
+      resolveTabId.then((resolvedTabId) =>
+        resolveStreamTitle(resolvedTabId, url, sender.tab?.title).then((title) =>
+          bridge.cast(url, {}, title).then((r) =>
+            sendResponse({ success: r.ok, reason: r.ok ? null : (r.error ?? "Not connected") }),
+          ),
+        ),
       );
     } else {
       sendResponse({ success: false, reason: "Unsupported target" });
@@ -592,7 +798,12 @@ menusApi.onClicked.addListener((info, tab) => {
     info.menuItemId === "playbridge-play"
       ? (info.srcUrl ?? info.linkUrl)
       : (info.linkUrl ?? info.pageUrl ?? tab?.url);
-  if (url) bridge.cast(url, {}, url.split("/").pop() || url);
+  if (url) {
+    const titleHint = tab?.title?.trim() || null;
+    void resolveStreamTitle(tab?.id, url, titleHint).then((title) =>
+      bridge.cast(url, {}, title),
+    );
+  }
 });
 
 // ==================== Startup ====================

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,4 +1,1082 @@
-// The on-page floating button (FAB) + injected iframe popup were removed — the
-// extension is now reached only via its toolbar icon. This file is intentionally
-// empty and is no longer built or referenced by any manifest.
-export {};
+/**
+ * On-video cast overlay content script.
+ *
+ * Non-destructive: never wraps, reparents, pauses, or modifies the site's
+ * <video>. Appends an extension-owned Shadow DOM host and positions a cast
+ * control over the primary visible video in this frame.
+ *
+ * Media URLs always come from background network detection (with stored
+ * headers). DOM `blob:` / `data:` sources are matching signals only.
+ */
+
+import browser from "./browser";
+import {
+  SHOW_VIDEO_CAST_OVERLAY_DEFAULT,
+  SHOW_VIDEO_CAST_OVERLAY_KEY,
+  getShowVideoCastOverlay,
+} from "./settings";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface DetectedVideo {
+  url: string;
+  tabId: number;
+  contentType: string;
+  detectedBy: string;
+  originUrl: string;
+  timestamp: number;
+  frameId?: number;
+  subtitles?: string[];
+  subtitlePreview?: string;
+  qualities?: unknown[];
+}
+
+type OverlayState =
+  | "idle"
+  | "disabled-no-stream"
+  | "casting"
+  | "success"
+  | "error";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const HOST_ID = "playbridge-cast-overlay-host";
+const MIN_VIDEO_WIDTH = 200;
+const MIN_VIDEO_HEIGHT = 112;
+const MIN_VIDEO_AREA = MIN_VIDEO_WIDTH * MIN_VIDEO_HEIGHT;
+const OVERLAY_INSET = 14;
+const BUTTON_SIZE = 40;
+const Z_INDEX = 2147483646;
+const STATUS_RESET_MS = 2800;
+const NO_STREAM_STATUS_MS = 2800;
+const NO_STREAM_MSG = "No castable stream detected yet";
+const RESOLVE_DEBOUNCE_MS = 120;
+/** Fade the cast chrome after this idle period (player-control style). */
+const AUTO_HIDE_MS = 3500;
+
+const SEGMENT_OR_SUB_RE =
+  /\.(?:vtt|srt|ts|m4s)(?:$|\?)|\/segment|frag(?:ment)?|\/chunks?\//i;
+
+// ── State ────────────────────────────────────────────────────────────────────
+
+let enabled = false;
+let settingLoaded = false;
+let primaryVideo: HTMLVideoElement | null = null;
+let overlayHost: HTMLElement | null = null;
+let shadowRoot: ShadowRoot | null = null;
+let chromeEl: HTMLElement | null = null;
+let castBtn: HTMLButtonElement | null = null;
+let statusEl: HTMLElement | null = null;
+let overlayState: OverlayState = "idle";
+let castInFlight = false;
+let statusResetTimer: ReturnType<typeof setTimeout> | null = null;
+let resolveTimer: ReturnType<typeof setTimeout> | null = null;
+let autoHideTimer: ReturnType<typeof setTimeout> | null = null;
+let rafId: number | null = null;
+let mutationObserver: MutationObserver | null = null;
+let resizeObserver: ResizeObserver | null = null;
+let lastCandidateUrl: string | null = null;
+let listenersAttached = false;
+/** Cast chrome currently shown (not auto-hidden). */
+let chromeVisible = true;
+let lastPointerX = Number.NaN;
+let lastPointerY = Number.NaN;
+
+// ── URL helpers ──────────────────────────────────────────────────────────────
+
+function normalizeUrl(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  try {
+    return new URL(trimmed, document.baseURI).href;
+  } catch {
+    return trimmed;
+  }
+}
+
+function isBlobOrData(url: string): boolean {
+  return url.startsWith("blob:") || url.startsWith("data:");
+}
+
+function isExcludedMedia(url: string, detectedBy?: string): boolean {
+  if (detectedBy === "subtitle_extension") return true;
+  if (SEGMENT_OR_SUB_RE.test(url)) return true;
+  const lower = url.toLowerCase();
+  if (lower.endsWith(".vtt") || lower.endsWith(".srt")) return true;
+  return false;
+}
+
+function isHls(url: string, contentType = ""): boolean {
+  const u = url.toLowerCase();
+  const ct = contentType.toLowerCase();
+  return (
+    u.includes("m3u8") ||
+    ct.includes("mpegurl") ||
+    ct.includes("vnd.apple.mpegurl")
+  );
+}
+
+function isDash(url: string, contentType = ""): boolean {
+  const u = url.toLowerCase();
+  const ct = contentType.toLowerCase();
+  return u.includes(".mpd") || ct.includes("dash");
+}
+
+function isDirectFile(url: string): boolean {
+  const path = url.toLowerCase().split("?")[0] ?? "";
+  return [".mp4", ".mkv", ".webm", ".avi", ".mov", ".flv", ".m4v", ".wmv", ".3gp"].some(
+    (ext) => path.endsWith(ext),
+  );
+}
+
+function networkPriority(v: DetectedVideo): number {
+  // Parsed qualities are only populated for an HLS master playlist.
+  if (isHls(v.url, v.contentType) && Array.isArray(v.qualities) && v.qualities.length > 0) return 4;
+  if (isHls(v.url, v.contentType)) return 3;
+  if (isDash(v.url, v.contentType)) return 2;
+  if (isDirectFile(v.url)) return 1;
+  return 0;
+}
+
+// ── Video discovery (open shadow roots) ──────────────────────────────────────
+
+function queryVideosIncludingShadows(
+  root: Document | ShadowRoot | Element = document,
+): HTMLVideoElement[] {
+  const results: HTMLVideoElement[] = [];
+  const visit = (node: Document | ShadowRoot | Element) => {
+    let list: NodeListOf<Element> | Element[];
+    try {
+      list = node.querySelectorAll("video");
+    } catch {
+      return;
+    }
+    for (const el of Array.from(list)) {
+      if (el instanceof HTMLVideoElement) results.push(el);
+    }
+    let all: NodeListOf<Element> | Element[];
+    try {
+      all = node.querySelectorAll("*");
+    } catch {
+      return;
+    }
+    for (const el of Array.from(all)) {
+      const sr = (el as Element & { shadowRoot?: ShadowRoot | null }).shadowRoot;
+      if (sr) visit(sr);
+    }
+  };
+  visit(root);
+  return results;
+}
+
+function visibleArea(el: Element): number {
+  if (!(el as HTMLElement).isConnected) return 0;
+  const style = window.getComputedStyle(el);
+  if (
+    style.display === "none" ||
+    style.visibility === "hidden" ||
+    style.opacity === "0" ||
+    (el as HTMLElement).hidden
+  ) {
+    return 0;
+  }
+  const rect = el.getBoundingClientRect();
+  if (rect.width < 1 || rect.height < 1) return 0;
+  const vw = window.innerWidth || document.documentElement.clientWidth;
+  const vh = window.innerHeight || document.documentElement.clientHeight;
+  const left = Math.max(rect.left, 0);
+  const top = Math.max(rect.top, 0);
+  const right = Math.min(rect.right, vw);
+  const bottom = Math.min(rect.bottom, vh);
+  const w = Math.max(0, right - left);
+  const h = Math.max(0, bottom - top);
+  return w * h;
+}
+
+function isEligibleVideo(video: HTMLVideoElement): boolean {
+  if (!video.isConnected) return false;
+  const rect = video.getBoundingClientRect();
+  if (rect.width < MIN_VIDEO_WIDTH || rect.height < MIN_VIDEO_HEIGHT) return false;
+  if (rect.width * rect.height < MIN_VIDEO_AREA) return false;
+  const area = visibleArea(video);
+  // Reject players represented by only a tiny off-screen sliver.
+  return area >= Math.min(MIN_VIDEO_AREA, rect.width * rect.height * 0.15);
+}
+
+/**
+ * Primary video = largest visible eligible <video> in this frame.
+ * Tiny previews, ads, and off-screen players are filtered out.
+ */
+function selectPrimaryVideo(): HTMLVideoElement | null {
+  const videos = queryVideosIncludingShadows();
+  let best: HTMLVideoElement | null = null;
+  let bestArea = 0;
+  for (const video of videos) {
+    if (!isEligibleVideo(video)) continue;
+    const area = visibleArea(video);
+    if (area > bestArea) {
+      bestArea = area;
+      best = video;
+    }
+  }
+  return best;
+}
+
+// ── Candidate ranking ────────────────────────────────────────────────────────
+
+function domSourceUrls(video: HTMLVideoElement): string[] {
+  const urls: string[] = [];
+  const push = (raw: string | null | undefined) => {
+    const n = normalizeUrl(raw);
+    if (n) urls.push(n);
+  };
+  push(video.currentSrc);
+  push(video.src);
+  try {
+    for (const source of Array.from(video.querySelectorAll("source"))) {
+      push(source.getAttribute("src") ?? (source as HTMLSourceElement).src);
+    }
+  } catch {
+    /* ignore */
+  }
+  return urls;
+}
+
+/**
+ * Deterministic ranking of detected network records for a video element.
+ * Never returns blob:/data: URLs. Prefers exact DOM matches, then same-frame
+ * HLS/DASH/direct, then newest plausible tab candidate.
+ */
+function rankCandidate(
+  video: HTMLVideoElement,
+  records: DetectedVideo[],
+): DetectedVideo | null {
+  const playable = records.filter(
+    (r) =>
+      r.url &&
+      !isBlobOrData(r.url) &&
+      !isExcludedMedia(r.url, r.detectedBy),
+  );
+  if (playable.length === 0) return null;
+
+  const domUrls = domSourceUrls(video);
+  const nonBlobDom = domUrls.filter((u) => !isBlobOrData(u));
+
+  const byExact = (target: string | null | undefined): DetectedVideo | null => {
+    if (!target || isBlobOrData(target)) return null;
+    const n = normalizeUrl(target);
+    if (!n) return null;
+    return playable.find((r) => normalizeUrl(r.url) === n) ?? null;
+  };
+
+  // 1. Exact match currentSrc
+  const current = byExact(video.currentSrc);
+  if (current) return current;
+
+  // 2. Exact match src or <source>
+  for (const u of nonBlobDom) {
+    const hit = byExact(u);
+    if (hit) return hit;
+  }
+
+  // 3–4. Same-frame network records when frame metadata exists.
+  // Background already prefers the sender frame when records have frameId;
+  // if any returned records are frame-tagged, rank within that set first.
+  const withFrame = playable.filter((r) => typeof r.frameId === "number");
+  const pool = withFrame.length > 0 ? withFrame : playable;
+
+  // Prefer HLS master > DASH > direct, then newest
+  const sorted = [...pool].sort((a, b) => {
+    const pr = networkPriority(b) - networkPriority(a);
+    if (pr !== 0) return pr;
+    return b.timestamp - a.timestamp;
+  });
+
+  if (sorted.length === 0) return null;
+
+  // 5. If only tab-level records and many competing streams of different kinds
+  // with no DOM signal, still pick the best-ranked (newest high-priority).
+  // Ambiguous multi-player pages are a known limitation.
+  return sorted[0] ?? null;
+}
+
+// ── Overlay UI ───────────────────────────────────────────────────────────────
+
+/**
+ * Original generic cast glyph: a display outline plus two local signal arcs.
+ * It uses currentColor and no third-party assets or branding.
+ */
+const CAST_SVG = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="23" height="23" fill="none" aria-hidden="true" focusable="false">
+  <path d="M4 5.75A1.75 1.75 0 0 1 5.75 4h12.5A1.75 1.75 0 0 1 20 5.75v9.5A1.75 1.75 0 0 1 18.25 17H16"
+        stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M4 15.5a4.5 4.5 0 0 1 4.5 4.5M4 11.5A8.5 8.5 0 0 1 12.5 20"
+        stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+  <circle cx="4" cy="20" r="1.15" fill="currentColor"/>
+</svg>`.trim();
+
+function injectOverlayStyles(root: ShadowRoot): void {
+  const style = document.createElement("style");
+  style.textContent = `
+    :host {
+      all: initial;
+      position: fixed;
+      pointer-events: none;
+      z-index: ${Z_INDEX};
+      display: block;
+    }
+    .wrap {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+    }
+    .chrome {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      opacity: 1;
+      transition: opacity 0.25s ease;
+    }
+    .chrome.is-hidden {
+      opacity: 0;
+    }
+    .chrome.is-hidden .controls {
+      pointer-events: none !important;
+    }
+    /* Isolated hit target for the cast control. */
+    .controls {
+      pointer-events: auto;
+      position: absolute;
+      top: ${OVERLAY_INSET - 4}px;
+      right: ${OVERLAY_INSET - 2}px;
+      width: ${BUTTON_SIZE + 8}px;
+      height: ${BUTTON_SIZE + 8}px;
+    }
+    button.cast {
+      pointer-events: auto;
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      width: ${BUTTON_SIZE}px;
+      height: ${BUTTON_SIZE}px;
+      border: none;
+      border-radius: 50%;
+      background: rgba(28, 27, 31, 0.78);
+      color: #D0BCFF;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+      transition: background 0.15s ease, transform 0.15s ease, color 0.15s ease, opacity 0.15s ease;
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+    }
+    button.cast:hover:not(:disabled) {
+      background: rgba(44, 44, 50, 0.92);
+      color: #E8DEF8;
+      transform: scale(1.05);
+    }
+    button.cast:focus-visible {
+      outline: 2px solid #D0BCFF;
+      outline-offset: 2px;
+    }
+    button.cast:active:not(:disabled) {
+      transform: scale(0.96);
+    }
+    button.cast:disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
+    }
+    button.cast.state-casting {
+      color: #E8DEF8;
+    }
+    button.cast.state-success {
+      color: #A8E6CF;
+    }
+    button.cast.state-error,
+    button.cast.state-disabled-no-stream {
+      color: #F2B8B5;
+    }
+    .status {
+      position: absolute;
+      top: ${OVERLAY_INSET + BUTTON_SIZE + 6}px;
+      right: ${OVERLAY_INSET + 4}px;
+      max-width: min(220px, 70vw);
+      padding: 6px 10px;
+      border-radius: 8px;
+      background: rgba(28, 27, 31, 0.88);
+      color: #E6E1E5;
+      font: 600 11px/1.35 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      pointer-events: none;
+      opacity: 0;
+      transform: translateY(-4px);
+      transition: opacity 0.2s ease, transform 0.2s ease;
+      text-align: right;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+      /* Keep layout during fade-out so text doesn't vanish before opacity finishes. */
+      visibility: hidden;
+    }
+    .status.show {
+      opacity: 1;
+      transform: translateY(0);
+      visibility: visible;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .chrome,
+      button.cast,
+      .status {
+        transition: none;
+      }
+      button.cast:hover:not(:disabled),
+      button.cast:active:not(:disabled) {
+        transform: none;
+      }
+    }
+  `;
+  root.appendChild(style);
+}
+
+function ensureOverlay(): void {
+  if (overlayHost && shadowRoot && castBtn && chromeEl) return;
+
+  const host = document.createElement("div");
+  host.id = HOST_ID;
+  host.setAttribute("data-playbridge", "cast-overlay");
+
+  const shadow = host.attachShadow({ mode: "open" });
+  injectOverlayStyles(shadow);
+
+  const wrap = document.createElement("div");
+  wrap.className = "wrap";
+
+  const chrome = document.createElement("div");
+  chrome.className = "chrome";
+
+  const controls = document.createElement("div");
+  controls.className = "controls";
+
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "cast";
+  btn.setAttribute("aria-label", "Cast this video with PlayBridge");
+  btn.title = "Cast this video with PlayBridge";
+  // Inline SVG via DOM parse for a single trusted constant string.
+  const tpl = document.createElement("template");
+  tpl.innerHTML = CAST_SVG;
+  const svg = tpl.content.firstElementChild;
+  if (svg) btn.appendChild(svg.cloneNode(true));
+
+  const status = document.createElement("div");
+  status.className = "status";
+  status.setAttribute("role", "status");
+  status.setAttribute("aria-live", "polite");
+
+  controls.appendChild(btn);
+  chrome.appendChild(controls);
+  chrome.appendChild(status);
+  wrap.appendChild(chrome);
+  shadow.appendChild(wrap);
+
+  btn.addEventListener("click", onCastClick, true);
+  btn.addEventListener("mousedown", stopBubble, true);
+  btn.addEventListener("mouseup", stopBubble, true);
+  btn.addEventListener("pointerdown", stopBubble, true);
+  btn.addEventListener("pointerenter", onCastPointerEnter);
+  btn.addEventListener("pointerleave", onCastPointerLeave);
+  controls.addEventListener("focusin", onChromeFocusIn);
+  controls.addEventListener("focusout", onChromeFocusOut);
+
+  overlayHost = host;
+  shadowRoot = shadow;
+  chromeEl = chrome;
+  castBtn = btn;
+  statusEl = status;
+  attachOverlayHost();
+  showChrome({ restartTimer: true });
+}
+
+function stopBubble(e: Event): void {
+  e.stopPropagation();
+}
+
+function clearAutoHideTimer(): void {
+  if (autoHideTimer) {
+    clearTimeout(autoHideTimer);
+    autoHideTimer = null;
+  }
+}
+
+function shouldHoldChromeVisible(): boolean {
+  return (
+    castInFlight ||
+    overlayState === "casting" ||
+    overlayState === "success" ||
+    overlayState === "error"
+  );
+}
+
+function scheduleAutoHide(): void {
+  clearAutoHideTimer();
+  if (!enabled || !chromeVisible) return;
+  if (shouldHoldChromeVisible()) return;
+  autoHideTimer = setTimeout(() => {
+    autoHideTimer = null;
+    if (!enabled || shouldHoldChromeVisible()) return;
+    hideChrome();
+  }, AUTO_HIDE_MS);
+}
+
+function showChrome(opts: { restartTimer?: boolean } = {}): void {
+  if (!enabled) return;
+  chromeVisible = true;
+  chromeEl?.classList.remove("is-hidden");
+  if (castBtn) castBtn.tabIndex = 0;
+  if (opts.restartTimer !== false) scheduleAutoHide();
+}
+
+function hideChrome(): void {
+  chromeVisible = false;
+  clearAutoHideTimer();
+  chromeEl?.classList.add("is-hidden");
+  if (castBtn) castBtn.tabIndex = -1;
+}
+
+function onChromeFocusIn(): void {
+  clearAutoHideTimer();
+  showChrome({ restartTimer: false });
+}
+
+function onChromeFocusOut(): void {
+  scheduleAutoHide();
+}
+
+function onVideoPointerActivity(event: PointerEvent): void {
+  if (!enabled || !primaryVideo) return;
+  const rect = primaryVideo.getBoundingClientRect();
+  if (
+    event.clientX < rect.left ||
+    event.clientX > rect.right ||
+    event.clientY < rect.top ||
+    event.clientY > rect.bottom
+  ) {
+    return;
+  }
+  // Some fullscreen players emit repeated pointermove events without actual
+  // movement. Only genuine coordinate changes should restart the idle timer.
+  if (event.type === "pointermove" && event.clientX === lastPointerX && event.clientY === lastPointerY) return;
+  lastPointerX = event.clientX;
+  lastPointerY = event.clientY;
+  showChrome({ restartTimer: true });
+}
+
+function attachOverlayHost(): void {
+  if (!overlayHost) return;
+  const fs = document.fullscreenElement;
+  const parent =
+    fs && fs !== overlayHost && !(overlayHost.contains(fs))
+      ? fs
+      : document.documentElement;
+  if (overlayHost.parentElement !== parent) {
+    try {
+      parent.appendChild(overlayHost);
+    } catch {
+      try {
+        document.documentElement.appendChild(overlayHost);
+      } catch {
+        /* restricted pages */
+      }
+    }
+  }
+}
+
+function destroyOverlay(): void {
+  if (statusResetTimer) {
+    clearTimeout(statusResetTimer);
+    statusResetTimer = null;
+  }
+  clearAutoHideTimer();
+  if (castBtn) {
+    castBtn.removeEventListener("click", onCastClick, true);
+    castBtn.removeEventListener("mousedown", stopBubble, true);
+    castBtn.removeEventListener("mouseup", stopBubble, true);
+    castBtn.removeEventListener("pointerdown", stopBubble, true);
+    castBtn.removeEventListener("pointerenter", onCastPointerEnter);
+    castBtn.removeEventListener("pointerleave", onCastPointerLeave);
+  }
+  const controlsEl = chromeEl?.querySelector(".controls");
+  if (controlsEl) {
+    controlsEl.removeEventListener("focusin", onChromeFocusIn);
+    controlsEl.removeEventListener("focusout", onChromeFocusOut);
+  }
+  overlayHost?.remove();
+  overlayHost = null;
+  shadowRoot = null;
+  chromeEl = null;
+  castBtn = null;
+  statusEl = null;
+  overlayState = "idle";
+  castInFlight = false;
+  chromeVisible = true;
+  lastCandidateUrl = null;
+}
+
+const STATUS_FADE_MS = 200;
+
+function clearStatusTimer(): void {
+  if (statusResetTimer) {
+    clearTimeout(statusResetTimer);
+    statusResetTimer = null;
+  }
+}
+
+/**
+ * Fade the status toast out (remove .show). Clears text after the CSS transition
+ * so the opacity animation can complete smoothly.
+ */
+function hideStatusMessage(): void {
+  clearStatusTimer();
+  if (!statusEl) return;
+  statusEl.classList.remove("show");
+  const el = statusEl;
+  statusResetTimer = setTimeout(() => {
+    statusResetTimer = null;
+    // Only clear if still hidden (a new show may have started).
+    if (statusEl === el && !el.classList.contains("show")) {
+      el.textContent = "";
+    }
+  }, STATUS_FADE_MS);
+}
+
+function setStatusText(message: string): void {
+  if (!statusEl) return;
+  clearStatusTimer();
+  statusEl.textContent = message;
+  // Force reflow so re-showing after a quick leave restarts the fade-in.
+  void statusEl.offsetWidth;
+  statusEl.classList.add("show");
+}
+
+/** Toast while hovering the cast icon; also auto-fades if the pointer stays put. */
+function showEphemeralStatus(message: string, durationMs = STATUS_RESET_MS): void {
+  setStatusText(message);
+  clearStatusTimer();
+  statusResetTimer = setTimeout(() => {
+    statusResetTimer = null;
+    hideStatusMessage();
+  }, durationMs);
+}
+
+/** No-stream hint only while the pointer is over the cast icon. */
+function onCastPointerEnter(): void {
+  if (!enabled) return;
+  if (overlayState === "disabled-no-stream") {
+    showEphemeralStatus(NO_STREAM_MSG, NO_STREAM_STATUS_MS);
+  }
+}
+
+/** Hide the no-stream hint as soon as the pointer leaves the icon. */
+function onCastPointerLeave(): void {
+  if (overlayState === "disabled-no-stream") {
+    hideStatusMessage();
+  }
+}
+
+function setOverlayVisualState(state: OverlayState, message?: string): void {
+  overlayState = state;
+  if (!castBtn) return;
+  castBtn.classList.remove(
+    "state-casting",
+    "state-success",
+    "state-error",
+    "state-disabled-no-stream",
+  );
+  const noStream = state === "disabled-no-stream";
+  castBtn.disabled = noStream || state === "casting" || castInFlight;
+  if (state === "casting") castBtn.classList.add("state-casting");
+  if (state === "success") castBtn.classList.add("state-success");
+  if (state === "error") castBtn.classList.add("state-error");
+  if (noStream) castBtn.classList.add("state-disabled-no-stream");
+
+  if (state === "casting") {
+    clearStatusTimer();
+    setStatusText(message || "Casting…");
+    showChrome({ restartTimer: false });
+    return;
+  }
+
+  if (state === "success" || state === "error") {
+    showChrome({ restartTimer: false });
+    setStatusText(message || (state === "success" ? "Casting to TV" : "Cast failed"));
+    clearStatusTimer();
+    statusResetTimer = setTimeout(() => {
+      statusResetTimer = null;
+      if (!enabled) return;
+      hideStatusMessage();
+      // Restore button state; no-stream toast only returns on icon hover.
+      const next: OverlayState = lastCandidateUrl ? "idle" : "disabled-no-stream";
+      setOverlayVisualState(next);
+      scheduleAutoHide();
+    }, STATUS_RESET_MS);
+    return;
+  }
+
+  if (noStream) {
+    // No auto toast — only show on cast-icon hover (onCastPointerEnter).
+    return;
+  }
+
+  // idle
+  hideStatusMessage();
+}
+
+function schedulePosition(): void {
+  if (rafId != null) return;
+  rafId = requestAnimationFrame(() => {
+    rafId = null;
+    positionOverlay();
+  });
+}
+
+function positionOverlay(): void {
+  if (!enabled || !overlayHost || !primaryVideo) {
+    if (overlayHost) overlayHost.style.display = "none";
+    return;
+  }
+  if (!primaryVideo.isConnected || !isEligibleVideo(primaryVideo)) {
+    overlayHost.style.display = "none";
+    return;
+  }
+  attachOverlayHost();
+  const rect = primaryVideo.getBoundingClientRect();
+  overlayHost.style.display = "block";
+  overlayHost.style.top = `${Math.round(rect.top)}px`;
+  overlayHost.style.left = `${Math.round(rect.left)}px`;
+  overlayHost.style.width = `${Math.round(rect.width)}px`;
+  overlayHost.style.height = `${Math.round(rect.height)}px`;
+}
+
+// ── Detection fetch + resolve ────────────────────────────────────────────────
+
+async function fetchDetectedVideos(): Promise<DetectedVideo[]> {
+  try {
+    const res = (await browser.runtime.sendMessage({
+      action: "getVideos",
+      scope: "frame",
+    })) as { videos?: DetectedVideo[] } | undefined;
+    return Array.isArray(res?.videos) ? res!.videos! : [];
+  } catch {
+    return [];
+  }
+}
+
+async function resolveAndRender(): Promise<void> {
+  if (!enabled || !settingLoaded) return;
+
+  const video = selectPrimaryVideo();
+  if (video !== primaryVideo) {
+    unbindVideoListeners(primaryVideo);
+    primaryVideo = video;
+    bindVideoListeners(primaryVideo);
+    observeVideoSize(primaryVideo);
+    if (primaryVideo) {
+      showChrome({ restartTimer: true });
+    }
+  }
+
+  if (!primaryVideo) {
+    destroyOverlay();
+    return;
+  }
+
+  ensureOverlay();
+  const records = await fetchDetectedVideos();
+  if (!enabled) return;
+
+  const candidate = rankCandidate(primaryVideo, records);
+  lastCandidateUrl = candidate?.url ?? null;
+
+  if (!candidate) {
+    setOverlayVisualState("disabled-no-stream");
+  } else if (overlayState === "disabled-no-stream" || overlayState === "idle") {
+    setOverlayVisualState("idle");
+  }
+  schedulePosition();
+}
+
+function scheduleResolve(): void {
+  if (!enabled) return;
+  if (resolveTimer) clearTimeout(resolveTimer);
+  resolveTimer = setTimeout(() => {
+    resolveTimer = null;
+    void resolveAndRender();
+  }, RESOLVE_DEBOUNCE_MS);
+}
+
+// ── Cast interaction ─────────────────────────────────────────────────────────
+
+async function onCastClick(e: Event): Promise<void> {
+  e.preventDefault();
+  e.stopPropagation();
+  if (!enabled || castInFlight || !primaryVideo || !chromeVisible) return;
+
+  castInFlight = true;
+  showChrome({ restartTimer: false });
+  setOverlayVisualState("casting", "Casting…");
+
+  try {
+    const records = await fetchDetectedVideos();
+    const candidate = rankCandidate(primaryVideo, records);
+    lastCandidateUrl = candidate?.url ?? null;
+
+    if (!candidate) {
+      setOverlayVisualState("error", "No castable stream detected yet");
+      return;
+    }
+
+    const status = (await browser.runtime.sendMessage({
+      action: "wsGetStatus",
+    })) as {
+      status?: string;
+      desktopConnected?: boolean;
+    } | null;
+
+    if (!status?.desktopConnected) {
+      setOverlayVisualState("error", "Open the PlayBridge desktop app.");
+      return;
+    }
+    if (status.status !== "connected") {
+      setOverlayVisualState("error", "Connect a TV in PlayBridge.");
+      return;
+    }
+
+    // Send only the URL identifier; background uses sender.tab + stored headers.
+    const res = (await browser.runtime.sendMessage({
+      action: "castDetectedVideo",
+      url: candidate.url,
+    })) as { success?: boolean; reason?: string | null } | null;
+
+    if (res?.success) {
+      setOverlayVisualState("success", "Casting to TV");
+    } else {
+      const reason = res?.reason || "Cast failed";
+      if (reason === "Not connected" || reason === "Not connected to TV") {
+        setOverlayVisualState("error", "Connect a TV in PlayBridge.");
+      } else {
+        setOverlayVisualState("error", reason);
+      }
+    }
+  } catch {
+    setOverlayVisualState("error", "Cast failed");
+  } finally {
+    castInFlight = false;
+    if (castBtn && overlayState !== "disabled-no-stream") {
+      // Re-enable unless still in a transitional disable state.
+      if (overlayState === "idle" || overlayState === "success" || overlayState === "error") {
+        castBtn.disabled = false;
+      }
+    }
+  }
+}
+
+// ── Observers / listeners ────────────────────────────────────────────────────
+
+function onDomMutated(records?: MutationRecord[]): void {
+  if (
+    records?.length &&
+    overlayHost &&
+    records.every(
+      (record) =>
+        record.target === overlayHost || overlayHost?.contains(record.target),
+    )
+  ) {
+    return;
+  }
+  scheduleResolve();
+}
+
+function onPopState(): void {
+  scheduleResolve();
+}
+
+function onViewportChange(): void {
+  schedulePosition();
+  scheduleResolve();
+}
+
+function onFullscreenChange(): void {
+  attachOverlayHost();
+  showChrome({ restartTimer: true });
+  schedulePosition();
+  scheduleResolve();
+}
+
+function onMediaSourceChange(): void {
+  scheduleResolve();
+}
+
+function bindVideoListeners(video: HTMLVideoElement | null): void {
+  if (!video) return;
+  video.addEventListener("loadedmetadata", onMediaSourceChange);
+  video.addEventListener("emptied", onMediaSourceChange);
+  video.addEventListener("loadstart", onMediaSourceChange);
+  video.addEventListener("play", onMediaSourceChange);
+  // Reveal chrome when the user interacts with the player area (after auto-hide).
+  video.addEventListener("pointerenter", onVideoPointerActivity);
+  video.addEventListener("pointermove", onVideoPointerActivity);
+}
+
+function unbindVideoListeners(video: HTMLVideoElement | null): void {
+  if (!video) return;
+  video.removeEventListener("loadedmetadata", onMediaSourceChange);
+  video.removeEventListener("emptied", onMediaSourceChange);
+  video.removeEventListener("loadstart", onMediaSourceChange);
+  video.removeEventListener("play", onMediaSourceChange);
+  video.removeEventListener("pointerenter", onVideoPointerActivity);
+  video.removeEventListener("pointermove", onVideoPointerActivity);
+}
+
+function observeVideoSize(video: HTMLVideoElement | null): void {
+  resizeObserver?.disconnect();
+  if (!video || typeof ResizeObserver === "undefined") return;
+  resizeObserver = new ResizeObserver(() => schedulePosition());
+  try {
+    resizeObserver.observe(video);
+  } catch {
+    /* ignore */
+  }
+}
+
+function attachGlobalListeners(): void {
+  if (listenersAttached) return;
+  listenersAttached = true;
+
+  window.addEventListener("resize", onViewportChange, { passive: true });
+  window.addEventListener("scroll", onViewportChange, {
+    capture: true,
+    passive: true,
+  });
+  document.addEventListener("fullscreenchange", onFullscreenChange);
+  document.addEventListener("webkitfullscreenchange", onFullscreenChange);
+  // Capture at document level because site controls commonly sit above the
+  // video and prevent pointer events from targeting the <video> itself.
+  document.addEventListener("pointermove", onVideoPointerActivity, {
+    capture: true,
+    passive: true,
+  });
+
+  mutationObserver = new MutationObserver(onDomMutated);
+  try {
+    mutationObserver.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["src", "style", "class", "hidden"],
+    });
+  } catch {
+    /* ignore */
+  }
+
+  window.addEventListener("popstate", onPopState);
+}
+
+function detachGlobalListeners(): void {
+  if (!listenersAttached) return;
+  listenersAttached = false;
+
+  window.removeEventListener("resize", onViewportChange);
+  window.removeEventListener("scroll", onViewportChange, true);
+  document.removeEventListener("fullscreenchange", onFullscreenChange);
+  document.removeEventListener("webkitfullscreenchange", onFullscreenChange);
+  document.removeEventListener("pointermove", onVideoPointerActivity, true);
+  window.removeEventListener("popstate", onPopState);
+
+  mutationObserver?.disconnect();
+  mutationObserver = null;
+  resizeObserver?.disconnect();
+  resizeObserver = null;
+
+  if (rafId != null) {
+    cancelAnimationFrame(rafId);
+    rafId = null;
+  }
+  if (resolveTimer) {
+    clearTimeout(resolveTimer);
+    resolveTimer = null;
+  }
+  clearAutoHideTimer();
+}
+
+// ── Enable / disable ─────────────────────────────────────────────────────────
+
+function startOverlayFeature(): void {
+  if (!settingLoaded || !enabled) return;
+  attachGlobalListeners();
+  void resolveAndRender();
+}
+
+function stopOverlayFeature(): void {
+  unbindVideoListeners(primaryVideo);
+  primaryVideo = null;
+  lastPointerX = Number.NaN;
+  lastPointerY = Number.NaN;
+  detachGlobalListeners();
+  destroyOverlay();
+  lastCandidateUrl = null;
+}
+
+function applyEnabled(next: boolean): void {
+  const was = enabled;
+  enabled = next;
+  if (!settingLoaded) return;
+  if (enabled && !was) startOverlayFeature();
+  else if (!enabled && was) stopOverlayFeature();
+}
+
+// ── Init ─────────────────────────────────────────────────────────────────────
+
+function onStorageChanged(
+  changes: Record<string, browser.Storage.StorageChange>,
+  area: string,
+): void {
+  if (area !== "local") return;
+  if (!(SHOW_VIDEO_CAST_OVERLAY_KEY in changes)) return;
+  const change = changes[SHOW_VIDEO_CAST_OVERLAY_KEY];
+  const value =
+    typeof change.newValue === "boolean"
+      ? change.newValue
+      : SHOW_VIDEO_CAST_OVERLAY_DEFAULT;
+  applyEnabled(value);
+}
+
+function onRuntimeMessage(message: unknown): void {
+  if (!enabled || !settingLoaded) return;
+  const msg = message as { type?: string };
+  // New detection or bridge status — re-rank without high-frequency polling.
+  if (
+    msg?.type === "video_detected" ||
+    msg?.type === "ws_status_update" ||
+    msg?.type === "overlay_navigation"
+  ) {
+    scheduleResolve();
+  }
+}
+
+async function init(): Promise<void> {
+  // Avoid FOUC: do not create UI until the setting is known.
+  try {
+    enabled = await getShowVideoCastOverlay(browser.storage.local);
+  } catch {
+    enabled = SHOW_VIDEO_CAST_OVERLAY_DEFAULT;
+  }
+  settingLoaded = true;
+
+  browser.storage.onChanged.addListener(onStorageChanged);
+  browser.runtime.onMessage.addListener(onRuntimeMessage);
+
+  if (enabled) startOverlayFeature();
+}
+
+void init();

--- a/extension/src/settings.ts
+++ b/extension/src/settings.ts
@@ -1,0 +1,35 @@
+// Shared extension preference keys. Safe to import from popup and content
+// entry points (no background/native dependencies).
+
+/** When true, show the on-video cast overlay in content scripts. */
+export const SHOW_VIDEO_CAST_OVERLAY_KEY = "showVideoCastOverlay";
+
+/**
+ * Default: enabled. The overlay is non-destructive and users can turn it off
+ * from the Settings tab; opt-out matches "useful by default" for a cast tool.
+ */
+export const SHOW_VIDEO_CAST_OVERLAY_DEFAULT = true;
+
+export async function getShowVideoCastOverlay(
+  storage: {
+    get: (keys: string | string[] | null) => Promise<Record<string, unknown>>;
+  },
+): Promise<boolean> {
+  try {
+    const result = await storage.get(SHOW_VIDEO_CAST_OVERLAY_KEY);
+    const value = result[SHOW_VIDEO_CAST_OVERLAY_KEY];
+    if (typeof value === "boolean") return value;
+    return SHOW_VIDEO_CAST_OVERLAY_DEFAULT;
+  } catch {
+    return SHOW_VIDEO_CAST_OVERLAY_DEFAULT;
+  }
+}
+
+export async function setShowVideoCastOverlay(
+  storage: {
+    set: (items: Record<string, unknown>) => Promise<void>;
+  },
+  enabled: boolean,
+): Promise<void> {
+  await storage.set({ [SHOW_VIDEO_CAST_OVERLAY_KEY]: enabled });
+}

--- a/extension/src/ui/popup.css
+++ b/extension/src/ui/popup.css
@@ -523,6 +523,35 @@ button {
     display: block !important;
 }
 
+/* Settings rows */
+.setting-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 4px 0;
+}
+
+.setting-text {
+    flex: 1;
+    min-width: 0;
+}
+
+.setting-label {
+    display: block;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-main);
+    cursor: pointer;
+}
+
+.setting-desc {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 4px;
+    line-height: 1.4;
+}
+
 /* Toggle Switch */
 .switch {
     position: relative;
@@ -530,6 +559,7 @@ button {
     width: 36px;
     height: 20px;
     flex-shrink: 0;
+    margin-top: 2px;
 }
 
 .switch input {

--- a/extension/src/ui/popup.html
+++ b/extension/src/ui/popup.html
@@ -29,6 +29,10 @@
                 <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 0 24 24" width="20" fill="currentColor"><path d="M0 0h24v24H0z" fill="none"/><path d="M21 3H3c-1.11 0-2 .89-2 2v12c0 1.1.89 2 2 2h5v2h8v-2h5c1.1 0 1.99-.9 1.99-2L23 5c0-1.11-.9-2-2-2zm0 14H3V5h18v12zm-5-6l-7 4V7z"/></svg>
                 <span class="tab-text">Connections</span>
             </button>
+            <button class="tab-btn" data-tab="settings" title="Settings">
+                <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 0 24 24" width="20" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.488.488 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1 1 12 8.4a3.6 3.6 0 0 1 0 7.2z"/></svg>
+                <span class="tab-text">Settings</span>
+            </button>
         </div>
     </div>
 
@@ -98,6 +102,25 @@
                 <h3>TVs on your network</h3>
                 <p class="subtitle">Pairing and choosing a TV is done in the PlayBridge desktop app. This list is informational.</p>
                 <div id="devices-list" class="saved-connections-list"></div>
+            </div>
+        </div>
+
+        <!-- Settings Tab -->
+        <div id="settings-tab" class="tab-content">
+            <div class="settings-card">
+                <h2>Settings</h2>
+                <p class="subtitle">Preferences for this browser extension</p>
+
+                <div class="setting-row">
+                    <div class="setting-text">
+                        <label class="setting-label" for="show-video-cast-overlay">Show cast button on videos</label>
+                        <p class="setting-desc">Display a PlayBridge cast control on the primary video on each page.</p>
+                    </div>
+                    <label class="switch" title="Show cast button on videos">
+                        <input type="checkbox" id="show-video-cast-overlay" checked>
+                        <span class="slider"></span>
+                    </label>
+                </div>
             </div>
         </div>
 

--- a/extension/src/ui/popup.ts
+++ b/extension/src/ui/popup.ts
@@ -1,9 +1,14 @@
 // @ts-nocheck
 import browser from "../browser";
+import {
+    getShowVideoCastOverlay,
+    setShowVideoCastOverlay,
+} from "../settings";
 
 // DOM Elements
 const tabBtns = document.querySelectorAll('.tab-btn');
 const tabContents = document.querySelectorAll('.tab-content');
+const showVideoCastOverlayToggle = document.getElementById('show-video-cast-overlay');
 
 const videosList = document.getElementById('videos-list');
 const noVideosMsg = document.getElementById('no-videos-msg');
@@ -627,8 +632,30 @@ window.addEventListener('message', (event) => {
     }
 });
 
+// Settings: on-video cast overlay toggle (persisted; content scripts sync via storage.onChanged)
+async function loadOverlaySetting() {
+    if (!showVideoCastOverlayToggle) return;
+    const enabled = await getShowVideoCastOverlay(browser.storage.local);
+    showVideoCastOverlayToggle.checked = enabled;
+}
+
+if (showVideoCastOverlayToggle) {
+    showVideoCastOverlayToggle.addEventListener('change', async () => {
+        const enabled = !!showVideoCastOverlayToggle.checked;
+        try {
+            await setShowVideoCastOverlay(browser.storage.local, enabled);
+            showToast(enabled ? 'Cast button on videos enabled' : 'Cast button on videos disabled');
+        } catch (e) {
+            console.error('Failed to save overlay setting', e);
+            showVideoCastOverlayToggle.checked = !enabled;
+            showToast('Could not save setting');
+        }
+    });
+}
+
 // Init
 window.addEventListener('DOMContentLoaded', () => {
     loadStatus();
     loadVideos();
+    loadOverlaySetting();
 });


### PR DESCRIPTION
## Summary

- add a persisted popup setting for the on-video cast control
- inject a non-destructive, accessible overlay on the primary visible video
- rank frame-aware detected media and cast through the existing native bridge
- support Chrome MV3 and Firefox MV2 content-script builds

## Verification

- `npm run build`

## Risks and manual verification

- the content script observes dynamic player and SPA changes across all frames
- manually verify protected streams, MSE/blob players, fullscreen, nested frames, setting synchronization, and receiver error states in Chrome and Firefox
