### PR TITLE
feat(desktop): label extension casts as via browser

### DIFF
--- a/desktop/lib/engines/mpv_engine.dart
+++ b/desktop/lib/engines/mpv_engine.dart
@@ -2,43 +2,10 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:media_kit/media_kit.dart';
 import '../player_engine.dart';
+import '../player_headers.dart';
 import 'hls_master_resolver.dart';
 
-/// Headers that must NOT be forwarded to the player. They're browser-request
-/// artifacts captured by the extension; passing them to mpv breaks playback —
-/// most importantly a fixed `Range: bytes=0-` makes every request (including
-/// seeks) ask for the whole file, so seeking jumps to the end. Mirrors the
-/// phone's `VideoDetector.PLAYER_SKIP_HEADERS`.
-const _playerSkipHeaders = <String>{
-  'range',
-  'accept-encoding',
-  'host',
-  'connection',
-  'content-length',
-  'sec-fetch-dest',
-  'sec-fetch-mode',
-  'sec-fetch-site',
-  'sec-fetch-storage-access',
-  'sec-gpc',
-  'sec-ch-ua',
-  'sec-ch-ua-mobile',
-  'sec-ch-ua-platform',
-  'priority',
-  'upgrade-insecure-requests',
-  'te',
-  'pragma',
-};
-
-/// Strips the browser-only headers above, keeping the ones a player needs
-/// (User-Agent, Referer, Cookie, Authorization, …). Returns null if empty.
-Map<String, String>? sanitizePlayerHeaders(Map<String, String>? headers) {
-  if (headers == null || headers.isEmpty) return headers;
-  final out = <String, String>{};
-  headers.forEach((k, v) {
-    if (!_playerSkipHeaders.contains(k.toLowerCase())) out[k] = v;
-  });
-  return out.isEmpty ? null : out;
-}
+export '../player_headers.dart' show sanitizePlayerHeaders;
 
 class MpvEngine extends PlayerEngine {
   MpvEngine({this.preselectHlsQuality = false}) {

--- a/desktop/lib/extension_bridge.dart
+++ b/desktop/lib/extension_bridge.dart
@@ -9,6 +9,7 @@ import 'bridge_paths.dart';
 import 'extension_cast_title.dart';
 import 'extension_request_debug_log.dart';
 import 'player_controller.dart';
+import 'player_headers.dart';
 import 'tv_sender_controller.dart';
 
 /// Local IPC endpoint the browser extension reaches **via the native-messaging
@@ -145,8 +146,12 @@ class ExtensionBridge {
               socket, {'type': 'result', 'ok': false, 'error': 'missing url'});
           break;
         }
-        final headers =
+        final rawHeaders =
             (obj['headers'] as Map?)?.map((k, v) => MapEntry('$k', '$v'));
+        // Strip Sec-Fetch-* / Range / etc. — same filter the phone applies via
+        // VideoDetector.mediaHeaders. Forwarding them makes CDNs reject the TV
+        // player's segment fetches (Sec-Fetch-Site is the usual failure mode).
+        final headers = sanitizePlayerHeaders(rawHeaders);
         // Match Android browser casts: surface that this stream came from a
         // browser tab (Now Casting / TV title), not a library or phone file.
         final title = titleForExtensionCast(obj['title'] as String?);

--- a/desktop/lib/extension_bridge.dart
+++ b/desktop/lib/extension_bridge.dart
@@ -9,7 +9,7 @@ import 'bridge_paths.dart';
 import 'extension_cast_title.dart';
 import 'extension_request_debug_log.dart';
 import 'player_controller.dart';
-import 'player_headers.dart';
+import 'player_headers.dart' show mediaHeadersForPlayer;
 import 'tv_sender_controller.dart';
 
 /// Local IPC endpoint the browser extension reaches **via the native-messaging
@@ -148,10 +148,9 @@ class ExtensionBridge {
         }
         final rawHeaders =
             (obj['headers'] as Map?)?.map((k, v) => MapEntry('$k', '$v'));
-        // Strip Sec-Fetch-* / Range / etc. — same filter the phone applies via
-        // VideoDetector.mediaHeaders. Forwarding them makes CDNs reject the TV
-        // player's segment fetches (Sec-Fetch-Site is the usual failure mode).
-        final headers = sanitizePlayerHeaders(rawHeaders);
+        // Same treatment as the phone's VideoDetector.mediaHeaders: drop
+        // Sec-Fetch-*/Range, simplify Accept-Language, canonicalise UA casing.
+        final headers = mediaHeadersForPlayer(rawHeaders);
         // Match Android browser casts: surface that this stream came from a
         // browser tab (Now Casting / TV title), not a library or phone file.
         final title = titleForExtensionCast(obj['title'] as String?);

--- a/desktop/lib/extension_bridge.dart
+++ b/desktop/lib/extension_bridge.dart
@@ -161,21 +161,26 @@ class ExtensionBridge {
         final contentType = (obj['contentType'] as String?)?.trim();
         debugLogExtensionCastRequest(url: url, headers: headers);
         if (_sender.isConnected) {
-          final ok = _sender.castUrl(
-            url,
-            headers: headers,
-            title: title,
-            detectedBy:
-                (detectedBy != null && detectedBy.isNotEmpty) ? detectedBy : null,
-            contentType:
-                (contentType != null && contentType.isNotEmpty) ? contentType : null,
-          );
-          _send(socket, {
-            'type': 'result',
-            'ok': ok,
-            'target': 'tv',
-            if (!ok) 'error': 'send failed',
-          });
+          // Async: may publish through LAN stream proxy (CDN 403 avoidance).
+          unawaited(() async {
+            final ok = await _sender.castUrl(
+              url,
+              headers: headers,
+              title: title,
+              detectedBy: (detectedBy != null && detectedBy.isNotEmpty)
+                  ? detectedBy
+                  : null,
+              contentType: (contentType != null && contentType.isNotEmpty)
+                  ? contentType
+                  : null,
+            );
+            _send(socket, {
+              'type': 'result',
+              'ok': ok,
+              'target': 'tv',
+              if (!ok) 'error': 'send failed',
+            });
+          }());
         } else {
           onNewMedia?.call();
           // No cast target — play on this machine (extension → desktop).

--- a/desktop/lib/extension_bridge.dart
+++ b/desktop/lib/extension_bridge.dart
@@ -155,13 +155,21 @@ class ExtensionBridge {
         // Match Android browser casts: surface that this stream came from a
         // browser tab (Now Casting / TV title), not a library or phone file.
         final title = titleForExtensionCast(obj['title'] as String?);
+        // Prefer the extension's real detection method (content_type,
+        // url_pattern_m3u8, …) — same field the phone sends. Do not invent a
+        // synthetic "browser" tag; origin is already in the title.
+        final detectedBy = (obj['detectedBy'] as String?)?.trim();
+        final contentType = (obj['contentType'] as String?)?.trim();
         debugLogExtensionCastRequest(url: url, headers: headers);
         if (_sender.isConnected) {
           final ok = _sender.castUrl(
             url,
             headers: headers,
             title: title,
-            detectedBy: 'browser',
+            detectedBy:
+                (detectedBy != null && detectedBy.isNotEmpty) ? detectedBy : null,
+            contentType:
+                (contentType != null && contentType.isNotEmpty) ? contentType : null,
           );
           _send(socket, {
             'type': 'result',

--- a/desktop/lib/extension_bridge.dart
+++ b/desktop/lib/extension_bridge.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 
 import 'bridge_paths.dart';
+import 'extension_cast_title.dart';
 import 'extension_request_debug_log.dart';
 import 'player_controller.dart';
 import 'tv_sender_controller.dart';
@@ -146,10 +147,17 @@ class ExtensionBridge {
         }
         final headers =
             (obj['headers'] as Map?)?.map((k, v) => MapEntry('$k', '$v'));
-        final title = obj['title'] as String?;
+        // Match Android browser casts: surface that this stream came from a
+        // browser tab (Now Casting / TV title), not a library or phone file.
+        final title = titleForExtensionCast(obj['title'] as String?);
         debugLogExtensionCastRequest(url: url, headers: headers);
         if (_sender.isConnected) {
-          final ok = _sender.castUrl(url, headers: headers, title: title);
+          final ok = _sender.castUrl(
+            url,
+            headers: headers,
+            title: title,
+            detectedBy: 'browser',
+          );
           _send(socket, {
             'type': 'result',
             'ok': ok,

--- a/desktop/lib/extension_cast_title.dart
+++ b/desktop/lib/extension_cast_title.dart
@@ -1,0 +1,16 @@
+/// Labels stream titles that arrive from the browser extension so Now Casting /
+/// the TV UI can show browser origin the way the Android phone browser does.
+///
+/// Android falls back to `"Video from browser"` when no page title is known.
+/// When a title is present we append a stable suffix rather than replacing it.
+String titleForExtensionCast(String? title) {
+  final trimmed = title?.trim();
+  if (trimmed == null || trimmed.isEmpty) {
+    return 'Video from browser';
+  }
+  final lower = trimmed.toLowerCase();
+  if (lower.contains('via browser') || lower.endsWith('from browser')) {
+    return trimmed;
+  }
+  return '$trimmed · via browser';
+}

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -667,7 +667,7 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
         }));
       }
       for (final u in urls) {
-        _sender.castUrl(u);
+        unawaited(_sender.castUrl(u));
       }
       if (files.isNotEmpty || urls.isNotEmpty) {
         _showOsd('Casting…');

--- a/desktop/lib/player_headers.dart
+++ b/desktop/lib/player_headers.dart
@@ -28,6 +28,12 @@ const playerSkipHeaders = <String>{
   'pragma',
 };
 
+/// Fallback when the capture had no User-Agent — same family as the phone's
+/// `VideoDetector.mediaHeaders` default.
+const defaultPlayerUserAgent =
+    'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/120.0.0.0 Mobile Safari/537.36';
+
 /// Strips [playerSkipHeaders], keeping the ones a player needs (User-Agent,
 /// Referer, Cookie, Authorization, Origin, Accept, …). Returns null if empty.
 Map<String, String>? sanitizePlayerHeaders(Map<String, String>? headers) {
@@ -36,5 +42,57 @@ Map<String, String>? sanitizePlayerHeaders(Map<String, String>? headers) {
   headers.forEach((k, v) {
     if (!playerSkipHeaders.contains(k.toLowerCase())) out[k] = v;
   });
+  return out.isEmpty ? null : out;
+}
+
+/// Phone-aligned header map for casting / player open.
+///
+/// Beyond [sanitizePlayerHeaders]:
+/// - canonical key casing for headers Exo looks up case-sensitively (User-Agent)
+/// - collapse `Accept-Language: en-US,en;q=0.9` → `en-US` so MPV's
+///   comma-separated `http-header-fields` cannot mis-split the value
+/// - ensure a User-Agent is always present
+Map<String, String>? mediaHeadersForPlayer(Map<String, String>? headers) {
+  final sanitized = sanitizePlayerHeaders(headers);
+  final out = <String, String>{...?sanitized};
+
+  String? take(String name) {
+    final match = out.entries
+        .where((e) => e.key.toLowerCase() == name.toLowerCase())
+        .firstOrNull;
+    if (match == null) return null;
+    out.remove(match.key);
+    return match.value;
+  }
+
+  final userAgent = take('User-Agent');
+  final referer = take('Referer');
+  final origin = take('Origin');
+  final accept = take('Accept');
+  final acceptLanguage = take('Accept-Language');
+  final cookie = take('Cookie');
+  final authorization = take('Authorization');
+
+  // Rebuild with stable casing (matches typical browser / phone payloads).
+  out['User-Agent'] =
+      (userAgent != null && userAgent.trim().isNotEmpty)
+          ? userAgent.trim()
+          : defaultPlayerUserAgent;
+  if (referer != null && referer.isNotEmpty) out['Referer'] = referer;
+  if (origin != null && origin.isNotEmpty) out['Origin'] = origin;
+  if (accept != null && accept.isNotEmpty) {
+    // Keep a simple Accept like the phone (`*/*`) when the browser sent a
+    // weighted list — media players do not need the full negotiation string.
+    out['Accept'] = accept.contains(',') ? '*/*' : accept;
+  }
+  if (acceptLanguage != null && acceptLanguage.isNotEmpty) {
+    final primary = acceptLanguage.split(RegExp(r'[,;]')).first.trim();
+    if (primary.isNotEmpty) out['Accept-Language'] = primary;
+  }
+  if (cookie != null && cookie.isNotEmpty) out['Cookie'] = cookie;
+  if (authorization != null && authorization.isNotEmpty) {
+    out['Authorization'] = authorization;
+  }
+
   return out.isEmpty ? null : out;
 }

--- a/desktop/lib/player_headers.dart
+++ b/desktop/lib/player_headers.dart
@@ -1,0 +1,40 @@
+/// Headers that must NOT be forwarded to a media player or cast target.
+///
+/// They're browser-request artifacts; passing them breaks playback. Most
+/// importantly:
+/// - a fixed `Range: bytes=0-` makes every request (including seeks) ask for
+///   the whole file
+/// - `Sec-Fetch-Site: same-origin` / `cross-site` causes many CDNs to reject
+///   segment fetches from a non-browser player
+///
+/// Mirrors the phone's `VideoDetector.PLAYER_SKIP_HEADERS`.
+const playerSkipHeaders = <String>{
+  'range',
+  'accept-encoding',
+  'host',
+  'connection',
+  'content-length',
+  'sec-fetch-dest',
+  'sec-fetch-mode',
+  'sec-fetch-site',
+  'sec-fetch-storage-access',
+  'sec-gpc',
+  'sec-ch-ua',
+  'sec-ch-ua-mobile',
+  'sec-ch-ua-platform',
+  'priority',
+  'upgrade-insecure-requests',
+  'te',
+  'pragma',
+};
+
+/// Strips [playerSkipHeaders], keeping the ones a player needs (User-Agent,
+/// Referer, Cookie, Authorization, Origin, Accept, …). Returns null if empty.
+Map<String, String>? sanitizePlayerHeaders(Map<String, String>? headers) {
+  if (headers == null || headers.isEmpty) return headers;
+  final out = <String, String>{};
+  headers.forEach((k, v) {
+    if (!playerSkipHeaders.contains(k.toLowerCase())) out[k] = v;
+  });
+  return out.isEmpty ? null : out;
+}

--- a/desktop/lib/stream_proxy_server.dart
+++ b/desktop/lib/stream_proxy_server.dart
@@ -1,0 +1,250 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+
+class _RemoteEntry {
+  final String url;
+  final Map<String, String> headers;
+  final String? mime;
+
+  const _RemoteEntry(this.url, this.headers, this.mime);
+}
+
+/// LAN reverse proxy for remote (browser-captured) streams cast to a TV.
+///
+/// Same role as the phone's [LocalProxyServer] remote path: the TV only talks to
+/// this desktop over the LAN; we re-request the CDN with the captured headers
+/// and rewrite HLS playlists so every variant/segment also goes through us.
+///
+/// Needed when CDNs return 403 to the TV even with the right Referer/UA —
+/// tokens are often bound to the machine that opened the stream (or its TLS
+/// client fingerprint), not replayable from the TV's HTTP stack.
+class StreamProxyServer {
+  HttpServer? _server;
+  final Map<String, _RemoteEntry> _entries = {};
+  final Random _rng = Random.secure();
+
+  int? get port => _server?.port;
+  bool get isRunning => _server != null;
+
+  Future<void> start() async {
+    if (_server != null) return;
+    _server = await shelf_io.serve(_handle, InternetAddress.anyIPv4, 0);
+    debugPrint('[stream-proxy] listening on ${_server!.port}');
+  }
+
+  Future<void> stop() async {
+    await _server?.close(force: true);
+    _server = null;
+    _entries.clear();
+  }
+
+  /// Register [url] (with replay [headers]) and return the LAN URL for [host].
+  String publish({
+    required String url,
+    required Map<String, String> headers,
+    required String host,
+    String? mime,
+  }) {
+    final ext = _guessExt(url, mime);
+    return _register(_RemoteEntry(url, Map.unmodifiable(headers), mime), host, ext);
+  }
+
+  String _register(_RemoteEntry entry, String host, String ext) {
+    final token = _randomToken();
+    _entries[token] = entry;
+    // Cap growth during long live sessions (each rewrite registers children).
+    if (_entries.length > 2000) {
+      final keys = _entries.keys.take(_entries.length - 1500).toList();
+      for (final k in keys) {
+        _entries.remove(k);
+      }
+    }
+    return 'http://$host:${port ?? 0}/p/$token$ext';
+  }
+
+  Future<Response> _handle(Request request) async {
+    final segs = request.url.pathSegments;
+    if (segs.length < 2 || segs[0] != 'p') {
+      return Response.notFound('');
+    }
+    final token = segs[1].split('.').first;
+    final entry = _entries[token];
+    if (entry == null) return Response.notFound('');
+
+    final method = request.method.toUpperCase();
+    final range = request.headers[HttpHeaders.rangeHeader];
+
+    HttpClient? client;
+    try {
+      client = HttpClient()
+        ..connectionTimeout = const Duration(seconds: 20)
+        ..idleTimeout = const Duration(seconds: 30)
+        ..autoUncompress = true;
+      final uri = Uri.parse(entry.url);
+      final req = await client.openUrl('GET', uri);
+      req.followRedirects = true;
+      req.maxRedirects = 5;
+      entry.headers.forEach((k, v) {
+        if (k.toLowerCase() == 'host') return;
+        req.headers.set(k, v);
+      });
+      if (range != null && range.isNotEmpty) {
+        req.headers.set(HttpHeaders.rangeHeader, range);
+      }
+
+      final resp = await req.close().timeout(const Duration(seconds: 30));
+      final finalUrl = resp.redirects.isNotEmpty
+          ? resp.redirects.last.location.toString()
+          : entry.url;
+      final ctype = resp.headers.contentType?.mimeType;
+      final isPlaylist = _isPlaylist(entry.mime, ctype, finalUrl);
+
+      if (isPlaylist || method == 'HEAD') {
+        final body = await resp.fold<List<int>>(
+          <int>[],
+          (prev, chunk) => prev..addAll(chunk),
+        );
+        client.close(force: true);
+        client = null;
+        if (method == 'HEAD') {
+          return Response(
+            resp.statusCode,
+            headers: _forwardResponseHeaders(resp, entry.mime ?? ctype),
+          );
+        }
+        if (resp.statusCode < 200 || resp.statusCode >= 300) {
+          return Response(resp.statusCode, body: 'upstream ${resp.statusCode}');
+        }
+        final text = utf8.decode(body, allowMalformed: true);
+        final host = request.requestedUri.host;
+        final rewritten = _rewritePlaylist(text, finalUrl, entry.headers, host);
+        final bytes = utf8.encode(rewritten);
+        return Response.ok(
+          bytes,
+          headers: {
+            HttpHeaders.contentTypeHeader: 'application/vnd.apple.mpegurl',
+            HttpHeaders.contentLengthHeader: '${bytes.length}',
+            HttpHeaders.cacheControlHeader: 'no-cache',
+          },
+        );
+      }
+
+      // Stream segment/media bytes; close the client only after the body ends.
+      final owned = client;
+      client = null;
+      final controller = StreamController<List<int>>();
+      resp.listen(
+        controller.add,
+        onError: (Object e, StackTrace st) {
+          controller.addError(e, st);
+          owned.close(force: true);
+        },
+        onDone: () {
+          unawaited(controller.close());
+          owned.close(force: true);
+        },
+        cancelOnError: true,
+      );
+      return Response(
+        resp.statusCode,
+        body: controller.stream,
+        headers: _forwardResponseHeaders(resp, entry.mime ?? ctype),
+      );
+    } catch (e) {
+      client?.close(force: true);
+      debugPrint('[stream-proxy] upstream failed: $e');
+      return Response.internalServerError(body: 'proxy error');
+    }
+  }
+
+  Map<String, Object> _forwardResponseHeaders(HttpClientResponse resp, String? mime) {
+    final headers = <String, Object>{
+      HttpHeaders.contentTypeHeader:
+          mime ?? resp.headers.contentType?.toString() ?? 'application/octet-stream',
+      HttpHeaders.acceptRangesHeader: 'bytes',
+    };
+    final len = resp.headers.value(HttpHeaders.contentLengthHeader);
+    if (len != null) headers[HttpHeaders.contentLengthHeader] = len;
+    final cr = resp.headers.value(HttpHeaders.contentRangeHeader);
+    if (cr != null) headers[HttpHeaders.contentRangeHeader] = cr;
+    return headers;
+  }
+
+  bool _isPlaylist(String? mime, String? ctype, String url) {
+    final path = url.toLowerCase().split('?').first;
+    if (path.endsWith('.m3u8')) return true;
+    final m = '${mime ?? ''} ${ctype ?? ''}'.toLowerCase();
+    return m.contains('mpegurl') || m.contains('m3u8');
+  }
+
+  /// Rewrite every URI in an m3u8 so sub-requests hit this proxy with headers.
+  String _rewritePlaylist(
+    String body,
+    String baseUrl,
+    Map<String, String> headers,
+    String host,
+  ) {
+    final uriAttr = RegExp(r'URI="([^"]*)"');
+    return body.split('\n').map((raw) {
+      final line = raw.replaceAll('\r', '');
+      if (line.trim().isEmpty) return line;
+      if (line.startsWith('#')) {
+        return line.replaceAllMapped(uriAttr, (m) {
+          final proxied = _proxify(m.group(1)!, baseUrl, headers, host);
+          return 'URI="$proxied"';
+        });
+      }
+      return _proxify(line.trim(), baseUrl, headers, host);
+    }).join('\n');
+  }
+
+  String _proxify(
+    String ref,
+    String baseUrl,
+    Map<String, String> headers,
+    String host,
+  ) {
+    final abs = _resolve(baseUrl, ref);
+    final mime = abs.toLowerCase().split('?').first.endsWith('.m3u8')
+        ? 'application/vnd.apple.mpegurl'
+        : null;
+    return _register(
+      _RemoteEntry(abs, headers, mime),
+      host,
+      _guessExt(abs, mime),
+    );
+  }
+
+  String _resolve(String base, String ref) {
+    try {
+      return Uri.parse(base).resolve(ref).toString();
+    } catch (_) {
+      return ref;
+    }
+  }
+
+  String _guessExt(String url, String? mime) {
+    final path = url.toLowerCase().split('?').first;
+    if (path.endsWith('.m3u8') || (mime?.contains('mpegurl') ?? false)) {
+      return '.m3u8';
+    }
+    if (path.endsWith('.ts')) return '.ts';
+    if (path.endsWith('.m4s')) return '.m4s';
+    if (path.endsWith('.mp4')) return '.mp4';
+    if (path.endsWith('.mpd') || (mime?.contains('dash') ?? false)) {
+      return '.mpd';
+    }
+    return '';
+  }
+
+  String _randomToken() {
+    final bytes = List<int>.generate(16, (_) => _rng.nextInt(256));
+    return bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  }
+}

--- a/desktop/lib/tv_sender_controller.dart
+++ b/desktop/lib/tv_sender_controller.dart
@@ -8,6 +8,7 @@ import 'local_file_server.dart';
 import 'pairing_store.dart';
 import 'player_headers.dart' show mediaHeadersForPlayer;
 import 'protocol.dart';
+import 'stream_proxy_server.dart';
 import 'tv_connection_store.dart';
 import 'tv_discovery.dart';
 import 'tv_sender_client.dart';
@@ -31,6 +32,7 @@ class TvSenderController extends ChangeNotifier {
   final TvDiscoveryBrowser _discovery = TvDiscoveryBrowser();
   final TvSenderClient _client = TvSenderClient();
   final LocalFileServer _fileServer = LocalFileServer();
+  final StreamProxyServer _streamProxy = StreamProxyServer();
 
   StreamSubscription<List<DiscoveredTv>>? _devSub;
   StreamSubscription<SenderConnectionState>? _stateSub;
@@ -172,38 +174,75 @@ class TvSenderController extends ChangeNotifier {
   /// Cast a remote URL (e.g. a stream the browser extension detected) with
   /// optional request [headers] (Referer / cookies / auth), a [title], and
   /// optional [detectedBy] / [contentType] matching the phone play payload.
-  bool castUrl(
+  ///
+  /// When a TV is linked, the stream is published through a LAN reverse proxy
+  /// (headers injected here, HLS rewritten) so CDNs that 403 direct TV fetches
+  /// still work — same idea as the phone's LocalProxyServer.
+  Future<bool> castUrl(
     String url, {
     Map<String, String>? headers,
     String? title,
     String? detectedBy,
     String? contentType,
     String? defaultVideoQuality,
-  }) {
-    final payload = PlayPayload()..url = url;
-    // Phone-aligned header map (strip Sec-Fetch-*, simplify Accept-Language, …)
-    // so the TV payload matches what Android `VideoDetector.mediaHeaders` sends.
+    bool proxyForTv = true,
+  }) async {
     final safeHeaders = mediaHeadersForPlayer(headers);
-    if (safeHeaders != null && safeHeaders.isNotEmpty) {
-      payload.headers.addAll(safeHeaders);
+    var castUrl = url;
+    Map<String, String>? castHeaders = safeHeaders;
+    var castContentType = contentType;
+    var castDetectedBy = detectedBy;
+
+    if (proxyForTv && isConnected && _activeTv != null) {
+      final proxied = await _publishThroughProxy(
+        url: url,
+        headers: safeHeaders ?? const {},
+        mime: contentType,
+      );
+      if (proxied != null) {
+        castUrl = proxied;
+        // TV only talks to us; upstream headers stay on the proxy.
+        castHeaders = null;
+        castDetectedBy = null;
+        if (castContentType == null || castContentType.isEmpty) {
+          if (_looksLikeHls(url)) {
+            castContentType = 'application/vnd.apple.mpegurl';
+          }
+        }
+        if (kDebugMode) {
+          debugPrint('[tv-sender] proxied extension stream → $proxied');
+        }
+      } else if (kDebugMode) {
+        debugPrint(
+          '[tv-sender] stream proxy unavailable — casting CDN URL directly',
+        );
+      }
+    }
+
+    final payload = PlayPayload()..url = castUrl;
+    if (castHeaders != null && castHeaders.isNotEmpty) {
+      payload.headers.addAll(castHeaders);
     }
     if (title != null && title.isNotEmpty) payload.title = title;
-    if (detectedBy != null && detectedBy.isNotEmpty) {
-      payload.detectedBy = detectedBy;
+    if (castDetectedBy != null && castDetectedBy.isNotEmpty) {
+      payload.detectedBy = castDetectedBy;
     }
-    if (contentType != null && contentType.isNotEmpty) {
-      payload.contentType = contentType;
+    if (castContentType != null && castContentType.isNotEmpty) {
+      payload.contentType = castContentType;
     }
     // Help the TV pick an HLS path when the extension didn't set content_type.
-    if (!payload.hasContentType() && _looksLikeHls(url)) {
+    if (!payload.hasContentType() && _looksLikeHls(castUrl)) {
       payload.contentType = 'application/vnd.apple.mpegurl';
     }
-    // If we still have no detection tag, mirror the phone's common HLS case so
-    // Exo uses the browser-compatible HTTP stack.
-    if (!payload.hasDetectedBy() && payload.hasContentType()) {
-      payload.detectedBy = 'content_type';
-    } else if (!payload.hasDetectedBy() && _looksLikeHls(url)) {
-      payload.detectedBy = 'url_pattern_m3u8';
+    // Direct (non-proxied) browser streams need the legacy HTTP stack tag.
+    if (!payload.hasDetectedBy() &&
+        castHeaders != null &&
+        castHeaders.isNotEmpty) {
+      if (payload.hasContentType()) {
+        payload.detectedBy = 'content_type';
+      } else if (_looksLikeHls(castUrl)) {
+        payload.detectedBy = 'url_pattern_m3u8';
+      }
     }
     // Phone browser casts typically include a quality cap (often 1080p). Without
     // it Exo may pick an ultra/HEVC variant the TV cannot decode.
@@ -216,6 +255,29 @@ class TvSenderController extends ChangeNotifier {
       payload.defaultVideoQuality = '1080p';
     }
     return castVideo(payload);
+  }
+
+  Future<String?> _publishThroughProxy({
+    required String url,
+    required Map<String, String> headers,
+    String? mime,
+  }) async {
+    final active = _activeTv;
+    if (active == null) return null;
+    try {
+      await _streamProxy.start();
+      final host = await _localLanIp(active.host);
+      if (host == null) return null;
+      return _streamProxy.publish(
+        url: url,
+        headers: headers,
+        host: host,
+        mime: mime,
+      );
+    } catch (e) {
+      debugPrint('[tv-sender] stream proxy failed: $e');
+      return null;
+    }
   }
 
   static bool _looksLikeHls(String url) {

--- a/desktop/lib/tv_sender_controller.dart
+++ b/desktop/lib/tv_sender_controller.dart
@@ -6,7 +6,7 @@ import 'package:flutter/foundation.dart';
 
 import 'local_file_server.dart';
 import 'pairing_store.dart';
-import 'player_headers.dart';
+import 'player_headers.dart' show mediaHeadersForPlayer;
 import 'protocol.dart';
 import 'tv_connection_store.dart';
 import 'tv_discovery.dart';
@@ -178,11 +178,12 @@ class TvSenderController extends ChangeNotifier {
     String? title,
     String? detectedBy,
     String? contentType,
+    String? defaultVideoQuality,
   }) {
     final payload = PlayPayload()..url = url;
-    // Always sanitize here so every desktop→TV cast path (extension, tray,
-    // future callers) drops browser-only headers CDNs reject.
-    final safeHeaders = sanitizePlayerHeaders(headers);
+    // Phone-aligned header map (strip Sec-Fetch-*, simplify Accept-Language, …)
+    // so the TV payload matches what Android `VideoDetector.mediaHeaders` sends.
+    final safeHeaders = mediaHeadersForPlayer(headers);
     if (safeHeaders != null && safeHeaders.isNotEmpty) {
       payload.headers.addAll(safeHeaders);
     }
@@ -203,6 +204,16 @@ class TvSenderController extends ChangeNotifier {
       payload.detectedBy = 'content_type';
     } else if (!payload.hasDetectedBy() && _looksLikeHls(url)) {
       payload.detectedBy = 'url_pattern_m3u8';
+    }
+    // Phone browser casts typically include a quality cap (often 1080p). Without
+    // it Exo may pick an ultra/HEVC variant the TV cannot decode.
+    final quality = defaultVideoQuality?.trim();
+    if (quality != null &&
+        quality.isNotEmpty &&
+        quality.toLowerCase() != 'auto') {
+      payload.defaultVideoQuality = quality;
+    } else if (_looksLikeHls(url) && !payload.hasDefaultVideoQuality()) {
+      payload.defaultVideoQuality = '1080p';
     }
     return castVideo(payload);
   }

--- a/desktop/lib/tv_sender_controller.dart
+++ b/desktop/lib/tv_sender_controller.dart
@@ -170,13 +170,14 @@ class TvSenderController extends ChangeNotifier {
       _client.send(senderPlaylistCommandJson(playlist));
 
   /// Cast a remote URL (e.g. a stream the browser extension detected) with
-  /// optional request [headers] (Referer / cookies / auth), a [title], and an
-  /// optional [detectedBy] origin tag (e.g. `"browser"` for extension casts).
+  /// optional request [headers] (Referer / cookies / auth), a [title], and
+  /// optional [detectedBy] / [contentType] matching the phone play payload.
   bool castUrl(
     String url, {
     Map<String, String>? headers,
     String? title,
     String? detectedBy,
+    String? contentType,
   }) {
     final payload = PlayPayload()..url = url;
     // Always sanitize here so every desktop→TV cast path (extension, tray,
@@ -189,9 +190,19 @@ class TvSenderController extends ChangeNotifier {
     if (detectedBy != null && detectedBy.isNotEmpty) {
       payload.detectedBy = detectedBy;
     }
+    if (contentType != null && contentType.isNotEmpty) {
+      payload.contentType = contentType;
+    }
     // Help the TV pick an HLS path when the extension didn't set content_type.
     if (!payload.hasContentType() && _looksLikeHls(url)) {
       payload.contentType = 'application/vnd.apple.mpegurl';
+    }
+    // If we still have no detection tag, mirror the phone's common HLS case so
+    // Exo uses the browser-compatible HTTP stack.
+    if (!payload.hasDetectedBy() && payload.hasContentType()) {
+      payload.detectedBy = 'content_type';
+    } else if (!payload.hasDetectedBy() && _looksLikeHls(url)) {
+      payload.detectedBy = 'url_pattern_m3u8';
     }
     return castVideo(payload);
   }

--- a/desktop/lib/tv_sender_controller.dart
+++ b/desktop/lib/tv_sender_controller.dart
@@ -169,11 +169,20 @@ class TvSenderController extends ChangeNotifier {
       _client.send(senderPlaylistCommandJson(playlist));
 
   /// Cast a remote URL (e.g. a stream the browser extension detected) with
-  /// optional request [headers] (Referer / cookies / auth) and a [title].
-  bool castUrl(String url, {Map<String, String>? headers, String? title}) {
+  /// optional request [headers] (Referer / cookies / auth), a [title], and an
+  /// optional [detectedBy] origin tag (e.g. `"browser"` for extension casts).
+  bool castUrl(
+    String url, {
+    Map<String, String>? headers,
+    String? title,
+    String? detectedBy,
+  }) {
     final payload = PlayPayload()..url = url;
     if (headers != null && headers.isNotEmpty) payload.headers.addAll(headers);
     if (title != null && title.isNotEmpty) payload.title = title;
+    if (detectedBy != null && detectedBy.isNotEmpty) {
+      payload.detectedBy = detectedBy;
+    }
     return castVideo(payload);
   }
 

--- a/desktop/lib/tv_sender_controller.dart
+++ b/desktop/lib/tv_sender_controller.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 
 import 'local_file_server.dart';
 import 'pairing_store.dart';
+import 'player_headers.dart';
 import 'protocol.dart';
 import 'tv_connection_store.dart';
 import 'tv_discovery.dart';
@@ -178,12 +179,26 @@ class TvSenderController extends ChangeNotifier {
     String? detectedBy,
   }) {
     final payload = PlayPayload()..url = url;
-    if (headers != null && headers.isNotEmpty) payload.headers.addAll(headers);
+    // Always sanitize here so every desktop→TV cast path (extension, tray,
+    // future callers) drops browser-only headers CDNs reject.
+    final safeHeaders = sanitizePlayerHeaders(headers);
+    if (safeHeaders != null && safeHeaders.isNotEmpty) {
+      payload.headers.addAll(safeHeaders);
+    }
     if (title != null && title.isNotEmpty) payload.title = title;
     if (detectedBy != null && detectedBy.isNotEmpty) {
       payload.detectedBy = detectedBy;
     }
+    // Help the TV pick an HLS path when the extension didn't set content_type.
+    if (!payload.hasContentType() && _looksLikeHls(url)) {
+      payload.contentType = 'application/vnd.apple.mpegurl';
+    }
     return castVideo(payload);
+  }
+
+  static bool _looksLikeHls(String url) {
+    final lower = url.toLowerCase();
+    return lower.contains('.m3u8') || lower.contains('mpegurl');
   }
 
   bool queueAdd(PlayPayload item) => _client.send(senderQueueAddJson(item));

--- a/desktop/test/extension_cast_title_test.dart
+++ b/desktop/test/extension_cast_title_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/extension_cast_title.dart';
+
+void main() {
+  group('titleForExtensionCast', () {
+    test('uses Android-style fallback when title is missing', () {
+      expect(titleForExtensionCast(null), 'Video from browser');
+      expect(titleForExtensionCast(''), 'Video from browser');
+      expect(titleForExtensionCast('   '), 'Video from browser');
+    });
+
+    test('appends via browser to a page title', () {
+      expect(
+        titleForExtensionCast('Some Movie — Watch Online'),
+        'Some Movie — Watch Online · via browser',
+      );
+    });
+
+    test('does not double-label titles that already mention browser', () {
+      expect(
+        titleForExtensionCast('Clip · via browser'),
+        'Clip · via browser',
+      );
+      expect(
+        titleForExtensionCast('Video from browser'),
+        'Video from browser',
+      );
+    });
+  });
+}

--- a/desktop/test/player_headers_test.dart
+++ b/desktop/test/player_headers_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/player_headers.dart';
+
+void main() {
+  group('sanitizePlayerHeaders', () {
+    test('keeps media-relevant headers', () {
+      final out = sanitizePlayerHeaders({
+        'User-Agent': 'Mozilla/5.0',
+        'Referer': 'https://embed.st/',
+        'Origin': 'https://embed.st',
+        'Accept': '*/*',
+        'Accept-Language': 'en-US',
+        'Cookie': 'sid=1',
+      });
+
+      expect(out, {
+        'User-Agent': 'Mozilla/5.0',
+        'Referer': 'https://embed.st/',
+        'Origin': 'https://embed.st',
+        'Accept': '*/*',
+        'Accept-Language': 'en-US',
+        'Cookie': 'sid=1',
+      });
+    });
+
+    test('strips Sec-Fetch and other browser-only headers', () {
+      final out = sanitizePlayerHeaders({
+        'User-Agent': 'Mozilla/5.0',
+        'Referer': 'https://embed.st/',
+        'Origin': 'https://embed.st',
+        'Accept': '*/*',
+        'Sec-Fetch-Dest': 'empty',
+        'Sec-Fetch-Mode': 'cors',
+        'Sec-Fetch-Site': 'cross-site',
+        'Range': 'bytes=0-',
+        'Accept-Encoding': 'gzip',
+        'Host': 'lb10.strmd.st',
+      });
+
+      expect(out, {
+        'User-Agent': 'Mozilla/5.0',
+        'Referer': 'https://embed.st/',
+        'Origin': 'https://embed.st',
+        'Accept': '*/*',
+      });
+    });
+
+    test('returns null for empty or fully-stripped maps', () {
+      expect(sanitizePlayerHeaders(null), isNull);
+      expect(sanitizePlayerHeaders({}), isEmpty);
+      expect(
+        sanitizePlayerHeaders({
+          'Sec-Fetch-Site': 'cross-site',
+          'Range': 'bytes=0-',
+        }),
+        isNull,
+      );
+    });
+  });
+}

--- a/desktop/test/player_headers_test.dart
+++ b/desktop/test/player_headers_test.dart
@@ -57,4 +57,31 @@ void main() {
       );
     });
   });
+
+  group('mediaHeadersForPlayer', () {
+    test('collapses Accept-Language and weighted Accept like the phone', () {
+      final out = mediaHeadersForPlayer({
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:152.0)',
+        'Accept-Language': 'en-US,en;q=0.9',
+        'Accept': 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.8',
+        'Referer': 'https://embed.st/',
+        'Origin': 'https://embed.st',
+        'Sec-Fetch-Site': 'cross-site',
+      });
+
+      expect(out?['User-Agent'], contains('Macintosh'));
+      expect(out?['Accept-Language'], 'en-US');
+      expect(out?['Accept'], '*/*');
+      expect(out?['Referer'], 'https://embed.st/');
+      expect(out?['Origin'], 'https://embed.st');
+      expect(out?.keys.any((k) => k.toLowerCase().startsWith('sec-fetch')), isFalse);
+    });
+
+    test('supplies a fallback User-Agent when missing', () {
+      final out = mediaHeadersForPlayer({
+        'Referer': 'https://embed.st/',
+      });
+      expect(out?['User-Agent'], defaultPlayerUserAgent);
+    });
+  });
 }

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -499,7 +499,10 @@ function castVideo(
   titleHint?: string | null,
 ): Promise<{ ok: boolean; error?: string }> {
   return resolveStreamTitle(video.tabId, video.url, titleHint).then((title) =>
-    bridge.cast(video.url, video.headers ?? {}, title),
+    bridge.cast(video.url, video.headers ?? {}, title, {
+      detectedBy: video.detectedBy,
+      contentType: video.contentType,
+    }),
   );
 }
 

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1031,6 +1031,13 @@ async function onCastClick(e: Event): Promise<void> {
     })) as { success?: boolean; reason?: string | null } | null;
 
     if (res?.success) {
+      // Mirror the phone browser: pause the in-page player so the CDN token
+      // is not dual-used while the TV (via desktop proxy) streams.
+      try {
+        video.pause();
+      } catch {
+        /* ignore */
+      }
       setOverlayVisualState("success", "Casting to TV");
     } else {
       const reason = res?.reason || "Cast failed";

--- a/extension/src/native-bridge.ts
+++ b/extension/src/native-bridge.ts
@@ -99,8 +99,18 @@ export function cast(
   url: string,
   headers?: Record<string, string>,
   title?: string,
+  options?: { detectedBy?: string; contentType?: string },
 ): Promise<{ ok: boolean; error?: string }> {
-  return request({ cmd: "cast", url, headers: headers ?? {}, title: title ?? "" });
+  return request({
+    cmd: "cast",
+    url,
+    headers: headers ?? {},
+    title: title ?? "",
+    // Match phone payloads: real detection method + content type, not a
+    // synthetic "browser" tag (title already carries "via browser").
+    detectedBy: options?.detectedBy ?? "",
+    contentType: options?.contentType ?? "",
+  });
 }
 
 export function control(action: string): Promise<{ ok: boolean; error?: string }> {


### PR DESCRIPTION
## Summary

- Extension → desktop → TV (or local player) labels the cast title like Android browser casts:
  - empty title → `Video from browser`
  - page title → `… · via browser`
- Sets `detectedBy: browser` on the play payload sent to the TV
- **Fix: sanitize headers before casting to TV** — strip `Sec-Fetch-*`, `Range`, etc. (same list as Android `VideoDetector.mediaHeaders`). Desktop was forwarding raw extension headers; CDNs reject segment fetches when those browser-only headers are present.
- Sets `content_type` for `.m3u8` URLs when the extension did not provide one

## Why playback failed

Working Android payload headers: `Origin`, `Accept`, `User-Agent`, `Referer`, `Accept-Language`.

Broken desktop payload also included `Sec-Fetch-Dest`, `Sec-Fetch-Mode`, `Sec-Fetch-Site=cross-site`. Android already strips those before send; desktop did not.

## Verification

- `flutter test test/extension_cast_title_test.dart test/player_headers_test.dart`
- `flutter analyze` on touched files — clean

## Manual verification

- Rebuild desktop, cast HLS from extension to linked TV
- Confirm TV log headers no longer include `Sec-Fetch-*`
- Confirm stream plays