### PR TITLE
feat: add configurable still-watching reminders

### DIFF
--- a/desktop/lib/extension_bridge.dart
+++ b/desktop/lib/extension_bridge.dart
@@ -28,10 +28,23 @@ import 'tv_sender_controller.dart';
 /// - client → app: `{"token":"…"}` (first line), then `{"cmd":…}`.
 /// - app → client: `{"type":"hello"|"state"|"result", …}`.
 class ExtensionBridge {
-  ExtensionBridge(this._sender, this._player);
+  ExtensionBridge(
+    this._sender,
+    this._player, {
+    this.isPlaybackPromptActive,
+    this.onPromptContinue,
+    this.onPromptStop,
+    this.onPlaybackActivity,
+    this.onNewMedia,
+  });
 
   final TvSenderController _sender;
   final PlayerController _player;
+  final bool Function()? isPlaybackPromptActive;
+  final VoidCallback? onPromptContinue;
+  final VoidCallback? onPromptStop;
+  final VoidCallback? onPlaybackActivity;
+  final VoidCallback? onNewMedia;
 
   ServerSocket? _server;
   final Set<Socket> _authed = {};
@@ -125,6 +138,7 @@ class ExtensionBridge {
             if (!ok) 'error': 'send failed',
           });
         } else {
+          onNewMedia?.call();
           // No cast target — play on this machine (extension → desktop).
           final headerCount = headers?.length ?? 0;
           debugPrint(
@@ -178,6 +192,7 @@ class ExtensionBridge {
               (file.uri.pathSegments.isNotEmpty
                   ? file.uri.pathSegments.last
                   : path);
+          onNewMedia?.call();
           await _player.playUrl(
             file.uri.toString(),
             title: name,
@@ -215,6 +230,19 @@ class ExtensionBridge {
   /// as the TV receiver / [TvSenderController.sendControl]).
   bool _localControl(String action) {
     try {
+      if (isPlaybackPromptActive?.call() ?? false) {
+        if (action == 'play') {
+          onPromptContinue?.call();
+          return true;
+        }
+        if (action == 'stop') {
+          onPromptStop?.call();
+          return true;
+        }
+        onPromptContinue?.call();
+        return true;
+      }
+      onPlaybackActivity?.call();
       if (action.startsWith('seek_to:')) {
         final ms = int.tryParse(action.substring('seek_to:'.length));
         if (ms == null) return false;

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -33,6 +33,8 @@ import 'server.dart';
 import 'settings_screen.dart';
 import 'shader_background.dart';
 import 'stats_overlay.dart';
+import 'still_watching_controller.dart';
+import 'still_watching_prompt.dart';
 import 'tray_controller.dart';
 import 'tv_connection_store.dart';
 import 'tv_sender_controller.dart';
@@ -141,6 +143,8 @@ class ReceiverApp extends StatefulWidget {
 }
 
 class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
+  final FocusNode _keyboardFocusNode =
+      FocusNode(debugLabel: 'desktop-shortcuts');
   late final PlayerController _player;
   late final ReceiverServer _server;
   late final DiscoveryPublisher _discovery;
@@ -148,6 +152,7 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   late final TvSenderController _sender;
   late final ExtensionBridge _extBridge;
   late final MediaSessionBridge _mediaSession;
+  late final StillWatchingController _stillWatching;
   final UpdateChecker _updateChecker = UpdateChecker();
 
   bool _hadMedia = false;
@@ -229,7 +234,23 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     _showStats = ValueNotifier<bool>(widget.store.showStats);
     _showStats.addListener(() => widget.store.setShowStats(_showStats.value));
     _player = PlayerController(initialEngine: widget.store.engineType);
-    _server = ReceiverServer(player: _player, store: widget.store);
+    _stillWatching = StillWatchingController(
+      player: _player,
+      enabled: widget.store.stillWatchingEnabled,
+      threshold: Duration(minutes: widget.store.stillWatchingThresholdMinutes),
+      gracePeriod: Duration(seconds: widget.store.stillWatchingResponseSeconds),
+      onAutoStop: () => _server.broadcastIdleContext(),
+    );
+    _stillWatching.addListener(_handleStillWatchingChange);
+    _server = ReceiverServer(
+      player: _player,
+      store: widget.store,
+      isPlaybackPromptActive: () => _stillWatching.isPrompting,
+      onPromptContinue: () => unawaited(_stillWatching.continueWatching()),
+      onPromptStop: () => unawaited(_stillWatching.stopWatching()),
+      onPlaybackActivity: _stillWatching.recordUserActivity,
+      onNewMedia: _stillWatching.resetForNewMedia,
+    );
     _discovery = DiscoveryPublisher(
       serviceName: widget.store.deviceName,
       port: kDefaultPort,
@@ -238,8 +259,22 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     _tray =
         TrayController(player: _player, server: _server, store: widget.store);
     _sender = TvSenderController(identity: widget.store, store: widget.tvStore);
-    _extBridge = ExtensionBridge(_sender, _player);
-    _mediaSession = MediaSessionBridge(_player);
+    _extBridge = ExtensionBridge(
+      _sender,
+      _player,
+      isPlaybackPromptActive: () => _stillWatching.isPrompting,
+      onPromptContinue: () => unawaited(_stillWatching.continueWatching()),
+      onPromptStop: () => unawaited(_stillWatching.stopWatching()),
+      onPlaybackActivity: _stillWatching.recordUserActivity,
+      onNewMedia: _stillWatching.resetForNewMedia,
+    );
+    _mediaSession = MediaSessionBridge(
+      _player,
+      isPlaybackPromptActive: () => _stillWatching.isPrompting,
+      onPromptContinue: () => unawaited(_stillWatching.continueWatching()),
+      onPromptStop: () => unawaited(_stillWatching.stopWatching()),
+      onPlaybackActivity: _stillWatching.recordUserActivity,
+    );
 
     windowManager.addListener(this);
     _player.addListener(_handlePlayerChange);
@@ -269,6 +304,12 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     // video here). Tracks the rising edge so it doesn't fight tab navigation.
     _sender.addListener(_handleSenderChange);
 
+    // `autofocus` is not enough on desktop once widgets/platform views have
+    // had a chance to take focus, so explicitly claim the shortcut focus.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _keyboardFocusNode.requestFocus();
+    });
+
     // Cold-start file open (`playbridge_cast` launched the app): cast to a TV
     // if already linked, otherwise play on this desktop (same as extension
     // bridge when disconnected).
@@ -283,6 +324,25 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   }
 
   bool _senderWasCasting = false;
+  bool _wasStillWatchingPrompting = false;
+
+  void _handleStillWatchingChange() {
+    final prompting = _stillWatching.isPrompting;
+    if (prompting && !_wasStillWatchingPrompting) {
+      unawaited(_revealWindow());
+    }
+    _wasStillWatchingPrompting = prompting;
+    if (mounted) setState(() {});
+  }
+
+  void _applyStillWatchingSettings() {
+    _stillWatching.updateSettings(
+      enabled: widget.store.stillWatchingEnabled,
+      threshold: Duration(minutes: widget.store.stillWatchingThresholdMinutes),
+      gracePeriod: Duration(seconds: widget.store.stillWatchingResponseSeconds),
+    );
+  }
+
   void _handleSenderChange() {
     final casting = _sender.isCasting;
     if (casting == _senderWasCasting) return; // only react to edges
@@ -341,6 +401,7 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   }
 
   void _handlePlayRequest() {
+    _stillWatching.resetForNewMedia();
     unawaited(_revealWindow(fullScreen: widget.store.autoFullScreen));
     if (!_showingVideo) {
       setState(() => _showingVideo = true);
@@ -641,6 +702,7 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     _hideTimer?.cancel();
     _osdTimer?.cancel();
     _tapTimer?.cancel();
+    _keyboardFocusNode.dispose();
     windowManager.removeListener(this);
     _player.removeListener(_handlePlayerChange);
     _player.playRequests.removeListener(_handlePlayRequest);
@@ -653,6 +715,8 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     _sender.dispose();
     _discovery.stop();
     _server.stop();
+    _stillWatching.removeListener(_handleStillWatchingChange);
+    _stillWatching.dispose();
     _player.dispose();
     _showStats.dispose();
     _updateChecker.dispose();
@@ -662,372 +726,412 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'PlayBridge Desktop',
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData.dark(useMaterial3: true).copyWith(
-        scaffoldBackgroundColor: Colors.transparent,
-        canvasColor: Colors.transparent,
-        // Brand font shared with the Android apps. Applies app-wide through the
-        // text theme; explicit monospace styles (logs) are unaffected.
-        textTheme: ThemeData.dark(useMaterial3: true).textTheme.apply(
-              fontFamily: 'Poppins',
-            ),
-        primaryTextTheme: ThemeData.dark(useMaterial3: true)
-            .primaryTextTheme
-            .apply(fontFamily: 'Poppins'),
-      ),
-      home: Shortcuts(
-        shortcuts: {
-          const SingleActivator(LogicalKeyboardKey.space):
-              const PlayPauseIntent(),
-          const SingleActivator(LogicalKeyboardKey.arrowRight):
-              const SeekForwardIntent(),
-          const SingleActivator(LogicalKeyboardKey.arrowLeft):
-              const SeekBackwardIntent(),
-          const SingleActivator(LogicalKeyboardKey.arrowUp):
-              const VolumeUpIntent(),
-          const SingleActivator(LogicalKeyboardKey.arrowDown):
-              const VolumeDownIntent(),
-          const SingleActivator(LogicalKeyboardKey.keyI):
-              const StatsToggleIntent(),
-          const SingleActivator(LogicalKeyboardKey.keyF):
-              const ToggleFullScreenIntent(),
-          // `?` is Shift+/ on US keyboards.
-          const SingleActivator(LogicalKeyboardKey.slash, shift: true):
-              const ShowShortcutsIntent(),
-          const SingleActivator(LogicalKeyboardKey.slash):
-              const ShowShortcutsIntent(),
-        },
-        child: Actions(
-          actions: {
-            PlayPauseIntent: CallbackAction<PlayPauseIntent>(
-              onInvoke: (_) {
-                _togglePlayPause();
-                return null;
-              },
-            ),
-            SeekForwardIntent: CallbackAction<SeekForwardIntent>(
-              onInvoke: (_) {
-                _seekBy(10000, osd: '≫ 10s');
-                return null;
-              },
-            ),
-            SeekBackwardIntent: CallbackAction<SeekBackwardIntent>(
-              onInvoke: (_) {
-                _seekBy(-10000, osd: '≪ 10s');
-                return null;
-              },
-            ),
-            VolumeUpIntent: CallbackAction<VolumeUpIntent>(
-              onInvoke: (_) {
-                _nudgeVolume(0.05);
-                return null;
-              },
-            ),
-            VolumeDownIntent: CallbackAction<VolumeDownIntent>(
-              onInvoke: (_) {
-                _nudgeVolume(-0.05);
-                return null;
-              },
-            ),
-            StatsToggleIntent: CallbackAction<StatsToggleIntent>(
-              onInvoke: (_) {
-                _showStats.value = !_showStats.value;
-                return null;
-              },
-            ),
-            ToggleFullScreenIntent: CallbackAction<ToggleFullScreenIntent>(
-              onInvoke: (_) {
-                unawaited(_toggleFullScreen());
-                return null;
-              },
-            ),
-            ShowShortcutsIntent: CallbackAction<ShowShortcutsIntent>(
-              onInvoke: (_) {
-                unawaited(showKeyboardShortcutsSheet(context));
-                return null;
-              },
-            ),
+        title: 'PlayBridge Desktop',
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData.dark(useMaterial3: true).copyWith(
+          scaffoldBackgroundColor: Colors.transparent,
+          canvasColor: Colors.transparent,
+          // Brand font shared with the Android apps. Applies app-wide through the
+          // text theme; explicit monospace styles (logs) are unaffected.
+          textTheme: ThemeData.dark(useMaterial3: true).textTheme.apply(
+                fontFamily: 'Poppins',
+              ),
+          primaryTextTheme: ThemeData.dark(useMaterial3: true)
+              .primaryTextTheme
+              .apply(fontFamily: 'Poppins'),
+        ),
+        home: Shortcuts(
+          shortcuts: {
+            const SingleActivator(LogicalKeyboardKey.space):
+                const PlayPauseIntent(),
+            const SingleActivator(LogicalKeyboardKey.arrowRight):
+                const SeekForwardIntent(),
+            const SingleActivator(LogicalKeyboardKey.arrowLeft):
+                const SeekBackwardIntent(),
+            const SingleActivator(LogicalKeyboardKey.arrowUp):
+                const VolumeUpIntent(),
+            const SingleActivator(LogicalKeyboardKey.arrowDown):
+                const VolumeDownIntent(),
+            const SingleActivator(LogicalKeyboardKey.keyI):
+                const StatsToggleIntent(),
+            const SingleActivator(LogicalKeyboardKey.keyF):
+                const ToggleFullScreenIntent(),
+            // `?` is Shift+/ on US keyboards.
+            const SingleActivator(LogicalKeyboardKey.slash, shift: true):
+                const ShowShortcutsIntent(),
+            const SingleActivator(LogicalKeyboardKey.slash):
+                const ShowShortcutsIntent(),
           },
-          child: Focus(
-            autofocus: true,
-            child: Scaffold(
-              backgroundColor: Colors.transparent,
-              // Deliberately NOT listening to _player here: it notifies on every
-              // ~200ms position tick, and rebuilding the whole shell (backdrop
-              // blurs included) at 5Hz steals frame time from the video. The
-              // controls/status bars listen to the player themselves; structural
-              // changes arrive via the coarse setState in _handlePlayerChange.
-              body: AnimatedBuilder(
-                animation: Listenable.merge([_server, _showStats]),
-                builder: (context, _) {
-                  final hasMedia = _player.queue.isNotEmpty;
-                  final hasQueue = _player.queue.length > 1;
-                  const titleBarHeight = 28.0;
-                  // Hide every piece of chrome (title bar, sidebar, status bar)
-                  // when the user is watching video in full-screen — the video
-                  // should fill the entire monitor, not be framed by panels.
-                  final hideChrome = _isFullScreen && _showingVideo && hasMedia;
+          child: Actions(
+            actions: {
+              PlayPauseIntent: CallbackAction<PlayPauseIntent>(
+                onInvoke: (_) {
+                  _togglePlayPause();
+                  return null;
+                },
+              ),
+              SeekForwardIntent: CallbackAction<SeekForwardIntent>(
+                onInvoke: (_) {
+                  _seekBy(10000, osd: '≫ 10s');
+                  return null;
+                },
+              ),
+              SeekBackwardIntent: CallbackAction<SeekBackwardIntent>(
+                onInvoke: (_) {
+                  _seekBy(-10000, osd: '≪ 10s');
+                  return null;
+                },
+              ),
+              VolumeUpIntent: CallbackAction<VolumeUpIntent>(
+                onInvoke: (_) {
+                  _nudgeVolume(0.05);
+                  return null;
+                },
+              ),
+              VolumeDownIntent: CallbackAction<VolumeDownIntent>(
+                onInvoke: (_) {
+                  _nudgeVolume(-0.05);
+                  return null;
+                },
+              ),
+              StatsToggleIntent: CallbackAction<StatsToggleIntent>(
+                onInvoke: (_) {
+                  _showStats.value = !_showStats.value;
+                  return null;
+                },
+              ),
+              ToggleFullScreenIntent: CallbackAction<ToggleFullScreenIntent>(
+                onInvoke: (_) {
+                  unawaited(_toggleFullScreen());
+                  return null;
+                },
+              ),
+              ShowShortcutsIntent: CallbackAction<ShowShortcutsIntent>(
+                onInvoke: (_) {
+                  unawaited(showKeyboardShortcutsSheet(context));
+                  return null;
+                },
+              ),
+            },
+            child: Focus(
+              focusNode: _keyboardFocusNode,
+              autofocus: true,
+              onKeyEvent: (_, event) {
+                if (event is KeyDownEvent && !_stillWatching.isPrompting) {
+                  _stillWatching.recordUserActivity();
+                }
+                return KeyEventResult.ignored;
+              },
+              child: Listener(
+                behavior: HitTestBehavior.translucent,
+                onPointerDown: (_) {
+                  if (_stillWatching.isPrompting) {
+                    unawaited(_stillWatching.continueWatching());
+                  } else {
+                    _stillWatching.recordUserActivity();
+                  }
+                  if (!_keyboardFocusNode.hasFocus) {
+                    _keyboardFocusNode.requestFocus();
+                  }
+                },
+                onPointerHover: (_) => _stillWatching.recordUserActivity(),
+                child: Scaffold(
+                  backgroundColor: Colors.transparent,
+                  // Deliberately NOT listening to _player here: it notifies on every
+                  // ~200ms position tick, and rebuilding the whole shell (backdrop
+                  // blurs included) at 5Hz steals frame time from the video. The
+                  // controls/status bars listen to the player themselves; structural
+                  // changes arrive via the coarse setState in _handlePlayerChange.
+                  body: AnimatedBuilder(
+                    animation: Listenable.merge([_server, _showStats]),
+                    builder: (context, _) {
+                      final hasMedia = _player.queue.isNotEmpty;
+                      final hasQueue = _player.queue.length > 1;
+                      const titleBarHeight = 28.0;
+                      // Hide every piece of chrome (title bar, sidebar, status bar)
+                      // when the user is watching video in full-screen — the video
+                      // should fill the entire monitor, not be framed by panels.
+                      final hideChrome =
+                          _isFullScreen && _showingVideo && hasMedia;
 
-                  return Stack(
-                    fit: StackFit.expand,
-                    children: [
-                      // Aurora background — only rendered when the user is NOT
-                      // watching video. Six-octave FBM + domain warping is expensive,
-                      // and during playback the video texture covers most of it
-                      // anyway, so leaving it running just steals GPU from mpv.
-                      if (!_showingVideo)
-                        const Positioned.fill(child: AuroraBackground()),
-
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                      return Stack(
+                        fit: StackFit.expand,
                         children: [
-                          if (!hideChrome)
-                            SizedBox(
-                              height: titleBarHeight,
-                              child: ClipRect(
-                                child: BackdropFilter(
-                                  filter:
-                                      ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-                                  child: DragToMoveArea(
-                                    child: Container(
-                                      decoration: BoxDecoration(
-                                        gradient: LinearGradient(
-                                          begin: Alignment.topCenter,
-                                          end: Alignment.bottomCenter,
-                                          colors: [
-                                            Colors.white
-                                                .withValues(alpha: 0.10),
-                                            Colors.black
-                                                .withValues(alpha: 0.20),
-                                          ],
-                                        ),
-                                        border: Border(
-                                          bottom: BorderSide(
-                                            color: Colors.white
-                                                .withValues(alpha: 0.08),
+                          // Aurora background — only rendered when the user is NOT
+                          // watching video. Six-octave FBM + domain warping is expensive,
+                          // and during playback the video texture covers most of it
+                          // anyway, so leaving it running just steals GPU from mpv.
+                          if (!_showingVideo)
+                            const Positioned.fill(child: AuroraBackground()),
+
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              if (!hideChrome)
+                                SizedBox(
+                                  height: titleBarHeight,
+                                  child: ClipRect(
+                                    child: BackdropFilter(
+                                      filter: ImageFilter.blur(
+                                          sigmaX: 30, sigmaY: 30),
+                                      child: DragToMoveArea(
+                                        child: Container(
+                                          decoration: BoxDecoration(
+                                            gradient: LinearGradient(
+                                              begin: Alignment.topCenter,
+                                              end: Alignment.bottomCenter,
+                                              colors: [
+                                                Colors.white
+                                                    .withValues(alpha: 0.10),
+                                                Colors.black
+                                                    .withValues(alpha: 0.20),
+                                              ],
+                                            ),
+                                            border: Border(
+                                              bottom: BorderSide(
+                                                color: Colors.white
+                                                    .withValues(alpha: 0.08),
+                                              ),
+                                            ),
+                                          ),
+                                          child: Row(
+                                            children: [
+                                              const SizedBox(width: 78),
+                                              Expanded(
+                                                child: Container(
+                                                    color: Colors.transparent),
+                                              ),
+                                            ],
                                           ),
                                         ),
-                                      ),
-                                      child: Row(
-                                        children: [
-                                          const SizedBox(width: 78),
-                                          Expanded(
-                                            child: Container(
-                                                color: Colors.transparent),
-                                          ),
-                                        ],
                                       ),
                                     ),
                                   ),
+                                ),
+                              Expanded(
+                                child: Row(
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: [
+                                    if (!hideChrome)
+                                      _NavSidebar(
+                                        dest: _dest,
+                                        showingVideo: _showingVideo,
+                                        hasMedia: hasMedia,
+                                        playerState: _player.state,
+                                        senderCasting: _sender.isCasting,
+                                        enableHistory:
+                                            widget.store.enableHistory,
+                                        onDestSelect: (d) => setState(() {
+                                          _dest = d;
+                                          _showingVideo = false;
+                                        }),
+                                        onShowVideo: () => setState(
+                                            () => _showingVideo = true),
+                                      ),
+                                    Expanded(
+                                      child: DropTarget(
+                                        onDragEntered: (_) => setState(
+                                            () => _mainDragging = true),
+                                        onDragExited: (_) => setState(
+                                            () => _mainDragging = false),
+                                        onDragDone: _onMainDrop,
+                                        child: MouseRegion(
+                                          onEnter: (_) => _markActive(),
+                                          onExit: (_) => _markInactive(),
+                                          onHover: (_) => _markActive(),
+                                          child: Stack(
+                                            fit: StackFit.expand,
+                                            children: [
+                                              // Video is always in the tree (Offstage) so
+                                              // mpv is never torn down on screen switch.
+                                              Positioned.fill(
+                                                child: Offstage(
+                                                  offstage: !_showingVideo ||
+                                                      !hasMedia,
+                                                  child: Container(
+                                                    color: Colors.black,
+                                                    child: PlaybackSurface(
+                                                      controller: _player,
+                                                      controlsVisible:
+                                                          _videoHovered ||
+                                                              _playlistDrawerOpen ||
+                                                              _menusOpen > 0,
+                                                    ),
+                                                  ),
+                                                ),
+                                              ),
+                                              // Tap / double-tap video (not controls).
+                                              // Below overlays so buttons/menus keep hits.
+                                              if (_showingVideo && hasMedia)
+                                                Positioned.fill(
+                                                  child: GestureDetector(
+                                                    behavior: HitTestBehavior
+                                                        .translucent,
+                                                    onTap: () {
+                                                      _markActive();
+                                                      // Wait out a possible double-tap.
+                                                      _tapTimer?.cancel();
+                                                      _tapTimer = Timer(
+                                                        const Duration(
+                                                            milliseconds: 220),
+                                                        () =>
+                                                            _togglePlayPause(),
+                                                      );
+                                                    },
+                                                    onDoubleTap: () {
+                                                      _tapTimer?.cancel();
+                                                      _markActive();
+                                                      final entering =
+                                                          !_isFullScreen;
+                                                      unawaited(
+                                                          _toggleFullScreen());
+                                                      _showOsd(entering
+                                                          ? 'Fullscreen'
+                                                          : 'Windowed');
+                                                    },
+                                                  ),
+                                                ),
+                                              if (!_showingVideo)
+                                                Positioned.fill(
+                                                    child: _buildScreen()),
+                                              if (_showingVideo &&
+                                                  hasMedia &&
+                                                  _showStats.value &&
+                                                  _player.engine is MpvEngine)
+                                                Positioned(
+                                                  top: 16,
+                                                  left: 16,
+                                                  child: StatsOverlay(
+                                                    engine: _player.engine
+                                                        as MpvEngine,
+                                                  ),
+                                                ),
+                                              if (_showingVideo && hasMedia)
+                                                Positioned(
+                                                  left: 0,
+                                                  right: 0,
+                                                  bottom: 0,
+                                                  child: _PlayerControlsBar(
+                                                    player: _player,
+                                                    store: widget.store,
+                                                    visible: _videoHovered ||
+                                                        _playlistDrawerOpen ||
+                                                        _menusOpen > 0,
+                                                    showQueueControls: hasQueue,
+                                                    onTogglePlaylist: () =>
+                                                        setState(
+                                                      () => _playlistDrawerOpen =
+                                                          !_playlistDrawerOpen,
+                                                    ),
+                                                    playlistOpen:
+                                                        _playlistDrawerOpen,
+                                                    onMenuOpened: () =>
+                                                        setState(
+                                                            () => _menusOpen++),
+                                                    onMenuClosed: () =>
+                                                        setState(
+                                                      () => _menusOpen =
+                                                          (_menusOpen - 1)
+                                                              .clamp(0, 99),
+                                                    ),
+                                                    isFullScreen: _isFullScreen,
+                                                    onToggleFullScreen:
+                                                        _toggleFullScreen,
+                                                  ),
+                                                ),
+                                              if (_showingVideo &&
+                                                  hasQueue &&
+                                                  _playlistDrawerOpen)
+                                                Positioned(
+                                                  right: 0,
+                                                  top: 0,
+                                                  bottom: 0,
+                                                  width: 360,
+                                                  child: _PlaylistDrawer(
+                                                    player: _player,
+                                                    onClose: () => setState(
+                                                      () =>
+                                                          _playlistDrawerOpen =
+                                                              false,
+                                                    ),
+                                                  ),
+                                                ),
+                                              // Title scrim along the top — same
+                                              // visibility as the controls bar, so
+                                              // the title is reachable in fullscreen.
+                                              if (_showingVideo && hasMedia)
+                                                Positioned(
+                                                  left: 0,
+                                                  right: 0,
+                                                  top: 0,
+                                                  child: _TitleOverlay(
+                                                    player: _player,
+                                                    visible: _videoHovered ||
+                                                        _playlistDrawerOpen ||
+                                                        _menusOpen > 0,
+                                                  ),
+                                                ),
+                                              // Pre-play screen for casts with
+                                              // metadata; sits above everything.
+                                              if (_showingVideo &&
+                                                  _prePlayItem != null)
+                                                Positioned.fill(
+                                                  child: PrePlayOverlay(
+                                                    key: ValueKey(
+                                                        _prePlayItem!.url),
+                                                    item: _prePlayItem!,
+                                                    onStart: _dismissPrePlay,
+                                                  ),
+                                                ),
+                                              if (_osdMessage != null)
+                                                PlaybackOsd(
+                                                    message: _osdMessage!),
+                                              if (_mainDragging)
+                                                const Positioned.fill(
+                                                  child: _MainDropOverlay(),
+                                                ),
+                                              if (_stillWatching.isPrompting)
+                                                Positioned.fill(
+                                                  child: StillWatchingPrompt(
+                                                    remainingSeconds:
+                                                        _stillWatching
+                                                            .remainingSeconds,
+                                                    title: _player.currentTitle,
+                                                    onContinue: () => unawaited(
+                                                        _stillWatching
+                                                            .continueWatching()),
+                                                  ),
+                                                ),
+                                            ],
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  ],
                                 ),
                               ),
-                            ),
-                          Expanded(
-                            child: Row(
-                              crossAxisAlignment: CrossAxisAlignment.stretch,
-                              children: [
-                                if (!hideChrome)
-                                  _NavSidebar(
-                                    dest: _dest,
-                                    showingVideo: _showingVideo,
-                                    hasMedia: hasMedia,
-                                    playerState: _player.state,
-                                    senderCasting: _sender.isCasting,
-                                    enableHistory: widget.store.enableHistory,
-                                    onDestSelect: (d) => setState(() {
-                                      _dest = d;
-                                      _showingVideo = false;
-                                    }),
-                                    onShowVideo: () =>
-                                        setState(() => _showingVideo = true),
-                                  ),
-                                Expanded(
-                                  child: DropTarget(
-                                    onDragEntered: (_) =>
-                                        setState(() => _mainDragging = true),
-                                    onDragExited: (_) =>
-                                        setState(() => _mainDragging = false),
-                                    onDragDone: _onMainDrop,
-                                    child: MouseRegion(
-                                      onEnter: (_) => _markActive(),
-                                      onExit: (_) => _markInactive(),
-                                      onHover: (_) => _markActive(),
-                                      child: Stack(
-                                        fit: StackFit.expand,
-                                        children: [
-                                          // Video is always in the tree (Offstage) so
-                                          // mpv is never torn down on screen switch.
-                                          Positioned.fill(
-                                            child: Offstage(
-                                              offstage:
-                                                  !_showingVideo || !hasMedia,
-                                              child: Container(
-                                                color: Colors.black,
-                                                child: PlaybackSurface(
-                                                  controller: _player,
-                                                  controlsVisible:
-                                                      _videoHovered ||
-                                                          _playlistDrawerOpen ||
-                                                          _menusOpen > 0,
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                          // Tap / double-tap video (not controls).
-                                          // Below overlays so buttons/menus keep hits.
-                                          if (_showingVideo && hasMedia)
-                                            Positioned.fill(
-                                              child: GestureDetector(
-                                                behavior:
-                                                    HitTestBehavior.translucent,
-                                                onTap: () {
-                                                  _markActive();
-                                                  // Wait out a possible double-tap.
-                                                  _tapTimer?.cancel();
-                                                  _tapTimer = Timer(
-                                                    const Duration(
-                                                        milliseconds: 220),
-                                                    () => _togglePlayPause(),
-                                                  );
-                                                },
-                                                onDoubleTap: () {
-                                                  _tapTimer?.cancel();
-                                                  _markActive();
-                                                  final entering =
-                                                      !_isFullScreen;
-                                                  unawaited(
-                                                      _toggleFullScreen());
-                                                  _showOsd(entering
-                                                      ? 'Fullscreen'
-                                                      : 'Windowed');
-                                                },
-                                              ),
-                                            ),
-                                          if (!_showingVideo)
-                                            Positioned.fill(
-                                                child: _buildScreen()),
-                                          if (_showingVideo &&
-                                              hasMedia &&
-                                              _showStats.value &&
-                                              _player.engine is MpvEngine)
-                                            Positioned(
-                                              top: 16,
-                                              left: 16,
-                                              child: StatsOverlay(
-                                                engine:
-                                                    _player.engine as MpvEngine,
-                                              ),
-                                            ),
-                                          if (_showingVideo && hasMedia)
-                                            Positioned(
-                                              left: 0,
-                                              right: 0,
-                                              bottom: 0,
-                                              child: _PlayerControlsBar(
-                                                player: _player,
-                                                store: widget.store,
-                                                visible: _videoHovered ||
-                                                    _playlistDrawerOpen ||
-                                                    _menusOpen > 0,
-                                                showQueueControls: hasQueue,
-                                                onTogglePlaylist: () =>
-                                                    setState(
-                                                  () => _playlistDrawerOpen =
-                                                      !_playlistDrawerOpen,
-                                                ),
-                                                playlistOpen:
-                                                    _playlistDrawerOpen,
-                                                onMenuOpened: () => setState(
-                                                    () => _menusOpen++),
-                                                onMenuClosed: () => setState(
-                                                  () => _menusOpen =
-                                                      (_menusOpen - 1)
-                                                          .clamp(0, 99),
-                                                ),
-                                                isFullScreen: _isFullScreen,
-                                                onToggleFullScreen:
-                                                    _toggleFullScreen,
-                                              ),
-                                            ),
-                                          if (_showingVideo &&
-                                              hasQueue &&
-                                              _playlistDrawerOpen)
-                                            Positioned(
-                                              right: 0,
-                                              top: 0,
-                                              bottom: 0,
-                                              width: 360,
-                                              child: _PlaylistDrawer(
-                                                player: _player,
-                                                onClose: () => setState(
-                                                  () => _playlistDrawerOpen =
-                                                      false,
-                                                ),
-                                              ),
-                                            ),
-                                          // Title scrim along the top — same
-                                          // visibility as the controls bar, so
-                                          // the title is reachable in fullscreen.
-                                          if (_showingVideo && hasMedia)
-                                            Positioned(
-                                              left: 0,
-                                              right: 0,
-                                              top: 0,
-                                              child: _TitleOverlay(
-                                                player: _player,
-                                                visible: _videoHovered ||
-                                                    _playlistDrawerOpen ||
-                                                    _menusOpen > 0,
-                                              ),
-                                            ),
-                                          // Pre-play screen for casts with
-                                          // metadata; sits above everything.
-                                          if (_showingVideo &&
-                                              _prePlayItem != null)
-                                            Positioned.fill(
-                                              child: PrePlayOverlay(
-                                                key:
-                                                    ValueKey(_prePlayItem!.url),
-                                                item: _prePlayItem!,
-                                                onStart: _dismissPrePlay,
-                                              ),
-                                            ),
-                                          if (_osdMessage != null)
-                                            PlaybackOsd(message: _osdMessage!),
-                                          if (_mainDragging)
-                                            const Positioned.fill(
-                                              child: _MainDropOverlay(),
-                                            ),
-                                        ],
-                                      ),
-                                    ),
-                                  ),
+                              if (!hideChrome)
+                                _StatusBar(
+                                  player: _player,
+                                  hostInfo: _hostInfo,
+                                  serverError: _serverError,
+                                  discoveryError: _discoveryError,
+                                  phase: _server.phase,
                                 ),
-                              ],
-                            ),
+                            ],
                           ),
-                          if (!hideChrome)
-                            _StatusBar(
-                              player: _player,
-                              hostInfo: _hostInfo,
-                              serverError: _serverError,
-                              discoveryError: _discoveryError,
-                              phase: _server.phase,
-                            ),
+                          // Self-update dialogs/banners; renders nothing while idle.
+                          UpdateGate(checker: _updateChecker),
                         ],
-                      ),
-                      // Self-update dialogs/banners; renders nothing while idle.
-                      UpdateGate(checker: _updateChecker),
-                    ],
-                  );
-                },
+                      );
+                    },
+                  ),
+                ),
               ),
             ),
           ),
-        ),
-      ),
-    );
+        ));
   }
 
   Widget _buildScreen() {
@@ -1062,11 +1166,14 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
           showStats: _showStats,
           updateChecker: _updateChecker,
           onNavigateToCast: () => setState(() => _dest = _Dest.cast),
-          onSettingsChanged: () => setState(() {
-            if (!widget.store.enableHistory && _dest == _Dest.history) {
-              _dest = _Dest.cast;
-            }
-          }),
+          onSettingsChanged: () {
+            _applyStillWatchingSettings();
+            setState(() {
+              if (!widget.store.enableHistory && _dest == _Dest.history) {
+                _dest = _Dest.cast;
+              }
+            });
+          },
           onQuit: () => unawaited(_tray.quit()),
         ),
     };

--- a/desktop/lib/media_session_bridge.dart
+++ b/desktop/lib/media_session_bridge.dart
@@ -18,9 +18,19 @@ import 'player_controller.dart';
 /// * **Windows** — `flutter_media_session` SMTC.
 /// * **Linux** — no-op (no MPRIS backend yet).
 class MediaSessionBridge {
-  MediaSessionBridge(this._player);
+  MediaSessionBridge(
+    this._player, {
+    this.isPlaybackPromptActive,
+    this.onPromptContinue,
+    this.onPromptStop,
+    this.onPlaybackActivity,
+  });
 
   final PlayerController _player;
+  final bool Function()? isPlaybackPromptActive;
+  final VoidCallback? onPromptContinue;
+  final VoidCallback? onPromptStop;
+  final VoidCallback? onPlaybackActivity;
   final FlutterMediaSession _pluginSession = FlutterMediaSession();
   _PluginAdapter? _pluginAdapter;
   StreamSubscription? _macEvents;
@@ -114,6 +124,8 @@ class MediaSessionBridge {
     final action = raw['action'] as String?;
     if (action == null) return;
     debugPrint('[media-session] mac action: $action');
+    if (_handlePromptAction(action)) return;
+    onPlaybackActivity?.call();
     switch (action) {
       case 'toggle':
         if (_player.state == 'playing') {
@@ -151,6 +163,16 @@ class MediaSessionBridge {
     }
   }
 
+  bool _handlePromptAction(String action) {
+    if (!(isPlaybackPromptActive?.call() ?? false)) return false;
+    if (action == 'stop') {
+      onPromptStop?.call();
+    } else {
+      onPromptContinue?.call();
+    }
+    return true;
+  }
+
   Future<void> _startPlugin() async {
     if (Platform.isWindows) {
       await _pluginSession.setWindowsAppUserModelId(
@@ -162,7 +184,13 @@ class MediaSessionBridge {
         forwardSeconds: 10, backwardSeconds: 10);
     await _pluginSession.setAutoHandleInterruptions(false);
     await _pluginSession.activate();
-    _pluginAdapter = _PluginAdapter(_player);
+    _pluginAdapter = _PluginAdapter(
+      _player,
+      isPlaybackPromptActive: isPlaybackPromptActive,
+      onPromptContinue: onPromptContinue,
+      onPromptStop: onPromptStop,
+      onPlaybackActivity: onPlaybackActivity,
+    );
     _pluginSession.bind(_pluginAdapter!);
   }
 
@@ -192,9 +220,19 @@ class MediaSessionBridge {
 
 /// Windows (and future non-mac) adapter via flutter_media_session.
 class _PluginAdapter implements MediaSessionAdapter {
-  _PluginAdapter(this._player);
+  _PluginAdapter(
+    this._player, {
+    this.isPlaybackPromptActive,
+    this.onPromptContinue,
+    this.onPromptStop,
+    this.onPlaybackActivity,
+  });
 
   final PlayerController _player;
+  final bool Function()? isPlaybackPromptActive;
+  final VoidCallback? onPromptContinue;
+  final VoidCallback? onPromptStop;
+  final VoidCallback? onPlaybackActivity;
   final List<StreamSubscription<dynamic>> _subs = [];
   FlutterMediaSession? _session;
 
@@ -299,6 +337,15 @@ class _PluginAdapter implements MediaSessionAdapter {
 
   void _onAction(MediaAction action) {
     debugPrint('[media-session] plugin action: ${action.name}');
+    if (isPlaybackPromptActive?.call() ?? false) {
+      if (action.name == 'stop') {
+        onPromptStop?.call();
+      } else {
+        onPromptContinue?.call();
+      }
+      return;
+    }
+    onPlaybackActivity?.call();
     switch (action.name) {
       case 'play':
         unawaited(_player.resume());

--- a/desktop/lib/pairing_store.dart
+++ b/desktop/lib/pairing_store.dart
@@ -41,6 +41,9 @@ class PairedDeviceRecord {
 class PairingStore {
   PairingStore._(this._prefs);
 
+  /// Creates a store around injected preferences for deterministic tests.
+  PairingStore.forTest(SharedPreferences prefs) : _prefs = prefs;
+
   static const _kDeviceId = 'pb.device_id';
   static const _kDeviceName = 'pb.device_name';
   static const _kEngineType = 'pb.engine_type';
@@ -49,6 +52,12 @@ class PairingStore {
   static const _kAutoFullScreen = 'pb.auto_fullscreen';
   static const _kPauseOnWindowHide = 'pb.pause_on_window_hide';
   static const _kEnableHistory = 'pb.enable_history';
+  static const _kStillWatchingEnabled = 'pb.still_watching_enabled';
+  static const _kStillWatchingThresholdMin = 'pb.still_watching_threshold_min';
+  static const _kStillWatchingResponseSec = 'pb.still_watching_response_sec';
+
+  static const stillWatchingPresets = <int>[30, 60, 90, 120, 180, 240];
+  static const stillWatchingResponsePresets = <int>[30, 60, 120, 300, 600];
 
   final SharedPreferences _prefs;
 
@@ -106,6 +115,32 @@ class PairingStore {
 
   Future<void> setEnableHistory(bool value) =>
       _prefs.setBool(_kEnableHistory, value);
+
+  bool get stillWatchingEnabled =>
+      _prefs.getBool(_kStillWatchingEnabled) ?? false;
+
+  Future<void> setStillWatchingEnabled(bool value) =>
+      _prefs.setBool(_kStillWatchingEnabled, value);
+
+  int get stillWatchingThresholdMinutes {
+    final saved = _prefs.getInt(_kStillWatchingThresholdMin);
+    return stillWatchingPresets.contains(saved) ? saved! : 90;
+  }
+
+  Future<void> setStillWatchingThresholdMinutes(int value) => _prefs.setInt(
+        _kStillWatchingThresholdMin,
+        stillWatchingPresets.contains(value) ? value : 90,
+      );
+
+  int get stillWatchingResponseSeconds {
+    final saved = _prefs.getInt(_kStillWatchingResponseSec);
+    return stillWatchingResponsePresets.contains(saved) ? saved! : 300;
+  }
+
+  Future<void> setStillWatchingResponseSeconds(int value) => _prefs.setInt(
+        _kStillWatchingResponseSec,
+        stillWatchingResponsePresets.contains(value) ? value : 300,
+      );
 
   // ─── Paired devices ──────────────────────────────────────────────────────
 

--- a/desktop/lib/server.dart
+++ b/desktop/lib/server.dart
@@ -74,10 +74,29 @@ class PendingPairingRequest {
 }
 
 class ReceiverServer extends ChangeNotifier {
-  ReceiverServer({required this.player, required this.store});
+  ReceiverServer({
+    required this.player,
+    required this.store,
+    this.isPlaybackPromptActive,
+    this.onPromptContinue,
+    this.onPromptStop,
+    this.onPlaybackActivity,
+    this.onNewMedia,
+  });
 
   final PlayerController player;
   final PairingStore store;
+  final bool Function()? isPlaybackPromptActive;
+  final VoidCallback? onPromptContinue;
+  final VoidCallback? onPromptStop;
+  final VoidCallback? onPlaybackActivity;
+  final VoidCallback? onNewMedia;
+
+  void broadcastIdleContext() {
+    for (final c in _authed) {
+      c.sink.add(contextJson('idle'));
+    }
+  }
 
   final List<HttpServer> _servers = [];
   Timer? _statusTimer;
@@ -672,6 +691,7 @@ class ReceiverServer extends ChangeNotifier {
           debugPrint('[server] dropping duplicate play for $startUrl');
           break;
         }
+        onNewMedia?.call();
         _lastPlayUrl = startUrl;
         _lastPlayAt = now;
         unawaited(player.playPlaylist(
@@ -681,14 +701,31 @@ class ReceiverServer extends ChangeNotifier {
         ));
         _broadcastPlaylistStatus();
       case PlaylistJumpCmd(:final index):
+        onNewMedia?.call();
         unawaited(player.jumpTo(index));
         _broadcastPlaylistStatus();
       case QueueAddCmd(:final item):
+        if (isPlaybackPromptActive?.call() ?? false) {
+          onPromptContinue?.call();
+        } else {
+          onPlaybackActivity?.call();
+        }
         // Appends to the live queue; if idle, starts playback.
         // playlist_status broadcast happens via the queueChanges listener.
         unawaited(player.queueAdd(_toQueueItem(item), isRemote: true));
       case ControlCmd(:final command):
         debugPrint('[server] control: $command');
+        if (isPlaybackPromptActive?.call() ?? false) {
+          if (command == 'play') {
+            onPromptContinue?.call();
+          } else if (command == 'stop') {
+            onPromptStop?.call();
+          } else {
+            onPromptContinue?.call();
+          }
+          break;
+        }
+        onPlaybackActivity?.call();
         // Parameterized commands (phone seekbar + track pickers).
         if (command.startsWith('seek_to:')) {
           final ms = int.tryParse(command.substring('seek_to:'.length));
@@ -722,9 +759,7 @@ class ReceiverServer extends ChangeNotifier {
             // Real stop: clear the queue and report idle so the phone's
             // remote leaves player mode (Android finishes the activity here).
             unawaited(player.stop());
-            for (final c in _authed) {
-              c.sink.add(contextJson('idle'));
-            }
+            broadcastIdleContext();
           case 'seek_back':
             final pos = player.positionMs - 10000;
             unawaited(player.seek(Duration(milliseconds: pos < 0 ? 0 : pos)));
@@ -735,6 +770,11 @@ class ReceiverServer extends ChangeNotifier {
             unawaited(player.seek(Duration(milliseconds: target)));
         }
       case RemoteCmd(:final key):
+        if (isPlaybackPromptActive?.call() ?? false) {
+          onPromptContinue?.call();
+          break;
+        }
+        onPlaybackActivity?.call();
         _handleRemoteKey(key);
       case UnknownCmd(:final type):
         debugPrint('[server] unknown command: $type');

--- a/desktop/lib/settings_screen.dart
+++ b/desktop/lib/settings_screen.dart
@@ -127,6 +127,106 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
             ),
             _Tile(
+              icon: Icons.bedtime_outlined,
+              title: 'Still watching reminder',
+              subtitle:
+                  'Pause after continuous viewing and stop if nobody responds.',
+              trailing: Switch(
+                value: widget.store.stillWatchingEnabled,
+                onChanged: (v) async {
+                  await widget.store.setStillWatchingEnabled(v);
+                  if (mounted) setState(() {});
+                  widget.onSettingsChanged?.call();
+                },
+              ),
+            ),
+            _Tile(
+              icon: Icons.timer_outlined,
+              title: 'Reminder interval',
+              subtitle: 'Only active playback counts toward this time.',
+              trailing: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.06),
+                  border: Border.all(color: Colors.white12),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<int>(
+                    value: widget.store.stillWatchingThresholdMinutes,
+                    borderRadius: BorderRadius.circular(10),
+                    dropdownColor: const Color(0xFF202126),
+                    icon: const Icon(Icons.expand_more, size: 18),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    onChanged: widget.store.stillWatchingEnabled
+                        ? (v) async {
+                            if (v == null) return;
+                            await widget.store
+                                .setStillWatchingThresholdMinutes(v);
+                            if (mounted) setState(() {});
+                            widget.onSettingsChanged?.call();
+                          }
+                        : null,
+                    items: PairingStore.stillWatchingPresets
+                        .map((minutes) => DropdownMenuItem(
+                              value: minutes,
+                              child: Text(minutes < 60
+                                  ? '$minutes min'
+                                  : '${minutes ~/ 60}${minutes % 60 == 0 ? '' : '.5'} hr'),
+                            ))
+                        .toList(),
+                  ),
+                ),
+              ),
+            ),
+            _Tile(
+              icon: Icons.hourglass_bottom,
+              title: 'Response time',
+              subtitle: 'Time to respond before playback stops.',
+              trailing: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.06),
+                  border: Border.all(color: Colors.white12),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<int>(
+                    value: widget.store.stillWatchingResponseSeconds,
+                    borderRadius: BorderRadius.circular(10),
+                    dropdownColor: const Color(0xFF202126),
+                    icon: const Icon(Icons.expand_more, size: 18),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    onChanged: widget.store.stillWatchingEnabled
+                        ? (v) async {
+                            if (v == null) return;
+                            await widget.store
+                                .setStillWatchingResponseSeconds(v);
+                            if (mounted) setState(() {});
+                            widget.onSettingsChanged?.call();
+                          }
+                        : null,
+                    items: PairingStore.stillWatchingResponsePresets
+                        .map((seconds) => DropdownMenuItem(
+                              value: seconds,
+                              child: Text(seconds < 60
+                                  ? '$seconds sec'
+                                  : '${seconds ~/ 60} min'),
+                            ))
+                        .toList(),
+                  ),
+                ),
+              ),
+            ),
+            _Tile(
               icon: Icons.keyboard,
               title: 'Keyboard shortcuts',
               subtitle: 'Space, arrows, F, I, and gestures — press ? anytime.',

--- a/desktop/lib/still_watching_controller.dart
+++ b/desktop/lib/still_watching_controller.dart
@@ -1,0 +1,328 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'player_controller.dart';
+
+enum StillWatchingPhase { inactive, counting, prompting, stopping }
+
+/// Tracks cumulative active playback and asks the viewer to confirm they are
+/// still present before leaving the receiver in its normal idle state.
+class StillWatchingController extends ChangeNotifier {
+  StillWatchingController({
+    required PlayerController player,
+    bool enabled = true,
+    Duration threshold = const Duration(minutes: 90),
+    Duration gracePeriod = const Duration(seconds: 300),
+    DateTime Function()? now,
+    VoidCallback? onAutoStop,
+  })  : _player = player,
+        _enabled = enabled,
+        _threshold = threshold,
+        _gracePeriod = gracePeriod,
+        _onAutoStop = onAutoStop,
+        _now = now ?? DateTime.now {
+    _player.addListener(_onPlayerChanged);
+    _onPlayerChanged();
+  }
+
+  final PlayerController _player;
+  final DateTime Function() _now;
+  final VoidCallback? _onAutoStop;
+  Duration _gracePeriod;
+
+  bool _enabled;
+  Duration _threshold;
+  Duration _activeElapsed = Duration.zero;
+  DateTime? _playingSince;
+  Timer? _thresholdTimer;
+  Timer? _countdownTimer;
+  Future<void>? _featurePause;
+  Future<void>? _staleFeaturePause;
+  int _stalePauseRecoveryOperation = 0;
+  int _generation = 0;
+  int _operation = 0;
+  bool _featurePaused = false;
+  StillWatchingPhase _phase = StillWatchingPhase.inactive;
+  int _remainingSeconds = 0;
+
+  bool get enabled => _enabled;
+  Duration get threshold => _threshold;
+  Duration get activeElapsed => _elapsedNow();
+  StillWatchingPhase get phase => _phase;
+  bool get isPrompting => _phase == StillWatchingPhase.prompting;
+  int get remainingSeconds => _remainingSeconds;
+
+  /// Treats an explicit viewer action as proof of presence and grants a fresh
+  /// interval. Playback position ticks must never call this method.
+  void recordUserActivity() {
+    if (!_enabled || isPrompting || _phase == StillWatchingPhase.stopping) {
+      return;
+    }
+    // Besides granting a fresh interval, an explicit viewer action owns any
+    // playback state that follows it. In particular, a late pause from a
+    // replaced reminder must not resume playback after the viewer pauses it.
+    _operation++;
+    _activeElapsed = Duration.zero;
+    _playingSince = null;
+    _syncCounting();
+  }
+
+  /// Ends the old reminder session before a new cast or playlist replaces it.
+  void resetForNewMedia() {
+    final pendingPause = _featurePause ?? _staleFeaturePause;
+    _featurePause = null;
+    _resetSession();
+    if (pendingPause != null) {
+      _stalePauseRecoveryOperation = _operation;
+      if (!identical(_staleFeaturePause, pendingPause)) {
+        _staleFeaturePause = pendingPause;
+        unawaited(_recoverFromStalePause(pendingPause));
+      }
+    }
+  }
+
+  Future<void> _recoverFromStalePause(Future<void> pause) async {
+    try {
+      await pause;
+    } catch (error) {
+      debugPrint('[still-watching] stale pause failed: $error');
+      if (identical(_staleFeaturePause, pause)) {
+        _staleFeaturePause = null;
+      }
+      return;
+    }
+    if (!identical(_staleFeaturePause, pause)) return;
+    final recoveryOperation = _stalePauseRecoveryOperation;
+    _staleFeaturePause = null;
+    if (recoveryOperation == _operation &&
+        _player.queue.isNotEmpty &&
+        _player.state == 'paused') {
+      await _player.resume();
+    }
+  }
+
+  void updateSettings({
+    required bool enabled,
+    required Duration threshold,
+    Duration? gracePeriod,
+  }) {
+    final nextGracePeriod = gracePeriod ?? _gracePeriod;
+    if (_enabled == enabled &&
+        _threshold == threshold &&
+        _gracePeriod == nextGracePeriod) {
+      return;
+    }
+    _accrueActiveTime();
+    _enabled = enabled;
+    _threshold = threshold;
+    _gracePeriod = nextGracePeriod;
+
+    if (!enabled) {
+      final shouldResume = isPrompting && _featurePaused;
+      final operation = ++_operation;
+      _cancelTimers();
+      _phase = StillWatchingPhase.inactive;
+      _featurePaused = false;
+      _activeElapsed = Duration.zero;
+      _playingSince = null;
+      notifyListeners();
+      if (shouldResume) unawaited(_resumeAfterFeaturePause(operation));
+      return;
+    }
+
+    if (isPrompting) {
+      notifyListeners();
+      return;
+    }
+    _syncCounting();
+  }
+
+  void _onPlayerChanged() {
+    if (_player.state == 'idle' || _player.queue.isEmpty) {
+      _resetSession();
+      return;
+    }
+
+    // Play commands from media keys and connected phones go straight to the
+    // player. While the prompt is open, treat that transition as Continue.
+    if (isPrompting && _player.state == 'playing') {
+      unawaited(_continueFromAlreadyPlaying());
+      return;
+    }
+    if (!_enabled || isPrompting || _phase == StillWatchingPhase.stopping) {
+      _accrueActiveTime();
+      return;
+    }
+    _syncCounting();
+  }
+
+  void _syncCounting() {
+    _thresholdTimer?.cancel();
+    _thresholdTimer = null;
+    _accrueActiveTime();
+    if (!_enabled || _player.queue.isEmpty) return;
+
+    if (_player.state != 'playing') {
+      _phase = StillWatchingPhase.inactive;
+      notifyListeners();
+      return;
+    }
+    _playingSince = _now();
+    final remaining = _threshold - _activeElapsed;
+    if (remaining <= Duration.zero) {
+      scheduleMicrotask(_showPrompt);
+      return;
+    }
+    _phase = StillWatchingPhase.counting;
+    final generation = _generation;
+    _thresholdTimer = Timer(remaining, () {
+      if (generation == _generation) _showPrompt();
+    });
+    notifyListeners();
+  }
+
+  void _accrueActiveTime() {
+    final since = _playingSince;
+    if (since == null) return;
+    final elapsed = _now().difference(since);
+    if (!elapsed.isNegative) _activeElapsed += elapsed;
+    _playingSince = null;
+  }
+
+  Duration _elapsedNow() {
+    final since = _playingSince;
+    if (since == null) return _activeElapsed;
+    final elapsed = _now().difference(since);
+    return elapsed.isNegative ? _activeElapsed : _activeElapsed + elapsed;
+  }
+
+  void _showPrompt() {
+    if (!_enabled || _player.state != 'playing' || _player.queue.isEmpty) {
+      _syncCounting();
+      return;
+    }
+    _accrueActiveTime();
+    _thresholdTimer?.cancel();
+    _phase = StillWatchingPhase.prompting;
+    _featurePaused = true;
+    _remainingSeconds = _gracePeriod.inSeconds;
+    notifyListeners();
+    _featurePause = _player.pause();
+
+    final generation = _generation;
+    _countdownTimer?.cancel();
+    _countdownTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (generation != _generation || !isPrompting) {
+        timer.cancel();
+        return;
+      }
+      _remainingSeconds--;
+      if (_remainingSeconds <= 0) {
+        timer.cancel();
+        unawaited(stopWatching());
+      } else {
+        notifyListeners();
+      }
+    });
+  }
+
+  Future<void> continueWatching() async {
+    if (!isPrompting) return;
+    final operation = ++_operation;
+    _countdownTimer?.cancel();
+    _featurePaused = false;
+    _activeElapsed = Duration.zero;
+    notifyListeners();
+    await _awaitFeaturePause();
+    if (operation != _operation || !isPrompting) {
+      return;
+    }
+    _phase = StillWatchingPhase.counting;
+    await _player.resume();
+    _syncCounting();
+  }
+
+  Future<void> _continueFromAlreadyPlaying() async {
+    final operation = ++_operation;
+    _countdownTimer?.cancel();
+    _featurePaused = false;
+    _activeElapsed = Duration.zero;
+    await _awaitFeaturePause();
+    if (operation != _operation || !isPrompting) {
+      return;
+    }
+    _phase = StillWatchingPhase.counting;
+    await _player.resume();
+    _syncCounting();
+  }
+
+  Future<void> stopWatching() async {
+    if (!isPrompting) return;
+    final operation = ++_operation;
+    _countdownTimer?.cancel();
+    _featurePaused = false;
+    _phase = StillWatchingPhase.stopping;
+    notifyListeners();
+    await _awaitFeaturePause();
+    if (operation != _operation || _phase != StillWatchingPhase.stopping) {
+      return;
+    }
+    await _player.stop();
+    _onAutoStop?.call();
+  }
+
+  Future<void> _resumeAfterFeaturePause(int operation) async {
+    await _awaitFeaturePause();
+    if (operation == _operation && !_enabled && _player.queue.isNotEmpty) {
+      await _player.resume();
+    }
+  }
+
+  Future<void> _awaitFeaturePause() async {
+    final pause = _featurePause;
+    if (pause == null) return;
+    try {
+      await pause;
+    } catch (error) {
+      debugPrint('[still-watching] pause failed: $error');
+    } finally {
+      if (identical(_featurePause, pause)) _featurePause = null;
+    }
+  }
+
+  void _resetSession() {
+    if (_phase == StillWatchingPhase.inactive &&
+        _activeElapsed == Duration.zero &&
+        _playingSince == null) {
+      return;
+    }
+    _generation++;
+    _operation++;
+    _cancelTimers();
+    _activeElapsed = Duration.zero;
+    _playingSince = null;
+    _featurePaused = false;
+    _remainingSeconds = 0;
+    _phase = StillWatchingPhase.inactive;
+    notifyListeners();
+  }
+
+  void _cancelTimers() {
+    _thresholdTimer?.cancel();
+    _thresholdTimer = null;
+    _countdownTimer?.cancel();
+    _countdownTimer = null;
+  }
+
+  @override
+  void dispose() {
+    _generation++;
+    _operation++;
+    _cancelTimers();
+    _featurePause = null;
+    _staleFeaturePause = null;
+    _player.removeListener(_onPlayerChanged);
+    super.dispose();
+  }
+}

--- a/desktop/lib/still_watching_prompt.dart
+++ b/desktop/lib/still_watching_prompt.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class _ContinueWatchingIntent extends Intent {
+  const _ContinueWatchingIntent();
+}
+
+class StillWatchingPrompt extends StatelessWidget {
+  const StillWatchingPrompt({
+    super.key,
+    required this.remainingSeconds,
+    required this.onContinue,
+    this.title,
+  });
+
+  final int remainingSeconds;
+  final String? title;
+  final VoidCallback onContinue;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final minutes = remainingSeconds ~/ 60;
+    final seconds = remainingSeconds % 60;
+    return Shortcuts(
+      shortcuts: const {
+        SingleActivator(LogicalKeyboardKey.space): _ContinueWatchingIntent(),
+        SingleActivator(LogicalKeyboardKey.escape): _ContinueWatchingIntent(),
+        SingleActivator(LogicalKeyboardKey.arrowLeft):
+            DirectionalFocusIntent(TraversalDirection.left),
+        SingleActivator(LogicalKeyboardKey.arrowRight):
+            DirectionalFocusIntent(TraversalDirection.right),
+        SingleActivator(LogicalKeyboardKey.arrowUp):
+            DirectionalFocusIntent(TraversalDirection.up),
+        SingleActivator(LogicalKeyboardKey.arrowDown):
+            DirectionalFocusIntent(TraversalDirection.down),
+        SingleActivator(LogicalKeyboardKey.keyF): DoNothingIntent(),
+        SingleActivator(LogicalKeyboardKey.keyI): DoNothingIntent(),
+        SingleActivator(LogicalKeyboardKey.slash): DoNothingIntent(),
+        SingleActivator(LogicalKeyboardKey.slash, shift: true):
+            DoNothingIntent(),
+      },
+      child: Actions(
+        actions: {
+          _ContinueWatchingIntent: CallbackAction<_ContinueWatchingIntent>(
+            onInvoke: (_) {
+              onContinue();
+              return null;
+            },
+          ),
+        },
+        child: FocusScope(
+          autofocus: true,
+          child: ColoredBox(
+            color: Colors.black.withValues(alpha: 0.82),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 520),
+                child: Card(
+                  color: colors.surfaceContainerHigh,
+                  surfaceTintColor: Colors.transparent,
+                  elevation: 24,
+                  child: Padding(
+                    padding: const EdgeInsets.all(32),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.play_circle_outline,
+                            size: 54, color: colors.primary),
+                        const SizedBox(height: 18),
+                        Text('Are you still watching?',
+                            style: Theme.of(context)
+                                .textTheme
+                                .headlineSmall
+                                ?.copyWith(color: colors.onSurface),
+                            textAlign: TextAlign.center),
+                        if (title != null && title!.isNotEmpty) ...[
+                          const SizedBox(height: 8),
+                          Text(title!,
+                              style: TextStyle(color: colors.onSurfaceVariant),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              textAlign: TextAlign.center),
+                        ],
+                        const SizedBox(height: 12),
+                        Text(
+                          'Playback will stop in $minutes:${seconds.toString().padLeft(2, '0')}',
+                          style: TextStyle(color: colors.onSurfaceVariant),
+                        ),
+                        const SizedBox(height: 24),
+                        FilledButton.icon(
+                          style: FilledButton.styleFrom(
+                            backgroundColor: colors.primary,
+                            foregroundColor: colors.onPrimary,
+                          ),
+                          autofocus: true,
+                          onPressed: onContinue,
+                          icon: const Icon(Icons.play_arrow),
+                          label: const Text('Continue watching'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/desktop/test/pairing_store_still_watching_test.dart
+++ b/desktop/test/pairing_store_still_watching_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/pairing_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test('still-watching preferences default and persist', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final store = PairingStore.forTest(prefs);
+
+    expect(store.stillWatchingEnabled, isFalse);
+    expect(store.stillWatchingThresholdMinutes, 90);
+    expect(store.stillWatchingResponseSeconds, 300);
+
+    await store.setStillWatchingEnabled(true);
+    await store.setStillWatchingThresholdMinutes(180);
+    await store.setStillWatchingResponseSeconds(120);
+    expect(store.stillWatchingEnabled, isTrue);
+    expect(store.stillWatchingThresholdMinutes, 180);
+    expect(store.stillWatchingResponseSeconds, 120);
+  });
+
+  test('invalid duration falls back to 90 minutes', () async {
+    SharedPreferences.setMockInitialValues({
+      'pb.still_watching_threshold_min': 17,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final store = PairingStore.forTest(prefs);
+    expect(store.stillWatchingThresholdMinutes, 90);
+
+    await store.setStillWatchingThresholdMinutes(17);
+    expect(store.stillWatchingThresholdMinutes, 90);
+  });
+
+  test('temporary testing presets fall back to 90 minutes', () async {
+    SharedPreferences.setMockInitialValues({
+      'pb.still_watching_threshold_min': 5,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final store = PairingStore.forTest(prefs);
+
+    expect(store.stillWatchingThresholdMinutes, 90);
+    await store.setStillWatchingThresholdMinutes(1);
+    expect(store.stillWatchingThresholdMinutes, 90);
+  });
+}

--- a/desktop/test/still_watching_controller_test.dart
+++ b/desktop/test/still_watching_controller_test.dart
@@ -1,0 +1,311 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/player_controller.dart';
+import 'package:playbridge_desktop/player_engine.dart';
+import 'package:playbridge_desktop/still_watching_controller.dart';
+
+class _FakeEngine extends PlayerEngine {
+  String _state = 'idle';
+  int pauseCount = 0;
+  int resumeCount = 0;
+  int stopCount = 0;
+  Completer<void>? pauseGate;
+
+  @override
+  String get state => _state;
+  @override
+  int get positionMs => 0;
+  @override
+  int get durationMs => 10000;
+  @override
+  dynamic get tracks => null;
+  @override
+  dynamic get track => null;
+
+  @override
+  Future<void> open(QueueItem item) async => _play();
+  @override
+  Future<void> openPlaylist(List<QueueItem> items, int startIndex) async =>
+      _play();
+  void _play() {
+    _state = 'playing';
+    notifyListeners();
+  }
+
+  @override
+  Future<void> pause() async {
+    pauseCount++;
+    final gate = pauseGate;
+    if (gate != null) await gate.future;
+    _state = 'paused';
+    notifyListeners();
+  }
+
+  @override
+  Future<void> resume() async {
+    resumeCount++;
+    _play();
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCount++;
+    _state = 'idle';
+    notifyListeners();
+  }
+
+  @override
+  Future<void> seek(Duration position) async {}
+  @override
+  Future<void> setAudioTrack(dynamic t) async {}
+  @override
+  Future<void> setSubtitleTrack(dynamic t) async {}
+
+  @override
+  Future<void> dispose() async {
+    super.dispose();
+  }
+}
+
+Future<void> _waitUntil(bool Function() condition) async {
+  for (var i = 0; i < 300 && !condition(); i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+  expect(condition(), isTrue);
+}
+
+void main() {
+  QueueItem item(int n) => QueueItem(url: 'https://x/$n', title: 'Episode $n');
+
+  test('threshold pauses once and Continue grants a fresh interval', () async {
+    final engine = _FakeEngine();
+    final player = PlayerController(engineForTest: engine);
+    final controller = StillWatchingController(
+      player: player,
+      threshold: const Duration(milliseconds: 40),
+    );
+    await player.playPlaylist([item(1), item(2)], 0);
+
+    await _waitUntil(() => controller.isPrompting);
+    expect(engine.pauseCount, 1);
+
+    await controller.continueWatching();
+    expect(engine.resumeCount, 1);
+    expect(controller.isPrompting, isFalse);
+    expect(
+        controller.activeElapsed, lessThan(const Duration(milliseconds: 30)));
+
+    await _waitUntil(() => controller.isPrompting);
+    expect(engine.pauseCount, 2);
+    controller.dispose();
+    await player.dispose();
+  });
+
+  test('paused time does not count and queue jumps preserve elapsed time',
+      () async {
+    final engine = _FakeEngine();
+    final player = PlayerController(engineForTest: engine);
+    final controller = StillWatchingController(
+      player: player,
+      threshold: const Duration(milliseconds: 100),
+    );
+    await player.playPlaylist([item(1), item(2)], 0);
+    await Future<void>.delayed(const Duration(milliseconds: 45));
+    await player.pause();
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    expect(controller.isPrompting, isFalse);
+
+    await player.resume();
+    await player.jumpTo(1);
+    await _waitUntil(() => controller.isPrompting);
+    expect(engine.pauseCount, 2); // manual pause + feature pause
+    controller.dispose();
+    await player.dispose();
+  });
+
+  test('expiry stops and clears the playback session', () async {
+    final engine = _FakeEngine();
+    final player = PlayerController(engineForTest: engine);
+    final controller = StillWatchingController(
+      player: player,
+      threshold: const Duration(milliseconds: 20),
+      gracePeriod: const Duration(seconds: 1),
+    );
+    await player.playPlaylist([item(1)], 0);
+    await _waitUntil(() => controller.isPrompting);
+    await _waitUntil(() => player.state == 'idle');
+
+    expect(engine.stopCount, 1);
+    expect(player.queue, isEmpty);
+    expect(controller.phase, StillWatchingPhase.inactive);
+    controller.dispose();
+    await player.dispose();
+  });
+
+  test('expiry reports idle after stopping', () async {
+    final engine = _FakeEngine();
+    final player = PlayerController(engineForTest: engine);
+    var idleReports = 0;
+    final controller = StillWatchingController(
+      player: player,
+      threshold: const Duration(milliseconds: 20),
+      gracePeriod: const Duration(seconds: 1),
+      onAutoStop: () => idleReports++,
+    );
+    await player.playPlaylist([item(1)], 0);
+    await _waitUntil(() => player.state == 'idle');
+    expect(idleReports, 1);
+    controller.dispose();
+    await player.dispose();
+  });
+
+  test('viewer activity grants a fresh interval', () async {
+    final engine = _FakeEngine();
+    final player = PlayerController(engineForTest: engine);
+    final controller = StillWatchingController(
+      player: player,
+      threshold: const Duration(milliseconds: 80),
+    );
+    await player.playPlaylist([item(1)], 0);
+    await Future<void>.delayed(const Duration(milliseconds: 55));
+    controller.recordUserActivity();
+    await Future<void>.delayed(const Duration(milliseconds: 45));
+    expect(controller.isPrompting, isFalse);
+    await _waitUntil(() => controller.isPrompting);
+    controller.dispose();
+    await player.dispose();
+  });
+
+  test('new media dismisses an existing prompt', () async {
+    final engine = _FakeEngine();
+    final player = PlayerController(engineForTest: engine);
+    final controller = StillWatchingController(
+      player: player,
+      threshold: const Duration(milliseconds: 20),
+    );
+    await player.playPlaylist([item(1)], 0);
+    await _waitUntil(() => controller.isPrompting);
+    controller.resetForNewMedia();
+    await player.playPlaylist([item(2)], 0);
+    expect(controller.isPrompting, isFalse);
+    expect(player.currentTitle, 'Episode 2');
+    controller.dispose();
+    await player.dispose();
+  });
+
+  test('new media recovers if the old feature pause finishes late', () async {
+    final engine = _FakeEngine()..pauseGate = Completer<void>();
+    final player = PlayerController(engineForTest: engine);
+    final controller = StillWatchingController(
+      player: player,
+      threshold: const Duration(milliseconds: 20),
+    );
+    await player.playPlaylist([item(1)], 0);
+    await _waitUntil(() => controller.isPrompting);
+
+    controller.resetForNewMedia();
+    await player.playPlaylist([item(2)], 0);
+    engine.pauseGate!.complete();
+    await _waitUntil(() => engine.resumeCount == 1);
+
+    expect(player.state, 'playing');
+    expect(player.currentTitle, 'Episode 2');
+    expect(controller.isPrompting, isFalse);
+    controller.dispose();
+    await player.dispose();
+  });
+
+  test('stale feature pause does not override a later viewer pause', () async {
+    final engine = _FakeEngine()..pauseGate = Completer<void>();
+    final player = PlayerController(engineForTest: engine);
+    final controller = StillWatchingController(
+      player: player,
+      threshold: const Duration(milliseconds: 20),
+    );
+    await player.playPlaylist([item(1)], 0);
+    await _waitUntil(() => controller.isPrompting);
+
+    controller.resetForNewMedia();
+    await player.playPlaylist([item(2)], 0);
+    controller.recordUserActivity();
+    final viewerPause = player.pause();
+    engine.pauseGate!.complete();
+    await viewerPause;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(player.state, 'paused');
+    expect(engine.resumeCount, 0);
+    controller.dispose();
+    await player.dispose();
+  });
+
+  test('repeated media resets retain one stale-pause recovery', () async {
+    final engine = _FakeEngine()..pauseGate = Completer<void>();
+    final player = PlayerController(engineForTest: engine);
+    final controller = StillWatchingController(
+      player: player,
+      threshold: const Duration(milliseconds: 20),
+    );
+    await player.playPlaylist([item(1)], 0);
+    await _waitUntil(() => controller.isPrompting);
+
+    controller.resetForNewMedia();
+    await player.playPlaylist([item(2)], 0);
+    controller.resetForNewMedia();
+    await player.playPlaylist([item(3)], 0);
+    engine.pauseGate!.complete();
+    await _waitUntil(() => engine.resumeCount == 1);
+
+    expect(player.state, 'playing');
+    expect(player.currentTitle, 'Episode 3');
+    expect(engine.resumeCount, 1);
+    controller.dispose();
+    await player.dispose();
+  });
+
+  test('disabling while prompted resumes feature-paused playback', () async {
+    final engine = _FakeEngine();
+    final player = PlayerController(engineForTest: engine);
+    final controller = StillWatchingController(
+      player: player,
+      threshold: const Duration(milliseconds: 20),
+    );
+    await player.playPlaylist([item(1)], 0);
+    await _waitUntil(() => controller.isPrompting);
+
+    controller.updateSettings(
+      enabled: false,
+      threshold: const Duration(milliseconds: 20),
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(player.state, 'playing');
+    expect(controller.phase, StillWatchingPhase.inactive);
+    controller.dispose();
+    await player.dispose();
+  });
+
+  test('Continue waits for an in-flight feature pause before resuming',
+      () async {
+    final engine = _FakeEngine()..pauseGate = Completer<void>();
+    final player = PlayerController(engineForTest: engine);
+    final controller = StillWatchingController(
+      player: player,
+      threshold: const Duration(milliseconds: 20),
+    );
+    await player.playPlaylist([item(1)], 0);
+    await _waitUntil(() => controller.isPrompting);
+
+    final continuing = controller.continueWatching();
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(engine.resumeCount, 0);
+
+    engine.pauseGate!.complete();
+    await continuing;
+    expect(engine.resumeCount, 1);
+    expect(player.state, 'playing');
+    expect(controller.phase, StillWatchingPhase.counting);
+    controller.dispose();
+    await player.dispose();
+  });
+}

--- a/desktop/test/still_watching_prompt_test.dart
+++ b/desktop/test/still_watching_prompt_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/still_watching_prompt.dart';
+
+void main() {
+  Future<void> pumpPrompt(
+    WidgetTester tester, {
+    required VoidCallback onContinue,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StillWatchingPrompt(
+            remainingSeconds: 60,
+            onContinue: onContinue,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('Enter activates the focused prompt button', (tester) async {
+    var continueCount = 0;
+    await pumpPrompt(
+      tester,
+      onContinue: () => continueCount++,
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    expect(continueCount, 1);
+    expect(find.text('Stop now'), findsNothing);
+  });
+
+  testWidgets('Space and Escape continue', (tester) async {
+    var continueCount = 0;
+    await pumpPrompt(
+      tester,
+      onContinue: () => continueCount++,
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    expect(continueCount, 2);
+  });
+}

--- a/docs/design-still-watching.md
+++ b/docs/design-still-watching.md
@@ -1,0 +1,142 @@
+# Design: "Are You Still Watching?" Prompt
+
+| Field | Value |
+|---|---|
+| **Date** | 2026-07-12 |
+| **Status** | Implemented |
+| **Scope** | Android TV, Apple TV, and Desktop receivers |
+| **Related** | Player controls, receiver settings, playback status |
+
+## Overview
+
+PlayBridge receivers can otherwise keep a cast playing indefinitely. The still-watching feature limits unattended playback by pausing the current media, showing a response countdown, and stopping playback if nobody responds.
+
+The feature is implemented independently in Android TV, Apple TV, and Desktop using the same product policy. It does not require a protocol schema change; existing phone control and remote messages provide presence and stop signals.
+
+## Product policy
+
+- The feature defaults to **Off** on every receiver.
+- The reminder interval defaults to **90 minutes**.
+- Reminder interval options are **30, 60, 90, 120, 180, and 240 minutes**.
+- The response time defaults to **5 minutes**.
+- Response-time options are **30 seconds, 1 minute, 2 minutes, 5 minutes, and 10 minutes**.
+- Only actively playing time advances the unattended timer. Paused, buffering, stopped, ended, and pre-play states do not advance it.
+- Genuine local or phone activity resets elapsed unattended time.
+- A new cast, playlist advance, or playlist jump resets elapsed time and dismisses an existing prompt.
+- Switching playback engines for the same title preserves the current media session while counting the switch interaction as user presence.
+
+## State and playback behavior
+
+```mermaid
+stateDiagram-v2
+    [*] --> Disabled: setting off
+    [*] --> Tracking: setting on and playing
+    Disabled --> Tracking: enable while playing
+    Tracking --> Tracking: user activity or media change resets elapsed
+    Tracking --> Suspended: paused, buffering, ended, or pre-play
+    Suspended --> Tracking: playback resumes
+    Tracking --> Prompting: reminder interval reached
+    Prompting --> Tracking: Continue or presence input
+    Prompting --> Idle: response countdown expires
+    Idle --> Tracking: new playback session
+```
+
+When the reminder interval is reached:
+
+1. Playback pauses immediately.
+2. The receiver displays an **Are you still watching?** prompt and starts the configured response countdown.
+3. TVs remain awake for the entire response countdown so the prompt stays visible.
+4. Continue or another accepted presence input dismisses the prompt, resumes playback, and resets elapsed unattended time.
+5. If the countdown expires, playback stops, the player exits, and the receiver returns to its idle context.
+
+The prompt has one visible action: **Continue watching**. There is no redundant Stop button because playback stops automatically when the countdown expires.
+
+## Input behavior
+
+### While tracking
+
+The following user-driven actions reset unattended elapsed time before their normal behavior is applied:
+
+- TV remote and D-pad presses
+- Desktop keyboard, mouse, trackpad, and media-key actions
+- Phone control and remote commands
+- User seeks, track changes, playback-setting changes, playlist interactions, and manual engine switches
+
+Automated progress updates, buffering events, status broadcasts, and automatic segment skipping are not presence signals.
+
+### While the prompt is visible
+
+- Selecting **Continue watching** resumes playback.
+- Back, Menu, Escape, Play/Pause, remote navigation, and other presence inputs act as Continue.
+- Presence inputs are consumed by the prompt. They do not also seek, pause again, change focus outside the prompt, or exit the player.
+- A phone `stop` command remains an explicit stop and exits immediately.
+- A platform physical media-stop action may also stop immediately where that action is available.
+
+This Continue-only handling is consistent across Android TV, Apple TV Native/VLC/MPV playback, and Desktop.
+
+## Settings
+
+Each receiver persists these local settings:
+
+| Setting | Default | Options |
+|---|---:|---|
+| Still Watching Reminder | Off | Off / On |
+| Reminder interval | 90 minutes | 30m, 60m, 90m, 120m, 180m, 240m |
+| Response time | 5 minutes | 30s, 1m, 2m, 5m, 10m |
+
+Changing a setting takes effect without restarting playback. Turning the feature off dismisses an active prompt, resumes playback, and clears accumulated unattended time.
+
+## Platform implementation
+
+### Android TV
+
+- `StillWatchingController` owns elapsed time, prompting, and response countdown state.
+- `PlayerActivity` coordinates engine pause, resume, stop, media changes, settings, and display wake state.
+- The still-watching overlay is protected from normal player-control auto-hide behavior.
+- Input handling consumes prompt responses before normal D-pad, Back, seek, or playback routing.
+
+### Apple TV
+
+- `StillWatchingController` owns tracking, prompt state, and the response countdown.
+- `PlayerView` coordinates all Native, VLC, and MPV engines.
+- Playback activity emitted during visual-metadata prebuffering is retained and applied when prebuffering ends.
+- Native, VLC, and MPV inputs use Continue-only prompt semantics.
+- `UIApplication.shared.isIdleTimerDisabled` remains enabled during playback and during the response countdown, then clears on stop, reset, expiry, or backgrounding as appropriate.
+
+### Desktop
+
+- The still-watching controller coordinates the Flutter player, prompt, countdown, and receiver server state.
+- The prompt is rendered above the player using the active application theme.
+- Keyboard, pointer, phone, extension bridge, and media-session actions provide presence signals.
+- Timeout stops playback and broadcasts idle context to paired senders.
+
+## Media identity and playlists
+
+Every fresh cast is a new media session, even when its URL matches the previous cast. Playlist auto-advance and explicit jumps also reset the timer and dismiss a prompt. Receivers must not allow an old prompt or response countdown to carry into newly selected media.
+
+Engine switches made for the current title should avoid creating a false media change. The switch itself is user activity, so elapsed unattended time resets through the presence path.
+
+## Display and receiver state
+
+TV receivers keep the display awake while the prompt countdown is visible. They release the keep-awake state only after timeout stops playback, an explicit stop, a session reset, or foreground playback otherwise ends.
+
+On timeout, every receiver stops/exits playback and returns to idle. Paired senders must receive the same idle/player-context transition used by an ordinary stop.
+
+## Verification
+
+Expected coverage includes:
+
+- Default-off preference behavior and persistence
+- Every reminder and response-time preset, including the 5-minute default and 10-minute option
+- Playing-time accumulation and pause/buffering/pre-play suspension
+- Immediate pause when prompting begins
+- Continue-only UI and Back/Menu/Escape/PlayPause handling
+- Explicit phone stop while prompting
+- Countdown expiry stopping playback and returning to idle
+- User activity resetting elapsed time across local and phone inputs
+- Fresh same-URL casts, playlist advances, and playlist jumps resetting state
+- TV display wake state throughout the response countdown
+- Apple visual-metadata prebuffer transitions for Native, VLC, and MPV
+- Desktop paired-sender idle-context synchronization after timeout
+
+Run focused controller tests where available, Desktop Flutter tests and analysis, Android TV unit tests, and an unsigned Apple TV build before merging.

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
@@ -132,6 +132,7 @@ class ExoPlayerActivity : PlayerActivity() {
     // Playlist queue / auto-advance — single source of truth, shared with MpvPlayerActivity.
     private val coordinator = PlaybackCoordinator(object : PlaybackCoordinator.Host {
         override fun loadItem(item: playbridge.PlayPayload, displayTitle: String?) {
+            recordStillWatchingMediaChanged()
             displayTitle?.takeIf { it.isNotBlank() }?.let {
                 android.widget.Toast.makeText(this@ExoPlayerActivity, it, android.widget.Toast.LENGTH_SHORT).show()
             }
@@ -188,6 +189,11 @@ class ExoPlayerActivity : PlayerActivity() {
             when (intent?.action) {
                 ServerService.ACTION_CONTROL -> {
                     val command = intent.getStringExtra(ServerService.EXTRA_COMMAND)
+                    if (stillWatchingController.state.value.isPrompting && command != "stop") {
+                        stillWatchingController.continueWatching()
+                        return
+                    }
+                    if (command != null && command != "stop") recordStillWatchingActivity()
                     when {
                         command == "loop_on"  -> setLooping(true)
                         command == "loop_off" -> setLooping(false)
@@ -218,11 +224,13 @@ class ExoPlayerActivity : PlayerActivity() {
                     val subtitles = intent.getStringArrayListExtra(ServerService.EXTRA_SUBTITLES)
 
                     if (url != null) {
+                        recordStillWatchingMediaChanged()
                         stopPlayback()
                         playVideo(url, title, contentType, detectedBy, headers, subtitles)
                     }
                 }
                 ServerService.ACTION_QUEUE_ADD -> {
+                    recordStillWatchingActivity()
                     coordinator.queueAdd(ServerService.drainPendingQueueItems())
                     controlsViewModel.setPlaylistVisible(true)
                 }
@@ -271,6 +279,7 @@ class ExoPlayerActivity : PlayerActivity() {
         windowInsetsController.hide(androidx.core.view.WindowInsetsCompat.Type.systemBars())
 
         // Initialize View Bindings
+        setupStillWatching(controlsViewModel)
         setContentView(com.playbridge.player.R.layout.activity_player)
         playerView = findViewById(com.playbridge.player.R.id.player_view)
 
@@ -278,8 +287,11 @@ class ExoPlayerActivity : PlayerActivity() {
             setContent {
                 PlayBridgeTVTheme {
                     val state by controlsViewModel.controlsState.collectAsState()
+                    val stillWatching by stillWatchingController.state.collectAsState()
                     PlayerControlsOverlay(
                         state = state,
+                        stillWatchingState = stillWatching,
+                        onContinueWatching = stillWatchingController::continueWatching,
                         onTogglePlay = { controlsViewModel.togglePlayPause() },
                         onTrackSelection = {
                             updateUnifiedTracks()
@@ -426,7 +438,10 @@ class ExoPlayerActivity : PlayerActivity() {
             audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager,
             engine = engineAdapter,
             controls = controlsViewModel,
-            isExternalOverlayVisible = { controlsViewModel.controlsState.value.prePlayMetadata != null || controlsViewModel.controlsState.value.activeOverlay != ActiveOverlay.NONE }
+            isExternalOverlayVisible = { controlsViewModel.controlsState.value.prePlayMetadata != null || controlsViewModel.controlsState.value.activeOverlay != ActiveOverlay.NONE },
+            isStillWatchingVisible = { stillWatchingController.state.value.isPrompting },
+            onContinueWatching = stillWatchingController::continueWatching,
+            onUserActivity = stillWatchingController::onUserActivity,
         )
         
         controlsViewModel.setEngine(engineAdapter, "exo", this)
@@ -460,6 +475,7 @@ class ExoPlayerActivity : PlayerActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         FileLogger.i(TAG, "onNewIntent received")
+        recordStillWatchingMediaChanged()
 
         launchJob?.cancel()
 
@@ -468,6 +484,7 @@ class ExoPlayerActivity : PlayerActivity() {
     }
 
     private fun handleIntent(intent: Intent?) {
+        recordStillWatchingMediaChanged()
         setupPlaybackExtras(intent)
 
         // Read playlist if present - needed early for button visibility logic
@@ -1093,7 +1110,9 @@ class ExoPlayerActivity : PlayerActivity() {
                 // during buffering, pre-play, or an engine switch and never got hidden.
                 controlsViewModel.hideControls()
             } else {
-                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                if (!stillWatchingController.state.value.isPrompting) {
+                    window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                }
                 // Hide spinner if we paused while buffering
                 controlsViewModel.setBuffering(false)
             }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/InputHandler.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/InputHandler.kt
@@ -18,7 +18,10 @@ class InputHandler(
     private val audioManager: AudioManager,
     private val engine: PlayerEngineAdapter,
     private val controls: PlayerControlsViewModel,
-    private val isExternalOverlayVisible: () -> Boolean = { false }
+    private val isExternalOverlayVisible: () -> Boolean = { false },
+    private val isStillWatchingVisible: () -> Boolean = { false },
+    private val onContinueWatching: () -> Unit = {},
+    private val onUserActivity: () -> Unit = {},
 ) {
 
     /**
@@ -26,6 +29,16 @@ class InputHandler(
      */
     fun handleControlCommand(command: String?) {
         Log.i(TAG, "Control command: $command")
+
+        if (isStillWatchingVisible()) {
+            if (command == "stop") {
+                activity.finish()
+            } else if (command != null) {
+                onContinueWatching()
+            }
+            return
+        }
+        if (command != null) onUserActivity()
 
         // Absolute seek from the phone seekbar: "seek_to:<positionMs>"
         if (command != null && command.startsWith("seek_to:")) {
@@ -100,6 +113,11 @@ class InputHandler(
      */
     fun handleRemoteCommand(key: String?) {
         Log.i(TAG, "Remote command: $key")
+        if (key != null && isStillWatchingVisible()) {
+            onContinueWatching()
+            return
+        }
+        if (key != null) onUserActivity()
 
         val keyCode = when (key) {
             "dpad_up" -> KeyEvent.KEYCODE_DPAD_UP
@@ -129,6 +147,17 @@ class InputHandler(
     fun handleKeyEvent(keyCode: Int, event: KeyEvent?): Boolean {
         // Only handle ACTION_DOWN
         if (event?.action != KeyEvent.ACTION_DOWN) return false
+
+        if (isStillWatchingVisible()) {
+            if (keyCode == KeyEvent.KEYCODE_MEDIA_STOP) {
+                activity.finish()
+                return true
+            }
+            onContinueWatching()
+            return true
+        }
+
+        onUserActivity()
 
         val state = controls.controlsState.value
         val isExtVisible = isExternalOverlayVisible()

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
@@ -151,6 +151,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
     // Playlist queue / auto-advance — single source of truth, shared with ExoPlayerActivity.
     private val coordinator = PlaybackCoordinator(object : PlaybackCoordinator.Host {
         override fun loadItem(item: playbridge.PlayPayload, displayTitle: String?) {
+            recordStillWatchingMediaChanged()
             runOnUiThread {
                 displayTitle?.takeIf { it.isNotBlank() }?.let {
                     Toast.makeText(this@MpvPlayerActivity, it, Toast.LENGTH_SHORT).show()
@@ -255,6 +256,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
             }
         )
 
+        setupStillWatching(controlsViewModel)
         setContentView(R.layout.activity_mpv_player)
         surfaceView = findViewById(R.id.surface_view)
         composeView = findViewById(R.id.modern_controls_view)
@@ -263,8 +265,11 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
             setContent {
                 PlayBridgeTVTheme {
                     val state by controlsViewModel.controlsState.collectAsState()
+                    val stillWatching by stillWatchingController.state.collectAsState()
                     PlayerControlsOverlay(
                         state = state,
+                        stillWatchingState = stillWatching,
+                        onContinueWatching = stillWatchingController::continueWatching,
                         onTogglePlay = { controlsViewModel.togglePlayPause() },
                         onTrackSelection = {
                             updateUnifiedTracks()
@@ -406,7 +411,10 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
             audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager,
             engine = engineAdapter,
             controls = controlsViewModel,
-            isExternalOverlayVisible = { controlsViewModel.controlsState.value.prePlayMetadata != null || controlsViewModel.controlsState.value.activeOverlay != ActiveOverlay.NONE }
+            isExternalOverlayVisible = { controlsViewModel.controlsState.value.prePlayMetadata != null || controlsViewModel.controlsState.value.activeOverlay != ActiveOverlay.NONE },
+            isStillWatchingVisible = { stillWatchingController.state.value.isPrompting },
+            onContinueWatching = stillWatchingController::continueWatching,
+            onUserActivity = stillWatchingController::onUserActivity,
         )
 
         controlsViewModel.setEngine(engineAdapter, "mpv", this)
@@ -534,6 +542,13 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
             // Must post to the UI thread: this callback fires on MPV's native event thread.
             runOnUiThread {
                 controlsViewModel.setPlaying(!value)
+                if (value) {
+                    if (!stillWatchingController.state.value.isPrompting) {
+                        window.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                    }
+                } else {
+                    window.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                }
                 // Invariant: controls/overlays are only shown while paused. On the
                 // play→playing transition (pause property false) dismiss any leftover overlay.
                 if (!value) controlsViewModel.hideControls()
@@ -701,6 +716,11 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
                 }
                 ServerService.ACTION_CONTROL -> {
                     val cmd = intent.getStringExtra(ServerService.EXTRA_COMMAND)
+                    if (stillWatchingController.state.value.isPrompting && cmd != "stop") {
+                        stillWatchingController.continueWatching()
+                        return
+                    }
+                    if (cmd != null && cmd != "stop") recordStillWatchingActivity()
                     when {
                         cmd?.startsWith("audio_track:") == true ->
                             applyMpvTrackSelection("audio", cmd.removePrefix("audio_track:"))
@@ -718,6 +738,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
                     }
                 }
                 ServerService.ACTION_QUEUE_ADD -> {
+                    recordStillWatchingActivity()
                     coordinator.queueAdd(ServerService.drainPendingQueueItems())
                     controlsViewModel.setPlaylistVisible(true)
                 }
@@ -750,6 +771,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
 
     private fun handleIntent(intent: Intent?) {
         if (isFinishing) return
+        recordStillWatchingMediaChanged()
         setupPlaybackExtras(intent)
 
         // Read playlist if present

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerActivity.kt
@@ -28,8 +28,69 @@ import kotlinx.coroutines.flow.map
 import com.playbridge.player.ui.player.PlayerControlsState
 import com.playbridge.player.ui.player.PlayerControlsViewModel
 import com.playbridge.player.ui.player.UnifiedTrack
+import android.content.SharedPreferences
 
 abstract class PlayerActivity : ComponentActivity() {
+
+    protected lateinit var stillWatchingController: StillWatchingController
+        private set
+    private var stillWatchingControls: PlayerControlsViewModel? = null
+    private var stillWatchingPrefsListener: SharedPreferences.OnSharedPreferenceChangeListener? = null
+
+    protected fun setupStillWatching(controls: PlayerControlsViewModel) {
+        stillWatchingControls = controls
+        stillWatchingController = StillWatchingController(
+            scope = lifecycleScope,
+            pausePlayback = {
+                pause()
+                controls.setPlaying(false)
+            },
+            resumePlayback = {
+                play()
+                controls.setPlaying(true)
+                window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            },
+            stopPlayback = { finish() },
+            onPromptChanged = { prompting ->
+                if (prompting || controls.controlsState.value.isPlaying) {
+                    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                } else {
+                    window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                }
+            },
+        )
+        val prefs = getSharedPreferences(STILL_WATCHING_PREFS, Context.MODE_PRIVATE)
+        fun applySettings() = stillWatchingController.updateSettings(
+            prefs.getBoolean(PREF_STILL_WATCHING_ENABLED, false),
+            normalizeStillWatchingThreshold(prefs.getInt(PREF_STILL_WATCHING_THRESHOLD_MIN, 90)),
+            normalizeStillWatchingResponseSeconds(prefs.getInt(PREF_STILL_WATCHING_RESPONSE_SEC, 300)),
+        )
+        applySettings()
+        stillWatchingPrefsListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == PREF_STILL_WATCHING_ENABLED ||
+                key == PREF_STILL_WATCHING_THRESHOLD_MIN ||
+                key == PREF_STILL_WATCHING_RESPONSE_SEC
+            ) applySettings()
+        }.also(prefs::registerOnSharedPreferenceChangeListener)
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                try {
+                    controls.controlsState.map { it.isPlaying && !it.isBuffering }.distinctUntilChanged()
+                        .collect(stillWatchingController::onPlayingChanged)
+                } finally {
+                    stillWatchingController.onPlayingChanged(false)
+                }
+            }
+        }
+    }
+
+    protected fun recordStillWatchingActivity() {
+        if (::stillWatchingController.isInitialized) stillWatchingController.onUserActivity()
+    }
+
+    protected fun recordStillWatchingMediaChanged() {
+        if (::stillWatchingController.isInitialized) stillWatchingController.onMediaChanged()
+    }
 
     protected var launchJob: Job? = null
     protected var watchdogJob: Job? = null
@@ -260,8 +321,7 @@ abstract class PlayerActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Keep screen on
-        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        // Playback engines set this flag only while media is actively playing.
 
         // Handle window insets
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -326,6 +386,11 @@ abstract class PlayerActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
+        if (::stillWatchingController.isInitialized) stillWatchingController.dispose()
+        stillWatchingPrefsListener?.let {
+            getSharedPreferences(STILL_WATCHING_PREFS, Context.MODE_PRIVATE)
+                .unregisterOnSharedPreferenceChangeListener(it)
+        }
         if (current?.get() === this) {
             current = null
             // Only reset activeContext when THIS is genuinely the last player being torn down —
@@ -337,6 +402,18 @@ abstract class PlayerActivity : ComponentActivity() {
             ServerService.notifyContextIdle()
         }
         super.onDestroy()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        if (stillWatchingControls?.controlsState?.value?.isPlaying == true) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+
+    override fun onStop() {
+        window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        super.onStop()
     }
 
 
@@ -689,6 +766,19 @@ abstract class PlayerActivity : ComponentActivity() {
     companion object {
         @Volatile
         private var current: java.lang.ref.WeakReference<PlayerActivity>? = null
+
+        const val STILL_WATCHING_PREFS = "browser_prefs"
+        const val PREF_STILL_WATCHING_ENABLED = "still_watching_enabled"
+        const val PREF_STILL_WATCHING_THRESHOLD_MIN = "still_watching_threshold_min"
+        const val PREF_STILL_WATCHING_RESPONSE_SEC = "still_watching_response_sec"
+        val STILL_WATCHING_PRESETS = setOf(30, 60, 90, 120, 180, 240)
+        val STILL_WATCHING_RESPONSE_PRESETS = setOf(30, 60, 120, 300, 600)
+
+        fun normalizeStillWatchingThreshold(value: Int): Int =
+            value.takeIf { it in STILL_WATCHING_PRESETS } ?: 90
+
+        fun normalizeStillWatchingResponseSeconds(value: Int): Int =
+            value.takeIf { it in STILL_WATCHING_RESPONSE_PRESETS } ?: 300
 
         /** Intent extra carrying how many automatic engine failovers this session has done. */
         private const val EXTRA_AUTO_SWITCH_COUNT = "extra_auto_engine_switch_count"

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/StillWatchingController.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/StillWatchingController.kt
@@ -1,0 +1,150 @@
+package com.playbridge.player.player
+
+import android.os.SystemClock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class StillWatchingState(val isPrompting: Boolean = false, val secondsRemaining: Int = 300)
+
+class StillWatchingController(
+    private val scope: CoroutineScope,
+    private val pausePlayback: () -> Unit,
+    private val resumePlayback: () -> Unit,
+    private val stopPlayback: () -> Unit,
+    private val nowMs: () -> Long = SystemClock::elapsedRealtime,
+    graceSeconds: Int = 300,
+    private val onPromptChanged: (Boolean) -> Unit = {},
+) {
+    private var graceSeconds = graceSeconds
+    private val _state = MutableStateFlow(StillWatchingState(secondsRemaining = graceSeconds))
+    val state: StateFlow<StillWatchingState> = _state.asStateFlow()
+
+    private var enabled = true
+    private var thresholdMs = 90 * 60_000L
+    private var accumulatedMs = 0L
+    private var playingSinceMs: Long? = null
+    private var isPlaying = false
+    private var thresholdJob: Job? = null
+    private var countdownJob: Job? = null
+    private var pausedByPrompt = false
+
+    fun updateSettings(enabled: Boolean, thresholdMinutes: Int, graceSeconds: Int? = null) {
+        accrue()
+        this.enabled = enabled
+        thresholdMs = thresholdMinutes.coerceAtLeast(1) * 60_000L
+        graceSeconds?.let { this.graceSeconds = it.coerceAtLeast(1) }
+        if (!enabled) {
+            thresholdJob?.cancel()
+            accumulatedMs = 0L
+            if (_state.value.isPrompting) dismissAndResume()
+        } else {
+            if (isPlaying && !_state.value.isPrompting) playingSinceMs = nowMs()
+            scheduleThreshold()
+        }
+    }
+
+    fun onUserActivity() {
+        if (_state.value.isPrompting) {
+            continueWatching()
+            return
+        }
+        accrue()
+        accumulatedMs = 0L
+        if (enabled && isPlaying) playingSinceMs = nowMs()
+        scheduleThreshold()
+    }
+
+    fun onMediaChanged() {
+        thresholdJob?.cancel()
+        countdownJob?.cancel()
+        accumulatedMs = 0L
+        playingSinceMs = if (enabled && isPlaying) nowMs() else null
+        pausedByPrompt = false
+        _state.value = StillWatchingState(secondsRemaining = graceSeconds)
+        onPromptChanged(false)
+        scheduleThreshold()
+    }
+
+    fun onPlayingChanged(isPlaying: Boolean) {
+        accrue()
+        this.isPlaying = isPlaying
+        if (isPlaying && enabled && !_state.value.isPrompting) {
+            if (playingSinceMs == null) playingSinceMs = nowMs()
+            scheduleThreshold()
+        } else {
+            thresholdJob?.cancel()
+        }
+    }
+
+    fun continueWatching() {
+        if (!_state.value.isPrompting) return
+        countdownJob?.cancel()
+        accumulatedMs = 0L
+        playingSinceMs = null
+        _state.value = StillWatchingState(secondsRemaining = graceSeconds)
+        onPromptChanged(false)
+        if (pausedByPrompt) resumePlayback()
+        pausedByPrompt = false
+    }
+
+    fun stopWatching() {
+        if (!_state.value.isPrompting) return
+        countdownJob?.cancel()
+        _state.value = StillWatchingState(secondsRemaining = graceSeconds)
+        onPromptChanged(false)
+        stopPlayback()
+    }
+
+    fun dispose() {
+        thresholdJob?.cancel()
+        countdownJob?.cancel()
+        playingSinceMs = null
+        isPlaying = false
+    }
+
+    private fun accrue() {
+        playingSinceMs?.let { accumulatedMs += (nowMs() - it).coerceAtLeast(0L) }
+        playingSinceMs = null
+    }
+
+    private fun scheduleThreshold() {
+        thresholdJob?.cancel()
+        if (!enabled || playingSinceMs == null || _state.value.isPrompting) return
+        val elapsed = accumulatedMs + (nowMs() - playingSinceMs!!).coerceAtLeast(0L)
+        val remaining = (thresholdMs - elapsed).coerceAtLeast(0L)
+        thresholdJob = scope.launch {
+            delay(remaining)
+            accrue()
+            if (enabled) showPrompt()
+        }
+    }
+
+    private fun showPrompt() {
+        if (_state.value.isPrompting) return
+        pausedByPrompt = true
+        pausePlayback()
+        _state.value = StillWatchingState(isPrompting = true, secondsRemaining = graceSeconds)
+        onPromptChanged(true)
+        countdownJob = scope.launch {
+            for (remaining in graceSeconds - 1 downTo 0) {
+                delay(1000)
+                if (!_state.value.isPrompting) return@launch
+                _state.value = StillWatchingState(isPrompting = true, secondsRemaining = remaining)
+            }
+            stopWatching()
+        }
+    }
+
+    private fun dismissAndResume() {
+        countdownJob?.cancel()
+        _state.value = StillWatchingState(secondsRemaining = graceSeconds)
+        onPromptChanged(false)
+        if (pausedByPrompt) resumePlayback()
+        pausedByPrompt = false
+    }
+}

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/SettingsScreen.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/SettingsScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.*
 import androidx.compose.ui.graphics.vector.ImageVector
+import com.playbridge.player.player.PlayerActivity
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -61,6 +62,13 @@ fun SettingsScreen(
     var frameRateMatching by remember { mutableStateOf(prefs.getBoolean("frame_rate_matching", false)) }
     var tunneledPlayback by remember { mutableStateOf(prefs.getBoolean("tunneled_playback", false)) }
     var loudnessEnhancer by remember { mutableStateOf(prefs.getBoolean("loudness_enhancer", false)) }
+    var stillWatchingEnabled by remember { mutableStateOf(prefs.getBoolean(PlayerActivity.PREF_STILL_WATCHING_ENABLED, false)) }
+    var stillWatchingMinutes by remember {
+        mutableStateOf(PlayerActivity.normalizeStillWatchingThreshold(prefs.getInt(PlayerActivity.PREF_STILL_WATCHING_THRESHOLD_MIN, 90)))
+    }
+    var stillWatchingResponseSeconds by remember {
+        mutableStateOf(PlayerActivity.normalizeStillWatchingResponseSeconds(prefs.getInt(PlayerActivity.PREF_STILL_WATCHING_RESPONSE_SEC, 300)))
+    }
     var enableHistory by remember { mutableStateOf(prefs.getBoolean("enable_history", true)) }
     var isRestarting by remember { mutableStateOf(false) }
     var showExitDialog by remember { mutableStateOf(false) }
@@ -190,6 +198,54 @@ fun SettingsScreen(
 
                 when (selectedCategory) {
                     SettingsCategory.PLAYER -> {
+                        item {
+                            SettingToggleItem(
+                                label = "Still Watching Check",
+                                description = "Pause after extended playback and return to idle if there is no response.",
+                                checked = stillWatchingEnabled,
+                                onCheckedChange = {
+                                    stillWatchingEnabled = it
+                                    prefs.edit().putBoolean(PlayerActivity.PREF_STILL_WATCHING_ENABLED, it).apply()
+                                }
+                            )
+                        }
+                        if (stillWatchingEnabled) item {
+                            SettingDropdownItem(
+                                label = "Check After",
+                                description = "Active playback time before asking whether to continue.",
+                                options = PlayerActivity.STILL_WATCHING_PRESETS.sorted().map { minutes ->
+                                    val label = when {
+                                        minutes < 60 -> "$minutes minutes"
+                                        minutes % 60 == 0 -> "${minutes / 60} ${if (minutes == 60) "hour" else "hours"}"
+                                        else -> "${minutes / 60.0} hours"
+                                    }
+                                    minutes.toString() to label
+                                },
+                                selected = stillWatchingMinutes.toString(),
+                                onSelected = { value ->
+                                    value.toIntOrNull()?.takeIf { it in PlayerActivity.STILL_WATCHING_PRESETS }?.let {
+                                        stillWatchingMinutes = it
+                                        prefs.edit().putInt(PlayerActivity.PREF_STILL_WATCHING_THRESHOLD_MIN, it).apply()
+                                    }
+                                }
+                            )
+                        }
+                        if (stillWatchingEnabled) item {
+                            SettingDropdownItem(
+                                label = "Response Time",
+                                description = "Time to respond before playback stops.",
+                                options = PlayerActivity.STILL_WATCHING_RESPONSE_PRESETS.sorted().map { seconds ->
+                                    seconds.toString() to if (seconds < 60) "$seconds seconds" else "${seconds / 60} ${if (seconds == 60) "minute" else "minutes"}"
+                                },
+                                selected = stillWatchingResponseSeconds.toString(),
+                                onSelected = { value ->
+                                    value.toIntOrNull()?.takeIf { it in PlayerActivity.STILL_WATCHING_RESPONSE_PRESETS }?.let {
+                                        stillWatchingResponseSeconds = it
+                                        prefs.edit().putInt(PlayerActivity.PREF_STILL_WATCHING_RESPONSE_SEC, it).apply()
+                                    }
+                                }
+                            )
+                        }
                         item {
                             SettingDropdownItem(
                                 label = "Video Player",

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsOverlay.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsOverlay.kt
@@ -26,11 +26,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import com.playbridge.player.player.PlaylistPickerDialog
 import com.playbridge.player.player.SwitchPlayerDialog
 import com.playbridge.player.ui.theme.TvExpressiveMotion
+import com.playbridge.player.player.StillWatchingState
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 fun PlayerControlsOverlay(
     state: PlayerControlsState,
+    stillWatchingState: StillWatchingState = StillWatchingState(),
+    onContinueWatching: () -> Unit = {},
     onTogglePlay: () -> Unit,
     onTrackSelection: () -> Unit,
     onSubtitles: () -> Unit,
@@ -304,6 +307,47 @@ fun PlayerControlsOverlay(
                 onStartNow = onPrePlayStartNow,
                 onBack = onPrePlayBack
             )
+        }
+
+        if (stillWatchingState.isPrompting) {
+            StillWatchingDialog(
+                title = state.title,
+                secondsRemaining = stillWatchingState.secondsRemaining,
+                onContinue = onContinueWatching,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun StillWatchingDialog(
+    title: String,
+    secondsRemaining: Int,
+    onContinue: () -> Unit,
+) {
+    val continueFocus = remember { FocusRequester() }
+    LaunchedEffect(Unit) { continueFocus.requestFocus() }
+    Box(
+        Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.78f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier.width(560.dp).background(MaterialTheme.colorScheme.surface, RoundedCornerShape(20.dp)).padding(36.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            Text("Are you still watching?", color = MaterialTheme.colorScheme.onSurface, fontSize = 30.sp, fontWeight = FontWeight.Bold)
+            if (title.isNotBlank()) Text(title, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 20.sp)
+            Text(
+                "Playback will stop in ${secondsRemaining.coerceAtLeast(0) / 60}:${(secondsRemaining.coerceAtLeast(0) % 60).toString().padStart(2, '0')}",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Surface(
+                onClick = onContinue,
+                modifier = Modifier.focusRequester(continueFocus),
+                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp)),
+            ) { Text("Continue watching", Modifier.padding(horizontal = 24.dp, vertical = 14.dp)) }
         }
     }
 }

--- a/tv/android/player/app/src/test/java/com/playbridge/player/player/StillWatchingControllerTest.kt
+++ b/tv/android/player/app/src/test/java/com/playbridge/player/player/StillWatchingControllerTest.kt
@@ -1,0 +1,153 @@
+package com.playbridge.player.player
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StillWatchingControllerTest {
+    @Test fun promptsOnlyAfterCumulativeActivePlaybackAndContinueResets() {
+        val dispatcher = StandardTestDispatcher()
+        val scope = TestScope(dispatcher)
+        var paused = 0
+        var resumed = 0
+        var now = 0L
+        val controller = StillWatchingController(scope, { paused++ }, { resumed++ }, {}, { now }, graceSeconds = 60)
+        controller.updateSettings(true, 1)
+        controller.onPlayingChanged(true)
+        now += 30_000; scope.advanceTimeBy(30_000)
+        controller.onPlayingChanged(false)
+        now += 100_000; scope.advanceTimeBy(100_000)
+        assertFalse(controller.state.value.isPrompting)
+        controller.onPlayingChanged(true)
+        now += 30_000; scope.advanceTimeBy(30_000); scope.runCurrent()
+        assertTrue(controller.state.value.isPrompting)
+        assertEquals(1, paused)
+        controller.continueWatching()
+        assertFalse(controller.state.value.isPrompting)
+        assertEquals(1, resumed)
+    }
+
+    @Test fun countdownExpiresAndStops() {
+        val dispatcher = StandardTestDispatcher()
+        val scope = TestScope(dispatcher)
+        var stopped = 0
+        var now = 0L
+        val controller = StillWatchingController(scope, {}, {}, { stopped++ }, { now }, graceSeconds = 2)
+        controller.updateSettings(true, 1)
+        controller.onPlayingChanged(true)
+        now = 60_000; scope.advanceTimeBy(60_000); scope.runCurrent()
+        assertTrue(controller.state.value.isPrompting)
+        scope.advanceTimeBy(2_000); scope.runCurrent()
+        assertEquals(1, stopped)
+    }
+
+    @Test fun liveSettingsChangesRescheduleActivePlayback() {
+        val dispatcher = StandardTestDispatcher()
+        val scope = TestScope(dispatcher)
+        var paused = 0
+        var now = 0L
+        val controller = StillWatchingController(scope, { paused++ }, {}, {}, { now })
+        controller.updateSettings(true, 2)
+        controller.onPlayingChanged(true)
+        now = 60_000; scope.advanceTimeBy(60_000); scope.runCurrent()
+
+        controller.updateSettings(true, 1)
+        scope.runCurrent()
+        assertTrue(controller.state.value.isPrompting)
+        assertEquals(1, paused)
+
+        controller.continueWatching()
+        controller.updateSettings(false, 1)
+        controller.onPlayingChanged(true)
+        now += 120_000; scope.advanceTimeBy(120_000); scope.runCurrent()
+        assertFalse(controller.state.value.isPrompting)
+
+        controller.updateSettings(true, 1)
+        now += 60_000; scope.advanceTimeBy(60_000); scope.runCurrent()
+        assertTrue(controller.state.value.isPrompting)
+    }
+
+    @Test fun userActivityRestartsUnattendedPlaybackWindow() {
+        val dispatcher = StandardTestDispatcher()
+        val scope = TestScope(dispatcher)
+        var now = 0L
+        val controller = StillWatchingController(scope, {}, {}, {}, nowMs = { now })
+        controller.updateSettings(true, 1)
+        controller.onPlayingChanged(true)
+
+        now = 50_000; scope.advanceTimeBy(50_000)
+        controller.onUserActivity()
+        now = 70_000; scope.advanceTimeBy(20_000); scope.runCurrent()
+        assertFalse(controller.state.value.isPrompting)
+
+        now = 110_000; scope.advanceTimeBy(40_000); scope.runCurrent()
+        assertTrue(controller.state.value.isPrompting)
+    }
+
+    @Test fun mediaChangeDismissesPromptWithoutResumingOldMedia() {
+        val dispatcher = StandardTestDispatcher()
+        val scope = TestScope(dispatcher)
+        var resumed = 0
+        var stopped = 0
+        var now = 0L
+        val controller = StillWatchingController(
+            scope, {}, { resumed++ }, { stopped++ }, nowMs = { now }, graceSeconds = 2,
+        )
+        controller.updateSettings(true, 1)
+        controller.onPlayingChanged(true)
+        now = 60_000; scope.advanceTimeBy(60_000); scope.runCurrent()
+        assertTrue(controller.state.value.isPrompting)
+
+        controller.onMediaChanged()
+        scope.advanceTimeBy(5_000); scope.runCurrent()
+        assertFalse(controller.state.value.isPrompting)
+        assertEquals(0, resumed)
+        assertEquals(0, stopped)
+    }
+
+    @Test fun userActivityDismissesPromptAndResumesPromptPausedPlayback() {
+        val dispatcher = StandardTestDispatcher()
+        val scope = TestScope(dispatcher)
+        var resumed = 0
+        var now = 0L
+        val controller = StillWatchingController(
+            scope, {}, { resumed++ }, {}, nowMs = { now }, graceSeconds = 2,
+        )
+        controller.updateSettings(true, 1)
+        controller.onPlayingChanged(true)
+        now = 60_000; scope.advanceTimeBy(60_000); scope.runCurrent()
+        assertTrue(controller.state.value.isPrompting)
+
+        controller.onUserActivity()
+
+        assertFalse(controller.state.value.isPrompting)
+        assertEquals(1, resumed)
+        scope.advanceTimeBy(5_000); scope.runCurrent()
+        assertFalse(controller.state.value.isPrompting)
+    }
+
+    @Test fun disablingClearsPreviouslyAccumulatedPlayback() {
+        val dispatcher = StandardTestDispatcher()
+        val scope = TestScope(dispatcher)
+        var now = 0L
+        val controller = StillWatchingController(scope, {}, {}, {}, nowMs = { now })
+        controller.updateSettings(true, 1)
+        controller.onPlayingChanged(true)
+        now = 50_000; scope.advanceTimeBy(50_000)
+        controller.updateSettings(false, 1)
+        now = 100_000; scope.advanceTimeBy(50_000)
+        controller.updateSettings(true, 1)
+        now = 110_000; scope.advanceTimeBy(10_000); scope.runCurrent()
+        assertFalse(controller.state.value.isPrompting)
+
+        now = 160_000; scope.advanceTimeBy(50_000); scope.runCurrent()
+        assertTrue(controller.state.value.isPrompting)
+    }
+}

--- a/tv/apple/PlayBridge TV/PlayBridge TV/ContentView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/ContentView.swift
@@ -16,10 +16,15 @@ struct ContentView: View {
     @StateObject private var historyStore = HistoryStore()
     @StateObject private var playlistStore = PlaylistStore()
     @StateObject private var server: WebSocketServer
+    @StateObject private var stillWatching = StillWatchingController()
     @AppStorage("enable_history") var enableHistory: Bool = true
+    @AppStorage("still_watching_enabled") var stillWatchingEnabled: Bool = false
+    @AppStorage("still_watching_threshold_min") var stillWatchingThreshold: Int = StillWatchingController.defaultThreshold
+    @AppStorage("still_watching_response_sec") var stillWatchingResponseSeconds: Int = StillWatchingController.defaultResponseSeconds
     @State private var currentScreen: AppScreen = .pairing
     @State private var time = 0.0
     @State private var playerStarted: Bool = false
+    @State private var playbackSessionID = 0
     @Environment(\.scenePhase) private var scenePhase
     let timer = Timer.publish(every: 0.05, on: .main, in: .common).autoconnect()
 
@@ -103,10 +108,12 @@ struct ContentView: View {
                 ZStack {
                     // PlayerView always renders so it can buffer in the background.
                     // isPreBuffering=true keeps it muted and UI-hidden during preplay.
-                    PlayerView(payload: request, isPreBuffering: isPreBuffering) {
+                    PlayerView(payload: request, isPreBuffering: isPreBuffering, stillWatching: stillWatching) {
+                        playlistStore.clear()
+                        stillWatching.reset()
                         withAnimation { server.currentPlayRequest = nil }
                     }
-                    .id(request.url)
+                    .id(playbackSessionID)
                     .zIndex(5)
                     .edgesIgnoringSafeArea(.all)
 
@@ -130,21 +137,16 @@ struct ContentView: View {
         }
         .onAppear {
             server.start()
-            // Keep the Apple TV awake while the receiver is foregrounded: otherwise the idle
-            // timer sleeps the device (dropping the WebSocket server, so casts can't reach it),
-            // and during MPV/VLC playback — which render into a custom layer the system doesn't
-            // recognise as "video playing" — the screensaver can interrupt mid-playback. AVPlayer
-            // suppresses this on its own, but this covers all engines + the idle receiver.
-            UIApplication.shared.isIdleTimerDisabled = true
+            UIApplication.shared.isIdleTimerDisabled = false
         }
         .onChange(of: scenePhase) { _, newPhase in
             switch newPhase {
             case .active:
                 server.restart()
-                UIApplication.shared.isIdleTimerDisabled = true
+                stillWatching.foregroundChanged(true)
             case .background:
                 server.stop()
-                UIApplication.shared.isIdleTimerDisabled = false  // allow normal sleep when backgrounded
+                stillWatching.foregroundChanged(false)
             default: break
             }
         }
@@ -153,9 +155,14 @@ struct ContentView: View {
                 currentScreen = .pairing
             }
         }
+        .onChange(of: stillWatchingEnabled) { _, _ in stillWatching.settingsChanged() }
+        .onChange(of: stillWatchingThreshold) { _, _ in stillWatching.settingsChanged() }
+        .onChange(of: stillWatchingResponseSeconds) { _, _ in stillWatching.settingsChanged() }
         .onReceive(server.$currentPlayRequest) { request in
-            // Reset playerStarted for every new incoming request
+            guard request != nil else { return }
             playerStarted = false
+            playbackSessionID &+= 1
+            stillWatching.reset()
         }
         .environmentObject(historyStore)
         .environmentObject(playlistStore)
@@ -164,7 +171,3 @@ struct ContentView: View {
 }
 
 // MARK: - Focusable Components
-
-
-
-

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
@@ -871,6 +871,15 @@ class WebSocketServer: ObservableObject {
         case "control":
             if let p = try? Playbridge_ControlPayload(jsonString: payloadJson), !p.command.isEmpty {
                 DispatchQueue.main.async {
+                    if StillWatchingGate.isPrompting {
+                        if p.command == "stop" {
+                            NotificationCenter.default.post(name: .playBridgeStillWatchingStop, object: nil)
+                        } else {
+                            NotificationCenter.default.post(name: .playBridgeStillWatchingResume, object: nil)
+                        }
+                        return
+                    }
+                    NotificationCenter.default.post(name: .playBridgeUserActivity, object: nil)
                     NotificationCenter.default.post(
                         name: Self.controlCommand, object: nil, userInfo: ["command": p.command])
                 }
@@ -878,6 +887,11 @@ class WebSocketServer: ObservableObject {
         case "remote":
             if let p = try? Playbridge_RemotePayload(jsonString: payloadJson), !p.key.isEmpty {
                 DispatchQueue.main.async {
+                    if StillWatchingGate.isPrompting {
+                        NotificationCenter.default.post(name: .playBridgeStillWatchingResume, object: nil)
+                        return
+                    }
+                    NotificationCenter.default.post(name: .playBridgeUserActivity, object: nil)
                     NotificationCenter.default.post(
                         name: Self.remoteKey, object: nil, userInfo: ["key": p.key])
                 }

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/MPVPlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/MPVPlayerView.swift
@@ -10,6 +10,7 @@ struct MPVPlayerView: UIViewControllerRepresentable {
     let headers: [String: String]?
     let subtitles: [String]?
     let initialTime: Double
+    let mediaIdentity: Int
     let isPreBuffering: Bool
     let title: String?
     let onDismiss: () -> Void
@@ -24,6 +25,7 @@ struct MPVPlayerView: UIViewControllerRepresentable {
         vc.headers = headers
         vc.subtitles = subtitles
         vc.initialTime = initialTime
+        vc.mediaIdentity = mediaIdentity
         vc.isPreBuffering = isPreBuffering
         vc.mediaTitle = title
         vc.onDismiss = onDismiss
@@ -44,7 +46,8 @@ struct MPVPlayerView: UIViewControllerRepresentable {
         // handle, render layer, caches) is reused — `loadfile replace` swaps the
         // media. This is what makes back-to-back episodes start fast and gapless
         // instead of paying a full mpv re-init per item.
-        if uiViewController.url != url {
+        if uiViewController.url != url || uiViewController.mediaIdentity != mediaIdentity {
+            uiViewController.mediaIdentity = mediaIdentity
             uiViewController.loadNewItem(
                 url: url,
                 headers: headers,
@@ -73,6 +76,7 @@ class MPVViewController: UIViewController {
     var headers: [String: String]?
     var subtitles: [String]?
     var initialTime: Double = 0.0
+    var mediaIdentity = 0
     var mediaTitle: String?
     var onDismiss: (() -> Void)?
     var onExit: (() -> Void)?
@@ -463,6 +467,12 @@ class MPVViewController: UIViewController {
                 mpv_get_property(handle, "demuxer-cache-duration", MPV_FORMAT_DOUBLE, &cacheDur)
             }
             print("[MPV] paused-for-cache: \(stalled ? "STALLED (network can't keep up)" : "resumed") — demuxer cache ahead = \(String(format: "%.1f", cacheDur))s")
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                NotificationCenter.default.post(
+                    name: .playBridgePlaybackActivity, object: nil,
+                    userInfo: ["isPlaying": self.playbackState.isPlaying && !stalled])
+            }
 
         case "duration":
             guard prop.format == MPV_FORMAT_DOUBLE,
@@ -477,6 +487,9 @@ class MPVViewController: UIViewController {
             DispatchQueue.main.async { [weak self] in
                 self?.playbackState.isPlaying = !isPaused
                 self?.broadcastStatus()
+                NotificationCenter.default.post(
+                    name: .playBridgePlaybackActivity, object: nil,
+                    userInfo: ["isPlaying": !isPaused])
             }
 
         case "current-ao":
@@ -720,6 +733,9 @@ class MPVViewController: UIViewController {
         } else {
             setPropertyAsync("mute", value: "no")
             showUI(autoHide: true)
+            NotificationCenter.default.post(
+                name: .playBridgePlaybackActivity, object: nil,
+                userInfo: ["isPlaying": !playbackState.userPaused])
         }
     }
 
@@ -838,8 +854,13 @@ class MPVViewController: UIViewController {
     // MARK: - Siri Remote
 
     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        if StillWatchingGate.isPrompting {
+            NotificationCenter.default.post(name: .playBridgeStillWatchingResume, object: nil)
+            return
+        }
         if isPreBuffering { super.pressesBegan(presses, with: event); return }
         guard let type = presses.first?.type else { super.pressesBegan(presses, with: event); return }
+        NotificationCenter.default.post(name: .playBridgeUserActivity, object: nil)
 
         if type == .menu {
             if playbackState.showSubtitleMenu  { playbackState.showSubtitleMenu = false; return }
@@ -987,6 +1008,12 @@ class MPVViewController: UIViewController {
         NotificationCenter.default.addObserver(
             self, selector: #selector(onResyncRequest),
             name: WebSocketServer.resyncRequest, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(onStillWatchingPause),
+            name: .playBridgeStillWatchingPause, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(onStillWatchingResume),
+            name: .playBridgeStillWatchingResume, object: nil)
 
         // Periodic status (covers live position) — 1s cadence matches the Android receiver.
         statusTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
@@ -1022,13 +1049,18 @@ class MPVViewController: UIViewController {
         broadcastTracks()
     }
 
+    @objc private func onStillWatchingPause() { setPropertyAsync("pause", value: "yes") }
+    @objc private func onStillWatchingResume() { setPropertyAsync("pause", value: "no") }
+
     @objc private func onControlNotification(_ note: Notification) {
         guard let cmd = note.userInfo?["command"] as? String else { return }
+        if StillWatchingGate.isPrompting { return }
         handleControlCommand(cmd)
     }
 
     @objc private func onRemoteNotification(_ note: Notification) {
         guard let key = note.userInfo?["key"] as? String else { return }
+        if StillWatchingGate.isPrompting { return }
         switch key {
         case "dpad_center": togglePlayPause()
         case "dpad_left":   skipBackward()

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/NativePlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/NativePlayerView.swift
@@ -1,6 +1,17 @@
 import SwiftUI
 import AVKit
 
+final class ActivityAVPlayerViewController: AVPlayerViewController {
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        if StillWatchingGate.isPrompting {
+            NotificationCenter.default.post(name: .playBridgeStillWatchingResume, object: nil)
+            return
+        }
+        NotificationCenter.default.post(name: .playBridgeUserActivity, object: nil)
+        super.pressesBegan(presses, with: event)
+    }
+}
+
 /// Using UIViewControllerRepresentable is much more stable on tvOS for custom headers and MKVs
 struct NativePlayerView: UIViewControllerRepresentable {
     let url: URL
@@ -15,7 +26,7 @@ struct NativePlayerView: UIViewControllerRepresentable {
     let onBroadcast: ([String: Any]) -> Void
 
     func makeUIViewController(context: Context) -> AVPlayerViewController {
-        let controller = AVPlayerViewController()
+        let controller = ActivityAVPlayerViewController()
         controller.delegate = context.coordinator
 
         // Setup Audio Session for TV output
@@ -101,6 +112,7 @@ struct NativePlayerView: UIViewControllerRepresentable {
         let onBroadcast: ([String: Any]) -> Void
 
         private var timeObserver: Any?
+        private var timeControlObservation: NSKeyValueObservation?
         private var didBroadcastTracks = false
         // Media-selection groups loaded once (async, tvOS 16+) when the item is ready, then used
         // synchronously by broadcastTracks/selectTrack. Avoids the deprecated sync accessor.
@@ -128,17 +140,29 @@ struct NativePlayerView: UIViewControllerRepresentable {
             NotificationCenter.default.addObserver(
                 self, selector: #selector(onResync),
                 name: WebSocketServer.resyncRequest, object: nil)
+            NotificationCenter.default.addObserver(
+                self, selector: #selector(onStillWatchingPause),
+                name: .playBridgeStillWatchingPause, object: nil)
+            NotificationCenter.default.addObserver(
+                self, selector: #selector(onStillWatchingResume),
+                name: .playBridgeStillWatchingResume, object: nil)
         }
 
         /// Called once the player exists: drive periodic now-playing status to the phone.
         func attach(player: AVPlayer) {
             self.player = player
+            timeControlObservation = player.observe(\.timeControlStatus, options: [.initial, .new]) {
+                [weak self] _, _ in
+                DispatchQueue.main.async { self?.broadcastStatus() }
+            }
             timeObserver = player.addPeriodicTimeObserver(
                 forInterval: CMTime(seconds: 1, preferredTimescale: 1), queue: .main
             ) { [weak self] _ in self?.broadcastStatus() }
         }
 
         func teardown() {
+            timeControlObservation?.invalidate()
+            timeControlObservation = nil
             if let token = timeObserver { player?.removeTimeObserver(token); timeObserver = nil }
             NotificationCenter.default.removeObserver(self)
         }
@@ -146,11 +170,13 @@ struct NativePlayerView: UIViewControllerRepresentable {
         deinit { teardown() }
 
         @objc func toggleLoop(_ action: UIAction) {
+            NotificationCenter.default.post(name: .playBridgeUserActivity, object: nil)
             isLooping.toggle()
             action.state = isLooping ? .on : .off
         }
 
         @objc func invokeSwitch() {
+            NotificationCenter.default.post(name: .playBridgeUserActivity, object: nil)
             onSwitch(player?.currentTime().seconds ?? 0)
         }
 
@@ -170,7 +196,12 @@ struct NativePlayerView: UIViewControllerRepresentable {
             willEndFullScreenPresentation interactivelyDismissed: Bool
         ) {
             // User pressed Menu/Back on the Siri Remote
-            onExit()
+            if StillWatchingGate.isPrompting {
+                NotificationCenter.default.post(name: .playBridgeStillWatchingResume, object: nil)
+            } else {
+                NotificationCenter.default.post(name: .playBridgeUserActivity, object: nil)
+                onExit()
+            }
         }
 
         // MARK: - Phone Now-Playing Sync
@@ -194,6 +225,9 @@ struct NativePlayerView: UIViewControllerRepresentable {
             ]
             if let t = title, !t.isEmpty { json["title"] = t }
             onBroadcast(json)
+            NotificationCenter.default.post(
+                name: .playBridgePlaybackActivity, object: nil,
+                userInfo: ["isPlaying": player.timeControlStatus == .playing])
 
             // Track lists become available once the item is ready; load the selection groups once
             // (async on tvOS 16+), cache them, then broadcast.
@@ -245,6 +279,7 @@ struct NativePlayerView: UIViewControllerRepresentable {
 
         @objc private func onControl(_ note: Notification) {
             guard let cmd = note.userInfo?["command"] as? String, let player else { return }
+            if StillWatchingGate.isPrompting { return }
             switch cmd {
             case "play": player.play()
             case "pause": player.pause()
@@ -271,6 +306,7 @@ struct NativePlayerView: UIViewControllerRepresentable {
 
         @objc private func onRemote(_ note: Notification) {
             guard let key = note.userInfo?["key"] as? String, let player else { return }
+            if StillWatchingGate.isPrompting { return }
             switch key {
             case "dpad_center":
                 if player.timeControlStatus == .playing { player.pause() } else { player.play() }
@@ -279,6 +315,9 @@ struct NativePlayerView: UIViewControllerRepresentable {
             default: break
             }
         }
+
+        @objc private func onStillWatchingPause() { player?.pause(); broadcastStatus() }
+        @objc private func onStillWatchingResume() { player?.play(); broadcastStatus() }
 
         private func seek(by delta: Double) {
             guard let player else { return }

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/PlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/PlayerView.swift
@@ -38,11 +38,16 @@ struct PlayerView: View {
     @State private var sessionEngine: String? = nil
     @State private var resumeTime: Double = 0.0
     @State private var showPlaylist: Bool = false
+    @State private var latestPlaybackIsPlaying = false
+    @State private var mediaGeneration = 0
+    @ObservedObject var stillWatching: StillWatchingController
     let isPreBuffering: Bool
 
-    init(payload: Playbridge_PlayPayload, isPreBuffering: Bool, onDismiss: @escaping () -> Void) {
+    init(payload: Playbridge_PlayPayload, isPreBuffering: Bool,
+         stillWatching: StillWatchingController, onDismiss: @escaping () -> Void) {
         self.payload = payload
         self.isPreBuffering = isPreBuffering
+        self.stillWatching = stillWatching
         self.onDismiss = onDismiss
     }
 
@@ -95,6 +100,8 @@ struct PlayerView: View {
     }
 
     private func handleNext() {
+        stillWatching.reset()
+        mediaGeneration &+= 1
         consumeStartPosition(at: playlistStore.currentIndex)
         if let nextRequest = playlistStore.next(), let nextURL = nextRequest.validURL {
             historyStore.addToHistory(url: nextURL, title: nextRequest.titleOrNil, headers: nextRequest.headersOrNil)
@@ -105,6 +112,8 @@ struct PlayerView: View {
     }
 
     private func handleJump(to index: Int) {
+        stillWatching.reset()
+        mediaGeneration &+= 1
         consumeStartPosition(at: playlistStore.currentIndex)
         if let jumpRequest = playlistStore.jumpTo(index: index), let jumpURL = jumpRequest.validURL {
             historyStore.addToHistory(url: jumpURL, title: jumpRequest.titleOrNil, headers: jumpRequest.headersOrNil)
@@ -135,13 +144,14 @@ struct PlayerView: View {
                     )
                     .ignoresSafeArea()
                     .focused($isPlayerFocused)
-                    .id(currentURL)
+                    .id("vlc-\(mediaGeneration)")
                 } else if effectiveEngine(for: currentRequest) == "mpv" {
                     MPVPlayerView(
                         url: currentURL,
                         headers: currentRequest.headersOrNil,
                         subtitles: currentRequest.subtitlesOrNil,
                         initialTime: initialSeekTime(for: currentRequest),
+                        mediaIdentity: mediaGeneration,
                         isPreBuffering: isPreBuffering,
                         title: currentRequest.titleOrNil,
                         onDismiss: handleNext,
@@ -170,7 +180,7 @@ struct PlayerView: View {
                     )
                     .ignoresSafeArea()
                     .focused($isPlayerFocused)
-                    .id(currentURL)
+                    .id("avplayer-\(mediaGeneration)")
                     .onExitCommand { onDismiss() }
                 }
             } else {
@@ -192,12 +202,53 @@ struct PlayerView: View {
                 )
                 .zIndex(20)
             }
+
+            if stillWatching.isPrompting {
+                StillWatchingPrompt(
+                    secondsRemaining: stillWatching.secondsRemaining,
+                    title: (playlistStore.currentItem ?? payload).titleOrNil,
+                    onContinue: stillWatching.continueWatching
+                )
+                .zIndex(100)
+            }
         }
         .onAppear {
             isPlayerFocused = true
         }
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("TogglePlaylist"))) { _ in
+            guard !stillWatching.isPrompting else { return }
             withAnimation { showPlaylist.toggle() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .playBridgePlaybackActivity)) { note in
+            guard let playing = note.userInfo?["isPlaying"] as? Bool else { return }
+            latestPlaybackIsPlaying = playing
+            stillWatching.playbackChanged(isPlaying: playing && !isPreBuffering)
+        }
+        .onChange(of: isPreBuffering) { wasPreBuffering, preBuffering in
+            if wasPreBuffering && !preBuffering {
+                stillWatching.playbackChanged(isPlaying: latestPlaybackIsPlaying)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .playBridgeUserActivity)) { _ in
+            stillWatching.onUserActivity()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: WebSocketServer.controlCommand)) { note in
+            guard stillWatching.isPrompting,
+                  let command = note.userInfo?["command"] as? String else { return }
+            switch command {
+            case "play": stillWatching.continueWatching()
+            case "stop": stillWatching.stopNow(onDismiss)
+            default: break
+            }
+        }
+        .onChange(of: stillWatching.didExpire) { _, expired in
+            if expired { stillWatching.stopNow(onDismiss) }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .playBridgeStillWatchingResume)) { _ in
+            if stillWatching.isPrompting { stillWatching.continueWatching() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .playBridgeStillWatchingStop)) { _ in
+            if stillWatching.isPrompting { stillWatching.stopNow(onDismiss) }
         }
     }
 }

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/StillWatchingController.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/StillWatchingController.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+import UIKit
+import Combine
+
+@MainActor enum StillWatchingGate {
+    static var isPrompting = false
+}
+
+extension Notification.Name {
+    static let playBridgePlaybackActivity = Notification.Name("PlayBridgePlaybackActivity")
+    static let playBridgeStillWatchingPause = Notification.Name("PlayBridgeStillWatchingPause")
+    static let playBridgeStillWatchingResume = Notification.Name("PlayBridgeStillWatchingResume")
+    static let playBridgeStillWatchingStop = Notification.Name("PlayBridgeStillWatchingStop")
+    static let playBridgeUserActivity = Notification.Name("PlayBridgeUserActivity")
+}
+
+@MainActor
+final class StillWatchingController: ObservableObject {
+    static let allowedThresholds = [30, 60, 90, 120, 180, 240]
+    static let defaultThreshold = 90
+    static let allowedResponseSeconds = [30, 60, 120, 300, 600]
+    static let defaultResponseSeconds = 300
+
+    @Published private(set) var isPrompting = false
+    @Published private(set) var secondsRemaining = 300
+    @Published private(set) var didExpire = false
+
+    private var activeSeconds: TimeInterval = 0
+    private var isPlaying = false
+    private var isForeground = true
+    private var lastTick = Date()
+    private var timer: Timer?
+
+    init() {
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.tick() }
+        }
+    }
+
+    deinit { timer?.invalidate() }
+
+    var isEnabled: Bool { UserDefaults.standard.object(forKey: "still_watching_enabled") as? Bool ?? false }
+
+    var thresholdMinutes: Int {
+        let value = UserDefaults.standard.integer(forKey: "still_watching_threshold_min")
+        return Self.allowedThresholds.contains(value) ? value : Self.defaultThreshold
+    }
+
+    var responseSeconds: Int {
+        let value = UserDefaults.standard.integer(forKey: "still_watching_response_sec")
+        return Self.allowedResponseSeconds.contains(value) ? value : Self.defaultResponseSeconds
+    }
+
+    func playbackChanged(isPlaying: Bool) {
+        accumulate()
+        self.isPlaying = isPlaying
+    }
+
+    func onUserActivity() {
+        if isPrompting {
+            continueWatching()
+            return
+        }
+        accumulate()
+        activeSeconds = 0
+    }
+
+    func foregroundChanged(_ foreground: Bool) {
+        accumulate()
+        isForeground = foreground
+        UIApplication.shared.isIdleTimerDisabled = foreground && (isPlaying || isPrompting)
+    }
+
+    func settingsChanged() {
+        accumulate()
+        guard isEnabled else {
+            if isPrompting { continueWatching() }
+            activeSeconds = 0
+            return
+        }
+        if activeSeconds >= TimeInterval(thresholdMinutes * 60), !isPrompting { beginPrompt() }
+    }
+
+    func continueWatching() {
+        guard isPrompting else { return }
+        isPrompting = false
+        StillWatchingGate.isPrompting = false
+        secondsRemaining = responseSeconds
+        activeSeconds = 0
+        lastTick = Date()
+        NotificationCenter.default.post(name: .playBridgeStillWatchingResume, object: nil)
+        UIApplication.shared.isIdleTimerDisabled = isForeground && isPlaying
+    }
+
+    func stopNow(_ stop: () -> Void) {
+        guard isPrompting else { return }
+        isPrompting = false
+        StillWatchingGate.isPrompting = false
+        isPlaying = false
+        activeSeconds = 0
+        secondsRemaining = responseSeconds
+        didExpire = false
+        UIApplication.shared.isIdleTimerDisabled = false
+        stop()
+    }
+
+    func reset() {
+        activeSeconds = 0
+        isPlaying = false
+        isPrompting = false
+        StillWatchingGate.isPrompting = false
+        secondsRemaining = responseSeconds
+        didExpire = false
+        lastTick = Date()
+        UIApplication.shared.isIdleTimerDisabled = false
+    }
+
+    private func accumulate(now: Date = Date()) {
+        if isEnabled && isPlaying && isForeground && !isPrompting {
+            activeSeconds += max(0, now.timeIntervalSince(lastTick))
+        }
+        lastTick = now
+        UIApplication.shared.isIdleTimerDisabled = isForeground && (isPlaying || isPrompting)
+    }
+
+    private func tick() {
+        accumulate()
+        if isPrompting {
+            secondsRemaining -= 1
+            if secondsRemaining <= 0 { didExpire = true }
+            return
+        }
+        if isEnabled && activeSeconds >= TimeInterval(thresholdMinutes * 60) { beginPrompt() }
+    }
+
+    private func beginPrompt() {
+        isPrompting = true
+        StillWatchingGate.isPrompting = true
+        didExpire = false
+        secondsRemaining = responseSeconds
+        UIApplication.shared.isIdleTimerDisabled = isForeground
+        NotificationCenter.default.post(name: .playBridgeStillWatchingPause, object: nil)
+    }
+}
+
+struct StillWatchingPrompt: View {
+    let secondsRemaining: Int
+    let title: String?
+    let onContinue: () -> Void
+    @FocusState private var continueFocused: Bool
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.72).ignoresSafeArea()
+            VStack(spacing: 24) {
+                Image(systemName: "play.circle.fill")
+                    .font(.system(size: 64)).foregroundStyle(Theme.accent)
+                Text("Are you still watching?")
+                    .font(.system(size: 44, weight: .bold)).foregroundStyle(.white)
+                if let title, !title.isEmpty {
+                    Text(title).font(.title3).foregroundStyle(Theme.secondaryText).lineLimit(1)
+                }
+                Text("Stopping in \(max(0, secondsRemaining) / 60):\(String(format: "%02d", max(0, secondsRemaining) % 60))")
+                    .font(.title2).foregroundStyle(Theme.secondaryText)
+                Button("Continue watching", action: onContinue)
+                    .focused($continueFocused)
+                    .buttonStyle(.borderedProminent)
+                    .tint(Theme.accent)
+            }
+            .padding(60)
+            .background(Color(white: 0.10), in: RoundedRectangle(cornerRadius: 28))
+            .overlay(RoundedRectangle(cornerRadius: 28).stroke(Color.white.opacity(0.18)))
+        }
+        .onAppear { continueFocused = true }
+        .onPlayPauseCommand { onContinue() }
+        .onExitCommand { onContinue() }
+    }
+}

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/VLCPlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/VLCPlayerView.swift
@@ -453,6 +453,9 @@ struct VLCPlayerView: UIViewControllerRepresentable {
                 hideControlsTimer?.invalidate()
             } else {
                 showUI(autoHide: true)
+                NotificationCenter.default.post(
+                    name: .playBridgePlaybackActivity, object: nil,
+                    userInfo: ["isPlaying": mediaPlayer.isPlaying])
             }
         }
 
@@ -483,6 +486,9 @@ struct VLCPlayerView: UIViewControllerRepresentable {
                 if self.playbackState.isPlaying != self.mediaPlayer.isPlaying {
                     self.playbackState.isPlaying = self.mediaPlayer.isPlaying
                 }
+                NotificationCenter.default.post(
+                    name: .playBridgePlaybackActivity, object: nil,
+                    userInfo: ["isPlaying": newState == .playing && self.mediaPlayer.isPlaying])
                 self.broadcastStatus()
 
                 // libvlc needs the input running before slaves attach to the current playback;
@@ -565,6 +571,10 @@ struct VLCPlayerView: UIViewControllerRepresentable {
         private var virtualScrubTickTimer: Timer?
 
         override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+            if StillWatchingGate.isPrompting {
+                NotificationCenter.default.post(name: .playBridgeStillWatchingResume, object: nil)
+                return
+            }
             // During pre-buffering, PrePlayView owns all input — pass everything through.
             if isPreBuffering {
                 super.pressesBegan(presses, with: event)
@@ -575,6 +585,7 @@ struct VLCPlayerView: UIViewControllerRepresentable {
                 super.pressesBegan(presses, with: event)
                 return
             }
+            NotificationCenter.default.post(name: .playBridgeUserActivity, object: nil)
 
             // Intercept Menu/Back button to close popups before exiting
             if type == .menu {
@@ -808,6 +819,12 @@ struct VLCPlayerView: UIViewControllerRepresentable {
             NotificationCenter.default.addObserver(
                 self, selector: #selector(onResyncRequest),
                 name: WebSocketServer.resyncRequest, object: nil)
+            NotificationCenter.default.addObserver(
+                self, selector: #selector(onStillWatchingPause),
+                name: .playBridgeStillWatchingPause, object: nil)
+            NotificationCenter.default.addObserver(
+                self, selector: #selector(onStillWatchingResume),
+                name: .playBridgeStillWatchingResume, object: nil)
 
             // Periodic position broadcast. 2s (was 1s) and only while actually playing — the JSON
             // build + WebSocket send is wasted work while paused/buffering (state transitions are
@@ -846,14 +863,19 @@ struct VLCPlayerView: UIViewControllerRepresentable {
             broadcastTracks()
         }
 
+        @objc private func onStillWatchingPause() { if mediaPlayer.isPlaying { mediaPlayer.pause() } }
+        @objc private func onStillWatchingResume() { if !mediaPlayer.isPlaying { mediaPlayer.play() } }
+
         @objc private func onControlNotification(_ note: Notification) {
             guard let cmd = note.userInfo?["command"] as? String else { return }
+            if StillWatchingGate.isPrompting { return }
             handleControlCommand(cmd)
             broadcastStatus()
         }
 
         @objc private func onRemoteNotification(_ note: Notification) {
             guard let key = note.userInfo?["key"] as? String else { return }
+            if StillWatchingGate.isPrompting { return }
             switch key {
             case "dpad_center": togglePlayPause()
             case "dpad_left":   seek(toMs: max(0, mediaPlayer.time.intValue - 15000))

--- a/tv/apple/PlayBridge TV/PlayBridge TV/UI/Views/SettingsView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/UI/Views/SettingsView.swift
@@ -1,9 +1,15 @@
 import SwiftUI
 
 struct SettingsView: View {
+    private enum FocusedSetting: Hashable { case reminderInterval, responseTime }
+
     @EnvironmentObject var server: WebSocketServer
     @AppStorage("preferredPlayer") var preferredPlayer: String = "avplayer"
     @AppStorage("enable_history") var enableHistory: Bool = true
+    @AppStorage("still_watching_enabled") var stillWatchingEnabled: Bool = false
+    @AppStorage("still_watching_threshold_min") var stillWatchingThreshold: Int = StillWatchingController.defaultThreshold
+    @AppStorage("still_watching_response_sec") var stillWatchingResponseSeconds: Int = StillWatchingController.defaultResponseSeconds
+    @FocusState private var focusedSetting: FocusedSetting?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 40) {
@@ -38,6 +44,31 @@ struct SettingsView: View {
                         }
                     }
                     Toggle("Save Cast History", isOn: $enableHistory)
+                    Toggle("Still Watching Reminder", isOn: $stillWatchingEnabled)
+                    Button(action: selectNextStillWatchingThreshold) {
+                        HStack {
+                            Text("Reminder interval")
+                                .foregroundColor(focusedSetting == .reminderInterval ? .black : .primary)
+                            Spacer()
+                            Text(stillWatchingThresholdLabel)
+                                .foregroundColor(focusedSetting == .reminderInterval ? .black : Theme.secondaryText)
+                            Image(systemName: "chevron.right")
+                                .foregroundColor(focusedSetting == .reminderInterval ? .black : Theme.accent)
+                        }
+                    }
+                    .focused($focusedSetting, equals: .reminderInterval)
+                    Button(action: selectNextStillWatchingResponseTime) {
+                        HStack {
+                            Text("Response time")
+                                .foregroundColor(focusedSetting == .responseTime ? .black : .primary)
+                            Spacer()
+                            Text(stillWatchingResponseTimeLabel)
+                                .foregroundColor(focusedSetting == .responseTime ? .black : Theme.secondaryText)
+                            Image(systemName: "chevron.right")
+                                .foregroundColor(focusedSetting == .responseTime ? .black : Theme.accent)
+                        }
+                    }
+                    .focused($focusedSetting, equals: .responseTime)
                 }
 
                 Section("Server Information") {
@@ -67,5 +98,41 @@ struct SettingsView: View {
             }
             .listStyle(.grouped)
         }
+        .onAppear {
+            if !StillWatchingController.allowedThresholds.contains(stillWatchingThreshold) {
+                stillWatchingThreshold = StillWatchingController.defaultThreshold
+            }
+            if !StillWatchingController.allowedResponseSeconds.contains(stillWatchingResponseSeconds) {
+                stillWatchingResponseSeconds = StillWatchingController.defaultResponseSeconds
+            }
+        }
+    }
+
+    private var stillWatchingThresholdLabel: String {
+        "\(stillWatchingThreshold) minutes"
+    }
+
+    private func selectNextStillWatchingThreshold() {
+        let values = StillWatchingController.allowedThresholds
+        guard let index = values.firstIndex(of: stillWatchingThreshold) else {
+            stillWatchingThreshold = StillWatchingController.defaultThreshold
+            return
+        }
+        stillWatchingThreshold = values[(index + 1) % values.count]
+    }
+
+    private var stillWatchingResponseTimeLabel: String {
+        stillWatchingResponseSeconds < 60
+            ? "\(stillWatchingResponseSeconds) seconds"
+            : "\(stillWatchingResponseSeconds / 60) \(stillWatchingResponseSeconds == 60 ? "minute" : "minutes")"
+    }
+
+    private func selectNextStillWatchingResponseTime() {
+        let values = StillWatchingController.allowedResponseSeconds
+        guard let index = values.firstIndex(of: stillWatchingResponseSeconds) else {
+            stillWatchingResponseSeconds = StillWatchingController.defaultResponseSeconds
+            return
+        }
+        stillWatchingResponseSeconds = values[(index + 1) % values.count]
     }
 }


### PR DESCRIPTION
## Summary
- add opt-in still-watching reminders to Desktop, Android TV, and Apple TV
- pause playback for a configurable response window, then stop and return to idle when unanswered
- reset unattended time on user activity and media changes with Continue-only prompt behavior
- add 30s, 1m, 2m, 5m, and 10m response options with a 5-minute default
- keep TV displays awake while the prompt is visible and synchronize desktop sender context on timeout

## Verification
- Desktop: flutter test (33 tests)
- Desktop: flutter analyze
- Android TV: focused StillWatchingController tests
- Apple TV: unsigned tvOS build
- Extension: Chrome and Firefox builds
- git diff --check HEAD

## Notes
- feature defaults to Off on fresh installs
- existing saved preferences remain authoritative
- manual device verification is still recommended for TV remote, screensaver, and tray-hidden prompt behavior