### PR TITLE
fix: prevent duplicate desktop instances

### DIFF
--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -31,6 +31,7 @@ import 'preplay_overlay.dart';
 import 'send_to_tv_screen.dart';
 import 'server.dart';
 import 'settings_screen.dart';
+import 'single_instance_coordinator.dart';
 import 'stream_proxy_server.dart';
 import 'shader_background.dart';
 import 'stats_overlay.dart';
@@ -43,6 +44,21 @@ import 'update/update_checker.dart';
 import 'update/update_gate.dart';
 
 Future<void> main(List<String> args) async {
+  final launchRequest = InstanceLaunchRequest.fromArgs(args);
+  final instanceResult = await SingleInstanceCoordinator.coordinate(
+    request: launchRequest,
+  );
+  if (!instanceResult.isPrimary) {
+    if (!instanceResult.forwarded) {
+      stderr.writeln(
+        '[single-instance] running instance could not be activated: '
+        '${instanceResult.forwardingError}',
+      );
+    }
+    return;
+  }
+  final instanceCoordinator = instanceResult.coordinator!;
+
   WidgetsFlutterBinding.ensureInitialized();
   MediaKit.ensureInitialized();
   await windowManager.ensureInitialized();
@@ -82,17 +98,12 @@ Future<void> main(List<String> args) async {
     store: results[0] as PairingStore,
     history: results[1] as HistoryStore,
     tvStore: results[2] as TvConnectionStore,
+    instanceCoordinator: instanceCoordinator,
     // "Play on TV" cold-start: the cast helper launches the app with these when
     // it isn't already running. The app casts the file once a TV connects.
-    initialCastFile: _argValue(args, '--cast-file'),
-    initialCastTitle: _argValue(args, '--cast-title'),
+    initialCastFile: launchRequest.castFile,
+    initialCastTitle: launchRequest.castTitle,
   ));
-}
-
-/// Reads `--flag value` from argv (null if absent).
-String? _argValue(List<String> args, String flag) {
-  final i = args.indexOf(flag);
-  return (i >= 0 && i + 1 < args.length) ? args[i + 1] : null;
 }
 
 // Keyboard shortcuts
@@ -129,6 +140,7 @@ class ReceiverApp extends StatefulWidget {
     required this.store,
     required this.history,
     required this.tvStore,
+    required this.instanceCoordinator,
     this.initialCastFile,
     this.initialCastTitle,
   });
@@ -136,6 +148,7 @@ class ReceiverApp extends StatefulWidget {
   final PairingStore store;
   final HistoryStore history;
   final TvConnectionStore tvStore;
+  final SingleInstanceCoordinator instanceCoordinator;
   final String? initialCastFile;
   final String? initialCastTitle;
 
@@ -318,14 +331,19 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     // Cold-start file open (`playbridge_cast` launched the app): cast to a TV
     // if already linked, otherwise play on this desktop (same as extension
     // bridge when disconnected).
-    if (widget.initialCastFile != null) {
-      _pendingCastFile = widget.initialCastFile;
-      _sender.addListener(_maybeCastPendingFile);
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        _resolvePendingCastFile();
-      });
+    final initialCastFile = widget.initialCastFile;
+    if (initialCastFile != null) {
+      _queuePendingCast(
+        initialCastFile,
+        widget.initialCastTitle,
+        afterFirstFrame: true,
+      );
     }
+
+    // A secondary process can arrive while Flutter and the player are still
+    // starting. The coordinator queues those requests until this handler is
+    // installed, then routes them through the same cold-start cast path.
+    widget.instanceCoordinator.setLaunchHandler(_handleInstanceLaunch);
   }
 
   bool _senderWasCasting = false;
@@ -365,6 +383,31 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   }
 
   String? _pendingCastFile;
+  String? _pendingCastTitle;
+
+  Future<void> _handleInstanceLaunch(InstanceLaunchRequest request) async {
+    await _revealWindow();
+    if (!mounted || request.castFile == null) return;
+    _queuePendingCast(request.castFile!, request.castTitle);
+  }
+
+  void _queuePendingCast(
+    String path,
+    String? title, {
+    bool afterFirstFrame = false,
+  }) {
+    _pendingCastFile = path;
+    _pendingCastTitle = title;
+    _sender.removeListener(_maybeCastPendingFile);
+    _sender.addListener(_maybeCastPendingFile);
+    if (afterFirstFrame) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _resolvePendingCastFile();
+      });
+    } else {
+      _resolvePendingCastFile();
+    }
+  }
 
   /// Rising edge: TV connected while a cold-start file is still pending → TV.
   void _maybeCastPendingFile() {
@@ -376,14 +419,15 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   void _resolvePendingCastFile() {
     final path = _pendingCastFile;
     if (path == null) return;
+    final title = _pendingCastTitle;
     _pendingCastFile = null;
+    _pendingCastTitle = null;
     _sender.removeListener(_maybeCastPendingFile);
     final file = File(path);
     if (!file.existsSync()) {
       debugPrint('[main] pending cast file missing: $path');
       return;
     }
-    final title = widget.initialCastTitle;
     if (_sender.isConnected) {
       unawaited(_sender.castLocalFile(file, title: title));
       return;

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -54,8 +54,14 @@ Future<void> main(List<String> args) async {
         '[single-instance] running instance could not be activated: '
         '${instanceResult.forwardingError}',
       );
+      exit(1);
     }
-    return;
+
+    // The native Flutter runner has already created its process and window by
+    // the time Dart starts. Returning from main leaves that secondary runner
+    // alive with a blank window, so terminate it after the primary acknowledges
+    // the forwarded launch request.
+    exit(0);
   }
   final instanceCoordinator = instanceResult.coordinator!;
 

--- a/desktop/lib/single_instance_coordinator.dart
+++ b/desktop/lib/single_instance_coordinator.dart
@@ -1,0 +1,352 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'bridge_paths.dart';
+
+const _lockFileName = 'instance.lock';
+const _metadataFileName = 'instance.json';
+const _requestTimeout = Duration(seconds: 2);
+const _retryDelay = Duration(milliseconds: 50);
+
+typedef InstanceLaunchHandler = FutureOr<void> Function(
+  InstanceLaunchRequest request,
+);
+
+/// Arguments a secondary process forwards to the running Desktop instance.
+class InstanceLaunchRequest {
+  const InstanceLaunchRequest({this.castFile, this.castTitle});
+
+  factory InstanceLaunchRequest.fromArgs(List<String> args) {
+    return InstanceLaunchRequest(
+      castFile: _argValue(args, '--cast-file'),
+      castTitle: _argValue(args, '--cast-title'),
+    );
+  }
+
+  factory InstanceLaunchRequest.fromJson(Map<String, dynamic> json) {
+    if (json['action'] != 'activate') {
+      throw const FormatException('unsupported instance action');
+    }
+    final castFile = json['castFile'];
+    final castTitle = json['castTitle'];
+    if (castFile != null && castFile is! String) {
+      throw const FormatException('castFile must be a string');
+    }
+    if (castTitle != null && castTitle is! String) {
+      throw const FormatException('castTitle must be a string');
+    }
+    return InstanceLaunchRequest(
+      castFile: castFile as String?,
+      castTitle: castTitle as String?,
+    );
+  }
+
+  final String? castFile;
+  final String? castTitle;
+
+  Map<String, dynamic> toJson({required String token}) => {
+        'token': token,
+        'action': 'activate',
+        if (castFile != null) 'castFile': castFile,
+        if (castTitle != null) 'castTitle': castTitle,
+      };
+}
+
+/// Result of coordinating this process with any existing Desktop process.
+class SingleInstanceStartResult {
+  const SingleInstanceStartResult._({
+    this.coordinator,
+    required this.forwarded,
+    this.forwardingError,
+  });
+
+  const SingleInstanceStartResult.primary(
+    SingleInstanceCoordinator coordinator,
+  ) : this._(coordinator: coordinator, forwarded: false);
+
+  const SingleInstanceStartResult.secondary({
+    required bool forwarded,
+    Object? forwardingError,
+  }) : this._(
+          forwarded: forwarded,
+          forwardingError: forwardingError,
+        );
+
+  final SingleInstanceCoordinator? coordinator;
+  final bool forwarded;
+  final Object? forwardingError;
+
+  bool get isPrimary => coordinator != null;
+}
+
+/// Ensures only one Desktop process starts receiver services for this user.
+///
+/// The primary process holds an operating-system file lock for its lifetime and
+/// publishes a token-authenticated loopback endpoint in `instance.json`.
+/// Secondary processes forward their launch request and exit. A failed forward
+/// never grants primary ownership while the lock is held.
+class SingleInstanceCoordinator {
+  SingleInstanceCoordinator._({
+    required this.directoryPath,
+    required RandomAccessFile lockHandle,
+    required ServerSocket server,
+    required String token,
+  })  : _lockHandle = lockHandle,
+        _server = server,
+        _token = token;
+
+  final String directoryPath;
+  final RandomAccessFile _lockHandle;
+  final ServerSocket _server;
+  final String _token;
+  final Queue<InstanceLaunchRequest> _pending = Queue();
+
+  InstanceLaunchHandler? _handler;
+  bool _closed = false;
+
+  String get metadataFilePath => _join(directoryPath, _metadataFileName);
+
+  static Future<SingleInstanceStartResult> coordinate({
+    required InstanceLaunchRequest request,
+    String? directoryPath,
+    Duration forwardTimeout = const Duration(seconds: 5),
+  }) async {
+    final dirPath = directoryPath ?? bridgeDirPath();
+    final directory = Directory(dirPath);
+    await directory.create(recursive: true);
+    await _restrictPermissions(directory.path, '700');
+
+    final lockHandle =
+        await File(_join(dirPath, _lockFileName)).open(mode: FileMode.append);
+    try {
+      await lockHandle.lock(FileLock.exclusive);
+    } on FileSystemException catch (lockError) {
+      await lockHandle.close();
+      return _forwardToPrimary(
+        directoryPath: dirPath,
+        request: request,
+        timeout: forwardTimeout,
+        lockError: lockError,
+      );
+    }
+
+    ServerSocket? server;
+    try {
+      server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final coordinator = SingleInstanceCoordinator._(
+        directoryPath: dirPath,
+        lockHandle: lockHandle,
+        server: server,
+        token: _randomToken(),
+      );
+      server.listen(
+        (socket) => unawaited(coordinator._handleClient(socket)),
+        onError: (Object error, StackTrace stack) {
+          stderr.writeln('[single-instance] IPC server error: $error');
+        },
+      );
+      await coordinator._writeMetadata();
+      return SingleInstanceStartResult.primary(coordinator);
+    } catch (_) {
+      await server?.close();
+      await lockHandle.unlock();
+      await lockHandle.close();
+      rethrow;
+    }
+  }
+
+  /// Installs the UI handler and drains requests received during app startup.
+  void setLaunchHandler(InstanceLaunchHandler handler) {
+    if (_closed) return;
+    _handler = handler;
+    while (_pending.isNotEmpty) {
+      _dispatch(_pending.removeFirst());
+    }
+  }
+
+  void _accept(InstanceLaunchRequest request) {
+    final handler = _handler;
+    if (handler == null) {
+      _pending.add(request);
+      return;
+    }
+    _dispatch(request);
+  }
+
+  void _dispatch(InstanceLaunchRequest request) {
+    final handler = _handler;
+    if (handler == null) {
+      _pending.add(request);
+      return;
+    }
+    Future<void>.sync(() => handler(request)).catchError(
+      (Object error, StackTrace stack) {
+        stderr.writeln('[single-instance] launch handler failed: $error');
+      },
+    );
+  }
+
+  Future<void> _handleClient(Socket socket) async {
+    var response = <String, dynamic>{'ok': false, 'error': 'invalid request'};
+    try {
+      final line = await utf8.decoder
+          .bind(socket)
+          .transform(const LineSplitter())
+          .first
+          .timeout(_requestTimeout);
+      final decoded = jsonDecode(line);
+      if (decoded is! Map<String, dynamic>) {
+        throw const FormatException('request must be an object');
+      }
+      if (decoded['token'] != _token) {
+        response = {'ok': false, 'error': 'unauthorized'};
+      } else {
+        final request = InstanceLaunchRequest.fromJson(decoded);
+        _accept(request);
+        response = {'ok': true};
+      }
+    } catch (error) {
+      response = {'ok': false, 'error': '$error'};
+    }
+
+    try {
+      socket.writeln(jsonEncode(response));
+      await socket.flush();
+    } catch (_) {
+      // The secondary may have exited while the request was being processed.
+    } finally {
+      await socket.close();
+    }
+  }
+
+  Future<void> _writeMetadata() async {
+    final file = File(metadataFilePath);
+    final handle = await file.open(mode: FileMode.write);
+    try {
+      await _restrictPermissions(file.path, '600');
+      await handle.writeString(jsonEncode({
+        'port': _server.port,
+        'token': _token,
+      }));
+      await handle.flush();
+    } finally {
+      await handle.close();
+    }
+  }
+
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    _handler = null;
+    _pending.clear();
+    await _server.close();
+    try {
+      await File(metadataFilePath).delete();
+    } on FileSystemException {
+      // A missing stale metadata file does not affect lock ownership.
+    }
+    await _lockHandle.unlock();
+    await _lockHandle.close();
+  }
+
+  static Future<SingleInstanceStartResult> _forwardToPrimary({
+    required String directoryPath,
+    required InstanceLaunchRequest request,
+    required Duration timeout,
+    required Object lockError,
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    Object lastError = lockError;
+    do {
+      Socket? socket;
+      try {
+        final metadata = await _readMetadata(directoryPath);
+        socket = await Socket.connect(
+          InternetAddress.loopbackIPv4,
+          metadata.port,
+          timeout: _requestTimeout,
+        );
+        socket.writeln(jsonEncode(request.toJson(token: metadata.token)));
+        await socket.flush();
+        final line = await utf8.decoder
+            .bind(socket)
+            .transform(const LineSplitter())
+            .first
+            .timeout(_requestTimeout);
+        final decoded = jsonDecode(line);
+        if (decoded is Map<String, dynamic> && decoded['ok'] == true) {
+          await socket.close();
+          return const SingleInstanceStartResult.secondary(forwarded: true);
+        }
+        throw StateError(
+          decoded is Map<String, dynamic>
+              ? '${decoded['error'] ?? 'primary rejected request'}'
+              : 'invalid primary response',
+        );
+      } catch (error) {
+        lastError = error;
+        socket?.destroy();
+        if (DateTime.now().isBefore(deadline)) {
+          await Future<void>.delayed(_retryDelay);
+        }
+      }
+    } while (DateTime.now().isBefore(deadline));
+
+    return SingleInstanceStartResult.secondary(
+      forwarded: false,
+      forwardingError: lastError,
+    );
+  }
+
+  static Future<_InstanceMetadata> _readMetadata(String directoryPath) async {
+    final value = jsonDecode(
+      await File(_join(directoryPath, _metadataFileName)).readAsString(),
+    );
+    if (value is! Map<String, dynamic>) {
+      throw const FormatException('instance metadata must be an object');
+    }
+    final port = value['port'];
+    final token = value['token'];
+    if (port is! int || port < 1 || port > 65535) {
+      throw const FormatException('invalid instance port');
+    }
+    if (token is! String || token.isEmpty) {
+      throw const FormatException('invalid instance token');
+    }
+    return _InstanceMetadata(port: port, token: token);
+  }
+}
+
+class _InstanceMetadata {
+  const _InstanceMetadata({required this.port, required this.token});
+
+  final int port;
+  final String token;
+}
+
+String? _argValue(List<String> args, String flag) {
+  final index = args.indexOf(flag);
+  return index >= 0 && index + 1 < args.length ? args[index + 1] : null;
+}
+
+String _join(String directory, String name) {
+  return Platform.isWindows ? '$directory\\$name' : '$directory/$name';
+}
+
+String _randomToken() {
+  final random = Random.secure();
+  return base64Url
+      .encode(List<int>.generate(32, (_) => random.nextInt(256)))
+      .replaceAll('=', '');
+}
+
+Future<void> _restrictPermissions(String path, String mode) async {
+  if (Platform.isWindows) return;
+  final result = await Process.run('chmod', [mode, path]);
+  if (result.exitCode != 0) {
+    throw FileSystemException('failed to chmod $mode', path);
+  }
+}

--- a/desktop/macos/Runner/AppDelegate.swift
+++ b/desktop/macos/Runner/AppDelegate.swift
@@ -9,6 +9,19 @@ class AppDelegate: FlutterAppDelegate {
     return false
   }
 
+  override func applicationShouldHandleReopen(
+    _ sender: NSApplication,
+    hasVisibleWindows flag: Bool
+  ) -> Bool {
+    // Clicking the Dock/Finder app while PlayBridge is hidden should activate
+    // the existing process and reveal its window, never create another window.
+    if !flag {
+      mainFlutterWindow?.makeKeyAndOrderFront(self)
+    }
+    sender.activate(ignoringOtherApps: true)
+    return true
+  }
+
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
   }

--- a/desktop/test/single_instance_coordinator_test.dart
+++ b/desktop/test/single_instance_coordinator_test.dart
@@ -1,0 +1,169 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/single_instance_coordinator.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('pb_single_instance_test_');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('parses cast arguments without requiring Flutter', () {
+    final request = InstanceLaunchRequest.fromArgs([
+      '--cast-file',
+      '/tmp/video.mp4',
+      '--cast-title',
+      'A title',
+    ]);
+
+    expect(request.castFile, '/tmp/video.mp4');
+    expect(request.castTitle, 'A title');
+  });
+
+  test('secondary forwards and primary queues until UI handler is ready',
+      () async {
+    final primary = await _PrimaryHelper.start(tempDir.path);
+    addTearDown(primary.stop);
+
+    final secondaryResult = await SingleInstanceCoordinator.coordinate(
+      request: const InstanceLaunchRequest(
+        castFile: '/tmp/movie.mkv',
+        castTitle: 'Movie',
+      ),
+      directoryPath: tempDir.path,
+    ).timeout(const Duration(seconds: 8));
+
+    expect(secondaryResult.isPrimary, isFalse);
+    expect(secondaryResult.forwarded, isTrue);
+
+    await primary.send('HANDLE');
+    final line = await primary.nextLine();
+    expect(line, startsWith('REQUEST:'));
+    final request =
+        jsonDecode(line.substring('REQUEST:'.length)) as Map<String, dynamic>;
+    expect(request['castFile'], '/tmp/movie.mkv');
+    expect(request['castTitle'], 'Movie');
+  });
+
+  test('IPC endpoint rejects a request with the wrong token', () async {
+    final primaryResult = await SingleInstanceCoordinator.coordinate(
+      request: const InstanceLaunchRequest(),
+      directoryPath: tempDir.path,
+    );
+    final primary = primaryResult.coordinator!;
+    addTearDown(primary.close);
+
+    final metadata = jsonDecode(
+      await File(primary.metadataFilePath).readAsString(),
+    ) as Map<String, dynamic>;
+    final socket = await Socket.connect(
+      InternetAddress.loopbackIPv4,
+      metadata['port'] as int,
+    );
+    socket.writeln(jsonEncode({
+      'token': 'wrong-token',
+      'action': 'activate',
+    }));
+    await socket.flush();
+
+    final line =
+        await utf8.decoder.bind(socket).transform(const LineSplitter()).first;
+    final response = jsonDecode(line) as Map<String, dynamic>;
+    expect(response['ok'], isFalse);
+    expect(response['error'], 'unauthorized');
+    await socket.close();
+  });
+
+  test('a forwarding failure never lets the secondary become primary',
+      () async {
+    final primary = await _PrimaryHelper.start(tempDir.path);
+    addTearDown(primary.stop);
+    await File(primary.metadataFilePath).delete();
+
+    final secondaryResult = await SingleInstanceCoordinator.coordinate(
+      request: const InstanceLaunchRequest(),
+      directoryPath: tempDir.path,
+      forwardTimeout: const Duration(milliseconds: 150),
+    ).timeout(const Duration(seconds: 2));
+
+    expect(secondaryResult.isPrimary, isFalse);
+    expect(secondaryResult.forwarded, isFalse);
+    expect(secondaryResult.forwardingError, isNotNull);
+  });
+}
+
+class _PrimaryHelper {
+  _PrimaryHelper._(this.process, this._lines, this.metadataFilePath);
+
+  final Process process;
+  final StreamIterator<String> _lines;
+  final String metadataFilePath;
+
+  static Future<_PrimaryHelper> start(String directoryPath) async {
+    final flutterRoot = Platform.environment['FLUTTER_ROOT'];
+    final dartExecutable = flutterRoot == null
+        ? 'dart'
+        : '$flutterRoot${Platform.pathSeparator}bin${Platform.pathSeparator}'
+            'cache${Platform.pathSeparator}dart-sdk${Platform.pathSeparator}'
+            'bin${Platform.pathSeparator}'
+            '${Platform.isWindows ? 'dart.exe' : 'dart'}';
+    final process = await Process.start(
+      dartExecutable,
+      [
+        '--packages=.dart_tool/package_config.json',
+        'test/support/single_instance_primary.dart',
+        directoryPath,
+      ],
+      workingDirectory: Directory.current.path,
+    ).timeout(const Duration(seconds: 5));
+    final lines = StreamIterator(
+      process.stdout.transform(utf8.decoder).transform(const LineSplitter()),
+    );
+    final hasLine = await lines.moveNext().timeout(const Duration(seconds: 5));
+    if (!hasLine || !lines.current.startsWith('READY:')) {
+      final error = await process.stderr.transform(utf8.decoder).join();
+      throw StateError('primary helper failed to start: $error');
+    }
+    return _PrimaryHelper._(
+      process,
+      lines,
+      lines.current.substring('READY:'.length),
+    );
+  }
+
+  Future<void> send(String command) async {
+    process.stdin.writeln(command);
+    await process.stdin.flush();
+  }
+
+  Future<String> nextLine() async {
+    final hasLine = await _lines.moveNext().timeout(const Duration(seconds: 2));
+    if (!hasLine) throw StateError('primary helper exited without a response');
+    return _lines.current;
+  }
+
+  Future<void> stop() async {
+    try {
+      await send('STOP').timeout(const Duration(seconds: 1));
+    } catch (_) {
+      // The helper may already have exited after a failed assertion.
+    }
+    try {
+      await process.exitCode.timeout(const Duration(seconds: 3));
+    } on TimeoutException {
+      process.kill();
+      await process.exitCode;
+    }
+    await _lines.cancel();
+  }
+}

--- a/desktop/test/support/single_instance_primary.dart
+++ b/desktop/test/support/single_instance_primary.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:playbridge_desktop/single_instance_coordinator.dart';
+
+Future<void> main(List<String> args) async {
+  final result = await SingleInstanceCoordinator.coordinate(
+    request: const InstanceLaunchRequest(),
+    directoryPath: args.single,
+  );
+  final coordinator = result.coordinator;
+  if (coordinator == null) {
+    stderr.writeln('helper did not become primary');
+    exitCode = 1;
+    return;
+  }
+
+  stdout.writeln('READY:${coordinator.metadataFilePath}');
+  await stdout.flush();
+
+  await for (final command
+      in stdin.transform(utf8.decoder).transform(const LineSplitter())) {
+    if (command == 'HANDLE') {
+      coordinator.setLaunchHandler((request) async {
+        stdout.writeln('REQUEST:${jsonEncode({
+              'castFile': request.castFile,
+              'castTitle': request.castTitle,
+            })}');
+        await stdout.flush();
+      });
+    } else if (command == 'STOP') {
+      await coordinator.close();
+      return;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- acquire a per-user OS file lock before Flutter, receiver, discovery, proxy, or extension services start
- forward activation and optional cast-file arguments from secondary launches over token-authenticated loopback IPC
- queue forwarded launches until the primary UI is ready, then reuse the existing cold-start cast path
- reveal the existing macOS window when Finder or the Dock reopens the app
- explicitly terminate a forwarded secondary runner so macOS cannot leave a blank second window
- keep singleton metadata separate from the browser extension bridge handshake

## Safety behavior

- a process that cannot acquire the lock never starts duplicate services, even when forwarding fails
- instance metadata is permission-restricted on POSIX systems
- stale or partially written metadata is retried while the primary lock remains held

## Verification

- flutter test: all 55 tests pass
- flutter analyze: no issues
- flutter build macos --debug: succeeds
- real subprocess tests cover OS lock contention, queued forwarding, token rejection, and forwarding failure without duplicate ownership
- git diff --check
- manual macOS regression: launching a real second executable focused the primary window and the secondary process exited without leaving a blank window

## Manual test plan

### Required: Basic single-instance behavior

1. Stop every PlayBridge Desktop process, then launch the app normally.
2. Launch the same Desktop executable a second time. On macOS, invoke `PlayBridge.app/Contents/MacOS/playbridge_desktop` directly so a real second process is attempted instead of relying only on LaunchServices.
3. The second process must exit, the existing window must become visible and focused, and Activity Monitor or the system process list must show only one PlayBridge process.
4. Confirm that only one receiver, discovery publisher, stream proxy, extension bridge, and tray item are active.
5. Hide or close the window to the tray, then launch the executable again. The same process and window must be revealed; no second tray item may appear.

### Required: Cast argument forwarding

1. Keep the primary instance running.
2. Run the executable again with `--cast-file "/absolute/path/test-video.mp4" --cast-title "Singleton test"`.
3. The primary window must activate and handle the file.
4. With a TV connected, the file must cast to that TV. Without a TV connected, it must play locally.
5. Repeat while the primary window is hidden.

### Required: Startup race

1. From two terminals, launch the Desktop executable as close together as possible. Optionally give the second launch a cast file.
2. Exactly one process must remain and exactly one tray icon must appear.
3. If a cast file was supplied, it must be queued during startup and handled once the primary UI is ready.
4. Confirm the receiver port, discovery service, proxy, and extension bridge were each started once.

### Required: Crash and stale-file recovery

1. Start PlayBridge and note the modification time of `~/.playbridge/instance.json` without sharing its token contents.
2. Force-kill the primary process. On macOS or Linux, `kill -9 PID` is suitable; on Windows, use End task.
3. The files `instance.lock` and `instance.json` may remain on disk. Relaunch PlayBridge.
4. The app must acquire a fresh OS lock, replace the stale metadata, and start normally. File existence alone must never block startup.
5. Quit normally from the tray and launch again to confirm normal lock release as well.

### Required: macOS reopen behavior

1. Hide the PlayBridge window or close it to the tray.
2. Open the application again from Finder or LaunchServices.
3. The existing window must become key and visible without creating a second process or window.

### Failure-mode safety on macOS or Linux

1. Start the primary and suspend it with `kill -STOP PID` so it stays alive while IPC cannot respond.
2. Launch another executable and wait for its forwarding timeout.
3. The secondary must exit without starting receiver services or creating another tray item. The suspended primary remains the only owner.
4. Resume it with `kill -CONT PID` and confirm it still operates.

### Security and regression checks

- On macOS or Linux, confirm `~/.playbridge` is user-only and `instance.json` is mode 600. Do not paste or publish the token.
- Confirm `instance.json` is separate from `bridge.json` and that the browser extension still connects and casts.
- Send a normal activation with no cast arguments and confirm it only reveals the app.
- Repeat the basic and cast-forwarding checks on Windows and Linux when builds are available.

### Combined check after PR #125 is also applied

Occupy receiver port 8765, then launch two Desktop executables nearly simultaneously. Exactly one process must remain, it must select and advertise a fallback receiver port, and a paired sender must cast successfully.