### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded keystore password

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,8 @@
+## 2025-02-09 - Hardcoded Keystore Password in Android TV App
+**Vulnerability:** The Android TV app used a hardcoded string (`"playbridge"`) as the password for its dynamically generated app-private TLS PKCS12 keystore in `TlsIdentity.kt`.
+**Learning:** While the keystore file is sandboxed in the app's internal storage, using a hardcoded password provides no defense-in-depth against attackers who manage to read files from that directory (e.g. via an arbitrary file read vulnerability or on a rooted device). The key shouldn't be accessible using a globally known constant.
+**Prevention:** Generate a strong, random password (e.g., using `UUID.randomUUID()`) when the keystore is first created, and store it securely (e.g., in a local text file with restricted permissions alongside the keystore, or via EncryptedSharedPreferences).
+
 ## 2025-02-09 - XSS Vulnerability in Extension Popup
 **Vulnerability:** XSS vulnerability in `extension/src/ui/popup.js` where user-controlled connection properties (`ip`, `pin`) were rendered directly into the DOM using `item.innerHTML = \`<span class="saved-connection-ip">${conn.ip}</span>\``.
 **Learning:** The extension builds some DOM views manually without a UI framework, increasing the risk of DOM-based XSS when interpolating variables into HTML strings.

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/TlsIdentity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/TlsIdentity.kt
@@ -1,6 +1,7 @@
 package com.playbridge.player.server
 
 import java.util.Base64
+import java.util.UUID
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
@@ -27,27 +28,47 @@ import javax.net.ssl.SSLContext
  */
 object TlsIdentity {
     private const val ENTRY = "playbridge"
-    private val PASSWORD = "playbridge".toCharArray()
     private const val FILE_NAME = "playbridge_tls.p12"
+    private const val PW_FILE_NAME = "playbridge_tls_pw.txt"
 
     data class Result(val sslContext: SSLContext, val fingerprint: String)
 
+    private fun getOrGeneratePassword(dir: File): CharArray {
+        val pwFile = File(dir, PW_FILE_NAME)
+        val ksFile = File(dir, FILE_NAME)
+        if (pwFile.exists()) {
+            return pwFile.readText().toCharArray()
+        }
+
+        // Backward compatibility: If the keystore exists but no password file, it's a legacy install.
+        // Fall back to the old hardcoded password so we don't break existing connections.
+        val newPw = if (ksFile.exists()) {
+            "playbridge".toCharArray()
+        } else {
+            UUID.randomUUID().toString().toCharArray()
+        }
+
+        pwFile.writeText(String(newPw))
+        return newPw
+    }
+
     fun loadOrCreate(dir: File, commonName: String = "PlayBridge TV"): Result {
         val file = File(dir, FILE_NAME)
+        val password = getOrGeneratePassword(dir)
         val ks = KeyStore.getInstance("PKCS12")
         if (file.exists()) {
-            file.inputStream().use { ks.load(it, PASSWORD) }
+            file.inputStream().use { ks.load(it, password) }
         } else {
             ks.load(null, null)
             val keyPair = generateKeyPair()
             val cert = selfSignedCert(keyPair, commonName)
-            ks.setKeyEntry(ENTRY, keyPair.private, PASSWORD, arrayOf(cert))
-            file.outputStream().use { ks.store(it, PASSWORD) }
+            ks.setKeyEntry(ENTRY, keyPair.private, password, arrayOf(cert))
+            file.outputStream().use { ks.store(it, password) }
         }
 
         val cert = ks.getCertificate(ENTRY) as X509Certificate
         val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
-        kmf.init(ks, PASSWORD)
+        kmf.init(ks, password)
         val sslContext = SSLContext.getInstance("TLS").apply {
             init(kmf.keyManagers, null, null)
         }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The Android TV app used a globally known hardcoded string (`"playbridge"`) as the password for its dynamically generated app-private TLS PKCS12 keystore (`TlsIdentity.kt`).
🎯 Impact: While the keystore file is sandboxed in the app's internal storage, using a hardcoded password provides no defense-in-depth against attackers who manage to read files from that directory (e.g. via an arbitrary file read vulnerability or on a rooted device). The key shouldn't be accessible using a globally known constant.
🔧 Fix: Replaced the hardcoded password with a dynamically generated random UUID that is created on first run and stored locally alongside the keystore. Added a backward compatibility check to use the legacy password for existing keystores without breaking functionality.
✅ Verification: Ran unit tests via `./gradlew test` in the `tv/android/player` directory. Verified that the `TlsIdentity.kt` file successfully handles backwards compatibility. Updated the Sentinel Journal.

---
*PR created automatically by Jules for task [16773797242433796785](https://jules.google.com/task/16773797242433796785) started by @playbridgeapp*