### PR TITLE
chore(release): prep playbridge release (desktop v0.7.0, extension v0.5.0)

### DIFF
--- a/.agents/skills/release-and-publish/SKILL.md
+++ b/.agents/skills/release-and-publish/SKILL.md
@@ -15,6 +15,7 @@ description: Prepare a PlayBridge release by explicitly requested version uprevs
 | iOS phone | `mobile/apple/PlayBridge Phone/PlayBridge Phone.xcodeproj/project.pbxproj` | `mobile/apple/CHANGELOG.md` |
 | Apple TV | `tv/apple/PlayBridge TV/PlayBridge TV.xcodeproj/project.pbxproj` | `tv/apple/CHANGELOG.md` |
 | Extension | `extension/manifests/chrome.json` | `extension/CHANGELOG.md` |
+| Stream proxy | `stream-proxy-dart/pubspec.yaml` | `stream-proxy-dart/CHANGELOG.md` |
 
 For Desktop, keep `version: <semver>+<build>` and `kAppVersion = '<semver>'` in lockstep. CI checks this in `desktop/test/update_test.dart`.
 

--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.7.0+27] — 2026-07-14
+
+### Added
+- **In-process Stream Proxy Server**: Integrated the `playbridge_stream_proxy` server directly in-process. Runs seamlessly inside the app, handles CORS, and intercepts HLS and DASH manifests to propagate session tokens and prevent `403` errors.
+- **Proxy Mode Configuration**: Adds a Proxy Mode selector in Settings (Off, Auto, Always) to route traffic through loopback for CDNs that block direct player requests.
+- **"Open in External Player" Dialog**: Adds a dialog to easily copy proxied stream URLs, view command lines for `mpv` and `vlc`, or launch them automatically.
+- **HLS Stream Preselection**: Adds an opt-in setting to pre-select HLS media playlists.
+- **Safer extension bridge logging**: Removes Debrid tokens and auth payloads from the logs.
+
 ## [0.6.8+26] — 2026-07-11
 
 ### Fixed

--- a/desktop/lib/update/app_version.dart
+++ b/desktop/lib/update/app_version.dart
@@ -2,7 +2,7 @@
 ///
 /// MUST match `version:` in pubspec.yaml (build-metadata part excluded) —
 /// guarded by `test/update_test.dart` so CI fails if they drift.
-const String kAppVersion = '0.6.8';
+const String kAppVersion = '0.7.0';
 
 /// Dotted numeric version (`0.6.4`, `1.10.2`) with sane comparison semantics.
 ///

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: playbridge_desktop
 description: "PlayBridge desktop receiver — accepts cast commands from the phone and plays via libmpv."
 publish_to: 'none'
-version: 0.6.8+26
+version: 0.7.0+27
 
 environment:
   sdk: ^3.6.0

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.0] — 2026-07-14
+
+### Added
+- **On-Video Cast Overlay**: Adds an intuitive overlay button on top of detected video players to allow casting directly from the page layout.
+- **Improved Casting UX**: Enhances candidate sorting and discovery status feedback on the popup panel.
+
+### Fixed
+- **DASH Segment Candidate Filtering**: Excluded DASH initialization and chunk segments (`init-*.mp4` / `seg-*.mp4`) from ranking to prevent listing duplicate segment file fragments as playable candidates.
+
 ## [0.4.2] — 2026-07-08
 
 ### Fixed

--- a/extension/manifests/chrome.json
+++ b/extension/manifests/chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PlayBridge Video Detector",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Detect and cast browser videos through the PlayBridge desktop app.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtZQGgGin2mHxxXXJOQzUD9RHd5Fv19263KYRWrc5W7l2j8zggs4DXiWp5yqe56klCln3+ZNjNO0uUrU33dbkIQKRfj8hPhibBcCc7E+/+ZTFC1VZ+hry29LlDOLruMA+N7dg0EkdPD5qsHoYq6mhVelG7gpUDwnI/GPQOWezyAvYHFTfuP32cBcrW2lEMG7EZAcpds6rnFrYbGsBs/KACgYcvVGEy653tvGKBb4A2rU2bUv+5ph01sok/HDqVwwMFHHGD+U/LTy5ZGX85mRgmNhKLr/WE8IOdFFxIWzdC7hLtgRDxDiYaj2EOAFWE8v+VHmYvl++X1cDVpzxbV/MvQIDAQAB",
   "icons": {

--- a/extension/manifests/firefox.json
+++ b/extension/manifests/firefox.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "PlayBridge Video Detector",
-    "version": "0.4.2",
+    "version": "0.5.0",
     "description": "Detect and cast browser videos through the PlayBridge desktop app.",
     "icons": {
         "128": "icon.png"

--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11.2] — 2026-07-14 (versionCode 221)
+
+### Fixed
+- **Pairing Security**: Hardened local pairing certificate generation and securely stored private keys from unauthorized local system reads.
+
 ## [0.11.1] — 2026-07-11 (versionCode 220)
 
 ### Fixed

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 220
-        versionName = "0.11.1"
+        versionCode = 221
+        versionName = "0.11.2"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,11 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [0.9.3] — 2026-07-14 (versionCode 223)
+
+### Fixed
+- **TLS Keystore Security**: Hardened pairing certificate keystore credentials and protected private key storage from unauthorized local system reads.
+
 ## Player [0.9.2] — 2026-07-11 (versionCode 222)
 
 ### Changed

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 222
-        versionName = "0.9.2"
+        versionCode = 223
+        versionName = "0.9.3"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
Prepares version uprevs and changelogs for all affected projects since the last release cycle. Desktop is bumped to v0.7.0 (with in-process proxy integration), browser extension is bumped to v0.5.0 (with casting overlays), and Android phone/TV apps are patch uprevved for security fixes.