### PR TITLE
fix(tv): protect TLS keystore password

### DIFF
--- a/tv/android/player/app/src/main/AndroidManifest.xml
+++ b/tv/android/player/app/src/main/AndroidManifest.xml
@@ -151,6 +151,8 @@
     <application
         android:name=".PlayBridgeApplication"
         android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:banner="@drawable/ic_banner"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/TlsIdentity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/TlsIdentity.kt
@@ -7,6 +7,8 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import javax.security.auth.x500.X500Principal
 import java.io.File
 import java.math.BigInteger
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.KeyStore
@@ -27,31 +29,68 @@ import javax.net.ssl.SSLContext
  */
 object TlsIdentity {
     private const val ENTRY = "playbridge"
-    private val PASSWORD = "playbridge".toCharArray()
+    private val LEGACY_PASSWORD = "playbridge".toCharArray()
     private const val FILE_NAME = "playbridge_tls.p12"
 
     data class Result(val sslContext: SSLContext, val fingerprint: String)
 
-    fun loadOrCreate(dir: File, commonName: String = "PlayBridge TV"): Result {
+    fun loadOrCreate(dir: File, commonName: String = "PlayBridge TV"): Result =
+        loadOrCreate(dir, commonName, AndroidKeystoreTlsPasswordStore)
+
+    internal fun loadOrCreate(
+        dir: File,
+        commonName: String = "PlayBridge TV",
+        passwordStore: TlsPasswordStore,
+    ): Result {
         val file = File(dir, FILE_NAME)
+        val password = passwordStore.getOrCreate(dir)
         val ks = KeyStore.getInstance("PKCS12")
         if (file.exists()) {
-            file.inputStream().use { ks.load(it, PASSWORD) }
+            if (!load(ks, file, password)) {
+                file.inputStream().use { ks.load(it, LEGACY_PASSWORD) }
+                val privateKey = ks.getKey(ENTRY, LEGACY_PASSWORD)
+                val certificateChain = ks.getCertificateChain(ENTRY)
+                ks.setKeyEntry(ENTRY, privateKey, password, certificateChain)
+                storeAtomically(ks, file, password)
+            }
         } else {
             ks.load(null, null)
             val keyPair = generateKeyPair()
             val cert = selfSignedCert(keyPair, commonName)
-            ks.setKeyEntry(ENTRY, keyPair.private, PASSWORD, arrayOf(cert))
-            file.outputStream().use { ks.store(it, PASSWORD) }
+            ks.setKeyEntry(ENTRY, keyPair.private, password, arrayOf(cert))
+            storeAtomically(ks, file, password)
         }
 
         val cert = ks.getCertificate(ENTRY) as X509Certificate
         val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
-        kmf.init(ks, PASSWORD)
+        kmf.init(ks, password)
         val sslContext = SSLContext.getInstance("TLS").apply {
             init(kmf.keyManagers, null, null)
         }
         return Result(sslContext, spkiPin(cert))
+    }
+
+    private fun load(ks: KeyStore, file: File, password: CharArray): Boolean =
+        try {
+            file.inputStream().use { ks.load(it, password) }
+            true
+        } catch (_: java.io.IOException) {
+            false
+        }
+
+    private fun storeAtomically(ks: KeyStore, file: File, password: CharArray) {
+        val temporary = File(file.parentFile, "${file.name}.new")
+        try {
+            temporary.outputStream().use { ks.store(it, password) }
+            Files.move(
+                temporary.toPath(),
+                file.toPath(),
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        } finally {
+            temporary.delete()
+        }
     }
 
     private fun generateKeyPair(): KeyPair =

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/TlsPasswordStore.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/TlsPasswordStore.kt
@@ -1,0 +1,105 @@
+package com.playbridge.player.server
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.AtomicFile
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.security.KeyStore
+import java.security.SecureRandom
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+internal fun interface TlsPasswordStore {
+    fun getOrCreate(dir: File): CharArray
+}
+
+/** Protects the exportable TLS key's PKCS12 password with a non-exportable Android Keystore key. */
+internal object AndroidKeystoreTlsPasswordStore : TlsPasswordStore {
+    private const val ANDROID_KEY_STORE = "AndroidKeyStore"
+    private const val KEY_ALIAS = "playbridge_tls_password_key"
+    private const val FILE_NAME = "playbridge_tls_pw.enc"
+    private const val MAGIC = 0x50425450 // PBTP
+    private const val VERSION = 1
+    private const val PASSWORD_BYTES = 32
+    private const val GCM_TAG_BITS = 128
+
+    override fun getOrCreate(dir: File): CharArray {
+        val file = AtomicFile(File(dir, FILE_NAME))
+        if (file.baseFile.exists()) {
+            return decrypt(file.readFully(), getOrCreateKey()).toCharArray()
+        }
+
+        val passwordBytes = ByteArray(PASSWORD_BYTES).also(SecureRandom()::nextBytes)
+        val password = Base64.getEncoder().withoutPadding().encodeToString(passwordBytes)
+        passwordBytes.fill(0)
+        write(file, encrypt(password, getOrCreateKey()))
+        return password.toCharArray()
+    }
+
+    private fun getOrCreateKey(): SecretKey {
+        val keyStore = KeyStore.getInstance(ANDROID_KEY_STORE).apply { load(null) }
+        (keyStore.getKey(KEY_ALIAS, null) as? SecretKey)?.let { return it }
+
+        val spec = KeyGenParameterSpec.Builder(
+            KEY_ALIAS,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setRandomizedEncryptionRequired(true)
+            .build()
+        return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE).run {
+            init(spec)
+            generateKey()
+        }
+    }
+
+    private fun encrypt(password: String, key: SecretKey): ByteArray {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding").apply {
+            init(Cipher.ENCRYPT_MODE, key)
+        }
+        val ciphertext = cipher.doFinal(password.toByteArray(Charsets.UTF_8))
+        return java.io.ByteArrayOutputStream().use { bytes ->
+            DataOutputStream(bytes).use { output ->
+                output.writeInt(MAGIC)
+                output.writeInt(VERSION)
+                output.writeInt(cipher.iv.size)
+                output.write(cipher.iv)
+                output.writeInt(ciphertext.size)
+                output.write(ciphertext)
+            }
+            bytes.toByteArray()
+        }
+    }
+
+    private fun decrypt(payload: ByteArray, key: SecretKey): String =
+        DataInputStream(payload.inputStream()).use { input ->
+            require(input.readInt() == MAGIC) { "Invalid TLS password file" }
+            require(input.readInt() == VERSION) { "Unsupported TLS password file version" }
+            val iv = ByteArray(input.readInt().also { require(it in 12..32) }).also(input::readFully)
+            val ciphertext = ByteArray(
+                input.readInt().also { require(it in 1..4096) },
+            ).also(input::readFully)
+            require(input.available() == 0) { "Trailing data in TLS password file" }
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding").apply {
+                init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+            }
+            String(cipher.doFinal(ciphertext), Charsets.UTF_8)
+        }
+
+    private fun write(file: AtomicFile, payload: ByteArray) {
+        val output = file.startWrite()
+        try {
+            output.write(payload)
+            file.finishWrite(output)
+        } catch (e: Exception) {
+            file.failWrite(output)
+            throw e
+        }
+    }
+}

--- a/tv/android/player/app/src/main/res/xml/backup_rules.xml
+++ b/tv/android/player/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <!-- Android Keystore keys are device-bound, so their encrypted TLS data cannot be restored. -->
+    <exclude domain="file" path="tls/" />
+</full-backup-content>

--- a/tv/android/player/app/src/main/res/xml/data_extraction_rules.xml
+++ b/tv/android/player/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="file" path="tls/" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="file" path="tls/" />
+    </device-transfer>
+</data-extraction-rules>

--- a/tv/android/player/app/src/test/java/com/playbridge/player/server/TlsIdentityTest.kt
+++ b/tv/android/player/app/src/test/java/com/playbridge/player/server/TlsIdentityTest.kt
@@ -7,8 +7,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
 import java.nio.file.Files
+import java.security.KeyStore
 
 class TlsIdentityTest {
+
+    private val testPassword = "test-password-not-from-source".toCharArray()
+    private val passwordStore = TlsPasswordStore { testPassword.copyOf() }
 
     private fun tempDir(): File = Files.createTempDirectory("pb_tls_test").toFile()
 
@@ -16,7 +20,7 @@ class TlsIdentityTest {
     fun generatesCertWithSha256SpkiPin() {
         val dir = tempDir()
         try {
-            val r = TlsIdentity.loadOrCreate(dir)
+            val r = TlsIdentity.loadOrCreate(dir, passwordStore = passwordStore)
             assertTrue(r.fingerprint.startsWith("sha256/"))
             // SHA-256 = 32 bytes → 44 base64 chars (with padding).
             assertEquals("sha256/".length + 44, r.fingerprint.length)
@@ -30,8 +34,8 @@ class TlsIdentityTest {
     fun persistsAndReusesIdentityAcrossReloads() {
         val dir = tempDir()
         try {
-            val first = TlsIdentity.loadOrCreate(dir)
-            val second = TlsIdentity.loadOrCreate(dir)
+            val first = TlsIdentity.loadOrCreate(dir, passwordStore = passwordStore)
+            val second = TlsIdentity.loadOrCreate(dir, passwordStore = passwordStore)
             assertEquals(first.fingerprint, second.fingerprint)
             assertTrue(File(dir, "playbridge_tls.p12").exists())
         } finally {
@@ -45,12 +49,38 @@ class TlsIdentityTest {
         val b = tempDir()
         try {
             assertNotEquals(
-                TlsIdentity.loadOrCreate(a).fingerprint,
-                TlsIdentity.loadOrCreate(b).fingerprint,
+                TlsIdentity.loadOrCreate(a, passwordStore = passwordStore).fingerprint,
+                TlsIdentity.loadOrCreate(b, passwordStore = passwordStore).fingerprint,
             )
         } finally {
             a.deleteRecursively()
             b.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun migratesLegacyKeystoreToProtectedPasswordWithoutChangingIdentity() {
+        val dir = tempDir()
+        try {
+            val legacyStore = TlsPasswordStore { "playbridge".toCharArray() }
+            val original = TlsIdentity.loadOrCreate(dir, passwordStore = legacyStore)
+
+            val migrated = TlsIdentity.loadOrCreate(dir, passwordStore = passwordStore)
+
+            assertEquals(original.fingerprint, migrated.fingerprint)
+            val file = File(dir, "playbridge_tls.p12")
+            KeyStore.getInstance("PKCS12").apply {
+                file.inputStream().use { load(it, testPassword) }
+                assertNotNull(getKey("playbridge", testPassword))
+            }
+            val legacyLoad = runCatching {
+                KeyStore.getInstance("PKCS12").apply {
+                    file.inputStream().use { load(it, "playbridge".toCharArray()) }
+                }
+            }
+            assertTrue("Legacy password must stop opening the migrated keystore", legacyLoad.isFailure)
+        } finally {
+            dir.deleteRecursively()
         }
     }
 }


### PR DESCRIPTION
## Summary

- generate a random PKCS12 password and encrypt it with a non-exportable Android Keystore AES-GCM key
- migrate legacy keystores by re-wrapping the private-key entry without changing the TLS fingerprint
- persist keystore and password data atomically and exclude device-bound TLS data from backup and transfer
- add regression coverage proving the legacy password no longer opens a migrated keystore

This is a separate replacement for #111 and addresses the plaintext-adjacent-password concern raised there.

## Verification

- zsh -c "source ~/.zshrc && ./gradlew test"
- zsh -c "source ~/.zshrc && ./gradlew :player:app:lintFossDebug"

## Risk

The migration retains the existing certificate and SPKI fingerprint, so paired senders do not need to re-pair. Android Keystore keys are device-bound, so the TLS directory is excluded from cloud backup and device transfer.