### PR TITLE
Slim stream-proxy Debian runtime image

### DIFF
--- a/stream-proxy-dart/Dockerfile
+++ b/stream-proxy-dart/Dockerfile
@@ -14,13 +14,15 @@ COPY . .
 RUN mkdir -p build && dart compile exe bin/stream_proxy.dart -o build/pb-proxy
 
 # Stage 2: Final minimal run container
-FROM debian:stable-slim
+# Pin Debian so the FFmpeg library ABI remains aligned with the FFI loader.
+FROM debian:13-slim
 
 WORKDIR /app
 
-# Install system dependencies including FFmpeg (which installs libavformat libraries for FFI fallback)
+# Install only the FFmpeg runtime library used by the AVIO FFI fallback.
+# libavformat61 pulls in libavutil and its other runtime dependencies.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ffmpeg libavformat-dev ca-certificates && \
+    apt-get install -y --no-install-recommends ca-certificates libavformat61 && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy the compiled native binary from Stage 1

--- a/stream-proxy-dart/README.md
+++ b/stream-proxy-dart/README.md
@@ -26,7 +26,7 @@ The easiest way to run the stream proxy on a home server (Raspberry Pi, NAS, VPS
 
 ### 1. Prerequisites
 - Docker and Docker Compose installed.
-- Note: The Docker image automatically installs `ffmpeg` and `libavformat-dev` dependencies, enabling the **AVIO FFI fallback out-of-the-box** inside the container.
+- Note: The Docker image installs the `libavformat` runtime and its dependencies, enabling the **AVIO FFI fallback out-of-the-box** without the FFmpeg CLI or development packages.
 
 ### 2. Startup
 To start the proxy, simply run:


### PR DESCRIPTION
## Summary
- pin the runtime image to Debian 13 for the FFmpeg ABI used by the Dart FFI loader
- install only the libavformat runtime instead of the FFmpeg CLI and development packages
- update the Docker documentation

## Verification
- Dart format and analyze pass
- ARM64 image builds successfully at 94,944,171 bytes (~90.5 MiB)
- container health endpoint returns OK
- direct signed stream request returns 403, while the same stream through the proxy returns HTTP 200 with a valid HLS manifest
- Docker runtime linkage smoke test confirms libavformat61 and libavutil59 dependencies resolve

The existing stream-proxy CI workflows already build this Dockerfile and cover linux/amd64 and linux/arm64; no workflow changes are required.