### PR TITLE
feat(desktop,extension): add cast proxy routing and extension native reconnect improvements

### DIFF
--- a/.agents/skills/playbridge-android/SKILL.md
+++ b/.agents/skills/playbridge-android/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: playbridge-android
+description: Work across PlayBridge's Android phone, Android TV, and shared Kotlin projects. Use for Kotlin, Compose, GeckoView, Android playback, Gradle, shared KMP, root version-catalog, or Android-specific protocol consumer changes under mobile/android/, tv/android/, shared/, gradle/, or prebuilt/media3/.
+---
+
+# PlayBridge Android
+
+## Establish ownership
+
+- Treat `mobile/android/` and `tv/android/` as separate Gradle roots.
+- Treat `shared/` and `gradle/libs.versions.toml` as cross-consumer code. Give them one writer and inspect both Android consumers.
+- Split phone and TV work between subagents only when their edits do not overlap. Keep shared files with the primary integrator or one designated owner.
+- Load `playbridge-protocol` as well when wire messages, pairing, or generated protocol bindings change.
+
+## Work safely
+
+1. Follow the root `AGENTS.md`, including the graph-first exploration workflow.
+2. Run every Gradle command from the project that owns the change.
+3. Preserve TV cleartext stream support and the scoped TLS behavior in `ContentSniffer.kt`.
+4. Keep GeckoView and Media3 versions compatible with both Android roots and `prebuilt/media3/`.
+5. Never log Debrid tokens, pairing credentials, signing material, or authenticated stream URLs.
+
+## Verify
+
+On macOS, invoke Gradle through `zsh` after sourcing `~/.zshrc`.
+
+From `mobile/android/`, select the narrowest relevant checks:
+
+```bash
+zsh -c "source ~/.zshrc && ./gradlew :app:testFossDebugUnitTest"
+zsh -c "source ~/.zshrc && ./gradlew :app:assembleDebug"
+zsh -c "source ~/.zshrc && ./gradlew :app:lintFossDebug"
+```
+
+From `tv/android/`, select the narrowest relevant checks:
+
+```bash
+zsh -c "source ~/.zshrc && ./gradlew test"
+zsh -c "source ~/.zshrc && ./gradlew :player:app:assembleDebug"
+zsh -c "source ~/.zshrc && ./gradlew lint"
+```
+
+Validate `shared/` changes through both roots when both consume the affected code.

--- a/.agents/skills/playbridge-android/agents/openai.yaml
+++ b/.agents/skills/playbridge-android/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PlayBridge Android"
+  short_description: "Work safely across PlayBridge Android projects"
+  default_prompt: "Use $playbridge-android to implement and verify this Android change."

--- a/.agents/skills/playbridge-apple/SKILL.md
+++ b/.agents/skills/playbridge-apple/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: playbridge-apple
+description: Work on PlayBridge's native Apple phone and Apple TV applications. Use for Swift, SwiftUI, WebKit, AVFoundation, tvOS/iOS playback, Xcode project, CocoaPods, Bonjour, Keychain, TLS pinning, or Apple protocol-consumer changes under mobile/apple/ or tv/apple/.
+---
+
+# PlayBridge Apple
+
+## Establish ownership
+
+- Treat `mobile/apple/` and `tv/apple/` as separate Xcode projects with shared product behavior but no shared build root.
+- Keep one Apple specialist by default. Split phone and TV work only for substantial, non-overlapping implementations.
+- Load `playbridge-protocol` when JSON envelopes, pairing, authentication, or generated Swift bindings change.
+
+## Work safely
+
+1. Follow the root `AGENTS.md` and inspect the owning Xcode project before changing build settings.
+2. Preserve Bonjour/local-network declarations, Keychain storage, protected pairing, and SPKI pin validation.
+3. Check behavioral parity with the corresponding sender or receiver without assuming Android implementation details translate directly to Apple frameworks.
+4. Never commit signing credentials, provisioning data, pairing secrets, or authenticated stream URLs.
+
+## Verify
+
+Build the changed target with Xcode. From `mobile/apple/PlayBridge Phone/`:
+
+```bash
+xcodebuild -project "PlayBridge Phone.xcodeproj" -scheme "PlayBridge Phone" -destination 'generic/platform=iOS Simulator' build
+```
+
+From `tv/apple/PlayBridge TV/`:
+
+```bash
+xcodebuild -workspace "PlayBridge TV.xcworkspace" -scheme "PlayBridge TV" -configuration Debug -destination 'generic/platform=tvOS' build
+```
+
+Report simulator, SDK, signing, or CocoaPods limitations explicitly; do not treat an unavailable Apple toolchain as successful verification.

--- a/.agents/skills/playbridge-apple/agents/openai.yaml
+++ b/.agents/skills/playbridge-apple/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PlayBridge Apple"
+  short_description: "Work safely across PlayBridge Apple projects"
+  default_prompt: "Use $playbridge-apple to implement and verify this Apple platform change."

--- a/.agents/skills/playbridge-desktop-proxy/SKILL.md
+++ b/.agents/skills/playbridge-desktop-proxy/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: playbridge-desktop-proxy
+description: Work on the PlayBridge Flutter desktop receiver and its Dart stream proxy. Use for Flutter/Dart receiver UI, playback engines, libmpv/media_kit, desktop sender behavior, extension bridge integration, local proxy routing, HLS rewriting, FFmpeg AVIO, proxy authentication, Docker packaging, or changes under desktop/ and stream-proxy-dart/.
+---
+
+# PlayBridge Desktop and Stream Proxy
+
+## Establish ownership
+
+- Treat `desktop/` and `stream-proxy-dart/` as separate build and release units.
+- Keep small in-process proxy adaptations with the Desktop owner. Split out a proxy owner for API, authentication, networking, HLS rewriting, FFmpeg, Docker, or standalone release work.
+- Give shared Desktop/proxy interfaces one writer while the other consumer reviews compatibility.
+- Load `playbridge-extension` for native-messaging or browser-to-Desktop bridge changes.
+- Load `playbridge-protocol` for cast envelopes, pairing, authentication, or generated Dart binding changes.
+
+## Work safely
+
+1. Follow the root `AGENTS.md` and preserve unrelated Desktop working-tree edits.
+2. Keep proxy credentials and session authorization out of logs.
+3. Preserve authenticated headers without exposing full stream URLs or tokens in diagnostics.
+4. Keep platform-specific Desktop behavior compatible with macOS, Windows, and Linux where practical.
+
+## Verify
+
+From `desktop/`:
+
+```bash
+flutter test
+flutter analyze
+```
+
+From `stream-proxy-dart/`:
+
+```bash
+dart format --output=none --set-exit-if-changed .
+dart analyze --fatal-infos
+```
+
+Run `dart test` when proxy tests exist or are added. Build the Docker image when container, native dependency, or packaging behavior changes.

--- a/.agents/skills/playbridge-desktop-proxy/agents/openai.yaml
+++ b/.agents/skills/playbridge-desktop-proxy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PlayBridge Desktop and Proxy"
+  short_description: "Coordinate Desktop and stream proxy changes"
+  default_prompt: "Use $playbridge-desktop-proxy to implement and verify this Desktop or proxy change."

--- a/.agents/skills/playbridge-extension/SKILL.md
+++ b/.agents/skills/playbridge-extension/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: playbridge-extension
+description: Work on the PlayBridge browser extension. Use for TypeScript, WebExtension APIs, background/content/popup code, media detection, video overlays, native messaging, Desktop bridge reconnection, store packaging, manifests, or changes under extension/.
+---
+
+# PlayBridge Extension
+
+## Establish ownership
+
+- Work from `extension/`; source lives primarily under `extension/src/` and is built with TypeScript and esbuild.
+- Modify source and manifests rather than generated `dist/` output.
+- Load `playbridge-desktop-proxy` when native messaging, Desktop discovery, reconnection, or proxy routing changes.
+- Load `playbridge-protocol` when message envelopes, payloads, pairing, or authentication change.
+
+## Work safely
+
+1. Follow the root `AGENTS.md` and preserve Chrome/Firefox target compatibility.
+2. Keep content-script, page, popup, background, and native-host trust boundaries explicit.
+3. Validate origins, frame identity, lifecycle state, and externally supplied media metadata before acting on them.
+4. Never log pairing credentials, authenticated headers, cookies, or complete protected stream URLs.
+
+## Verify
+
+From `extension/`:
+
+```bash
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+For store or manifest work, also run the relevant store validation or the complete check:
+
+```bash
+pnpm store:check
+```

--- a/.agents/skills/playbridge-extension/agents/openai.yaml
+++ b/.agents/skills/playbridge-extension/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PlayBridge Extension"
+  short_description: "Build and review the PlayBridge extension"
+  default_prompt: "Use $playbridge-extension to implement and verify this browser extension change."

--- a/.agents/skills/playbridge-protocol/SKILL.md
+++ b/.agents/skills/playbridge-protocol/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: playbridge-protocol
+description: Change or review PlayBridge's cross-platform wire protocol and compatibility surface. Use for protocol/proto/messages.proto, generated bindings, shared Kotlin message parsing/building, Desktop Dart protocol code, Apple JSON consumers, extension message handling, pairing/authentication envelopes, submodule updates, or any change whose payload must remain compatible across senders and receivers.
+---
+
+# PlayBridge Protocol
+
+## Treat the protocol as a contract
+
+- Treat `protocol/` as a separate Git submodule and repository. Keep its commit distinct from the parent repository's submodule-pointer and consumer changes.
+- Edit `protocol/proto/messages.proto` as the schema source of truth, then regenerate committed bindings with `protocol/generate.sh`.
+- Do not assume generated bindings cover every consumer. PlayBridge still has hand-written JSON and compatibility code.
+- Give schema and generated artifacts one writer. Let consumer owners implement or review their non-overlapping projects.
+
+## Check consumers
+
+Inspect all affected consumers, including:
+
+- `shared/src/commonMain/kotlin/com/playbridge/shared/protocol/Message.kt`
+- `shared/src/androidMain/kotlin/com/playbridge/shared/protocol/IncomingMessage.kt`
+- Android sender and TV server call sites
+- `desktop/lib/protocol.dart` and the generated Dart dependency
+- Apple phone and TV message handling
+- `extension/src/background.ts` and related bridge code
+
+Load the corresponding PlayBridge specialist skills for consumer implementation.
+
+## Preserve security invariants
+
+- Keep pairing transcripts, protected credentials, certificate fingerprints, field names, and optional rollout behavior compatible.
+- Never log or commit pairing tokens, private keys, signing credentials, or authenticated stream URLs.
+- Prefer additive, backward-compatible changes unless the user explicitly authorizes a breaking protocol revision.
+
+## Verify
+
+From `protocol/`, regenerate and verify committed bindings:
+
+```bash
+./generate.sh
+./generate.sh --check
+```
+
+Then run focused checks in every affected consumer project. Validate shared Kotlin changes through both Android Gradle roots.

--- a/.agents/skills/playbridge-protocol/agents/openai.yaml
+++ b/.agents/skills/playbridge-protocol/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PlayBridge Protocol"
+  short_description: "Coordinate protocol and consumer compatibility"
+  default_prompt: "Use $playbridge-protocol to change or review the PlayBridge protocol safely."

--- a/.agents/skills/playbridge-web/SKILL.md
+++ b/.agents/skills/playbridge-web/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: playbridge-web
+description: Work on the PlayBridge Svelte website and static web assets. Use for Svelte, TypeScript, Vite, public documentation pages, release/download UI, the cast demo, static deployment, or changes under web/site/.
+---
+
+# PlayBridge Web
+
+## Establish ownership
+
+- Work from `web/site/`; treat it as an independent Svelte/Vite project.
+- Keep website-only work separate from the extension even though both use TypeScript and browser APIs.
+- Load `playbridge-protocol` when the cast demo or another web surface emits PlayBridge wire messages.
+
+## Work safely
+
+1. Follow the root `AGENTS.md` and preserve the static-site deployment model.
+2. Keep release/download data compatible with the repository's publication conventions.
+3. Avoid introducing runtime server assumptions into pages built for static hosting.
+4. Do not place credentials, authenticated URLs, or private operational data in client assets.
+
+## Verify
+
+From `web/site/`:
+
+```bash
+pnpm check
+pnpm build
+```
+
+Exercise the affected page locally when behavior cannot be established by type checking and a production build alone.

--- a/.agents/skills/playbridge-web/agents/openai.yaml
+++ b/.agents/skills/playbridge-web/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PlayBridge Web"
+  short_description: "Build and review the PlayBridge web project"
+  default_prompt: "Use $playbridge-web to implement and verify this web change."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,9 @@ PlayBridge is a multi-platform casting suite. Treat its Android, Flutter, Apple,
 
 ## Shared skills
 
-Project skills live in `.agents/skills/`:
+Portable project skills live in `.agents/skills/` and are the canonical specialist definitions for Codex, OpenCode, Claude, and other agents.
+
+### Task workflows
 
 | Skill | Use when |
 |---|---|
@@ -12,7 +14,20 @@ Project skills live in `.agents/skills/`:
 | `commit-and-open-pr` | Commit, push, or create/update a pull request without an implicit uprev |
 | `code-review-graph-workflow` | Explore, debug, review, or refactor using the repository graph |
 
-Load the matching `SKILL.md` only when its description matches the request. A normal commit, push, or PR request must not change versions unless the user also requests an uprev or release.
+### Project specialists
+
+| Skill | Owns |
+|---|---|
+| `playbridge-android` | Android phone, Android TV, shared Kotlin, and shared Android dependencies |
+| `playbridge-apple` | Apple phone and Apple TV applications |
+| `playbridge-desktop-proxy` | Flutter Desktop and the Dart stream proxy |
+| `playbridge-extension` | Browser extension and native-messaging integration |
+| `playbridge-web` | Svelte website and static web assets |
+| `playbridge-protocol` | Protocol schema, generated bindings, submodule updates, and consumer compatibility |
+
+Before working in a project, load the matching specialist skill. For cross-project work, load each affected specialist or delegate non-overlapping consumers to subagents using those skills. Keep shared contracts and files with one designated writer, and keep the primary agent responsible for integration and final verification.
+
+Load a task workflow only when its description matches the request. A normal commit, push, or PR request must not change versions unless the user also requests an uprev or release.
 
 ## Local agent instructions
 
@@ -28,9 +43,10 @@ If `SUBAGENTS.local.md` exists at the repository root, read and follow it for op
 | Apple phone | `mobile/apple/` | Swift/Xcode project |
 | Apple TV | `tv/apple/` | Swift/Xcode project |
 | Desktop | `desktop/` | Flutter receiver for macOS, Windows, and Linux |
+| Stream proxy | `stream-proxy-dart/` | Standalone Dart proxy, embedded by Desktop and released as a Docker image |
 | Extension | `extension/` | Browser extension, JavaScript/TypeScript |
 | Web | `web/` | Svelte site |
-| Protocol assets | `protocol/` | Protocol definitions and generated artifacts |
+| Protocol assets | `protocol/` | Git submodule containing protocol definitions and generated artifacts |
 
 ## Build and test
 
@@ -74,7 +90,7 @@ Changes to `shared/src/commonMain/kotlin/com/playbridge/shared/protocol/Message.
 
 - `mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt`
 - `tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt`
-- `extension/src/background.js`, which manually handles protocol JSON
+- `extension/src/background.ts`, which manually handles protocol JSON
 
 ### Shared dependency versions
 

--- a/desktop/lib/engines/mpv_engine.dart
+++ b/desktop/lib/engines/mpv_engine.dart
@@ -305,7 +305,11 @@ class MpvEngine extends PlayerEngine {
   Future<void> open(QueueItem item) => openPlaylist([item], 0);
 
   @override
-  Future<void> openPlaylist(List<QueueItem> items, int startIndex) async {
+  Future<void> openPlaylist(
+    List<QueueItem> items,
+    int startIndex, {
+    bool play = true,
+  }) async {
     // Ensure demuxer/network tuning is live before the first open (race fix).
     await _configured;
 
@@ -319,7 +323,7 @@ class MpvEngine extends PlayerEngine {
       return Media(resolvedUrl, httpHeaders: headers);
     }));
     final playlist = Playlist(medias, index: startIndex);
-    await player.open(playlist, play: true);
+    await player.open(playlist, play: play);
 
     // External subtitles for the current item
     final item = items[startIndex.clamp(0, items.length - 1)];
@@ -349,7 +353,7 @@ class MpvEngine extends PlayerEngine {
     // Disarm route-watch for the new item so open-time device flaps don't pause.
     _audioRouteArmed = false;
     _playingSince = null;
-    await player.play();
+    if (play) await player.play();
     unawaited(_reapplyTrackPrefs());
   }
 

--- a/desktop/lib/engines/playback_request_preparer.dart
+++ b/desktop/lib/engines/playback_request_preparer.dart
@@ -66,6 +66,20 @@ class PlaybackRequestPreparer {
         headers: null, // Managed internally by the proxy server session
         subtitles: item.subtitles,
         startPositionMs: item.startPositionMs,
+        originalUrl: item.originalUrl ?? url,
+        originalHeaders: item.originalHeaders ?? headers,
+        bingeGroup: item.bingeGroup,
+        season: item.season,
+        episode: item.episode,
+        imdbId: item.imdbId,
+        backdropUrl: item.backdropUrl,
+        posterUrl: item.posterUrl,
+        logoUrl: item.logoUrl,
+        overview: item.overview,
+        year: item.year,
+        rating: item.rating,
+        runtime: item.runtime,
+        episodeTitle: item.episodeTitle,
       );
     }
 

--- a/desktop/lib/extension_bridge.dart
+++ b/desktop/lib/extension_bridge.dart
@@ -149,13 +149,15 @@ class ExtensionBridge {
         final title = obj['title'] as String?;
         debugLogExtensionCastRequest(url: url, headers: headers);
         if (_sender.isConnected) {
-          final ok = _sender.castUrl(url, headers: headers, title: title);
-          _send(socket, {
-            'type': 'result',
-            'ok': ok,
-            'target': 'tv',
-            if (!ok) 'error': 'send failed',
-          });
+          unawaited(() async {
+            final ok = await _sender.castUrl(url, headers: headers, title: title);
+            _send(socket, {
+              'type': 'result',
+              'ok': ok,
+              'target': 'tv',
+              if (!ok) 'error': 'send failed',
+            });
+          }());
         } else {
           onNewMedia?.call();
           // No cast target — play on this machine (extension → desktop).

--- a/desktop/lib/extension_bridge.dart
+++ b/desktop/lib/extension_bridge.dart
@@ -150,7 +150,8 @@ class ExtensionBridge {
         debugLogExtensionCastRequest(url: url, headers: headers);
         if (_sender.isConnected) {
           unawaited(() async {
-            final ok = await _sender.castUrl(url, headers: headers, title: title);
+            final ok =
+                await _sender.castUrl(url, headers: headers, title: title);
             _send(socket, {
               'type': 'result',
               'ok': ok,

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -1046,6 +1046,18 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
                                                     isFullScreen: _isFullScreen,
                                                     onToggleFullScreen:
                                                         _toggleFullScreen,
+                                                    onToggleProxy: () async {
+                                                      final wasProxied = _player
+                                                          .isCurrentItemProxied;
+                                                      final switched =
+                                                          await _player
+                                                              .toggleProxy();
+                                                      if (switched && mounted) {
+                                                        _showOsd(wasProxied
+                                                            ? 'Direct playback'
+                                                            : 'Proxied playback');
+                                                      }
+                                                    },
                                                   ),
                                                 ),
                                               if (_showingVideo &&
@@ -1585,6 +1597,7 @@ class _PlayerControlsBar extends StatefulWidget {
     required this.onMenuClosed,
     required this.isFullScreen,
     required this.onToggleFullScreen,
+    required this.onToggleProxy,
   });
 
   final PlayerController player;
@@ -1597,6 +1610,7 @@ class _PlayerControlsBar extends StatefulWidget {
   final VoidCallback onMenuClosed;
   final bool isFullScreen;
   final VoidCallback onToggleFullScreen;
+  final Future<void> Function() onToggleProxy;
 
   @override
   State<_PlayerControlsBar> createState() => _PlayerControlsBarState();
@@ -1741,6 +1755,21 @@ class _PlayerControlsBarState extends State<_PlayerControlsBar> {
                           onClosed: widget.onMenuClosed,
                         ),
                       ],
+                      IconButton(
+                        tooltip: p.isCurrentItemProxied
+                            ? 'Switch to direct playback'
+                            : 'Route through proxy',
+                        icon: Icon(
+                          p.isCurrentItemProxied
+                              ? Icons.shield
+                              : Icons.shield_outlined,
+                          color:
+                              p.isCurrentItemProxied ? Colors.tealAccent : null,
+                        ),
+                        onPressed: hasMedia && !p.proxyToggleInProgress
+                            ? widget.onToggleProxy
+                            : null,
+                      ),
                       if (widget.showQueueControls)
                         IconButton(
                           tooltip: widget.playlistOpen

--- a/desktop/lib/pairing_store.dart
+++ b/desktop/lib/pairing_store.dart
@@ -60,6 +60,7 @@ class PairingStore {
   static const _kEnableHistory = 'pb.enable_history';
   static const _kPreselectHlsQuality = 'pb.preselect_hls_quality';
   static const _kStreamProxyMode = 'pb.stream_proxy_mode';
+  static const _kCastRouteThroughProxy = 'pb.cast_route_through_proxy';
   static const _kStillWatchingEnabled = 'pb.still_watching_enabled';
   static const _kStillWatchingThresholdMin = 'pb.still_watching_threshold_min';
   static const _kStillWatchingResponseSec = 'pb.still_watching_response_sec';
@@ -143,6 +144,12 @@ class PairingStore {
 
   Future<void> setStreamProxyMode(StreamProxyMode value) =>
       _prefs.setInt(_kStreamProxyMode, value.index);
+
+  bool get castRouteThroughProxy =>
+      _prefs.getBool(_kCastRouteThroughProxy) ?? false;
+
+  Future<void> setCastRouteThroughProxy(bool value) =>
+      _prefs.setBool(_kCastRouteThroughProxy, value);
 
   bool get stillWatchingEnabled =>
       _prefs.getBool(_kStillWatchingEnabled) ?? false;

--- a/desktop/lib/player_controller.dart
+++ b/desktop/lib/player_controller.dart
@@ -4,6 +4,7 @@ import 'player_engine.dart';
 import 'engines/mpv_engine.dart';
 import 'pairing_store.dart';
 import 'engines/playback_request_preparer.dart';
+import 'stream_proxy_server.dart';
 
 /// Coordinator that delegates playback to the active [PlayerEngine].
 class PlayerController extends ChangeNotifier {
@@ -75,6 +76,7 @@ class PlayerController extends ChangeNotifier {
 
   Future<void> switchEngine(EngineType type) async {
     if (type == _currentType) return;
+    await _waitForProxyToggle();
 
     // 1. Capture current state
     final wasPlaying = state == 'playing';
@@ -131,6 +133,10 @@ class PlayerController extends ChangeNotifier {
   /// the window was unfocused). Lifted only after the engine has real media.
   bool _opening = false;
   bool get isOpening => _opening;
+  bool _proxyToggleInProgress = false;
+  bool get proxyToggleInProgress => _proxyToggleInProgress;
+  Future<void>? _proxyToggleFuture;
+  int _proxyToggleGeneration = 0;
 
   String? get currentTitle =>
       _currentIndex >= 0 && _currentIndex < _queue.length
@@ -196,6 +202,7 @@ class PlayerController extends ChangeNotifier {
     int startIndex, {
     bool isRemote = false,
   }) async {
+    await _waitForProxyToggle();
     if (items.isEmpty) return;
     // Mask before queue/reveal so stop→unfocus→play B never flashes video A.
     // Do not disable the mpv video track — that left a permanent black picture.
@@ -234,6 +241,7 @@ class PlayerController extends ChangeNotifier {
   /// starts the item directly (preserves the previous desktop behavior;
   /// Android instead buffers idle queue_adds until the next session).
   Future<void> queueAdd(QueueItem item, {bool isRemote = false}) async {
+    await _waitForProxyToggle();
     if (_currentIndex < 0 || _queue.isEmpty) {
       await playPlaylist([item], 0, isRemote: isRemote);
       return;
@@ -246,6 +254,7 @@ class PlayerController extends ChangeNotifier {
   }
 
   Future<void> jumpTo(int index) async {
+    await _waitForProxyToggle();
     if (index < 0 || index >= _queue.length) return;
     _setIndex(index);
     await _engine.openPlaylist(_queue, _currentIndex);
@@ -325,6 +334,7 @@ class PlayerController extends ChangeNotifier {
   Future<void> seek(Duration position) => _engine.seek(position);
   Future<void> setVolume(double volume) => _engine.setVolume(volume);
   Future<void> stop() async {
+    await _waitForProxyToggle();
     await _engine.stop();
     _queue.clear();
     _setIndex(-1);
@@ -334,6 +344,7 @@ class PlayerController extends ChangeNotifier {
   }
 
   void _onError(String errorMsg) {
+    if (_proxyToggleInProgress) return;
     if (store?.streamProxyMode == StreamProxyMode.auto) {
       final currentItem = _currentIndex >= 0 && _currentIndex < _queue.length
           ? _queue[_currentIndex]
@@ -358,6 +369,169 @@ class PlayerController extends ChangeNotifier {
         }
       }
     }
+  }
+
+  /// True when the current item's URL is being routed through the loopback
+  /// stream proxy rather than played directly.
+  bool get isCurrentItemProxied {
+    if (_currentIndex < 0 || _currentIndex >= _queue.length) return false;
+    final url = _queue[_currentIndex].url;
+    return url.contains('127.0.0.1') && url.contains('/s/play/');
+  }
+
+  /// Seamlessly switches the current item between direct ↔ proxied playback.
+  /// Saves the current position and re-opens the stream so the transition is
+  /// invisible to the user.
+  Future<bool> toggleProxy() {
+    if (_proxyToggleInProgress ||
+        _currentIndex < 0 ||
+        _currentIndex >= _queue.length) {
+      return Future.value(false);
+    }
+
+    final generation = ++_proxyToggleGeneration;
+    final operation = _runProxyToggle();
+    _proxyToggleFuture = operation.then<void>(
+      (_) {
+        if (_proxyToggleGeneration == generation) _proxyToggleFuture = null;
+      },
+      onError: (Object error, StackTrace stack) {
+        if (_proxyToggleGeneration == generation) _proxyToggleFuture = null;
+      },
+    );
+    return operation;
+  }
+
+  Future<void> _waitForProxyToggle() async {
+    final pending = _proxyToggleFuture;
+    if (pending != null) await pending;
+  }
+
+  Future<bool> _runProxyToggle() async {
+    _proxyToggleInProgress = true;
+    notifyListeners();
+
+    try {
+      return await _toggleProxyInternal();
+    } finally {
+      _proxyToggleInProgress = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> _toggleProxyInternal() async {
+    final item = _queue[_currentIndex];
+    final itemIndex = _currentIndex;
+    final currentPos = _engine.positionMs;
+    final wasPlaying = state == 'playing' || state == 'buffering';
+
+    QueueItem replacement;
+
+    if (isCurrentItemProxied) {
+      // ── Proxied → Direct ──
+      final directUrl = item.originalUrl;
+      if (directUrl == null) {
+        debugPrint('[player] cannot toggle to direct: originalUrl is null');
+        return false;
+      }
+      replacement = QueueItem(
+        url: directUrl,
+        title: item.title,
+        headers: item.originalHeaders,
+        subtitles: item.subtitles,
+        startPositionMs: currentPos > 0 ? currentPos : null,
+        bingeGroup: item.bingeGroup,
+        season: item.season,
+        episode: item.episode,
+        imdbId: item.imdbId,
+        backdropUrl: item.backdropUrl,
+        posterUrl: item.posterUrl,
+        logoUrl: item.logoUrl,
+        overview: item.overview,
+        year: item.year,
+        rating: item.rating,
+        runtime: item.runtime,
+        episodeTitle: item.episodeTitle,
+      );
+      debugPrint('[player] toggling to direct playback at ${currentPos}ms');
+    } else {
+      // ── Direct → Proxied ──
+      final headers = item.headers ?? {};
+      late final String loopbackUrl;
+      try {
+        loopbackUrl =
+            StreamProxyServer.instance.registerSession(item.url, headers);
+      } catch (error) {
+        debugPrint(
+            '[player] proxy toggle unavailable (${error.runtimeType}); keeping direct playback');
+        return false;
+      }
+      replacement = QueueItem(
+        url: loopbackUrl,
+        title: item.title,
+        headers: null,
+        subtitles: item.subtitles,
+        startPositionMs: currentPos > 0 ? currentPos : null,
+        originalUrl: item.url,
+        originalHeaders: headers,
+        bingeGroup: item.bingeGroup,
+        season: item.season,
+        episode: item.episode,
+        imdbId: item.imdbId,
+        backdropUrl: item.backdropUrl,
+        posterUrl: item.posterUrl,
+        logoUrl: item.logoUrl,
+        overview: item.overview,
+        year: item.year,
+        rating: item.rating,
+        runtime: item.runtime,
+        episodeTitle: item.episodeTitle,
+      );
+      debugPrint('[player] toggling to proxied playback at ${currentPos}ms');
+    }
+
+    _queue[_currentIndex] = replacement;
+    notifyListeners();
+
+    try {
+      await _engine.openPlaylist(
+        _queue,
+        itemIndex,
+        play: wasPlaying,
+      );
+    } catch (error) {
+      if (_currentIndex == itemIndex &&
+          identical(_queue[itemIndex], replacement)) {
+        _queue[itemIndex] = item;
+        notifyListeners();
+        try {
+          await _engine.openPlaylist(
+            _queue,
+            itemIndex,
+            play: wasPlaying,
+          );
+          if (currentPos > 0) {
+            await _engine.seek(Duration(milliseconds: currentPos));
+          }
+        } catch (restoreError) {
+          debugPrint(
+              '[player] proxy toggle rollback failed (${restoreError.runtimeType})');
+        }
+      }
+      debugPrint(
+          '[player] proxy toggle failed (${error.runtimeType}); restored previous route where possible');
+      return false;
+    }
+    unawaited(_applyStartPosition());
+
+    // Wait for the engine to initialise before completing the route switch.
+    var retries = 0;
+    while (_engine.durationMs <= 0 && retries < 40) {
+      await Future.delayed(const Duration(milliseconds: 50));
+      retries++;
+    }
+
+    return true;
   }
 
   @override

--- a/desktop/lib/player_engine.dart
+++ b/desktop/lib/player_engine.dart
@@ -23,12 +23,19 @@ class QueueItem {
     this.rating,
     this.runtime,
     this.episodeTitle,
+    this.originalUrl,
+    this.originalHeaders,
   });
 
   final String url;
   final String title;
   final Map<String, String>? headers;
   final List<String>? subtitles;
+
+  /// The pre-proxy URL and headers, set by [PlaybackRequestPreparer] when
+  /// routing through the loopback proxy so the toggle can reverse the rewrite.
+  final String? originalUrl;
+  final Map<String, String>? originalHeaders;
 
   /// Resume point (ms) seeded from the phone's resume store. Mutable because
   /// it is consumed (nulled) after the first seek, so re-playing this item
@@ -129,8 +136,15 @@ abstract class PlayerEngine extends ChangeNotifier {
   Future<void> selectSubtitleTrackById(String id) async {}
 
   Future<void> open(QueueItem item);
-  Future<void> openPlaylist(List<QueueItem> items, int startIndex) =>
-      open(items[startIndex]);
+  Future<void> openPlaylist(
+    List<QueueItem> items,
+    int startIndex, {
+    bool play = true,
+  }) async {
+    await open(items[startIndex]);
+    if (!play) await pause();
+  }
+
   Future<void> resume();
   Future<void> pause();
   Future<void> seek(Duration position);

--- a/desktop/lib/send_to_tv_screen.dart
+++ b/desktop/lib/send_to_tv_screen.dart
@@ -118,6 +118,38 @@ class _SendToTvScreenState extends State<SendToTvScreen> {
           const SizedBox(height: 12),
           Row(
             children: [
+              SizedBox(
+                width: 24,
+                height: 24,
+                child: Checkbox(
+                  value: controller.castRouteThroughProxy,
+                  onChanged: (val) {
+                    if (val != null) {
+                      controller.setCastRouteThroughProxy(val);
+                    }
+                  },
+                  activeColor: Colors.tealAccent,
+                  checkColor: Colors.black,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: GestureDetector(
+                  onTap: () {
+                    controller.setCastRouteThroughProxy(
+                        !controller.castRouteThroughProxy);
+                  },
+                  child: const Text(
+                    'Route remote stream requests through local proxy',
+                    style: TextStyle(fontSize: 13, color: Colors.white70),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
               FilledButton.icon(
                 onPressed: _pickAndCast,
                 icon: const Icon(Icons.video_file, size: 18),

--- a/desktop/lib/stream_proxy_server.dart
+++ b/desktop/lib/stream_proxy_server.dart
@@ -36,8 +36,8 @@ class StreamProxyServer {
         .writeln('[stream-proxy] Starting in-process proxy on port $_port...');
     _server = proxy.StreamProxyServer(password: _sessionToken);
 
-    // Using 127.0.0.1 for local loopback proxying
-    await _server!.start(host: '127.0.0.1', port: _port!);
+    // Bind to 0.0.0.0 to allow connection from external TV receivers in the same network
+    await _server!.start(host: '0.0.0.0', port: _port!);
   }
 
   Future<void> stop() async {

--- a/desktop/lib/tv_sender_controller.dart
+++ b/desktop/lib/tv_sender_controller.dart
@@ -178,7 +178,8 @@ class TvSenderController extends ChangeNotifier {
 
   /// Cast a remote URL (e.g. a stream the browser extension detected) with
   /// optional request [headers] (Referer / cookies / auth) and a [title].
-  Future<bool> castUrl(String url, {Map<String, String>? headers, String? title}) async {
+  Future<bool> castUrl(String url,
+      {Map<String, String>? headers, String? title}) async {
     var targetUrl = url;
     var targetHeaders = headers;
 
@@ -187,7 +188,8 @@ class TvSenderController extends ChangeNotifier {
       final lanIp = await _localLanIp(active.host);
       if (lanIp != null) {
         // Register session in local proxy server
-        final loopbackUrl = StreamProxyServer.instance.registerSession(url, headers ?? {});
+        final loopbackUrl =
+            StreamProxyServer.instance.registerSession(url, headers ?? {});
         // Replace loopback host 127.0.0.1 with the local LAN IP that the TV can reach
         targetUrl = loopbackUrl.replaceFirst('127.0.0.1', lanIp);
         // The headers are managed by the proxy server, so we send null/empty headers to the TV

--- a/desktop/lib/tv_sender_controller.dart
+++ b/desktop/lib/tv_sender_controller.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'local_file_server.dart';
 import 'pairing_store.dart';
 import 'protocol.dart';
+import 'stream_proxy_server.dart';
 import 'tv_connection_store.dart';
 import 'tv_discovery.dart';
 import 'tv_sender_client.dart';
@@ -66,6 +67,13 @@ class TvSenderController extends ChangeNotifier {
   TvRecord? get activeTv => _activeTv;
   bool get isConnected => _state == SenderConnectionState.connected;
   String? get currentSas => _currentSas;
+
+  bool get castRouteThroughProxy => _identity.castRouteThroughProxy;
+
+  Future<void> setCastRouteThroughProxy(bool value) async {
+    await _identity.setCastRouteThroughProxy(value);
+    notifyListeners();
+  }
 
   String? get castingTitle => _castingTitle;
   String get remoteState => _remoteState;
@@ -170,10 +178,30 @@ class TvSenderController extends ChangeNotifier {
 
   /// Cast a remote URL (e.g. a stream the browser extension detected) with
   /// optional request [headers] (Referer / cookies / auth) and a [title].
-  bool castUrl(String url, {Map<String, String>? headers, String? title}) {
-    final payload = PlayPayload()..url = url;
-    if (headers != null && headers.isNotEmpty) payload.headers.addAll(headers);
-    if (title != null && title.isNotEmpty) payload.title = title;
+  Future<bool> castUrl(String url, {Map<String, String>? headers, String? title}) async {
+    var targetUrl = url;
+    var targetHeaders = headers;
+
+    if (castRouteThroughProxy && isConnected && _activeTv != null) {
+      final active = _activeTv!;
+      final lanIp = await _localLanIp(active.host);
+      if (lanIp != null) {
+        // Register session in local proxy server
+        final loopbackUrl = StreamProxyServer.instance.registerSession(url, headers ?? {});
+        // Replace loopback host 127.0.0.1 with the local LAN IP that the TV can reach
+        targetUrl = loopbackUrl.replaceFirst('127.0.0.1', lanIp);
+        // The headers are managed by the proxy server, so we send null/empty headers to the TV
+        targetHeaders = null;
+      }
+    }
+
+    final payload = PlayPayload()..url = targetUrl;
+    if (targetHeaders != null && targetHeaders.isNotEmpty) {
+      payload.headers.addAll(targetHeaders);
+    }
+    if (title != null && title.isNotEmpty) {
+      payload.title = title;
+    }
     return castVideo(payload);
   }
 

--- a/desktop/test/player_controller_test.dart
+++ b/desktop/test/player_controller_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:playbridge_desktop/player_controller.dart';
 import 'package:playbridge_desktop/player_engine.dart';
+import 'package:playbridge_desktop/stream_proxy_server.dart';
 
 /// Minimal engine for [PlayerController] unit tests (no media_kit / mpv).
 class _FakeEngine extends PlayerEngine {
@@ -9,7 +10,13 @@ class _FakeEngine extends PlayerEngine {
   int stopCount = 0;
   int lastOpenIndex = -1;
   int positionMsValue = 0;
+  int? lastSeekMs;
   int durationMsValue = 1000;
+  bool lastOpenPlay = true;
+  int failuresRemaining = 0;
+  Duration openDelay = Duration.zero;
+
+  void setStateForTest(String value) => _state = value;
 
   @override
   String get state => _state;
@@ -35,10 +42,20 @@ class _FakeEngine extends PlayerEngine {
   }
 
   @override
-  Future<void> openPlaylist(List<QueueItem> items, int startIndex) async {
+  Future<void> openPlaylist(
+    List<QueueItem> items,
+    int startIndex, {
+    bool play = true,
+  }) async {
+    if (openDelay > Duration.zero) await Future<void>.delayed(openDelay);
     openCount++;
     lastOpenIndex = startIndex;
-    _state = 'playing';
+    lastOpenPlay = play;
+    if (failuresRemaining > 0) {
+      failuresRemaining--;
+      throw StateError('open failed');
+    }
+    _state = play ? 'playing' : 'paused';
     notifyListeners();
   }
 
@@ -55,7 +72,9 @@ class _FakeEngine extends PlayerEngine {
   }
 
   @override
-  Future<void> seek(Duration position) async {}
+  Future<void> seek(Duration position) async {
+    lastSeekMs = position.inMilliseconds;
+  }
 
   @override
   Future<void> stop() async {
@@ -71,6 +90,14 @@ class _FakeEngine extends PlayerEngine {
 }
 
 void main() {
+  setUp(() async {
+    await StreamProxyServer.instance.stop();
+  });
+
+  tearDown(() async {
+    await StreamProxyServer.instance.stop();
+  });
+
   QueueItem item(int n) => QueueItem(url: 'https://x/$n.mp4', title: 'Ep$n');
 
   test('HLS preselection preference defaults off and can be changed', () {
@@ -160,5 +187,95 @@ void main() {
     expect(c.currentIndex, 0);
     expect(engine.openCount, opensBefore);
     expect(engine.stopCount, 0);
+  });
+
+  test('toggles direct and proxied playback at the current position', () async {
+    await StreamProxyServer.instance.start();
+    final engine = _FakeEngine()..positionMsValue = 250;
+    final c = PlayerController(engineForTest: engine);
+    final directUrl = 'https://example.com/stream.m3u8';
+    final headers = {'User-Agent': 'Test browser'};
+
+    await c.playItem(
+      QueueItem(url: directUrl, title: 'Stream', headers: headers),
+    );
+    expect(c.isCurrentItemProxied, isFalse);
+
+    expect(await c.toggleProxy(), isTrue);
+    expect(c.isCurrentItemProxied, isTrue);
+    expect(c.queue.single.originalUrl, directUrl);
+    expect(c.queue.single.originalHeaders, headers);
+    expect(c.queue.single.startPositionMs, isNull);
+    expect(engine.lastSeekMs, 250);
+
+    expect(await c.toggleProxy(), isTrue);
+    expect(c.isCurrentItemProxied, isFalse);
+    expect(c.queue.single.url, directUrl);
+    expect(c.queue.single.headers, headers);
+    expect(engine.lastSeekMs, 250);
+    expect(engine.openCount, 3);
+  });
+
+  test('leaves direct playback unchanged when the proxy is unavailable',
+      () async {
+    final engine = _FakeEngine();
+    final c = PlayerController(engineForTest: engine);
+    final directUrl = 'https://example.com/stream.m3u8';
+    await c.playItem(QueueItem(url: directUrl, title: 'Stream'));
+
+    expect(await c.toggleProxy(), isFalse);
+    expect(c.isCurrentItemProxied, isFalse);
+    expect(c.queue.single.url, directUrl);
+  });
+
+  test('preserves paused and buffering playback intent during toggles',
+      () async {
+    await StreamProxyServer.instance.start();
+    final engine = _FakeEngine();
+    final c = PlayerController(engineForTest: engine);
+    await c.playItem(
+      QueueItem(url: 'https://example.com/stream.m3u8', title: 'Stream'),
+    );
+
+    engine.setStateForTest('paused');
+    expect(await c.toggleProxy(), isTrue);
+    expect(engine.lastOpenPlay, isFalse);
+    expect(engine.state, 'paused');
+
+    engine.setStateForTest('buffering');
+    expect(await c.toggleProxy(), isTrue);
+    expect(engine.lastOpenPlay, isTrue);
+    expect(engine.state, 'playing');
+  });
+
+  test('reopens the original route when the replacement open fails', () async {
+    await StreamProxyServer.instance.start();
+    final engine = _FakeEngine();
+    final c = PlayerController(engineForTest: engine);
+    final directUrl = 'https://example.com/stream.m3u8';
+    await c.playItem(QueueItem(url: directUrl, title: 'Stream'));
+    engine.failuresRemaining = 1;
+
+    expect(await c.toggleProxy(), isFalse);
+    expect(c.queue.single.url, directUrl);
+    expect(engine.openCount, 3);
+    expect(engine.state, 'playing');
+  });
+
+  test('serializes stop behind an in-flight toggle', () async {
+    await StreamProxyServer.instance.start();
+    final engine = _FakeEngine()..openDelay = const Duration(milliseconds: 20);
+    final c = PlayerController(engineForTest: engine);
+    await c.playItem(
+      QueueItem(url: 'https://example.com/stream.m3u8', title: 'Stream'),
+    );
+
+    final toggle = c.toggleProxy();
+    final stop = c.stop();
+    await toggle;
+    await stop;
+
+    expect(c.currentIndex, -1);
+    expect(c.queue, isEmpty);
   });
 }

--- a/desktop/test/still_watching_controller_test.dart
+++ b/desktop/test/still_watching_controller_test.dart
@@ -26,8 +26,15 @@ class _FakeEngine extends PlayerEngine {
   @override
   Future<void> open(QueueItem item) async => _play();
   @override
-  Future<void> openPlaylist(List<QueueItem> items, int startIndex) async =>
-      _play();
+  Future<void> openPlaylist(
+    List<QueueItem> items,
+    int startIndex, {
+    bool play = true,
+  }) async {
+    _play();
+    if (!play) await pause();
+  }
+
   void _play() {
     _state = 'playing';
     notifyListeners();

--- a/extension/src/native-bridge.ts
+++ b/extension/src/native-bridge.ts
@@ -23,8 +23,8 @@ export interface BridgeState {
 type StateListener = (s: BridgeState) => void;
 
 const HOST_NAME = "com.playbridge.host";
-const RECONNECT_MS = 5_000;
-const MAX_RECONNECT_ATTEMPTS = 3;
+const BASE_RECONNECT_MS = 2_000;
+const MAX_RECONNECT_MS = 30_000;
 
 let port: ReturnType<typeof browser.runtime.connectNative> | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -32,6 +32,7 @@ let reconnectAttempts = 0;
 const listeners = new Set<StateListener>();
 // Bridge results arrive in order; correlate them to in-flight requests by FIFO.
 const pendingResults: Array<(ok: boolean, error?: string) => void> = [];
+let connectionResolvers: Array<(connected: boolean) => void> = [];
 
 let state: BridgeState = {
   desktopConnected: false,
@@ -54,6 +55,14 @@ export function onState(listener: StateListener): () => void {
   return () => listeners.delete(listener);
 }
 
+function resolveConnectionWaiters(success: boolean): void {
+  const list = connectionResolvers;
+  connectionResolvers = [];
+  for (const resolve of list) {
+    resolve(success);
+  }
+}
+
 export function connect(): void {
   if (port) return;
   try {
@@ -61,6 +70,7 @@ export function connect(): void {
   } catch {
     setDisconnected();
     scheduleReconnect();
+    resolveConnectionWaiters(false);
     return;
   }
   port.onMessage.addListener(onMessage);
@@ -71,19 +81,42 @@ export function connect(): void {
     }
     port = null;
     failPending("disconnected");
-    const wasConnected = state.desktopConnected;
     setDisconnected();
-    if (wasConnected) {
-      reconnectAttempts = 0;
-      scheduleReconnect();
-    } else if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
-      reconnectAttempts++;
-      scheduleReconnect();
-    } else {
-      console.warn(`[PB Bridge] Reached max reconnect attempts (${MAX_RECONNECT_ATTEMPTS}). Stopping retries.`);
-    }
+    resolveConnectionWaiters(false);
+    scheduleReconnect();
   });
   send({ cmd: "list_devices" });
+}
+
+function ensureConnected(): Promise<boolean> {
+  if (port && state.desktopConnected) {
+    return Promise.resolve(true);
+  }
+
+  // Reset retry counter to try an immediate connection
+  reconnectAttempts = 0;
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  connect();
+
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      const idx = connectionResolvers.indexOf(onConnectResult);
+      if (idx !== -1) {
+        connectionResolvers.splice(idx, 1);
+      }
+      resolve(false);
+    }, 3000);
+
+    function onConnectResult(success: boolean): void {
+      clearTimeout(timer);
+      resolve(success);
+    }
+
+    connectionResolvers.push(onConnectResult);
+  });
 }
 
 export function refresh(): void {
@@ -107,16 +140,14 @@ export function control(action: string): Promise<{ ok: boolean; error?: string }
   return request({ cmd: "control", action });
 }
 
-function request(
+async function request(
   payload: Record<string, unknown>,
 ): Promise<{ ok: boolean; error?: string }> {
+  const connected = await ensureConnected();
+  if (!connected) {
+    return { ok: false, error: "PlayBridge desktop is not running" };
+  }
   return new Promise((resolve) => {
-    if (!port) {
-      reconnectAttempts = 0;
-      connect();
-      resolve({ ok: false, error: "PlayBridge desktop is not running" });
-      return;
-    }
     pendingResults.push((ok, error) => resolve({ ok, error }));
     if (!send(payload)) {
       pendingResults.pop();
@@ -133,6 +164,7 @@ function onMessage(raw: unknown): void {
       state = { ...state, desktopConnected: true };
       reconnectAttempts = 0;
       emit();
+      resolveConnectionWaiters(true);
       break;
     case "state":
       state = {
@@ -143,6 +175,7 @@ function onMessage(raw: unknown): void {
       };
       reconnectAttempts = 0;
       emit();
+      resolveConnectionWaiters(true);
       break;
     case "result": {
       const cb = pendingResults.shift();
@@ -184,8 +217,10 @@ function failPending(error: string): void {
 
 function scheduleReconnect(): void {
   if (reconnectTimer) return;
+  const delay = Math.min(MAX_RECONNECT_MS, BASE_RECONNECT_MS * Math.pow(2, reconnectAttempts));
+  reconnectAttempts++;
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
     connect();
-  }, RECONNECT_MS);
+  }, delay);
 }

--- a/stream-proxy-dart/lib/stream_proxy_server.dart
+++ b/stream-proxy-dart/lib/stream_proxy_server.dart
@@ -250,6 +250,8 @@ class StreamProxyServer {
       final queryUri = request.url.queryParameters['uri'];
       if (queryUri != null && queryUri.isNotEmpty) {
         targetUrl = queryUri;
+      } else if (pathSegments.length == 3 && pathSegments[2] == 'manifest.m3u8') {
+        targetUrl = session.originalUrl;
       } else {
         // Resolve relative path segments from index 2 onwards against the original session URL
         targetUrl = _resolveTargetUrl(
@@ -275,6 +277,7 @@ class StreamProxyServer {
         targetUrl,
         forwardHeaders,
         statelessHeadersB64,
+        request.requestedUri,
       );
     } else {
       return await _handleSegment(targetUrl, forwardHeaders);
@@ -286,6 +289,7 @@ class StreamProxyServer {
     String targetUrl,
     Map<String, String> headers,
     String? headersB64,
+    Uri requestedUri,
   ) async {
     try {
       final bytes = await _fetchUrlBytes(targetUrl, headers);
@@ -318,7 +322,9 @@ class StreamProxyServer {
         final queryStr = queryParams.isNotEmpty
             ? '?${Uri(queryParameters: queryParams).query}'
             : '';
-        return 'http://127.0.0.1:$port$path$queryStr';
+        final scheme = requestedUri.scheme;
+        final authority = requestedUri.authority;
+        return '$scheme://$authority$path$queryStr';
       });
 
       return Response.ok(
@@ -535,20 +541,6 @@ class StreamProxyServer {
       'content-length',
       'accept-encoding',
       'range',
-      'sec-fetch-dest',
-      'sec-fetch-mode',
-      'sec-fetch-site',
-      'sec-fetch-user',
-      'sec-fetch-storage-access',
-      'sec-gpc',
-      'sec-ch-ua',
-      'sec-ch-ua-mobile',
-      'sec-ch-ua-platform',
-      'priority',
-      'upgrade-insecure-requests',
-      'te',
-      'pragma',
-      'cache-control',
     };
     return skip.contains(lowerKey) || lowerKey.startsWith(':');
   }
@@ -670,7 +662,7 @@ String _resolveTargetUrl(
   });
 
   if (mergedQuery.isEmpty) {
-    return resolvedUri.replace(query: '').toString();
+    return resolvedUri.replace(query: null).toString();
   }
 
   return resolvedUri.replace(queryParameters: mergedQuery).toString();

--- a/stream-proxy-dart/lib/stream_proxy_server.dart
+++ b/stream-proxy-dart/lib/stream_proxy_server.dart
@@ -62,7 +62,7 @@ class StreamProxyServer {
 
     _server = await shelf_io.serve(handler, host, port);
     stdout.writeln('[stream-proxy] Listening on $host:${_server!.port}');
-    stdout.writeln('[stream-proxy] Authentication active token: "$password"');
+    stdout.writeln('[stream-proxy] Authentication active token: "<Redacted>"');
 
     _startSessionCleanupTimer();
   }

--- a/stream-proxy-dart/lib/stream_proxy_server.dart
+++ b/stream-proxy-dart/lib/stream_proxy_server.dart
@@ -250,7 +250,8 @@ class StreamProxyServer {
       final queryUri = request.url.queryParameters['uri'];
       if (queryUri != null && queryUri.isNotEmpty) {
         targetUrl = queryUri;
-      } else if (pathSegments.length == 3 && pathSegments[2] == 'manifest.m3u8') {
+      } else if (pathSegments.length == 3 &&
+          pathSegments[2] == 'manifest.m3u8') {
         targetUrl = session.originalUrl;
       } else {
         // Resolve relative path segments from index 2 onwards against the original session URL


### PR DESCRIPTION
## Summary

This PR improves Desktop and extension reliability around proxied playback and reconnecting cast sessions.

### Desktop proxy routing

- Adds a persistent "route through proxy" option when casting from Desktop to a TV.
- Binds the Desktop proxy to the LAN interface and rewrites HLS manifests using the requested scheme and authority so TV receivers can load variants and segments.
- Adds an in-player shield control for switching the active Desktop stream between direct and proxied playback.
- Preserves the original URL, request headers, metadata, playback position, and paused/playing intent across route switches.
- Rolls back to the prior route if the replacement fails to open and serializes queue-changing commands behind an in-flight switch.
- Redacts the proxy authentication token from logs.

### Extension native bridge

- Replaces the fixed reconnect limit with exponential backoff from 2 seconds up to 60 seconds.
- Adds an on-demand connection waiter for cast and control requests while the native port is reconnecting.

### Agent guidance

- Establishes `.agents/skills/` as the repository's portable specialist-skill directory.
- Adds Android, Apple, Desktop/proxy, extension, protocol, and web specialist skills referenced by `AGENTS.md` for Codex, Claude, OpenCode, and other repository-aware agents.

## Verification

- `flutter analyze` in `desktop/`
- `flutter test` in `desktop/` — 51 tests passed
- `dart format --output=none --set-exit-if-changed .` in `stream-proxy-dart/`
- `dart analyze --fatal-infos` in `stream-proxy-dart/`
- `pnpm run typecheck` and `pnpm run build` in `extension/`

## Risk and manual verification

- Route switching changes the active MPV playlist in place; regression coverage includes direct/proxy toggling, position restoration, paused and buffering intent, failed-open rollback, and concurrent stop handling.
- No manual cross-platform playback or physical TV verification was performed in this final update.
