### PR TITLE
chore(release): uprev and update changelogs for desktop, extension, and stream proxy versions

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.0+28] — 2026-07-15
+
+### Added
+- **Cast Proxy Routing Control**: Adds a checkbox to Send to TV and a playback proxy route toggle to force routing remote casts through the local proxy.
+- **Protocol Vendoring**: Integrates the protocol definitions and generated Kotlin/Dart/Swift bindings directly in the monorepo, removing the submodule dependency.
+
+### Changed
+- **Dynamic HLS Playlist Rewriting**: Rewrite HLS playlists using the requested host IP instead of hardcoding `127.0.0.1` so that TV receivers can access the proxy.
+
 ## [0.7.0+27] — 2026-07-14
 
 ### Added

--- a/desktop/lib/update/app_version.dart
+++ b/desktop/lib/update/app_version.dart
@@ -2,7 +2,7 @@
 ///
 /// MUST match `version:` in pubspec.yaml (build-metadata part excluded) —
 /// guarded by `test/update_test.dart` so CI fails if they drift.
-const String kAppVersion = '0.7.0';
+const String kAppVersion = '0.8.0';
 
 /// Dotted numeric version (`0.6.4`, `1.10.2`) with sane comparison semantics.
 ///

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: playbridge_desktop
 description: "PlayBridge desktop receiver — accepts cast commands from the phone and plays via libmpv."
 publish_to: 'none'
-version: 0.7.0+27
+version: 0.8.0+28
 
 environment:
   sdk: ^3.6.0

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.0] — 2026-07-15
+
+### Added
+- **Native Bridge Connection Delay**: Wait up to 3 seconds for the native messaging connection to establish when casting from the extension before giving up.
+
+### Changed
+- **Native Bridge Reconnection**: Implement exponential backoff reconnection for the extension native messaging host bridge.
+
 ## [0.5.0] — 2026-07-14
 
 ### Added

--- a/extension/manifests/chrome.json
+++ b/extension/manifests/chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PlayBridge Video Detector",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Detect and cast browser videos through the PlayBridge desktop app.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtZQGgGin2mHxxXXJOQzUD9RHd5Fv19263KYRWrc5W7l2j8zggs4DXiWp5yqe56klCln3+ZNjNO0uUrU33dbkIQKRfj8hPhibBcCc7E+/+ZTFC1VZ+hry29LlDOLruMA+N7dg0EkdPD5qsHoYq6mhVelG7gpUDwnI/GPQOWezyAvYHFTfuP32cBcrW2lEMG7EZAcpds6rnFrYbGsBs/KACgYcvVGEy653tvGKBb4A2rU2bUv+5ph01sok/HDqVwwMFHHGD+U/LTy5ZGX85mRgmNhKLr/WE8IOdFFxIWzdC7hLtgRDxDiYaj2EOAFWE8v+VHmYvl++X1cDVpzxbV/MvQIDAQAB",
   "icons": {

--- a/extension/manifests/firefox.json
+++ b/extension/manifests/firefox.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "PlayBridge Video Detector",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "description": "Detect and cast browser videos through the PlayBridge desktop app.",
     "icons": {
         "128": "icon.png"

--- a/stream-proxy-dart/CHANGELOG.md
+++ b/stream-proxy-dart/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the PlayBridge Stream Proxy (`playbridge_stream_proxy`) w
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-07-15
+
+### Added
+- **Dynamic URI Host Rewriting**: Rewrite HLS manifests to dynamically resolve targets using the requested URI scheme and authority (rather than hardcoded 127.0.0.1) so local proxies work when casting to TV receivers.
+
+### Changed
+- **Slim Container Image**: Migrated base runtime image to a slimmer Debian distribution to reduce Docker image footprint and optimize package overhead.
+
+### Fixed
+- **Authentication Token Redaction**: Prevent writing the active loopback proxy authentication token to stdout logs.
+- **Path Segment Resolution**: Properly resolve HLS variant playlists and DRM key URLs containing relative path segments.
+
 ## [0.1.0] - 2026-07-14
 
 ### Added

--- a/stream-proxy-dart/pubspec.yaml
+++ b/stream-proxy-dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: playbridge_stream_proxy
 description: Standalone high-performance streaming proxy in Dart.
-version: 0.1.0
+version: 0.2.0
 publish_to: 'none'
 
 environment:


### PR DESCRIPTION
## Summary

This PR prepares a release for the Desktop, Extension, and Stream Proxy packages following the recent in-repo protocol contract vendoring and cast proxy routing updates.

### Affected Versions

| Project | Old Version | New Version |
|---|---|---|
| Desktop | `0.7.0+27` | `0.8.0+28` |
| Extension | `0.5.0` | `0.6.0` |
| Stream Proxy | `0.1.0` | `0.2.0` |

## Verification

- **Desktop**:
  - Ran all 51 Flutter tests (`flutter test` inside `desktop/`): **Passed**
  - Ran update test drift guard (`flutter test test/update_test.dart` inside `desktop/`): **Passed**
- **Extension**:
  - Ran all 22 tests (`pnpm test` inside `extension/`): **Passed**
  - Checked TypeScript compiler (`pnpm typecheck` inside `extension/`): **Passed**
  - Ran store validations & packaged release zips (`pnpm store:check` inside `extension/`): **Passed (0 errors, 0 warnings)**

## Notes

- Android and Apple mobile apps remain unchanged as they contain no functional code changes since the last release.
