### PR TITLE
feat(desktop): opt-in HLS preselect and safer extension bridge logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ Project skills live in `.agents/skills/`:
 
 Load the matching `SKILL.md` only when its description matches the request. A normal commit, push, or PR request must not change versions unless the user also requests an uprev or release.
 
+## Local agent instructions
+
+If `SUBAGENTS.local.md` exists at the repository root, read and follow it for optional machine-local subagent tools and workflows. The file is intentionally gitignored; shared repository instructions in this file take precedence if they conflict.
+
 ## Project layout
 
 | Project | Path | Notes |

--- a/desktop/lib/engines/mpv_engine.dart
+++ b/desktop/lib/engines/mpv_engine.dart
@@ -41,7 +41,7 @@ Map<String, String>? sanitizePlayerHeaders(Map<String, String>? headers) {
 }
 
 class MpvEngine extends PlayerEngine {
-  MpvEngine() {
+  MpvEngine({this.preselectHlsQuality = false}) {
     _subs.addAll([
       player.stream.playing.listen((playing) {
         if (playing) _maybeArmAudioRoute();
@@ -74,6 +74,7 @@ class MpvEngine extends PlayerEngine {
   final Player player = Player();
   final List<StreamSubscription> _subs = [];
   VoidCallback? onCompleted;
+  bool preselectHlsQuality;
 
   /// Ignore device flaps until playback has been stable for a bit — arming on
   /// the first `playing` tick races mpv's open path (auto→concrete device) and
@@ -310,7 +311,9 @@ class MpvEngine extends PlayerEngine {
     // hls_master_resolver.dart for why mpv chokes on multi-rendition masters.
     final medias = await Future.wait(items.map((i) async {
       final headers = sanitizePlayerHeaders(i.headers);
-      final resolvedUrl = await resolveHlsMaster(i.url, headers: headers);
+      final resolvedUrl = preselectHlsQuality
+          ? await resolveHlsMaster(i.url, headers: headers)
+          : i.url;
       return Media(resolvedUrl, httpHeaders: headers);
     }));
     final playlist = Playlist(medias, index: startIndex);

--- a/desktop/lib/extension_bridge.dart
+++ b/desktop/lib/extension_bridge.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 
 import 'bridge_paths.dart';
+import 'extension_request_debug_log.dart';
 import 'player_controller.dart';
 import 'tv_sender_controller.dart';
 
@@ -63,6 +64,23 @@ class ExtensionBridge {
   }
 
   void _onClient(Socket socket) {
+    void dropClient() => _authed.remove(socket);
+
+    // Socket.listen handles errors from the inbound stream, but Socket is also
+    // an IOSink: a browser/native-host disconnect can complete `done` with an
+    // asynchronous ECONNRESET after `write` has already returned. Observe that
+    // future so a normal client shutdown never becomes an unhandled Flutter
+    // exception. Non-socket failures are still surfaced for diagnosis.
+    unawaited(socket.done.then<void>(
+      (_) => dropClient(),
+      onError: (Object error, StackTrace _) {
+        dropClient();
+        if (error is! SocketException) {
+          debugPrint('[ext-bridge] client sink failed: $error');
+        }
+      },
+    ));
+
     var authed = false;
     final buf = <int>[];
     socket.listen(
@@ -86,8 +104,8 @@ class ExtensionBridge {
           }
         }
       },
-      onDone: () => _authed.remove(socket),
-      onError: (_) => _authed.remove(socket),
+      onDone: dropClient,
+      onError: (_) => dropClient(),
       cancelOnError: true,
     );
   }
@@ -129,6 +147,7 @@ class ExtensionBridge {
         final headers =
             (obj['headers'] as Map?)?.map((k, v) => MapEntry('$k', '$v'));
         final title = obj['title'] as String?;
+        debugLogExtensionCastRequest(url: url, headers: headers);
         if (_sender.isConnected) {
           final ok = _sender.castUrl(url, headers: headers, title: title);
           _send(socket, {
@@ -140,9 +159,9 @@ class ExtensionBridge {
         } else {
           onNewMedia?.call();
           // No cast target — play on this machine (extension → desktop).
-          final headerCount = headers?.length ?? 0;
-          debugPrint(
-              '[ext-bridge] cast → local player: $url (headers=$headerCount)');
+          if (kDebugMode) {
+            debugPrint('[ext-bridge] cast → local player');
+          }
           unawaited(_player.playUrl(
             url,
             headers: headers,

--- a/desktop/lib/extension_request_debug_log.dart
+++ b/desktop/lib/extension_request_debug_log.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+const bool extensionRequestDebugLoggingEnabled = kDebugMode &&
+    bool.fromEnvironment(
+      'PLAYBRIDGE_DEBUG_EXTENSION_REQUESTS',
+      defaultValue: false,
+    );
+
+/// Writes the HTTP request context received from the browser extension.
+///
+/// This is disabled unless a debug build explicitly enables
+/// `PLAYBRIDGE_DEBUG_EXTENSION_REQUESTS`. Output goes directly to stderr so it
+/// is not captured by PlayBridge's persistent `debugPrint` diagnostics.
+void debugLogExtensionCastRequest({
+  required String url,
+  Map<String, String>? headers,
+}) {
+  if (!extensionRequestDebugLoggingEnabled) return;
+  for (final line in formatExtensionCastRequestForDebug(
+    url: url,
+    headers: headers,
+  )) {
+    stderr.writeln(line);
+  }
+}
+
+/// Formats a deterministic, complete representation for tests and explicitly
+/// enabled debug terminal output.
+List<String> formatExtensionCastRequestForDebug({
+  required String url,
+  Map<String, String>? headers,
+}) {
+  final entries = headers?.entries.toList() ?? <MapEntry<String, String>>[];
+  entries.sort((a, b) {
+    final byLowercaseName = a.key.toLowerCase().compareTo(b.key.toLowerCase());
+    return byLowercaseName != 0 ? byLowercaseName : a.key.compareTo(b.key);
+  });
+
+  final lines = <String>[
+    '[ext-bridge] extension cast request:',
+    '[ext-bridge]   URL: ${_escapeControlCharacters(url)}',
+    '[ext-bridge]   Headers (${entries.length}):',
+  ];
+  if (entries.isEmpty) {
+    lines.add('[ext-bridge]     (none)');
+    return lines;
+  }
+
+  for (final entry in entries) {
+    final name = _escapeControlCharacters(entry.key);
+    final value = _escapeControlCharacters(entry.value);
+    lines.add('[ext-bridge]     $name: $value');
+  }
+  return lines;
+}
+
+String _escapeControlCharacters(String value) => value
+    .replaceAll(r'\', r'\\')
+    .replaceAll('\r', r'\r')
+    .replaceAll('\n', r'\n')
+    .replaceAll('\t', r'\t');

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -233,7 +233,10 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     super.initState();
     _showStats = ValueNotifier<bool>(widget.store.showStats);
     _showStats.addListener(() => widget.store.setShowStats(_showStats.value));
-    _player = PlayerController(initialEngine: widget.store.engineType);
+    _player = PlayerController(
+      initialEngine: widget.store.engineType,
+      preselectHlsQuality: widget.store.preselectHlsQuality,
+    );
     _stillWatching = StillWatchingController(
       player: _player,
       enabled: widget.store.stillWatchingEnabled,

--- a/desktop/lib/pairing_store.dart
+++ b/desktop/lib/pairing_store.dart
@@ -52,6 +52,7 @@ class PairingStore {
   static const _kAutoFullScreen = 'pb.auto_fullscreen';
   static const _kPauseOnWindowHide = 'pb.pause_on_window_hide';
   static const _kEnableHistory = 'pb.enable_history';
+  static const _kPreselectHlsQuality = 'pb.preselect_hls_quality';
   static const _kStillWatchingEnabled = 'pb.still_watching_enabled';
   static const _kStillWatchingThresholdMin = 'pb.still_watching_threshold_min';
   static const _kStillWatchingResponseSec = 'pb.still_watching_response_sec';
@@ -115,6 +116,15 @@ class PairingStore {
 
   Future<void> setEnableHistory(bool value) =>
       _prefs.setBool(_kEnableHistory, value);
+
+  /// Resolve HLS master playlists to the best compatible rendition before
+  /// handing them to mpv. Disabled by default so mpv receives the original
+  /// master playlist unless the user opts into preselection.
+  bool get preselectHlsQuality =>
+      _prefs.getBool(_kPreselectHlsQuality) ?? false;
+
+  Future<void> setPreselectHlsQuality(bool value) =>
+      _prefs.setBool(_kPreselectHlsQuality, value);
 
   bool get stillWatchingEnabled =>
       _prefs.getBool(_kStillWatchingEnabled) ?? false;

--- a/desktop/lib/player_controller.dart
+++ b/desktop/lib/player_controller.dart
@@ -9,7 +9,8 @@ class PlayerController extends ChangeNotifier {
   PlayerController({
     EngineType initialEngine = EngineType.mpvInternal,
     PlayerEngine? engineForTest,
-  }) {
+    bool preselectHlsQuality = false,
+  }) : _preselectHlsQuality = preselectHlsQuality {
     if (engineForTest != null) {
       _currentType = initialEngine;
       _engine = engineForTest;
@@ -37,7 +38,7 @@ class PlayerController extends ChangeNotifier {
     _currentType = type;
     switch (type) {
       case EngineType.mpvInternal:
-        _engine = MpvEngine();
+        _engine = MpvEngine(preselectHlsQuality: _preselectHlsQuality);
         (_engine as MpvEngine).onCompleted = _onCompleted;
     }
 
@@ -51,8 +52,20 @@ class PlayerController extends ChangeNotifier {
   void notifyCompletedForTest() => _onCompleted();
 
   bool _hasInited = false;
+  bool _preselectHlsQuality;
   EngineType get engineType => _currentType;
   PlayerEngine get engine => _engine;
+
+  bool get preselectHlsQuality => _preselectHlsQuality;
+
+  /// Applies to the next item opened; current playback is left untouched.
+  void setPreselectHlsQuality(bool value) {
+    if (_preselectHlsQuality == value) return;
+    _preselectHlsQuality = value;
+    final engine = _engine;
+    if (engine is MpvEngine) engine.preselectHlsQuality = value;
+    notifyListeners();
+  }
 
   Future<void> switchEngine(EngineType type) async {
     if (type == _currentType) return;

--- a/desktop/lib/settings_screen.dart
+++ b/desktop/lib/settings_screen.dart
@@ -127,6 +127,20 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
             ),
             _Tile(
+              icon: Icons.high_quality_outlined,
+              title: 'Preselect HLS quality',
+              subtitle:
+                  'Choose the highest compatible H.264 rendition before playback '
+                  'for faster startup. Off: let MPV handle the master playlist.',
+              trailing: Switch(
+                value: widget.player.preselectHlsQuality,
+                onChanged: (v) async {
+                  widget.player.setPreselectHlsQuality(v);
+                  await widget.store.setPreselectHlsQuality(v);
+                },
+              ),
+            ),
+            _Tile(
               icon: Icons.bedtime_outlined,
               title: 'Still watching reminder',
               subtitle:

--- a/desktop/test/extension_request_debug_log_test.dart
+++ b/desktop/test/extension_request_debug_log_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/extension_request_debug_log.dart';
+
+void main() {
+  test('full request logging requires debug mode and explicit opt-in', () {
+    const explicitlyEnabled = bool.fromEnvironment(
+      'PLAYBRIDGE_DEBUG_EXTENSION_REQUESTS',
+      defaultValue: false,
+    );
+
+    expect(
+      extensionRequestDebugLoggingEnabled,
+      kDebugMode && explicitlyEnabled,
+    );
+  });
+
+  group('formatExtensionCastRequestForDebug', () {
+    test('shows useful browser headers in a deterministic order', () {
+      final lines = formatExtensionCastRequestForDebug(
+        url: 'https://media.example/video/master.m3u8',
+        headers: {
+          'User-Agent': 'Mozilla/5.0',
+          'Accept': '*/*',
+          'Origin': 'https://www.example.com',
+          'Accept-Language': 'en-CA',
+        },
+      );
+
+      expect(lines, [
+        '[ext-bridge] extension cast request:',
+        '[ext-bridge]   URL: https://media.example/video/master.m3u8',
+        '[ext-bridge]   Headers (4):',
+        '[ext-bridge]     Accept: */*',
+        '[ext-bridge]     Accept-Language: en-CA',
+        '[ext-bridge]     Origin: https://www.example.com',
+        '[ext-bridge]     User-Agent: Mozilla/5.0',
+      ]);
+    });
+
+    test('shows complete signed URLs and credential-bearing header values', () {
+      final lines = formatExtensionCastRequestForDebug(
+        url: 'https://user:password@media.example/master.m3u8'
+            '?token=secret#fragment',
+        headers: {
+          'Authorization': 'Bearer secret-token',
+          'Cookie': 'session=secret-cookie',
+          'Referer': 'https://www.example.com/watch?id=private#player',
+          'X-Api-Key': 'secret-api-key',
+          'X-Custom': 'possibly-sensitive-value',
+        },
+      );
+      final output = lines.join('\n');
+
+      expect(
+        output,
+        contains(
+          'URL: https://user:password@media.example/master.m3u8'
+          '?token=secret#fragment',
+        ),
+      );
+      expect(
+        output,
+        contains('Referer: https://www.example.com/watch?id=private#player'),
+      );
+      expect(output, contains('Authorization: Bearer secret-token'));
+      expect(output, contains('Cookie: session=secret-cookie'));
+      expect(output, contains('X-Api-Key: secret-api-key'));
+      expect(output, contains('X-Custom: possibly-sensitive-value'));
+    });
+
+    test('keeps log output on one line per header', () {
+      final lines = formatExtensionCastRequestForDebug(
+        url: 'https://media.example/video.mp4',
+        headers: {'User-Agent': 'first\r\nsecond\tthird'},
+      );
+
+      expect(
+        lines.last,
+        r'[ext-bridge]     User-Agent: first\r\nsecond\tthird',
+      );
+    });
+
+    test('reports when no headers were provided', () {
+      final lines = formatExtensionCastRequestForDebug(
+        url: 'https://media.example/video.mp4',
+      );
+
+      expect(lines, contains('[ext-bridge]   Headers (0):'));
+      expect(lines, contains('[ext-bridge]     (none)'));
+    });
+  });
+}

--- a/desktop/test/pairing_store_test.dart
+++ b/desktop/test/pairing_store_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/pairing_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test('HLS quality preselection defaults off and persists changes', () async {
+    SharedPreferences.setMockInitialValues({});
+    final store = await PairingStore.load();
+
+    expect(store.preselectHlsQuality, isFalse);
+    await store.setPreselectHlsQuality(true);
+
+    final reloaded = await PairingStore.load();
+    expect(reloaded.preselectHlsQuality, isTrue);
+  });
+}

--- a/desktop/test/player_controller_test.dart
+++ b/desktop/test/player_controller_test.dart
@@ -73,6 +73,14 @@ class _FakeEngine extends PlayerEngine {
 void main() {
   QueueItem item(int n) => QueueItem(url: 'https://x/$n.mp4', title: 'Ep$n');
 
+  test('HLS preselection preference defaults off and can be changed', () {
+    final c = PlayerController(engineForTest: _FakeEngine());
+
+    expect(c.preselectHlsQuality, isFalse);
+    c.setPreselectHlsQuality(true);
+    expect(c.preselectHlsQuality, isTrue);
+  });
+
   test('completion with next item advances the queue', () async {
     final engine = _FakeEngine()..positionMsValue = 5000;
     final c = PlayerController(engineForTest: engine);


### PR DESCRIPTION
## Summary

- **HLS quality preselect (opt-in):** Settings toggle and persisted preference; when off (default), mpv receives the original master playlist.
- **Extension cast request logging:** Full URL/header dumps only with `PLAYBRIDGE_DEBUG_EXTENSION_REQUESTS` in debug builds; normal debug logs no longer print full cast URLs by default.
- **Extension bridge robustness:** Observe `socket.done` so browser/native-host disconnects do not surface as unhandled Flutter sink errors.
- **AGENTS.md:** Document optional gitignored `SUBAGENTS.local.md` for machine-local agent workflows.
- **protocol:** Bump submodule to include protected pairing credentials docs.

## Verification

- `flutter test test/extension_request_debug_log_test.dart test/pairing_store_test.dart test/player_controller_test.dart` — all passed
- Merged cleanly onto current `main` (still-watching settings preserved)

## Manual verification still recommended

- Toggle **Preselect HLS quality** and cast an HLS stream with/without it
- Confirm extension cast still works after disconnect/reconnect of the browser extension
- Confirm request logging only appears when the debug flag is enabled

## Risk

Low. HLS preselect defaults off (behavior unchanged unless enabled). Debug logging is opt-in. Socket `done` handling is additive.