### PR TITLE
chore: promote v0.8.0 fixes to main

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.0+28] — 2026-07-15
+
+### Added
+- **Cast Proxy Routing Control**: Adds a checkbox to Send to TV and a playback proxy route toggle to force routing remote casts through the local proxy.
+- **Protocol Vendoring**: Integrates the protocol definitions and generated Kotlin/Dart/Swift bindings directly in the monorepo, removing the submodule dependency.
+
+### Changed
+- **Dynamic HLS Playlist Rewriting**: Rewrite HLS playlists using the requested host IP instead of hardcoding `127.0.0.1` so that TV receivers can access the proxy.
+
 ## [0.7.0+27] — 2026-07-14
 
 ### Added

--- a/desktop/lib/discovery.dart
+++ b/desktop/lib/discovery.dart
@@ -9,29 +9,35 @@ import 'package:flutter/foundation.dart';
 class DiscoveryPublisher {
   DiscoveryPublisher({
     required this.serviceName,
-    required this.port,
     required this.deviceId,
   });
 
   final String serviceName;
-  final int port;
   final String deviceId;
 
   BonsoirBroadcast? _broadcast;
   StreamSubscription? _eventsSub;
 
-  /// [wssPort] is advertised as the `wss_port` TXT attribute when non-null so
-  /// senders can find the encrypted endpoint. Older senders ignore it.
-  Future<void> start({int? wssPort}) async {
-    final service = BonsoirService(
+  /// Builds the service published by [start]. Both the SRV record and TXT
+  /// attribute identify the actual bound secure listener.
+  @visibleForTesting
+  BonsoirService serviceForPort(int port) {
+    if (port < 1 || port > 65535) {
+      throw ArgumentError.value(port, 'port', 'must be between 1 and 65535');
+    }
+    return BonsoirService(
       name: serviceName,
       type: '_playbridge._tcp',
       port: port,
       attributes: {
         'uuid': deviceId,
-        if (wssPort != null) 'wss_port': '$wssPort',
+        'wss_port': '$port',
       },
     );
+  }
+
+  Future<void> start({required int port}) async {
+    final service = serviceForPort(port);
 
     final broadcast = BonsoirBroadcast(service: service);
     await broadcast.ready;
@@ -41,7 +47,7 @@ class DiscoveryPublisher {
     await broadcast.start();
     _broadcast = broadcast;
     debugPrint('[discovery] published $serviceName on _playbridge._tcp.:$port '
-        '(uuid=$deviceId, wss_port=${wssPort ?? '-'})');
+        '(uuid=$deviceId, wss_port=$port)');
   }
 
   Future<void> stop() async {

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -31,6 +31,7 @@ import 'preplay_overlay.dart';
 import 'send_to_tv_screen.dart';
 import 'server.dart';
 import 'settings_screen.dart';
+import 'single_instance_coordinator.dart';
 import 'stream_proxy_server.dart';
 import 'shader_background.dart';
 import 'stats_overlay.dart';
@@ -43,6 +44,27 @@ import 'update/update_checker.dart';
 import 'update/update_gate.dart';
 
 Future<void> main(List<String> args) async {
+  final launchRequest = InstanceLaunchRequest.fromArgs(args);
+  final instanceResult = await SingleInstanceCoordinator.coordinate(
+    request: launchRequest,
+  );
+  if (!instanceResult.isPrimary) {
+    if (!instanceResult.forwarded) {
+      stderr.writeln(
+        '[single-instance] running instance could not be activated: '
+        '${instanceResult.forwardingError}',
+      );
+      exit(1);
+    }
+
+    // The native Flutter runner has already created its process and window by
+    // the time Dart starts. Returning from main leaves that secondary runner
+    // alive with a blank window, so terminate it after the primary acknowledges
+    // the forwarded launch request.
+    exit(0);
+  }
+  final instanceCoordinator = instanceResult.coordinator!;
+
   WidgetsFlutterBinding.ensureInitialized();
   MediaKit.ensureInitialized();
   await windowManager.ensureInitialized();
@@ -82,17 +104,12 @@ Future<void> main(List<String> args) async {
     store: results[0] as PairingStore,
     history: results[1] as HistoryStore,
     tvStore: results[2] as TvConnectionStore,
+    instanceCoordinator: instanceCoordinator,
     // "Play on TV" cold-start: the cast helper launches the app with these when
     // it isn't already running. The app casts the file once a TV connects.
-    initialCastFile: _argValue(args, '--cast-file'),
-    initialCastTitle: _argValue(args, '--cast-title'),
+    initialCastFile: launchRequest.castFile,
+    initialCastTitle: launchRequest.castTitle,
   ));
-}
-
-/// Reads `--flag value` from argv (null if absent).
-String? _argValue(List<String> args, String flag) {
-  final i = args.indexOf(flag);
-  return (i >= 0 && i + 1 < args.length) ? args[i + 1] : null;
 }
 
 // Keyboard shortcuts
@@ -129,6 +146,7 @@ class ReceiverApp extends StatefulWidget {
     required this.store,
     required this.history,
     required this.tvStore,
+    required this.instanceCoordinator,
     this.initialCastFile,
     this.initialCastTitle,
   });
@@ -136,6 +154,7 @@ class ReceiverApp extends StatefulWidget {
   final PairingStore store;
   final HistoryStore history;
   final TvConnectionStore tvStore;
+  final SingleInstanceCoordinator instanceCoordinator;
   final String? initialCastFile;
   final String? initialCastTitle;
 
@@ -317,14 +336,19 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     // Cold-start file open (`playbridge_cast` launched the app): cast to a TV
     // if already linked, otherwise play on this desktop (same as extension
     // bridge when disconnected).
-    if (widget.initialCastFile != null) {
-      _pendingCastFile = widget.initialCastFile;
-      _sender.addListener(_maybeCastPendingFile);
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        _resolvePendingCastFile();
-      });
+    final initialCastFile = widget.initialCastFile;
+    if (initialCastFile != null) {
+      _queuePendingCast(
+        initialCastFile,
+        widget.initialCastTitle,
+        afterFirstFrame: true,
+      );
     }
+
+    // A secondary process can arrive while Flutter and the player are still
+    // starting. The coordinator queues those requests until this handler is
+    // installed, then routes them through the same cold-start cast path.
+    widget.instanceCoordinator.setLaunchHandler(_handleInstanceLaunch);
   }
 
   bool _senderWasCasting = false;
@@ -364,6 +388,31 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   }
 
   String? _pendingCastFile;
+  String? _pendingCastTitle;
+
+  Future<void> _handleInstanceLaunch(InstanceLaunchRequest request) async {
+    await _revealWindow();
+    if (!mounted || request.castFile == null) return;
+    _queuePendingCast(request.castFile!, request.castTitle);
+  }
+
+  void _queuePendingCast(
+    String path,
+    String? title, {
+    bool afterFirstFrame = false,
+  }) {
+    _pendingCastFile = path;
+    _pendingCastTitle = title;
+    _sender.removeListener(_maybeCastPendingFile);
+    _sender.addListener(_maybeCastPendingFile);
+    if (afterFirstFrame) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _resolvePendingCastFile();
+      });
+    } else {
+      _resolvePendingCastFile();
+    }
+  }
 
   /// Rising edge: TV connected while a cold-start file is still pending → TV.
   void _maybeCastPendingFile() {
@@ -375,14 +424,15 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   void _resolvePendingCastFile() {
     final path = _pendingCastFile;
     if (path == null) return;
+    final title = _pendingCastTitle;
     _pendingCastFile = null;
+    _pendingCastTitle = null;
     _sender.removeListener(_maybeCastPendingFile);
     final file = File(path);
     if (!file.existsSync()) {
       debugPrint('[main] pending cast file missing: $path');
       return;
     }
-    final title = widget.initialCastTitle;
     if (_sender.isConnected) {
       unawaited(_sender.castLocalFile(file, title: title));
       return;

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -258,7 +258,6 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
     );
     _discovery = DiscoveryPublisher(
       serviceName: widget.store.deviceName,
-      port: kDefaultPort,
       deviceId: widget.store.deviceId,
     );
     _tray =
@@ -557,24 +556,33 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
   // Discovery starts after the server so it can advertise the actual bound
   // wss port (only known once the TLS listener is up).
   Future<void> _bootServerThenDiscovery() async {
-    await _bootServer();
-    await _bootDiscovery();
+    final port = await _bootServer();
+    if (port == null) return;
+    await _bootDiscovery(port);
   }
 
-  Future<void> _bootServer() async {
+  Future<int?> _bootServer() async {
+    late final int port;
     try {
-      await _server.start();
+      port = await _server.start();
+    } catch (e) {
+      if (mounted) setState(() => _serverError = '$e');
+      return null;
+    }
+
+    try {
       await StreamProxyServer.instance.start();
     } catch (e) {
-      setState(() => _serverError = '$e');
+      if (mounted) setState(() => _serverError = '$e');
     }
+    return port;
   }
 
-  Future<void> _bootDiscovery() async {
+  Future<void> _bootDiscovery(int port) async {
     try {
-      await _discovery.start(wssPort: _server.wssPort);
+      await _discovery.start(port: port);
     } catch (e) {
-      setState(() => _discoveryError = '$e');
+      if (mounted) setState(() => _discoveryError = '$e');
     }
   }
 

--- a/desktop/lib/pairing_store.dart
+++ b/desktop/lib/pairing_store.dart
@@ -64,6 +64,9 @@ class PairingStore {
   static const _kStillWatchingEnabled = 'pb.still_watching_enabled';
   static const _kStillWatchingThresholdMin = 'pb.still_watching_threshold_min';
   static const _kStillWatchingResponseSec = 'pb.still_watching_response_sec';
+  static const _kReceiverPort = 'pb.receiver_port';
+
+  static const int defaultReceiverPort = 8765;
 
   static const stillWatchingPresets = <int>[30, 60, 90, 120, 180, 240];
   static const stillWatchingResponsePresets = <int>[30, 60, 120, 300, 600];
@@ -176,6 +179,25 @@ class PairingStore {
         _kStillWatchingResponseSec,
         stillWatchingResponsePresets.contains(value) ? value : 300,
       );
+
+  /// Last port on which the secure receiver successfully started.
+  ///
+  /// Invalid values from older or manually edited preferences are ignored so
+  /// startup always begins with a valid TCP port.
+  int get receiverPort {
+    final saved = _prefs.getInt(_kReceiverPort);
+    if (saved == null || saved < 1 || saved > 65535) {
+      return defaultReceiverPort;
+    }
+    return saved;
+  }
+
+  Future<void> setReceiverPort(int port) {
+    if (port < 1 || port > 65535) {
+      throw ArgumentError.value(port, 'port', 'must be between 1 and 65535');
+    }
+    return _prefs.setInt(_kReceiverPort, port);
+  }
 
   // ─── Paired devices ──────────────────────────────────────────────────────
 

--- a/desktop/lib/server.dart
+++ b/desktop/lib/server.dart
@@ -17,7 +17,52 @@ import 'protocol.dart';
 import 'sas_crypto.dart';
 import 'system_volume.dart';
 
-const int kDefaultPort = 8765;
+const int kDefaultPort = PairingStore.defaultReceiverPort;
+const int kReceiverPortFallbackAttempts = 32;
+
+typedef ReceiverCertificateLoader = Future<CertManager> Function(
+    String commonName);
+typedef SecureServerBinder = Future<HttpServer> Function(
+  Handler handler,
+  InternetAddress address,
+  int port,
+  SecurityContext securityContext,
+);
+
+/// Consecutive valid ports to try, beginning with [preferredPort].
+///
+/// Invalid preferences are normalized to [kDefaultPort], and the range ends at
+/// 65535 rather than wrapping around.
+List<int> receiverPortCandidates(
+  int preferredPort, {
+  int maxAttempts = kReceiverPortFallbackAttempts,
+}) {
+  if (maxAttempts <= 0) return const [];
+  final first = preferredPort >= 1 && preferredPort <= 65535
+      ? preferredPort
+      : kDefaultPort;
+  final candidates = <int>[];
+  for (var port = first;
+      port <= 65535 && candidates.length < maxAttempts;
+      port++) {
+    candidates.add(port);
+  }
+  return candidates;
+}
+
+/// Whether [error] represents a TCP bind collision on a supported desktop OS.
+@visibleForTesting
+bool isAddressInUseError(Object error) {
+  if (error is! SocketException) return false;
+  final code = error.osError?.errorCode;
+  if (code == 48 || code == 98 || code == 10048) return true;
+
+  final message =
+      '${error.message} ${error.osError?.message ?? ''}'.toLowerCase();
+  return message.contains('address already in use') ||
+      message.contains('only one usage of each socket address') ||
+      message.contains('shared flag to bind() needs to be');
+}
 
 /// Surfaced to the UI so it can show an approval prompt or the player view.
 enum PairingPhase {
@@ -82,7 +127,10 @@ class ReceiverServer extends ChangeNotifier {
     this.onPromptStop,
     this.onPlaybackActivity,
     this.onNewMedia,
-  });
+    ReceiverCertificateLoader? certificateLoader,
+    SecureServerBinder? secureServerBinder,
+  })  : _certificateLoader = certificateLoader ?? _loadCertificate,
+        _secureServerBinder = secureServerBinder ?? _serveSecure;
 
   final PlayerController player;
   final PairingStore store;
@@ -91,6 +139,8 @@ class ReceiverServer extends ChangeNotifier {
   final VoidCallback? onPromptStop;
   final VoidCallback? onPlaybackActivity;
   final VoidCallback? onNewMedia;
+  final ReceiverCertificateLoader _certificateLoader;
+  final SecureServerBinder _secureServerBinder;
 
   void broadcastIdleContext() {
     for (final c in _authed) {
@@ -120,8 +170,6 @@ class ReceiverServer extends ChangeNotifier {
   /// Advertised over mDNS so senders know where to connect.
   int? _wssPort;
   int? get wssPort => _wssPort;
-
-  int _port = kDefaultPort;
 
   // All connected channels — only authed ones receive status broadcasts
   // and can issue commands.
@@ -166,9 +214,9 @@ class ReceiverServer extends ChangeNotifier {
 
   PendingPairingRequest? get pendingPairingRequest => _pendingPairingRequest;
 
-  Future<void> start({int port = kDefaultPort}) async {
-    _port = port;
-    await _bindListeners();
+  /// Starts the secure listener and returns the actual bound port.
+  Future<int> start({int? port}) async {
+    final boundPort = await _bindListeners(port ?? store.receiverPort);
 
     player.addListener(_broadcastStatus);
     player.indexChanges.addListener(_broadcastPlaylistStatus);
@@ -177,40 +225,87 @@ class ReceiverServer extends ChangeNotifier {
       const Duration(milliseconds: 500),
       (_) => _broadcastStatus(),
     );
+    return boundPort;
   }
 
-  /// (Re)binds the wss:// (always) and ws:// (opt-in) listeners. Re-runnable
-  /// after [reloadListeners] closes the previous sockets.
-  Future<void> _bindListeners() async {
+  /// Binds wss://, advancing only when the requested port is already occupied.
+  Future<int> _bindListeners(int preferredPort) async {
     final handler = _requestHandler();
-
-    // Encrypted wss:// on port — the default, preferred transport.
-    var wssUp = false;
+    late final CertManager cert;
     try {
-      final cert = await CertManager.loadOrCreate(commonName: store.deviceName);
-      _certFingerprint = cert.fingerprint;
-      final https = await shelf_io.serve(
-        handler,
-        InternetAddress.anyIPv4,
-        _port,
-        securityContext: cert.securityContext,
-      );
+      cert = await _certificateLoader(store.deviceName);
+    } catch (error, stackTrace) {
+      _recordStartupFailure(error);
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+    _certFingerprint = cert.fingerprint;
+
+    final candidates = receiverPortCandidates(preferredPort);
+    for (var index = 0; index < candidates.length; index++) {
+      final candidate = candidates[index];
+      late final HttpServer https;
+      try {
+        https = await _secureServerBinder(
+          handler,
+          InternetAddress.anyIPv4,
+          candidate,
+          cert.securityContext,
+        );
+      } catch (error, stackTrace) {
+        final canRetry =
+            isAddressInUseError(error) && index + 1 < candidates.length;
+        if (canRetry) {
+          debugPrint('[server] port $candidate is in use; trying next port');
+          continue;
+        }
+        _recordStartupFailure(error);
+        Error.throwWithStackTrace(error, stackTrace);
+      }
+
       _servers.add(https);
       _wssPort = https.port;
-      wssUp = true;
+      try {
+        await store.setReceiverPort(https.port);
+      } catch (error, stackTrace) {
+        _servers.remove(https);
+        _wssPort = null;
+        await https.close(force: true);
+        _recordStartupFailure(error);
+        Error.throwWithStackTrace(error, stackTrace);
+      }
+      tlsError = null;
       debugPrint(
         '[server] wss listening on ${https.address.address}:${https.port} '
         '(pin ${cert.fingerprint})',
       );
-    } catch (e) {
-      debugPrint('[server] TLS listener failed to start: $e');
+      notifyListeners();
+      return https.port;
     }
 
-    tlsError = !wssUp ? 'Secure server failed to start' : null;
+    throw StateError('No valid receiver ports are available');
+  }
 
-    // Notify so UI (e.g. the Cast screen address) reflects the bound wss port.
+  void _recordStartupFailure(Object error) {
+    tlsError = 'Secure server failed to start';
+    debugPrint('[server] TLS listener failed to start: $error');
     notifyListeners();
   }
+
+  static Future<CertManager> _loadCertificate(String commonName) =>
+      CertManager.loadOrCreate(commonName: commonName);
+
+  static Future<HttpServer> _serveSecure(
+    Handler handler,
+    InternetAddress address,
+    int port,
+    SecurityContext securityContext,
+  ) =>
+      shelf_io.serve(
+        handler,
+        address,
+        port,
+        securityContext: securityContext,
+      );
 
   /// Associates the request address directly with its upgraded channel. Logs are
   /// intentionally unavailable over LAN; use the in-app diagnostics screen.

--- a/desktop/lib/single_instance_coordinator.dart
+++ b/desktop/lib/single_instance_coordinator.dart
@@ -1,0 +1,352 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'bridge_paths.dart';
+
+const _lockFileName = 'instance.lock';
+const _metadataFileName = 'instance.json';
+const _requestTimeout = Duration(seconds: 2);
+const _retryDelay = Duration(milliseconds: 50);
+
+typedef InstanceLaunchHandler = FutureOr<void> Function(
+  InstanceLaunchRequest request,
+);
+
+/// Arguments a secondary process forwards to the running Desktop instance.
+class InstanceLaunchRequest {
+  const InstanceLaunchRequest({this.castFile, this.castTitle});
+
+  factory InstanceLaunchRequest.fromArgs(List<String> args) {
+    return InstanceLaunchRequest(
+      castFile: _argValue(args, '--cast-file'),
+      castTitle: _argValue(args, '--cast-title'),
+    );
+  }
+
+  factory InstanceLaunchRequest.fromJson(Map<String, dynamic> json) {
+    if (json['action'] != 'activate') {
+      throw const FormatException('unsupported instance action');
+    }
+    final castFile = json['castFile'];
+    final castTitle = json['castTitle'];
+    if (castFile != null && castFile is! String) {
+      throw const FormatException('castFile must be a string');
+    }
+    if (castTitle != null && castTitle is! String) {
+      throw const FormatException('castTitle must be a string');
+    }
+    return InstanceLaunchRequest(
+      castFile: castFile as String?,
+      castTitle: castTitle as String?,
+    );
+  }
+
+  final String? castFile;
+  final String? castTitle;
+
+  Map<String, dynamic> toJson({required String token}) => {
+        'token': token,
+        'action': 'activate',
+        if (castFile != null) 'castFile': castFile,
+        if (castTitle != null) 'castTitle': castTitle,
+      };
+}
+
+/// Result of coordinating this process with any existing Desktop process.
+class SingleInstanceStartResult {
+  const SingleInstanceStartResult._({
+    this.coordinator,
+    required this.forwarded,
+    this.forwardingError,
+  });
+
+  const SingleInstanceStartResult.primary(
+    SingleInstanceCoordinator coordinator,
+  ) : this._(coordinator: coordinator, forwarded: false);
+
+  const SingleInstanceStartResult.secondary({
+    required bool forwarded,
+    Object? forwardingError,
+  }) : this._(
+          forwarded: forwarded,
+          forwardingError: forwardingError,
+        );
+
+  final SingleInstanceCoordinator? coordinator;
+  final bool forwarded;
+  final Object? forwardingError;
+
+  bool get isPrimary => coordinator != null;
+}
+
+/// Ensures only one Desktop process starts receiver services for this user.
+///
+/// The primary process holds an operating-system file lock for its lifetime and
+/// publishes a token-authenticated loopback endpoint in `instance.json`.
+/// Secondary processes forward their launch request and exit. A failed forward
+/// never grants primary ownership while the lock is held.
+class SingleInstanceCoordinator {
+  SingleInstanceCoordinator._({
+    required this.directoryPath,
+    required RandomAccessFile lockHandle,
+    required ServerSocket server,
+    required String token,
+  })  : _lockHandle = lockHandle,
+        _server = server,
+        _token = token;
+
+  final String directoryPath;
+  final RandomAccessFile _lockHandle;
+  final ServerSocket _server;
+  final String _token;
+  final Queue<InstanceLaunchRequest> _pending = Queue();
+
+  InstanceLaunchHandler? _handler;
+  bool _closed = false;
+
+  String get metadataFilePath => _join(directoryPath, _metadataFileName);
+
+  static Future<SingleInstanceStartResult> coordinate({
+    required InstanceLaunchRequest request,
+    String? directoryPath,
+    Duration forwardTimeout = const Duration(seconds: 5),
+  }) async {
+    final dirPath = directoryPath ?? bridgeDirPath();
+    final directory = Directory(dirPath);
+    await directory.create(recursive: true);
+    await _restrictPermissions(directory.path, '700');
+
+    final lockHandle =
+        await File(_join(dirPath, _lockFileName)).open(mode: FileMode.append);
+    try {
+      await lockHandle.lock(FileLock.exclusive);
+    } on FileSystemException catch (lockError) {
+      await lockHandle.close();
+      return _forwardToPrimary(
+        directoryPath: dirPath,
+        request: request,
+        timeout: forwardTimeout,
+        lockError: lockError,
+      );
+    }
+
+    ServerSocket? server;
+    try {
+      server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final coordinator = SingleInstanceCoordinator._(
+        directoryPath: dirPath,
+        lockHandle: lockHandle,
+        server: server,
+        token: _randomToken(),
+      );
+      server.listen(
+        (socket) => unawaited(coordinator._handleClient(socket)),
+        onError: (Object error, StackTrace stack) {
+          stderr.writeln('[single-instance] IPC server error: $error');
+        },
+      );
+      await coordinator._writeMetadata();
+      return SingleInstanceStartResult.primary(coordinator);
+    } catch (_) {
+      await server?.close();
+      await lockHandle.unlock();
+      await lockHandle.close();
+      rethrow;
+    }
+  }
+
+  /// Installs the UI handler and drains requests received during app startup.
+  void setLaunchHandler(InstanceLaunchHandler handler) {
+    if (_closed) return;
+    _handler = handler;
+    while (_pending.isNotEmpty) {
+      _dispatch(_pending.removeFirst());
+    }
+  }
+
+  void _accept(InstanceLaunchRequest request) {
+    final handler = _handler;
+    if (handler == null) {
+      _pending.add(request);
+      return;
+    }
+    _dispatch(request);
+  }
+
+  void _dispatch(InstanceLaunchRequest request) {
+    final handler = _handler;
+    if (handler == null) {
+      _pending.add(request);
+      return;
+    }
+    Future<void>.sync(() => handler(request)).catchError(
+      (Object error, StackTrace stack) {
+        stderr.writeln('[single-instance] launch handler failed: $error');
+      },
+    );
+  }
+
+  Future<void> _handleClient(Socket socket) async {
+    var response = <String, dynamic>{'ok': false, 'error': 'invalid request'};
+    try {
+      final line = await utf8.decoder
+          .bind(socket)
+          .transform(const LineSplitter())
+          .first
+          .timeout(_requestTimeout);
+      final decoded = jsonDecode(line);
+      if (decoded is! Map<String, dynamic>) {
+        throw const FormatException('request must be an object');
+      }
+      if (decoded['token'] != _token) {
+        response = {'ok': false, 'error': 'unauthorized'};
+      } else {
+        final request = InstanceLaunchRequest.fromJson(decoded);
+        _accept(request);
+        response = {'ok': true};
+      }
+    } catch (error) {
+      response = {'ok': false, 'error': '$error'};
+    }
+
+    try {
+      socket.writeln(jsonEncode(response));
+      await socket.flush();
+    } catch (_) {
+      // The secondary may have exited while the request was being processed.
+    } finally {
+      await socket.close();
+    }
+  }
+
+  Future<void> _writeMetadata() async {
+    final file = File(metadataFilePath);
+    final handle = await file.open(mode: FileMode.write);
+    try {
+      await _restrictPermissions(file.path, '600');
+      await handle.writeString(jsonEncode({
+        'port': _server.port,
+        'token': _token,
+      }));
+      await handle.flush();
+    } finally {
+      await handle.close();
+    }
+  }
+
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    _handler = null;
+    _pending.clear();
+    await _server.close();
+    try {
+      await File(metadataFilePath).delete();
+    } on FileSystemException {
+      // A missing stale metadata file does not affect lock ownership.
+    }
+    await _lockHandle.unlock();
+    await _lockHandle.close();
+  }
+
+  static Future<SingleInstanceStartResult> _forwardToPrimary({
+    required String directoryPath,
+    required InstanceLaunchRequest request,
+    required Duration timeout,
+    required Object lockError,
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    Object lastError = lockError;
+    do {
+      Socket? socket;
+      try {
+        final metadata = await _readMetadata(directoryPath);
+        socket = await Socket.connect(
+          InternetAddress.loopbackIPv4,
+          metadata.port,
+          timeout: _requestTimeout,
+        );
+        socket.writeln(jsonEncode(request.toJson(token: metadata.token)));
+        await socket.flush();
+        final line = await utf8.decoder
+            .bind(socket)
+            .transform(const LineSplitter())
+            .first
+            .timeout(_requestTimeout);
+        final decoded = jsonDecode(line);
+        if (decoded is Map<String, dynamic> && decoded['ok'] == true) {
+          await socket.close();
+          return const SingleInstanceStartResult.secondary(forwarded: true);
+        }
+        throw StateError(
+          decoded is Map<String, dynamic>
+              ? '${decoded['error'] ?? 'primary rejected request'}'
+              : 'invalid primary response',
+        );
+      } catch (error) {
+        lastError = error;
+        socket?.destroy();
+        if (DateTime.now().isBefore(deadline)) {
+          await Future<void>.delayed(_retryDelay);
+        }
+      }
+    } while (DateTime.now().isBefore(deadline));
+
+    return SingleInstanceStartResult.secondary(
+      forwarded: false,
+      forwardingError: lastError,
+    );
+  }
+
+  static Future<_InstanceMetadata> _readMetadata(String directoryPath) async {
+    final value = jsonDecode(
+      await File(_join(directoryPath, _metadataFileName)).readAsString(),
+    );
+    if (value is! Map<String, dynamic>) {
+      throw const FormatException('instance metadata must be an object');
+    }
+    final port = value['port'];
+    final token = value['token'];
+    if (port is! int || port < 1 || port > 65535) {
+      throw const FormatException('invalid instance port');
+    }
+    if (token is! String || token.isEmpty) {
+      throw const FormatException('invalid instance token');
+    }
+    return _InstanceMetadata(port: port, token: token);
+  }
+}
+
+class _InstanceMetadata {
+  const _InstanceMetadata({required this.port, required this.token});
+
+  final int port;
+  final String token;
+}
+
+String? _argValue(List<String> args, String flag) {
+  final index = args.indexOf(flag);
+  return index >= 0 && index + 1 < args.length ? args[index + 1] : null;
+}
+
+String _join(String directory, String name) {
+  return Platform.isWindows ? '$directory\\$name' : '$directory/$name';
+}
+
+String _randomToken() {
+  final random = Random.secure();
+  return base64Url
+      .encode(List<int>.generate(32, (_) => random.nextInt(256)))
+      .replaceAll('=', '');
+}
+
+Future<void> _restrictPermissions(String path, String mode) async {
+  if (Platform.isWindows) return;
+  final result = await Process.run('chmod', [mode, path]);
+  if (result.exitCode != 0) {
+    throw FileSystemException('failed to chmod $mode', path);
+  }
+}

--- a/desktop/lib/update/app_version.dart
+++ b/desktop/lib/update/app_version.dart
@@ -2,7 +2,7 @@
 ///
 /// MUST match `version:` in pubspec.yaml (build-metadata part excluded) —
 /// guarded by `test/update_test.dart` so CI fails if they drift.
-const String kAppVersion = '0.7.0';
+const String kAppVersion = '0.8.0';
 
 /// Dotted numeric version (`0.6.4`, `1.10.2`) with sane comparison semantics.
 ///

--- a/desktop/macos/Runner/AppDelegate.swift
+++ b/desktop/macos/Runner/AppDelegate.swift
@@ -9,6 +9,19 @@ class AppDelegate: FlutterAppDelegate {
     return false
   }
 
+  override func applicationShouldHandleReopen(
+    _ sender: NSApplication,
+    hasVisibleWindows flag: Bool
+  ) -> Bool {
+    // Clicking the Dock/Finder app while PlayBridge is hidden should activate
+    // the existing process and reveal its window, never create another window.
+    if !flag {
+      mainFlutterWindow?.makeKeyAndOrderFront(self)
+    }
+    sender.activate(ignoringOtherApps: true)
+    return true
+  }
+
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
   }

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: playbridge_desktop
 description: "PlayBridge desktop receiver — accepts cast commands from the phone and plays via libmpv."
 publish_to: 'none'
-version: 0.7.0+27
+version: 0.8.0+28
 
 environment:
   sdk: ^3.6.0

--- a/desktop/test/discovery_test.dart
+++ b/desktop/test/discovery_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/discovery.dart';
+
+void main() {
+  test('advertises the bound port in both SRV and wss_port', () {
+    final publisher = DiscoveryPublisher(
+      serviceName: 'Living Room',
+      deviceId: 'receiver-uuid',
+    );
+
+    final service = publisher.serviceForPort(8766);
+
+    expect(service.port, 8766);
+    expect(service.attributes, {
+      'uuid': 'receiver-uuid',
+      'wss_port': '8766',
+    });
+  });
+
+  test('rejects an invalid listener port before creating a broadcast', () {
+    final publisher = DiscoveryPublisher(
+      serviceName: 'Living Room',
+      deviceId: 'receiver-uuid',
+    );
+
+    expect(() => publisher.serviceForPort(0), throwsArgumentError);
+    expect(() => publisher.serviceForPort(65536), throwsArgumentError);
+  });
+}

--- a/desktop/test/pairing_store_test.dart
+++ b/desktop/test/pairing_store_test.dart
@@ -13,4 +13,35 @@ void main() {
     final reloaded = await PairingStore.load();
     expect(reloaded.preselectHlsQuality, isTrue);
   });
+
+  test('receiver port defaults to 8765 and persists successful values',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    final store = await PairingStore.load();
+
+    expect(store.receiverPort, PairingStore.defaultReceiverPort);
+    await store.setReceiverPort(8768);
+
+    final reloaded = await PairingStore.load();
+    expect(reloaded.receiverPort, 8768);
+  });
+
+  test('invalid persisted receiver ports fall back to 8765', () async {
+    for (final invalidPort in [0, -1, 65536]) {
+      SharedPreferences.setMockInitialValues({
+        'pb.receiver_port': invalidPort,
+      });
+      final store = await PairingStore.load();
+      expect(store.receiverPort, PairingStore.defaultReceiverPort);
+    }
+  });
+
+  test('invalid receiver ports are not persisted', () async {
+    SharedPreferences.setMockInitialValues({});
+    final store = await PairingStore.load();
+
+    expect(() => store.setReceiverPort(0), throwsArgumentError);
+    expect(() => store.setReceiverPort(65536), throwsArgumentError);
+    expect(store.receiverPort, PairingStore.defaultReceiverPort);
+  });
 }

--- a/desktop/test/server_port_test.dart
+++ b/desktop/test/server_port_test.dart
@@ -1,0 +1,165 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/cert_manager.dart';
+import 'package:playbridge_desktop/pairing_store.dart';
+import 'package:playbridge_desktop/player_controller.dart';
+import 'package:playbridge_desktop/player_engine.dart';
+import 'package:playbridge_desktop/server.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeEngine extends PlayerEngine {
+  @override
+  String get state => 'idle';
+
+  @override
+  int get positionMs => 0;
+
+  @override
+  int get durationMs => 0;
+
+  @override
+  dynamic get tracks => null;
+
+  @override
+  dynamic get track => null;
+
+  @override
+  Future<void> setAudioTrack(dynamic track) async {}
+
+  @override
+  Future<void> setSubtitleTrack(dynamic track) async {}
+
+  @override
+  Future<void> open(QueueItem item) async {}
+
+  @override
+  Future<void> resume() async {}
+
+  @override
+  Future<void> pause() async {}
+
+  @override
+  Future<void> seek(Duration position) async {}
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> dispose() async {
+    super.dispose();
+  }
+}
+
+void main() {
+  test('candidate ports are consecutive, bounded, and normalize invalid input',
+      () {
+    expect(
+      receiverPortCandidates(8765),
+      List<int>.generate(32, (index) => 8765 + index),
+    );
+    expect(receiverPortCandidates(65534), [65534, 65535]);
+    expect(receiverPortCandidates(0, maxAttempts: 2), [8765, 8766]);
+    expect(receiverPortCandidates(8765, maxAttempts: 0), isEmpty);
+  });
+
+  test('recognizes supported address-in-use errors only', () {
+    for (final code in [48, 98, 10048]) {
+      expect(
+        isAddressInUseError(
+          SocketException('bind failed', osError: OSError('busy', code)),
+        ),
+        isTrue,
+      );
+    }
+    expect(
+      isAddressInUseError(const SocketException('Address already in use')),
+      isTrue,
+    );
+    expect(
+      isAddressInUseError(const SocketException(
+        'The shared flag to bind() needs to be `true` if binding multiple times',
+      )),
+      isTrue,
+    );
+    expect(
+      isAddressInUseError(
+        const SocketException('Permission denied',
+            osError: OSError('denied', 13)),
+      ),
+      isFalse,
+    );
+    expect(isAddressInUseError(StateError('Address already in use')), isFalse);
+  });
+
+  test('occupied preferred port falls forward and persists only the bound port',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final store = PairingStore.forTest(prefs);
+    final tlsDir = Directory.systemTemp.createTempSync('pb_server_tls_');
+    final cert = await CertManager.loadOrCreate(dir: tlsDir);
+    final blocker = await ServerSocket.bind(InternetAddress.anyIPv4, 0);
+    final preferredPort = blocker.port;
+    final player = PlayerController(engineForTest: _FakeEngine());
+    var certificateLoads = 0;
+    final server = ReceiverServer(
+      player: player,
+      store: store,
+      certificateLoader: (_) async {
+        certificateLoads++;
+        return cert;
+      },
+    );
+
+    try {
+      final boundPort = await server.start(port: preferredPort);
+
+      expect(boundPort, greaterThan(preferredPort));
+      expect(boundPort, lessThanOrEqualTo(preferredPort + 31));
+      expect(server.wssPort, boundPort);
+      expect(store.receiverPort, boundPort);
+      expect(certificateLoads, 1);
+    } finally {
+      await server.stop();
+      await blocker.close();
+      await player.dispose();
+      if (tlsDir.existsSync()) tlsDir.deleteSync(recursive: true);
+    }
+  });
+
+  test('non-collision bind failure is surfaced without trying another port',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final store = PairingStore.forTest(prefs);
+    final tlsDir = Directory.systemTemp.createTempSync('pb_server_tls_');
+    final cert = await CertManager.loadOrCreate(dir: tlsDir);
+    final player = PlayerController(engineForTest: _FakeEngine());
+    var bindAttempts = 0;
+    final server = ReceiverServer(
+      player: player,
+      store: store,
+      certificateLoader: (_) async => cert,
+      secureServerBinder: (_, __, ___, ____) async {
+        bindAttempts++;
+        throw const SocketException(
+          'Permission denied',
+          osError: OSError('Permission denied', 13),
+        );
+      },
+    );
+
+    try {
+      await expectLater(server.start(), throwsA(isA<SocketException>()));
+      expect(bindAttempts, 1);
+      expect(server.wssPort, isNull);
+      expect(store.receiverPort, PairingStore.defaultReceiverPort);
+      expect(server.tlsError, isNotNull);
+    } finally {
+      await server.stop();
+      await player.dispose();
+      if (tlsDir.existsSync()) tlsDir.deleteSync(recursive: true);
+    }
+  });
+}

--- a/desktop/test/single_instance_coordinator_test.dart
+++ b/desktop/test/single_instance_coordinator_test.dart
@@ -1,0 +1,169 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/single_instance_coordinator.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('pb_single_instance_test_');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('parses cast arguments without requiring Flutter', () {
+    final request = InstanceLaunchRequest.fromArgs([
+      '--cast-file',
+      '/tmp/video.mp4',
+      '--cast-title',
+      'A title',
+    ]);
+
+    expect(request.castFile, '/tmp/video.mp4');
+    expect(request.castTitle, 'A title');
+  });
+
+  test('secondary forwards and primary queues until UI handler is ready',
+      () async {
+    final primary = await _PrimaryHelper.start(tempDir.path);
+    addTearDown(primary.stop);
+
+    final secondaryResult = await SingleInstanceCoordinator.coordinate(
+      request: const InstanceLaunchRequest(
+        castFile: '/tmp/movie.mkv',
+        castTitle: 'Movie',
+      ),
+      directoryPath: tempDir.path,
+    ).timeout(const Duration(seconds: 8));
+
+    expect(secondaryResult.isPrimary, isFalse);
+    expect(secondaryResult.forwarded, isTrue);
+
+    await primary.send('HANDLE');
+    final line = await primary.nextLine();
+    expect(line, startsWith('REQUEST:'));
+    final request =
+        jsonDecode(line.substring('REQUEST:'.length)) as Map<String, dynamic>;
+    expect(request['castFile'], '/tmp/movie.mkv');
+    expect(request['castTitle'], 'Movie');
+  });
+
+  test('IPC endpoint rejects a request with the wrong token', () async {
+    final primaryResult = await SingleInstanceCoordinator.coordinate(
+      request: const InstanceLaunchRequest(),
+      directoryPath: tempDir.path,
+    );
+    final primary = primaryResult.coordinator!;
+    addTearDown(primary.close);
+
+    final metadata = jsonDecode(
+      await File(primary.metadataFilePath).readAsString(),
+    ) as Map<String, dynamic>;
+    final socket = await Socket.connect(
+      InternetAddress.loopbackIPv4,
+      metadata['port'] as int,
+    );
+    socket.writeln(jsonEncode({
+      'token': 'wrong-token',
+      'action': 'activate',
+    }));
+    await socket.flush();
+
+    final line =
+        await utf8.decoder.bind(socket).transform(const LineSplitter()).first;
+    final response = jsonDecode(line) as Map<String, dynamic>;
+    expect(response['ok'], isFalse);
+    expect(response['error'], 'unauthorized');
+    await socket.close();
+  });
+
+  test('a forwarding failure never lets the secondary become primary',
+      () async {
+    final primary = await _PrimaryHelper.start(tempDir.path);
+    addTearDown(primary.stop);
+    await File(primary.metadataFilePath).delete();
+
+    final secondaryResult = await SingleInstanceCoordinator.coordinate(
+      request: const InstanceLaunchRequest(),
+      directoryPath: tempDir.path,
+      forwardTimeout: const Duration(milliseconds: 150),
+    ).timeout(const Duration(seconds: 2));
+
+    expect(secondaryResult.isPrimary, isFalse);
+    expect(secondaryResult.forwarded, isFalse);
+    expect(secondaryResult.forwardingError, isNotNull);
+  });
+}
+
+class _PrimaryHelper {
+  _PrimaryHelper._(this.process, this._lines, this.metadataFilePath);
+
+  final Process process;
+  final StreamIterator<String> _lines;
+  final String metadataFilePath;
+
+  static Future<_PrimaryHelper> start(String directoryPath) async {
+    final flutterRoot = Platform.environment['FLUTTER_ROOT'];
+    final dartExecutable = flutterRoot == null
+        ? 'dart'
+        : '$flutterRoot${Platform.pathSeparator}bin${Platform.pathSeparator}'
+            'cache${Platform.pathSeparator}dart-sdk${Platform.pathSeparator}'
+            'bin${Platform.pathSeparator}'
+            '${Platform.isWindows ? 'dart.exe' : 'dart'}';
+    final process = await Process.start(
+      dartExecutable,
+      [
+        '--packages=.dart_tool/package_config.json',
+        'test/support/single_instance_primary.dart',
+        directoryPath,
+      ],
+      workingDirectory: Directory.current.path,
+    ).timeout(const Duration(seconds: 5));
+    final lines = StreamIterator(
+      process.stdout.transform(utf8.decoder).transform(const LineSplitter()),
+    );
+    final hasLine = await lines.moveNext().timeout(const Duration(seconds: 5));
+    if (!hasLine || !lines.current.startsWith('READY:')) {
+      final error = await process.stderr.transform(utf8.decoder).join();
+      throw StateError('primary helper failed to start: $error');
+    }
+    return _PrimaryHelper._(
+      process,
+      lines,
+      lines.current.substring('READY:'.length),
+    );
+  }
+
+  Future<void> send(String command) async {
+    process.stdin.writeln(command);
+    await process.stdin.flush();
+  }
+
+  Future<String> nextLine() async {
+    final hasLine = await _lines.moveNext().timeout(const Duration(seconds: 2));
+    if (!hasLine) throw StateError('primary helper exited without a response');
+    return _lines.current;
+  }
+
+  Future<void> stop() async {
+    try {
+      await send('STOP').timeout(const Duration(seconds: 1));
+    } catch (_) {
+      // The helper may already have exited after a failed assertion.
+    }
+    try {
+      await process.exitCode.timeout(const Duration(seconds: 3));
+    } on TimeoutException {
+      process.kill();
+      await process.exitCode;
+    }
+    await _lines.cancel();
+  }
+}

--- a/desktop/test/support/single_instance_primary.dart
+++ b/desktop/test/support/single_instance_primary.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:playbridge_desktop/single_instance_coordinator.dart';
+
+Future<void> main(List<String> args) async {
+  final result = await SingleInstanceCoordinator.coordinate(
+    request: const InstanceLaunchRequest(),
+    directoryPath: args.single,
+  );
+  final coordinator = result.coordinator;
+  if (coordinator == null) {
+    stderr.writeln('helper did not become primary');
+    exitCode = 1;
+    return;
+  }
+
+  stdout.writeln('READY:${coordinator.metadataFilePath}');
+  await stdout.flush();
+
+  await for (final command
+      in stdin.transform(utf8.decoder).transform(const LineSplitter())) {
+    if (command == 'HANDLE') {
+      coordinator.setLaunchHandler((request) async {
+        stdout.writeln('REQUEST:${jsonEncode({
+              'castFile': request.castFile,
+              'castTitle': request.castTitle,
+            })}');
+        await stdout.flush();
+      });
+    } else if (command == 'STOP') {
+      await coordinator.close();
+      return;
+    }
+  }
+}

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.0] — 2026-07-15
+
+### Added
+- **Native Bridge Connection Delay**: Wait up to 3 seconds for the native messaging connection to establish when casting from the extension before giving up.
+
+### Changed
+- **Native Bridge Reconnection**: Implement exponential backoff reconnection for the extension native messaging host bridge.
+
 ## [0.5.0] — 2026-07-14
 
 ### Added

--- a/extension/manifests/chrome.json
+++ b/extension/manifests/chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PlayBridge Video Detector",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Detect and cast browser videos through the PlayBridge desktop app.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtZQGgGin2mHxxXXJOQzUD9RHd5Fv19263KYRWrc5W7l2j8zggs4DXiWp5yqe56klCln3+ZNjNO0uUrU33dbkIQKRfj8hPhibBcCc7E+/+ZTFC1VZ+hry29LlDOLruMA+N7dg0EkdPD5qsHoYq6mhVelG7gpUDwnI/GPQOWezyAvYHFTfuP32cBcrW2lEMG7EZAcpds6rnFrYbGsBs/KACgYcvVGEy653tvGKBb4A2rU2bUv+5ph01sok/HDqVwwMFHHGD+U/LTy5ZGX85mRgmNhKLr/WE8IOdFFxIWzdC7hLtgRDxDiYaj2EOAFWE8v+VHmYvl++X1cDVpzxbV/MvQIDAQAB",
   "icons": {

--- a/extension/manifests/firefox.json
+++ b/extension/manifests/firefox.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "PlayBridge Video Detector",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "description": "Detect and cast browser videos through the PlayBridge desktop app.",
     "icons": {
         "128": "icon.png"

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -742,7 +742,12 @@ fun AppNavHost(
                     SettingsScreen(
                         onBack = { onScreenChange(lastMainScreen) },
                         tvIp = if (connectionState is WebSocketClient.ConnectionState.Connected) tvDevice?.ip else null,
-                        tvPort = if (connectionState is WebSocketClient.ConnectionState.Connected) tvDevice?.port else null,
+                        // New receivers advertise the independent diagnostics listener.
+                        // Legacy Android TVs used receiverPort + 1 without a TXT key.
+                        tvPort = if (connectionState is WebSocketClient.ConnectionState.Connected) {
+                            tvDevice?.logsPort
+                                ?: tvDevice?.port?.takeIf { it < 65535 }?.plus(1)
+                        } else null,
                         showBack = true,
                     )
                 }
@@ -1819,4 +1824,3 @@ private fun TvUserAgentRow(
         trailing?.invoke()
     }
 }
-

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionMerge.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionMerge.kt
@@ -5,14 +5,21 @@ import com.playbridge.sender.model.TvDevice
 /** Pure connection-bookkeeping helpers, extracted for testability. */
 object ConnectionMerge {
     /**
-     * Returns [device] with its wssPort taken from the live [discovered] list when a
-     * match is found (by uuid, then ip/port). A saved/history entry may predate TLS,
-     * so we prefer the currently-advertised port. Token + certFingerprint are kept.
+     * Returns [device] with its complete endpoint taken from the live [discovered] list
+     * when a match is found (by uuid, then ip/port). Receiver ports and DHCP addresses
+     * can change between launches, while credentials remain attached to stable identity.
      */
-    fun withDiscoveredWssPort(device: TvDevice, discovered: List<TvDevice>): TvDevice {
+    fun withDiscoveredEndpoint(device: TvDevice, discovered: List<TvDevice>): TvDevice {
         val match = (if (device.uuid.isNotEmpty()) discovered.find { it.uuid == device.uuid } else null)
             ?: discovered.find { it.ip == device.ip && it.port == device.port }
-        return device.copy(wssPort = match?.wssPort ?: device.wssPort)
+            ?: return device
+        return device.copy(
+            ip = match.ip,
+            port = match.port,
+            name = match.name,
+            wssPort = match.wssPort,
+            logsPort = match.logsPort,
+        )
     }
 
     /**
@@ -26,6 +33,27 @@ object ConnectionMerge {
     /** Same physical device: uuid match when both known, else ip/port. */
     fun isSameDevice(a: TvDevice, b: TvDevice): Boolean =
         (a.uuid.isNotEmpty() && a.uuid == b.uuid) || (a.ip == b.ip && a.port == b.port)
+
+    /**
+     * Put [device] at the front of connection history while replacing every older
+     * endpoint for the same receiver. UUID is the stable identity; ip/port remains
+     * the fallback for manual and legacy entries that do not have one.
+     */
+    fun upsertHistory(current: List<TvDevice>, device: TvDevice, limit: Int = 10): List<TvDevice> =
+        (listOf(device) + current.filterNot { isSameDevice(it, device) }).take(limit)
+
+    /**
+     * Collapse duplicates already written by older builds. History is newest-first,
+     * so the first entry retains the current endpoint and pairing credentials.
+     */
+    fun normalizeHistory(history: List<TvDevice>): List<TvDevice> =
+        history.fold(emptyList()) { unique, device ->
+            if (unique.any { isSameDevice(it, device) }) unique else unique + device
+        }
+
+    /** Remove every stale endpoint that belongs to [device]. */
+    fun removeHistoryDevice(history: List<TvDevice>, device: TvDevice): List<TvDevice> =
+        history.filterNot { isSameDevice(it, device) }
 
     /** What to do with stored credentials after an auth failure / pairing denial. */
     enum class AuthFailureAction {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionStore.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionStore.kt
@@ -68,10 +68,7 @@ class ConnectionStore(private val context: Context) {
     }
 
     /**
-     * Add to history
-     */
-    /**
-     * Add to history
+     * Add to history, replacing any stale endpoint for the same receiver UUID.
      */
     suspend fun addToHistory(device: TvDevice) {
         context.dataStore.edit { prefs ->
@@ -86,11 +83,7 @@ class ConnectionStore(private val context: Context) {
                 emptyList()
             }
 
-            // Remove existing entry for same IP/Port if exists
-            val filtered = currentHistory.filterNot { it.ip == device.ip && it.port == device.port }
-
-            // Add to front
-            val newHistory = (listOf(device) + filtered).take(10)
+            val newHistory = ConnectionMerge.upsertHistory(currentHistory, device)
 
             prefs[DEVICE_HISTORY] = protocolJson.encodeToString(
                 kotlinx.serialization.builtins.ListSerializer(TvDevice.serializer()),
@@ -139,7 +132,7 @@ class ConnectionStore(private val context: Context) {
                 emptyList()
             }
 
-            val newHistory = currentHistory.filterNot { it.ip == device.ip && it.port == device.port }
+            val newHistory = ConnectionMerge.removeHistoryDevice(currentHistory, device)
 
             prefs[DEVICE_HISTORY] = protocolJson.encodeToString(
                 kotlinx.serialization.builtins.ListSerializer(TvDevice.serializer()),
@@ -165,7 +158,9 @@ class ConnectionStore(private val context: Context) {
     }
 
     private fun decodeHistory(json: String): List<TvDevice> =
-        protocolJson.decodeFromString<List<TvDevice>>(json).map(::unprotect)
+        ConnectionMerge.normalizeHistory(
+            protocolJson.decodeFromString<List<TvDevice>>(json).map(::unprotect)
+        )
 
     private fun protect(device: TvDevice): TvDevice =
         if (device.token.isEmpty() || device.token.startsWith(ENCRYPTED_PREFIX)) device

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
@@ -64,7 +64,15 @@ class ConnectionViewModel(
         dlnaDiscovery.renderers,
     ) { native, renderers ->
         val nativeTv = native.map {
-            TvDevice(ip = it.ip, port = it.port, name = it.name, token = "", uuid = it.uuid, wssPort = it.wssPort)
+            TvDevice(
+                ip = it.ip,
+                port = it.port,
+                name = it.name,
+                token = "",
+                uuid = it.uuid,
+                wssPort = it.wssPort,
+                logsPort = it.logsPort,
+            )
         }
         ConnectionMerge.mergeDiscovered(nativeTv, renderers.map { it.toDlnaTvDevice() })
     }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
@@ -207,15 +215,9 @@ class ConnectionViewModel(
             discoveredDevices.combine(tvDevice) { devices, savedDevice ->
                 Pair(devices, savedDevice)
             }.collect { (devices, savedDevice) ->
-                if (_autoConnectEnabled.value && savedDevice != null && savedDevice.uuid.isNotEmpty()) {
-                    val matchedDevice = devices.find { it.uuid == savedDevice.uuid }
-                    if (matchedDevice != null && (matchedDevice.ip != savedDevice.ip || matchedDevice.port != savedDevice.port || matchedDevice.wssPort != savedDevice.wssPort)) {
-                        val updatedDevice = savedDevice.copy(
-                            ip = matchedDevice.ip,
-                            port = matchedDevice.port,
-                            name = matchedDevice.name,
-                            wssPort = matchedDevice.wssPort
-                        )
+                if (savedDevice != null && savedDevice.uuid.isNotEmpty()) {
+                    val updatedDevice = ConnectionMerge.withDiscoveredEndpoint(savedDevice, devices)
+                    if (updatedDevice != savedDevice) {
                         // Keep the saved address fresh for the next connect. Additionally
                         // (change 4): if the startup auto-connect already fired and lost the
                         // race against discovery — it tried the stale IP and failed while the
@@ -231,7 +233,7 @@ class ConnectionViewModel(
                             (st is WebSocketClient.ConnectionState.Disconnected ||
                                 st is WebSocketClient.ConnectionState.Error)
                         ) {
-                            Log.i(TAG, "Saved TV moved (${savedDevice.ip} → ${matchedDevice.ip}); re-arming auto-connect")
+                            Log.i(TAG, "Saved TV endpoint changed (${savedDevice.ip}:${savedDevice.port} → ${updatedDevice.ip}:${updatedDevice.port}); re-arming auto-connect")
                             hasAttemptedInitialConnect = false
                         }
                         connectionStore.saveTvDevice(updatedDevice)
@@ -338,9 +340,9 @@ class ConnectionViewModel(
         _autoConnectEnabled.value = true
         prefs.edit { putBoolean("auto_connect_tv", true) }
         viewModelScope.launch {
-            // wss_port is a live property of the receiver; a saved/history entry may
-            // predate TLS, so prefer the port from current discovery.
-            val merged = ConnectionMerge.withDiscoveredWssPort(device, discoveredDevices.value)
+            // The complete endpoint is live receiver state; a saved/history entry may
+            // contain a stale address or predate TLS, so prefer current discovery by UUID.
+            val merged = ConnectionMerge.withDiscoveredEndpoint(device, discoveredDevices.value)
             Log.d(TAG, "Connecting to: ${merged.name} at ${merged.ip}:${merged.port} (wss=${merged.wssPort})")
             hasAttemptedInitialConnect = true
             activeConnectingDevice = merged

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/NsdHelper.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/NsdHelper.kt
@@ -27,7 +27,9 @@ class NsdHelper(context: Context) {
         val uuid: String = "",
         // Port of the receiver's wss:// listener, advertised via the wss_port TXT
         // attribute. Null when the receiver only serves plaintext ws://.
-        val wssPort: Int? = null
+        val wssPort: Int? = null,
+        // Optional HTTP diagnostics port advertised via the logs_port TXT attribute.
+        val logsPort: Int? = null,
     )
 
     // Discovery is refcounted by owner so independent clients (the UI scan window and the
@@ -68,8 +70,12 @@ class NsdHelper(context: Context) {
 
                             // Update list
                             val currentList = _discoveredDevices.value.toMutableList()
-                            // Remove existing entry for same IP if exists
-                            currentList.removeAll { it.ip == device.ip }
+                            // A receiver may move to a new IP or select a different port.
+                            // Replace its previous endpoint by stable UUID when available.
+                            currentList.removeAll {
+                                (device.uuid.isNotEmpty() && it.uuid == device.uuid) ||
+                                    (device.uuid.isEmpty() && it.ip == device.ip)
+                            }
                             currentList.add(device)
                             _discoveredDevices.value = currentList
                         }
@@ -152,7 +158,9 @@ class NsdHelper(context: Context) {
             val customIp = attributes["custom_ip"]?.let { String(it) }
             val ip = if (!customIp.isNullOrEmpty() && customIp != "auto") customIp else resolvedIp
             val wssPort = attributes[NsdConstants.KEY_WSS_PORT]?.let { String(it).toIntOrNull() }
-            return DiscoveredDevice(ip, port, name, uuid, wssPort)
+            val logsPort = attributes[NsdConstants.KEY_LOGS_PORT]?.let { String(it).toIntOrNull() }
+                ?.takeIf { it in 1..65535 }
+            return DiscoveredDevice(ip, port, name, uuid, wssPort, logsPort)
         }
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/model/TvDevice.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/model/TvDevice.kt
@@ -15,6 +15,8 @@ data class TvDevice(
     // Port of the receiver's wss:// listener (from the wss_port mDNS TXT attr).
     // Null means the receiver only serves plaintext ws://.
     val wssPort: Int? = null,
+    // Optional HTTP diagnostics port advertised via the logs_port mDNS TXT attr.
+    val logsPort: Int? = null,
     // SPKI pin (sha256/<base64>) captured at pairing; validated on every wss
     // connection. Null until paired with a TLS-capable receiver.
     val certFingerprint: String? = null,

--- a/mobile/android/app/src/test/java/com/playbridge/sender/connection/ConnectionMergeTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/connection/ConnectionMergeTest.kt
@@ -12,19 +12,25 @@ class ConnectionMergeTest {
         port: Int,
         uuid: String = "",
         wssPort: Int? = null,
+        logsPort: Int? = null,
         token: String = "",
         cert: String? = null,
     ) = TvDevice(
         ip = ip, port = port, token = token, name = "TV",
-        uuid = uuid, wssPort = wssPort, certFingerprint = cert,
+        uuid = uuid, wssPort = wssPort, logsPort = logsPort, certFingerprint = cert,
     )
 
     @Test
-    fun takesDiscoveredWssPortByUuidAndKeepsCredentials() {
+    fun takesCompleteDiscoveredEndpointByUuidAndKeepsCredentials() {
         val device = dev("1.1.1.1", 8765, uuid = "u1", token = "t", cert = "sha256/x")
-        val discovered = listOf(dev("9.9.9.9", 8765, uuid = "u1", wssPort = 8766))
-        val merged = ConnectionMerge.withDiscoveredWssPort(device, discovered)
-        assertEquals(8766, merged.wssPort)
+        val discovered = listOf(
+            dev("9.9.9.9", 9020, uuid = "u1", wssPort = 9020, logsPort = 9021)
+        )
+        val merged = ConnectionMerge.withDiscoveredEndpoint(device, discovered)
+        assertEquals("9.9.9.9", merged.ip)
+        assertEquals(9020, merged.port)
+        assertEquals(9020, merged.wssPort)
+        assertEquals(9021, merged.logsPort)
         assertEquals("t", merged.token)               // token preserved
         assertEquals("sha256/x", merged.certFingerprint) // pin preserved
     }
@@ -33,19 +39,70 @@ class ConnectionMergeTest {
     fun fallsBackToIpPortMatchWhenNoUuid() {
         val device = dev("1.1.1.1", 8765, uuid = "")
         val discovered = listOf(dev("1.1.1.1", 8765, uuid = "other", wssPort = 8766))
-        assertEquals(8766, ConnectionMerge.withDiscoveredWssPort(device, discovered).wssPort)
+        assertEquals(8766, ConnectionMerge.withDiscoveredEndpoint(device, discovered).wssPort)
     }
 
     @Test
     fun keepsDeviceWssPortWhenNoMatch() {
         val device = dev("1.1.1.1", 8765, uuid = "u1", wssPort = 9000)
-        assertEquals(9000, ConnectionMerge.withDiscoveredWssPort(device, emptyList()).wssPort)
+        assertEquals(9000, ConnectionMerge.withDiscoveredEndpoint(device, emptyList()).wssPort)
     }
 
     @Test
     fun nullWhenNoMatchAndNoDeviceWssPort() {
         val device = dev("1.1.1.1", 8765, uuid = "u1")
-        assertNull(ConnectionMerge.withDiscoveredWssPort(device, emptyList()).wssPort)
+        assertNull(ConnectionMerge.withDiscoveredEndpoint(device, emptyList()).wssPort)
+    }
+
+    // ── connection history identity ────────────────────────────────────────
+
+    @Test
+    fun newPortReplacesHistoryEntryWithSameUuid() {
+        val oldEndpoint = dev("1.1.1.1", 8765, uuid = "u1", token = "old")
+        val newEndpoint = dev("1.1.1.1", 8766, uuid = "u1", token = "current")
+
+        val history = ConnectionMerge.upsertHistory(listOf(oldEndpoint), newEndpoint)
+
+        assertEquals(listOf(newEndpoint), history)
+    }
+
+    @Test
+    fun normalizesDuplicatesAlreadyStoredAtDifferentPorts() {
+        val current = dev("1.1.1.1", 8766, uuid = "u1", token = "current")
+        val stale = dev("1.1.1.1", 8765, uuid = "u1", token = "old")
+        val other = dev("2.2.2.2", 8765, uuid = "u2", token = "other")
+
+        val history = ConnectionMerge.normalizeHistory(listOf(current, stale, other))
+
+        assertEquals(listOf(current, other), history)
+    }
+
+    @Test
+    fun legacyEntriesWithoutUuidStillUseIpAndPortIdentity() {
+        val first = dev("1.1.1.1", 8765)
+        val sameEndpoint = dev("1.1.1.1", 8765, token = "new")
+        val otherPort = dev("1.1.1.1", 8766)
+
+        val history = ConnectionMerge.upsertHistory(
+            listOf(first, otherPort),
+            sameEndpoint,
+        )
+
+        assertEquals(listOf(sameEndpoint, otherPort), history)
+    }
+
+    @Test
+    fun removingByUuidClearsEveryStaleEndpoint() {
+        val current = dev("1.1.1.1", 8766, uuid = "u1")
+        val stale = dev("1.1.1.1", 8765, uuid = "u1")
+        val other = dev("2.2.2.2", 8765, uuid = "u2")
+
+        val history = ConnectionMerge.removeHistoryDevice(
+            listOf(current, stale, other),
+            current,
+        )
+
+        assertEquals(listOf(other), history)
     }
 
     // ── resolveAuthFailure ──────────────────────────────────────────────────

--- a/mobile/android/app/src/test/java/com/playbridge/sender/connection/NsdHelperParseTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/connection/NsdHelperParseTest.kt
@@ -37,6 +37,21 @@ class NsdHelperParseTest {
     }
 
     @Test
+    fun logsPortParsedOnlyWhenValid() {
+        val valid = NsdHelper.parseDevice(
+            "TV", "192.168.1.5", 8765,
+            mapOf(NsdConstants.KEY_LOGS_PORT to b("9010")),
+        )
+        val invalid = NsdHelper.parseDevice(
+            "TV", "192.168.1.5", 8765,
+            mapOf(NsdConstants.KEY_LOGS_PORT to b("70000")),
+        )
+
+        assertEquals(9010, valid.logsPort)
+        assertNull(invalid.logsPort)
+    }
+
+    @Test
     fun customIpOverridesResolvedIp() {
         val d = NsdHelper.parseDevice(
             "TV", "192.168.1.5", 8765,

--- a/mobile/apple/PlayBridge Phone/PlayBridge Phone/Network/BonjourBrowser.swift
+++ b/mobile/apple/PlayBridge Phone/PlayBridge Phone/Network/BonjourBrowser.swift
@@ -5,14 +5,21 @@ import Network
 /// Uses `NetService` because it resolves the IP, port, and TXT record in one shot (NWBrowser
 /// needs a separate connection to resolve an address).
 final class BonjourBrowser: NSObject, ObservableObject {
+    enum ScanOwner: Hashable {
+        case userInterface
+        case savedReconnect
+    }
+
     @Published private(set) var devices: [DiscoveredDevice] = []
     @Published private(set) var isScanning = false
 
     private var browser: NetServiceBrowser?
+    private var scanOwnerCounts: [ScanOwner: Int] = [:]
     /// Services currently resolving — held strongly so they aren't deallocated mid-resolve.
     private var resolving: Set<NetService> = []
 
-    func start() {
+    func start(owner: ScanOwner = .userInterface) {
+        scanOwnerCounts[owner, default: 0] += 1
         guard browser == nil else { return }
         devices = []
         resolving = []
@@ -23,7 +30,15 @@ final class BonjourBrowser: NSObject, ObservableObject {
         isScanning = true
     }
 
-    func stop() {
+    func stop(owner: ScanOwner = .userInterface) {
+        if let count = scanOwnerCounts[owner] {
+            if count > 1 {
+                scanOwnerCounts[owner] = count - 1
+            } else {
+                scanOwnerCounts[owner] = nil
+            }
+        }
+        guard scanOwnerCounts.isEmpty else { return }
         browser?.stop()
         browser = nil
         resolving.forEach { $0.stop() }
@@ -32,7 +47,10 @@ final class BonjourBrowser: NSObject, ObservableObject {
     }
 
     private func upsert(_ device: DiscoveredDevice) {
-        devices.removeAll { $0.ip == device.ip }
+        devices.removeAll {
+            if !device.uuid.isEmpty, !$0.uuid.isEmpty { return $0.uuid == device.uuid }
+            return $0.ip == device.ip
+        }
         devices.append(device)
         devices.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }

--- a/mobile/apple/PlayBridge Phone/PlayBridge Phone/Network/ConnectionViewModel.swift
+++ b/mobile/apple/PlayBridge Phone/PlayBridge Phone/Network/ConnectionViewModel.swift
@@ -20,6 +20,9 @@ final class ConnectionViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     /// The device we're currently bringing up, so we can persist a full record once paired.
     private var connectingDevice: DiscoveredDevice?
+    private var savedReconnectDiscovery: AnyCancellable?
+    private var savedReconnectTimeout: DispatchWorkItem?
+    private static let savedReconnectDiscoveryTimeout: TimeInterval = 10
 
     func deviceKey(_ d: PairedDevice) -> String { d.uuid.isEmpty ? "\(d.ip):\(d.port)" : d.uuid }
 
@@ -51,13 +54,14 @@ final class ConnectionViewModel: ObservableObject {
 
     // MARK: - Discovery
 
-    func startDiscovery() { browser.start() }
-    func stopDiscovery() { browser.stop() }
+    func startDiscovery() { browser.start(owner: .userInterface) }
+    func stopDiscovery() { browser.stop(owner: .userInterface) }
 
     // MARK: - Connect
 
     /// Connect to a device found via Bonjour. Reuses a saved token/pin if we've paired with it.
     func connect(to device: DiscoveredDevice) {
+        endSavedReconnectDiscovery()
         connectingDevice = device
         let saved = matchingSaved(for: device)
         ws.connect(
@@ -81,6 +85,7 @@ final class ConnectionViewModel: ObservableObject {
     /// Reconnect to the previously paired device (used on launch).
     func reconnectSaved() {
         guard let saved = pairedDevice else { return }
+        endSavedReconnectDiscovery()
         connectingDevice = DiscoveredDevice(ip: saved.ip, port: saved.port, name: saved.name,
                                             uuid: saved.uuid, wssPort: saved.wssPort)
         ws.connect(
@@ -93,10 +98,12 @@ final class ConnectionViewModel: ObservableObject {
             wssPort: saved.wssPort,
             certFingerprint: saved.certFingerprint
         )
+        beginSavedReconnectDiscovery(for: saved)
     }
 
     /// Connect to a specific saved TV from the history list.
     func connectSaved(_ device: PairedDevice) {
+        endSavedReconnectDiscovery()
         pairedDevice = device
         connectingDevice = DiscoveredDevice(ip: device.ip, port: device.port, name: device.name,
                                             uuid: device.uuid, wssPort: device.wssPort)
@@ -112,8 +119,86 @@ final class ConnectionViewModel: ObservableObject {
         )
     }
 
+    /// Keep launch reconnect discovery independent of the discovery screen. The stored
+    /// endpoint is tried immediately; a live Bonjour endpoint for the same UUID replaces
+    /// it once, without disturbing the receiver's token, pin, or capabilities.
+    private func beginSavedReconnectDiscovery(for saved: PairedDevice) {
+        guard !saved.uuid.isEmpty else { return }
+
+        browser.start(owner: .savedReconnect)
+        savedReconnectDiscovery = browser.$devices
+            .receive(on: RunLoop.main)
+            .sink { [weak self] devices in
+                guard let live = devices.first(where: { $0.uuid == saved.uuid }) else { return }
+                // `$devices` can synchronously emit its current value while the
+                // cancellable is still being assigned. Defer handling so cleanup can
+                // always cancel the installed subscription and prevent duplicate retries.
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, self.savedReconnectDiscovery != nil else { return }
+                    self.handleSavedReconnectEndpoint(live, replacing: saved)
+                }
+            }
+
+        let timeout = DispatchWorkItem { [weak self] in
+            self?.endSavedReconnectDiscovery()
+        }
+        savedReconnectTimeout = timeout
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.savedReconnectDiscoveryTimeout,
+            execute: timeout
+        )
+    }
+
+    private func handleSavedReconnectEndpoint(
+        _ live: DiscoveredDevice,
+        replacing saved: PairedDevice
+    ) {
+        let endpointChanged = live.ip != saved.ip
+            || live.port != saved.port
+            || live.wssPort != saved.wssPort
+        endSavedReconnectDiscovery()
+        guard endpointChanged else { return }
+
+        var refreshed = saved
+        refreshed.ip = live.ip
+        refreshed.port = live.port
+        refreshed.name = live.name
+        refreshed.wssPort = live.wssPort
+        // Copying the saved record preserves its token, SPKI pin, capabilities,
+        // last-connected timestamp, and stable receiver UUID.
+        store.savePairedDevice(refreshed)
+        upsertSaved(refreshed)
+        pairedDevice = refreshed
+        connectingDevice = DiscoveredDevice(
+            ip: refreshed.ip,
+            port: refreshed.port,
+            name: refreshed.name,
+            uuid: refreshed.uuid,
+            wssPort: refreshed.wssPort
+        )
+        ws.connect(
+            ip: refreshed.ip,
+            port: refreshed.port,
+            token: refreshed.token ?? "",
+            serverName: refreshed.name,
+            deviceName: store.localDeviceName,
+            deviceUUID: store.localDeviceUUID,
+            wssPort: refreshed.wssPort,
+            certFingerprint: refreshed.certFingerprint
+        )
+    }
+
+    private func endSavedReconnectDiscovery() {
+        savedReconnectTimeout?.cancel()
+        savedReconnectTimeout = nil
+        savedReconnectDiscovery?.cancel()
+        savedReconnectDiscovery = nil
+        browser.stop(owner: .savedReconnect)
+    }
+
     /// Remove one saved TV from history (and disconnect if it's the active one).
     func forget(_ device: PairedDevice) {
+        endSavedReconnectDiscovery()
         var list = store.loadSavedDevices()
         list.removeAll { deviceKey($0) == deviceKey(device) }
         store.saveSavedDevices(list)
@@ -167,7 +252,10 @@ final class ConnectionViewModel: ObservableObject {
         DispatchQueue.main.async { self.savedDevices = list }
     }
 
-    func disconnect() { ws.disconnect() }
+    func disconnect() {
+        endSavedReconnectDiscovery()
+        ws.disconnect()
+    }
 
     /// Submit the 6-digit SAS code the user read off the TV during pairing.
     func submitPairingCode(_ code: String) { ws.submitPairingCode(code) }

--- a/protocol/asyncapi.yaml
+++ b/protocol/asyncapi.yaml
@@ -21,6 +21,9 @@ servers:
         default: 192.0.2.1
       port:
         default: '8765'
+        description: >-
+          Preferred receiver port. Receivers may select another available port;
+          mDNS discovery supplies the active endpoint.
 channels:
   receiverSocket:
     address: /

--- a/protocol/constants/constants.go
+++ b/protocol/constants/constants.go
@@ -15,4 +15,6 @@ const (
 	// NsdKeyWssPort is the TXT key advertising the receiver's wss:// port.
 	// Absent when the receiver has no TLS listener.
 	NsdKeyWssPort     = "wss_port"
+	// NsdKeyLogsPort is the optional TXT key advertising an HTTP diagnostics endpoint.
+	NsdKeyLogsPort    = "logs_port"
 )

--- a/protocol/docs/WSS_FLOW.md
+++ b/protocol/docs/WSS_FLOW.md
@@ -10,8 +10,12 @@ schema disagree, the schema defines JSON shape and this document defines sequenc
 - A **sender** (Android phone, Apple phone, or Desktop sender mode) discovers the receiver or is
   given its IP address manually.
 - The receiver is the WebSocket server. The sender is the WebSocket client.
-- The default port is `8765`. The mDNS TXT key `wss_port` overrides it. `device_name` is only a
-  display hint and is not trusted identity.
+- The preferred port is `8765`. A receiver may select another available port when that port is
+  occupied. The mDNS SRV port is the active receiver endpoint, and the `wss_port` TXT key mirrors
+  the active secure port for compatibility. `device_name` is only a display hint and is not
+  trusted identity.
+- Receivers with a separate HTTP diagnostics listener may advertise its active port in the
+  optional `logs_port` TXT key. It is not part of the authenticated WSS transport.
 - The WebSocket URL is `wss://<host>:<wss_port>/`. IPv6 literals must be bracketed. All protocol
   messages after the HTTP upgrade are either UTF-8 JSON text frames or the 9-byte pointer frame.
 - Receivers use a locally generated TLS identity. Paired senders validate its SPKI pin on every

--- a/shared/src/commonMain/kotlin/com/playbridge/shared/protocol/NsdConstants.kt
+++ b/shared/src/commonMain/kotlin/com/playbridge/shared/protocol/NsdConstants.kt
@@ -7,4 +7,7 @@ object NsdConstants {
     // TXT key advertising the receiver's wss:// port. Absent when the receiver
     // has no TLS listener.
     const val KEY_WSS_PORT = "wss_port"
+
+    // Optional TXT key advertising Android TV's HTTP diagnostics endpoint.
+    const val KEY_LOGS_PORT = "logs_port"
 }

--- a/stream-proxy-dart/CHANGELOG.md
+++ b/stream-proxy-dart/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the PlayBridge Stream Proxy (`playbridge_stream_proxy`) w
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-07-15
+
+### Added
+- **Dynamic URI Host Rewriting**: Rewrite HLS manifests to dynamically resolve targets using the requested URI scheme and authority (rather than hardcoded 127.0.0.1) so local proxies work when casting to TV receivers.
+
+### Changed
+- **Slim Container Image**: Migrated base runtime image to a slimmer Debian distribution to reduce Docker image footprint and optimize package overhead.
+
+### Fixed
+- **Authentication Token Redaction**: Prevent writing the active loopback proxy authentication token to stdout logs.
+- **Path Segment Resolution**: Properly resolve HLS variant playlists and DRM key URLs containing relative path segments.
+
 ## [0.1.0] - 2026-07-14
 
 ### Added

--- a/stream-proxy-dart/pubspec.yaml
+++ b/stream-proxy-dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: playbridge_stream_proxy
 description: Standalone high-performance streaming proxy in Dart.
-version: 0.1.0
+version: 0.2.0
 publish_to: 'none'
 
 environment:

--- a/tv/android/player/app/src/main/java/com/playbridge/player/MainActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/MainActivity.kt
@@ -234,9 +234,15 @@ fun MainContent(
         val appCtx = currentContext.applicationContext ?: currentContext
         kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
             deviceId = pairingStore.getOrCreateDeviceId()
-            serverPort = pairingStore.serverPort.first()
             serverIp = getLocalIpAddress(appCtx)
         }
+    }
+    LaunchedEffect(Unit) {
+        pairingStore.serverPort.collect { port ->
+            serverPort = port
+        }
+    }
+    LaunchedEffect(Unit) {
         pairingStore.deviceName.collect { name ->
             deviceName = name
         }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/pairing/PairingStore.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/pairing/PairingStore.kt
@@ -93,13 +93,14 @@ class PairingStore(private val context: Context) {
      * Server port flow
      */
     val serverPort: Flow<Int> = context.dataStore.data.map { prefs ->
-        prefs[SERVER_PORT] ?: DEFAULT_PORT
+        prefs[SERVER_PORT]?.takeIf { it in 1..65535 } ?: DEFAULT_PORT
     }
     
     /**
      * Set server port
      */
     suspend fun setServerPort(port: Int) {
+        require(port in 1..65535) { "Server port must be between 1 and 65535" }
         context.dataStore.edit { prefs ->
             prefs[SERVER_PORT] = port
         }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
@@ -115,7 +115,7 @@ class ServerService : Service() {
         return START_STICKY
     }
 
-    private fun registerNsdService(port: Int, wssPort: Int?) {
+    private fun registerNsdService(port: Int, wssPort: Int?, logsPort: Int?) {
         if (registrationListener != null) return // Already registered
 
         val deviceName = android.provider.Settings.Global.getString(
@@ -138,6 +138,12 @@ class ServerService : Service() {
                     setAttribute(
                         com.playbridge.shared.protocol.NsdConstants.KEY_WSS_PORT,
                         wssPort.toString()
+                    )
+                }
+                if (logsPort != null) {
+                    setAttribute(
+                        com.playbridge.shared.protocol.NsdConstants.KEY_LOGS_PORT,
+                        logsPort.toString()
                     )
                 }
                 if (preferredIp != null && preferredIp != "auto" && preferredIp.isNotEmpty()) {
@@ -226,16 +232,20 @@ class ServerService : Service() {
                     newToken
                 },
                 tlsDir = tlsDir,
-                // Register NSD once the wss bind result is known, advertising
-                // wss_port only if it actually came up.
-                onWssReady = { wssPort -> registerNsdService(port, wssPort) },
+                // Persist and advertise only after Java-WebSocket confirms the listener
+                // is bound. The SRV port and wss_port must describe the same live endpoint.
+                onWssReady = { actualPort, logsPort ->
+                    scope.launch {
+                        pairingStore.setServerPort(actualPort)
+                        _serverInfo.value = ServerInfo(ip = ip, port = actualPort, token = "")
+                        registerNsdService(actualPort, actualPort, logsPort)
+                    }
+                },
                 // Resolved per auth so a GeckoView plugin installed later is picked up
                 // on the next (re)connect without restarting the server.
                 capabilities = { TvCapabilityProvider.current(this@ServerService) },
             ).also { server ->
                 server.start()
-
-                _serverInfo.value = ServerInfo(ip = ip, port = port, token = "")
 
                 // Observe connection state for notification updates and expose to UI
                 launch {
@@ -339,7 +349,7 @@ class ServerService : Service() {
                 }
             }
 
-            FileLogger.i(TAG, "Server started at $ip:$port")
+            FileLogger.i(TAG, "Server startup requested at $ip beginning with port $port")
         }
     }
 

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/WebSocketServer.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/WebSocketServer.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.io.File
+import java.net.BindException
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -32,6 +33,29 @@ import kotlinx.serialization.json.add
 import kotlinx.serialization.json.put
 
 private const val TAG = "WebSocketServer"
+private const val WSS_START_TIMEOUT_MS = 10_000L
+
+internal fun receiverPortCandidates(
+    requestedPort: Int,
+    defaultPort: Int = com.playbridge.shared.protocol.Config.DEFAULT_PORT,
+    maxAttempts: Int = 32,
+): List<Int> {
+    if (maxAttempts <= 0) return emptyList()
+    val firstPort = requestedPort.takeIf { it in 1..65535 }
+        ?: defaultPort.takeIf { it in 1..65535 }
+        ?: return emptyList()
+    val attemptCount = minOf(maxAttempts, 65535 - firstPort + 1)
+    return List(attemptCount) { offset -> firstPort + offset }
+}
+
+internal fun Throwable.isAddressAlreadyInUse(): Boolean =
+    generateSequence(this) { it.cause }
+        .any { cause ->
+            cause is BindException && (
+                cause.message?.contains("address already in use", ignoreCase = true) == true ||
+                    cause.message?.contains("EADDRINUSE", ignoreCase = true) == true
+                )
+        }
 
 /**
  * WebSocket server for receiving commands from the phone app
@@ -43,9 +67,9 @@ class WebSocketServer(
     // App-private directory for the persisted TLS identity (PKCS12). wss:// is
     // disabled if null.
     private val tlsDir: File? = null,
-    // Invoked after the wss bind attempt with the bound port (null if it failed),
-    // so the caller advertises wss_port over NSD only when it's actually up.
-    private val onWssReady: ((Int?) -> Unit)? = null,
+    // Invoked from Java-WebSocket's onStart path with the actual bound port. It is
+    // never invoked for a failed bind, so callers cannot advertise a dead endpoint.
+    private val onWssReady: ((wssPort: Int, logsPort: Int?) -> Unit)? = null,
     // Players/browsers this receiver supports, re-evaluated per auth so a plugin installed
     // after start-up is picked up on the next (re)connect. Reported to the phone at auth.
     private val capabilities: () -> TvCapabilities = { TvCapabilities(emptyList(), emptyList()) },
@@ -74,8 +98,9 @@ class WebSocketServer(
     private val failedAttemptsMap = ConcurrentHashMap<String, Int>()
     private val lockoutMap = ConcurrentHashMap<String, Long>()
 
-    private var server: EmbeddedServer<*, *>? = null
+    private var diagnosticsServer: EmbeddedServer<*, *>? = null
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var startJob: Job? = null
 
     // wss:// (Java-WebSocket) transport + its authenticated connections.
     private var wssServer: WssTransport? = null
@@ -127,82 +152,26 @@ class WebSocketServer(
     }
 
     fun start() {
-        if (server != null) {
+        if (startJob?.isActive == true || wssServer != null) {
             FileLogger.w(TAG, "Server already running")
             return
         }
 
         _connectionState.value = ConnectionState.Starting
 
-        scope.launch {
+        startJob = scope.launch {
             try {
-                // Ensure previous instance is stopped if it was somehow left valid but not running
-                server?.stop(1000, 2000)
-                server = null
-
-                val bindHost = "0.0.0.0"
-                server = embeddedServer(CIO, host = bindHost, port = port + 1) {
-                    routing {
-                        // HTTP endpoint: download log files
-                        get("/logs") {
-                            if (!FileLogger.isEnabled()) {
-                                call.respondText(
-                                    "Logging is disabled on the TV.",
-                                    ContentType.Text.Plain,
-                                    HttpStatusCode.Forbidden
-                                )
-                                return@get
-                            }
-                            val logFiles = FileLogger.getLogFiles()
-                            if (logFiles.isEmpty()) {
-                                call.respondText("No log files found.", ContentType.Text.Plain)
-                                return@get
-                            }
-                            val combined = logFiles.reversed().joinToString("\n") { it.readText() }
-                            call.response.header(
-                                HttpHeaders.ContentDisposition,
-                                ContentDisposition.Attachment.withParameter(
-                                    ContentDisposition.Parameters.FileName, "playbridge_tv_logs.txt"
-                                ).toString()
-                            )
-                            call.respondText(combined, ContentType.Text.Plain)
-                        }
-
-                        // HTTP endpoint: clear log files. Gated like GET: this listener is
-                        // reachable by anyone on the LAN, so honour the on-TV logging
-                        // opt-in rather than letting arbitrary peers wipe diagnostics.
-                        delete("/logs") {
-                            if (!FileLogger.isEnabled()) {
-                                call.respondText(
-                                    "Logging is disabled on the TV.",
-                                    ContentType.Text.Plain,
-                                    HttpStatusCode.Forbidden
-                                )
-                                return@delete
-                            }
-                            FileLogger.clearLogs()
-                            call.respondText("Logs cleared.", ContentType.Text.Plain)
-                        }
-                    }
-                }.start(wait = false)
-
-                _connectionState.value = ConnectionState.Running(port)
-                FileLogger.i(TAG, "http log server on $bindHost:${port + 1}")
-                startWssTransport()
-                onWssReady?.invoke(boundWssPort)
-
-            } catch (e: java.net.BindException) {
-                FileLogger.w(TAG, "Port $port already in use. Assuming server from previous instance is still active.")
-                // If the port is in use, it's likely our own service from a previous run that hasn't fully released yet,
-                // or a separate instance. We'll mark as running for the UI.
-                _connectionState.value = ConnectionState.Running(port)
-                // The prior instance holds the ports and is serving wss on port; keep the
-                // service advertised (registerNsdService no-ops if already registered). We
-                // don't re-attempt the wss bind here — that'd just log a spurious failure.
-                onWssReady?.invoke(port)
+                val selectedPort = startWssTransport()
+                val logsPort = startDiagnosticsServer(selectedPort)
+                _connectionState.value = ConnectionState.Running(selectedPort)
+                onWssReady?.invoke(selectedPort, logsPort)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 FileLogger.e(TAG, "Failed to start server", e)
                 _connectionState.value = ConnectionState.Error(e.message ?: "Unknown error")
+            } finally {
+                startJob = null
             }
         }
     }
@@ -213,9 +182,11 @@ class WebSocketServer(
         // teardown off the caller's thread. This is invoked from ServerService.onDestroy
         // on the main thread — the previous runBlocking teardown could stall it for
         // 1.5s+ (ANR territory).
-        val ktor = server
+        val ktor = diagnosticsServer
         val wss = wssServer
-        server = null
+        startJob?.cancel()
+        startJob = null
+        diagnosticsServer = null
         wssServer = null
         wssClients.clear()
         boundWssPort = null
@@ -245,37 +216,125 @@ class WebSocketServer(
         }
     }
 
-    fun getPort(): Int = port
+    fun getPort(): Int = boundWssPort ?: port
 
-    private fun startWssTransport() {
+    private suspend fun startWssTransport(): Int {
         val dir = tlsDir
         if (dir == null) {
-            FileLogger.w(TAG, "No tlsDir provided — wss:// disabled")
-            signalUnreachableIfSecureOnly()
-            return
+            throw IllegalStateException("No TLS identity directory configured")
         }
-        try {
-            val tls = TlsIdentity.loadOrCreate(dir)
-            certFingerprint = tls.fingerprint
-            val wssPort = port
-            WssTransport(wssPort, tls.sslContext).also {
-                it.start()
-                wssServer = it
-                boundWssPort = wssPort
-            }
-            FileLogger.i(TAG, "wss server started on $wssPort (pin ${tls.fingerprint})")
-        } catch (e: Exception) {
-            FileLogger.e(TAG, "Failed to start wss transport", e)
-            signalUnreachableIfSecureOnly()
-        }
-    }
 
-    // wss failed and ws:// is loopback-only ⇒ unreachable by external senders.
-    private fun signalUnreachableIfSecureOnly() {
-        _connectionState.value = ConnectionState.Error(
-            "Secure server failed to start"
+        val tls = TlsIdentity.loadOrCreate(dir)
+        val candidates = receiverPortCandidates(port)
+        var lastBindFailure: Throwable? = null
+        for (candidate in candidates) {
+            val transport = WssTransport(candidate, tls.sslContext)
+            wssServer = transport
+            val startupFailure = try {
+                transport.start()
+                transport.awaitStartup()
+            } catch (e: Exception) {
+                e
+            }
+
+            if (startupFailure == null) {
+                certFingerprint = tls.fingerprint
+                boundWssPort = candidate
+                FileLogger.i(TAG, "wss server started on $candidate (pin ${tls.fingerprint})")
+                return candidate
+            }
+
+            if (wssServer === transport) wssServer = null
+            try {
+                transport.stop(500)
+            } catch (_: Exception) {
+                // A transport that failed before binding may already be fully stopped.
+            }
+
+            if (!startupFailure.isAddressAlreadyInUse()) throw startupFailure
+            lastBindFailure = startupFailure
+            FileLogger.w(TAG, "Port $candidate is in use; trying the next receiver port")
+        }
+
+        throw IllegalStateException(
+            "No available receiver port in ${candidates.firstOrNull()}..${candidates.lastOrNull()}",
+            lastBindFailure,
         )
     }
+
+    private suspend fun startDiagnosticsServer(selectedPort: Int): Int? {
+        val preferredPort = if (selectedPort < 65535) selectedPort + 1 else 0
+        val started = try {
+            startDiagnosticsServerOn(preferredPort)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (preferredFailure: Exception) {
+            FileLogger.w(TAG, "Diagnostics server failed on port $preferredPort; trying an OS-assigned port")
+            if (preferredPort == 0) {
+                FileLogger.e(TAG, "Diagnostics server unavailable", preferredFailure)
+                return null
+            }
+            try {
+                startDiagnosticsServerOn(0)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (fallbackFailure: Exception) {
+                FileLogger.e(TAG, "Diagnostics server unavailable", fallbackFailure)
+                return null
+            }
+        }
+        diagnosticsServer = started
+        val actualPort = try {
+            started.engine.resolvedConnectors().firstOrNull()?.port
+        } catch (e: Exception) {
+            FileLogger.w(TAG, "Could not resolve diagnostics server port", e)
+            null
+        }?.takeIf { it in 1..65535 }
+        FileLogger.i(TAG, "http log server on 0.0.0.0:${actualPort ?: "OS-assigned"}")
+        return actualPort
+    }
+
+    private fun startDiagnosticsServerOn(diagnosticsPort: Int): EmbeddedServer<*, *> =
+        embeddedServer(CIO, host = "0.0.0.0", port = diagnosticsPort) {
+            routing {
+                get("/logs") {
+                    if (!FileLogger.isEnabled()) {
+                        call.respondText(
+                            "Logging is disabled on the TV.",
+                            ContentType.Text.Plain,
+                            HttpStatusCode.Forbidden
+                        )
+                        return@get
+                    }
+                    val logFiles = FileLogger.getLogFiles()
+                    if (logFiles.isEmpty()) {
+                        call.respondText("No log files found.", ContentType.Text.Plain)
+                        return@get
+                    }
+                    val combined = logFiles.reversed().joinToString("\n") { it.readText() }
+                    call.response.header(
+                        HttpHeaders.ContentDisposition,
+                        ContentDisposition.Attachment.withParameter(
+                            ContentDisposition.Parameters.FileName, "playbridge_tv_logs.txt"
+                        ).toString()
+                    )
+                    call.respondText(combined, ContentType.Text.Plain)
+                }
+
+                delete("/logs") {
+                    if (!FileLogger.isEnabled()) {
+                        call.respondText(
+                            "Logging is disabled on the TV.",
+                            ContentType.Text.Plain,
+                            HttpStatusCode.Forbidden
+                        )
+                        return@delete
+                    }
+                    FileLogger.clearLogs()
+                    call.respondText("Logs cleared.", ContentType.Text.Plain)
+                }
+            }
+        }.start(wait = false)
 
     // Shared pairing approval: displays the SAS code and awaits the phone's confirmation MAC
     // (auto-deny after 60s). The window matches the desktop receiver and gives the user room
@@ -301,6 +360,7 @@ class WebSocketServer(
     ) : org.java_websocket.server.WebSocketServer(java.net.InetSocketAddress(wssPort)) {
 
         private val authed = ConcurrentHashMap.newKeySet<org.java_websocket.WebSocket>()
+        private val startup = CompletableDeferred<Throwable?>()
 
         init {
             setWebSocketFactory(org.java_websocket.server.DefaultSSLWebSocketServerFactory(sslContext))
@@ -310,6 +370,7 @@ class WebSocketServer(
 
         override fun onStart() {
             FileLogger.i(TAG, "wss transport listening on $wssPort")
+            startup.complete(null)
         }
 
         override fun onOpen(conn: org.java_websocket.WebSocket, handshake: org.java_websocket.handshake.ClientHandshake) {
@@ -343,6 +404,13 @@ class WebSocketServer(
 
         override fun onError(conn: org.java_websocket.WebSocket?, ex: Exception) {
             FileLogger.e(TAG, "wss error", ex)
+            if (conn == null) startup.complete(ex)
+        }
+
+        suspend fun awaitStartup(): Throwable? = try {
+            withTimeout(WSS_START_TIMEOUT_MS) { startup.await() }
+        } catch (e: TimeoutCancellationException) {
+            IllegalStateException("Timed out waiting for port $wssPort to bind", e)
         }
 
         override fun onMessage(conn: org.java_websocket.WebSocket, message: String) {
@@ -573,7 +641,7 @@ class WebSocketServer(
             val clients = wssClients.toList()
             _connectedClientCount.value = clients.size
             if (clients.isEmpty()) {
-                _connectionState.value = ConnectionState.Running(port)
+                _connectionState.value = ConnectionState.Running(getPort())
             } else {
                 if (_connectionState.value !is ConnectionState.Connected) {
                     _connectionState.value = ConnectionState.Connected(clients.first().remoteSocketAddress?.toString() ?: "wss")

--- a/tv/android/player/app/src/test/java/com/playbridge/player/server/WebSocketServerPortSelectionTest.kt
+++ b/tv/android/player/app/src/test/java/com/playbridge/player/server/WebSocketServerPortSelectionTest.kt
@@ -1,0 +1,41 @@
+package com.playbridge.player.server
+
+import java.net.BindException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WebSocketServerPortSelectionTest {
+    @Test
+    fun invalidPersistedPortFallsBackToDefaultAndTries32Ports() {
+        val candidates = receiverPortCandidates(requestedPort = 0)
+
+        assertEquals(32, candidates.size)
+        assertEquals(8765, candidates.first())
+        assertEquals(8796, candidates.last())
+    }
+
+    @Test
+    fun validPersistedPortIsFirstCandidate() {
+        assertEquals((9000..9031).toList(), receiverPortCandidates(requestedPort = 9000))
+    }
+
+    @Test
+    fun candidatesStopAtHighestValidPort() {
+        assertEquals(listOf(65534, 65535), receiverPortCandidates(requestedPort = 65534))
+    }
+
+    @Test
+    fun onlyAddressInUseBindFailuresAreRetryable() {
+        val inUse = IllegalStateException(
+            "wrapped",
+            BindException("bind failed: EADDRINUSE (Address already in use)"),
+        )
+        val otherBindFailure = BindException("Cannot assign requested address")
+
+        assertTrue(inUse.isAddressAlreadyInUse())
+        assertFalse(otherBindFailure.isAddressAlreadyInUse())
+        assertFalse(IllegalStateException("TLS configuration failed").isAddressAlreadyInUse())
+    }
+}

--- a/tv/apple/PlayBridge TV/PlayBridge TV/ContentView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/ContentView.swift
@@ -142,7 +142,9 @@ struct ContentView: View {
         .onChange(of: scenePhase) { _, newPhase in
             switch newPhase {
             case .active:
-                server.restart()
+                // start() is idempotent, which avoids rebinding a listener already
+                // created by onAppear during the same foreground transition.
+                server.start()
                 stillWatching.foregroundChanged(true)
             case .background:
                 server.stop()

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
@@ -56,6 +56,9 @@ class WebSocketServer: ObservableObject {
     private let authorizedTokensKey = "pb_authorized_tokens"
     private let deviceUUIDKey = "pb_device_uuid"
     private let pairedDevicesKey = "pb_paired_devices"
+    private let receiverPortKey = "pb_receiver_port"
+    private static let defaultReceiverPort: UInt16 = 8765
+    private static let maxReceiverPortAttempts = 32
 
     private var autoTimeoutWork: DispatchWorkItem?
     private var keepaliveTimer: Timer?
@@ -110,48 +113,42 @@ class WebSocketServer: ObservableObject {
             .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in self?.broadcastPlaylistStatus() }
 
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleForeground),
-            name: UIApplication.willEnterForegroundNotification,
-            object: nil
+    }
+
+    func start(port: UInt16? = nil) {
+        // ContentView owns app lifecycle. Its onAppear and scenePhase callbacks can
+        // occur close together, so starting must be idempotent: cancelling and
+        // immediately rebinding our own fresh listener looks like EADDRINUSE and
+        // would incorrectly advance the persisted receiver port on every foreground.
+        guard tlsListener == nil else { return }
+
+        let preferredPort = port ?? storedReceiverPort
+        serverState = "Starting..."
+        wssPort = nil
+
+        // wss is the default and only transport. Bonjour is attached only after
+        // NWListener confirms that the selected port is ready to accept connections.
+        startTLSListener(
+            port: preferredPort,
+            attemptsRemaining: Self.maxReceiverPortAttempts
         )
-    }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
-    @objc private func handleForeground() {
-        if serverState != "Ready to Connect" { restart() }
-    }
-
-    func start(port: UInt16 = 8765) {
-        let wssPort = port
-
-        // wss is the default and only transport. It carries the mDNS service.
-        let tlsUp = startTLSListener(
-            port: wssPort,
-            service: makeBonjourService(wssPort: wssPort)
-        )
-
-        if !tlsUp {
-            // Fail closed: no listener is running, so surface why.
-            DispatchQueue.main.async {
-                self.serverState = "Secure server failed to start"
-            }
-        }
         startKeepalive()
     }
 
-    private func makeBonjourService(wssPort: UInt16?) -> NWListener.Service {
-        var txtDict: [String: Data] = [
+    private var storedReceiverPort: UInt16 {
+        let stored = UserDefaults.standard.integer(forKey: receiverPortKey)
+        guard stored >= 1, let port = UInt16(exactly: stored) else {
+            return Self.defaultReceiverPort
+        }
+        return port
+    }
+
+    private func makeBonjourService(wssPort: UInt16) -> NWListener.Service {
+        let txtDict: [String: Data] = [
             "uuid": deviceUUID.data(using: .utf8)!,
             "device_name": deviceName.data(using: .utf8)!,
+            "wss_port": String(wssPort).data(using: .utf8)!,
         ]
-        if let wssPort {
-            txtDict["wss_port"] = String(wssPort).data(using: .utf8)!
-        }
         return NWListener.Service(
             name: deviceName, type: "_playbridge._tcp", domain: nil,
             txtRecord: NetService.data(fromTXTRecord: txtDict))
@@ -166,50 +163,17 @@ class WebSocketServer: ObservableObject {
         return tcp
     }
 
-    /// The listener carrying the bonjour service is "primary" and drives the UI
-    /// serverState + restart; a secondary listener just logs.
-    private func makeStateHandler(label: String, primary: Bool) -> (NWListener.State) -> Void {
-        return { [weak self] state in
-            if primary {
-                DispatchQueue.main.async {
-                    guard let self = self else { return }
-                    switch state {
-                    case .ready:
-                        self.serverState = "Ready to Connect"
-                        self.restartAttempts = 0
-                    case .failed(let error):
-                        self.serverState = "Error: \(error.localizedDescription)"
-                        self.scheduleRestart()
-                    case .waiting(let error):
-                        self.serverState = "Waiting: \(error.localizedDescription)"
-                    case .setup: self.serverState = "Starting..."
-                    case .cancelled: self.serverState = "Stopped"
-                    default: break
-                    }
-                }
-            } else {
-                switch state {
-                case .ready: print("[\(label)] ready")
-                case .failed(let error): print("[\(label)] failed: \(error)")
-                default: break
-                }
-            }
-        }
-    }
-
-
-
-    /// Starts the encrypted wss:// listener on [port], reusing the plaintext
-    /// connection handler. Returns false if the TLS identity is unavailable or
-    /// the listener fails to bind (in which case we serve ws:// only).
-    @discardableResult
-    private func startTLSListener(port: UInt16, service: NWListener.Service?) -> Bool {
+    /// Starts the encrypted wss:// listener on `port`. Address collisions advance
+    /// through a bounded range; every other failure stops startup and is surfaced.
+    private func startTLSListener(port: UInt16, attemptsRemaining: Int) {
         let identity: TLSIdentity.Result
         do {
             identity = try TLSIdentity.loadOrCreate(commonName: deviceName)
         } catch {
-            print("[wss] TLS identity unavailable — encrypted listener disabled: \(error)")
-            return false
+            print("[wss] TLS identity unavailable: \(error)")
+            certFingerprint = nil
+            serverState = "Secure server failed to start"
+            return
         }
         certFingerprint = identity.fingerprint
 
@@ -226,20 +190,99 @@ class WebSocketServer: ObservableObject {
 
         do {
             let l = try NWListener(using: parameters, on: NWEndpoint.Port(integerLiteral: port))
-            l.service = service
-            l.stateUpdateHandler = makeStateHandler(label: "wss", primary: service != nil)
+            l.stateUpdateHandler = { [weak self, weak l] state in
+                guard let self, let l, self.tlsListener === l else { return }
+                self.handleTLSListenerState(
+                    state,
+                    listener: l,
+                    port: port,
+                    attemptsRemaining: attemptsRemaining
+                )
+            }
             l.newConnectionHandler = { [weak self] connection in
                 self?.handleNewConnection(connection)
             }
-            l.start(queue: .main)
             tlsListener = l
-            DispatchQueue.main.async { self.wssPort = port }
-            print("[wss] listening on \(port) (pin \(identity.fingerprint))")
-            return true
+            l.start(queue: .main)
         } catch {
             print("[wss] listener error: \(error)")
-            return false
+            if let nwError = error as? NWError, isAddressInUse(nwError) {
+                retryAfterAddressInUse(port: port, attemptsRemaining: attemptsRemaining)
+            } else {
+                certFingerprint = nil
+                serverState = "Error: \(error.localizedDescription)"
+            }
         }
+    }
+
+    private func handleTLSListenerState(
+        _ state: NWListener.State,
+        listener: NWListener,
+        port: UInt16,
+        attemptsRemaining: Int
+    ) {
+        switch state {
+        case .ready:
+            // NWListener.service can be assigned after readiness. Doing so ensures a
+            // collided candidate is never advertised and TXT/SRV use the bound port.
+            listener.service = makeBonjourService(wssPort: port)
+            wssPort = port
+            UserDefaults.standard.set(Int(port), forKey: receiverPortKey)
+            serverState = "Ready to Connect"
+            restartAttempts = 0
+            print("[wss] listening on \(port)")
+        case .failed(let error):
+            let failedAfterReadiness = wssPort == port
+            abandonTLSListener(listener)
+            if isAddressInUse(error) {
+                retryAfterAddressInUse(port: port, attemptsRemaining: attemptsRemaining)
+            } else {
+                certFingerprint = nil
+                serverState = "Error: \(error.localizedDescription)"
+                print("[wss] failed: \(error)")
+                if failedAfterReadiness {
+                    scheduleRestart(port: port)
+                }
+            }
+        case .waiting(let error):
+            if isAddressInUse(error) {
+                abandonTLSListener(listener)
+                retryAfterAddressInUse(port: port, attemptsRemaining: attemptsRemaining)
+            } else {
+                serverState = "Waiting: \(error.localizedDescription)"
+            }
+        case .setup:
+            serverState = "Starting..."
+        case .cancelled:
+            serverState = "Stopped"
+        @unknown default:
+            break
+        }
+    }
+
+    private func abandonTLSListener(_ listener: NWListener) {
+        listener.stateUpdateHandler = nil
+        listener.newConnectionHandler = nil
+        listener.cancel()
+        tlsListener = nil
+        wssPort = nil
+    }
+
+    private func isAddressInUse(_ error: NWError) -> Bool {
+        if case .posix(let code) = error { return code == .EADDRINUSE }
+        return false
+    }
+
+    private func retryAfterAddressInUse(port: UInt16, attemptsRemaining: Int) {
+        guard attemptsRemaining > 1, port < UInt16.max else {
+            certFingerprint = nil
+            serverState = "No available receiver port"
+            print("[wss] no available port after bounded fallback from \(storedReceiverPort)")
+            return
+        }
+        let nextPort = port + 1
+        serverState = "Port \(port) in use; trying \(nextPort)"
+        startTLSListener(port: nextPort, attemptsRemaining: attemptsRemaining - 1)
     }
 
     func stop() {
@@ -263,12 +306,15 @@ class WebSocketServer: ObservableObject {
         }
     }
 
-    func restart(port: UInt16 = 8765) {
+    func restart(port: UInt16? = nil) {
         stop()
         start(port: port)
     }
 
-    private func scheduleRestart(port: UInt16 = 8765) {
+    /// A listener that was previously ready may fail after a network transition.
+    /// Recover that listener on the same selected port without treating the failure
+    /// as a collision or scanning additional ports.
+    private func scheduleRestart(port: UInt16) {
         restartWork?.cancel()
         let delay = min(pow(2.0, Double(restartAttempts)), 30.0)
         restartAttempts += 1

--- a/tv/apple/PlayBridge TV/PlayBridge TV/UI/Views/PairingView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/UI/Views/PairingView.swift
@@ -92,7 +92,7 @@ struct PairingIdleView: View {
                     .foregroundColor(.white)
             }
 
-            Text("\(server.localIP):\(String(server.wssPort ?? 8765))")
+            Text(server.wssPort.map { "\(server.localIP):\($0)" } ?? "\(server.localIP) · port pending")
                 .font(.system(size: 32, design: .monospaced))
                 .foregroundColor(.white.opacity(0.6))
 


### PR DESCRIPTION
## Summary

Promote the changes merged into `release/v0.8.0` after the previous release promotion:

- select an available receiver port when 8765 is occupied
- deduplicate Android receiver history when a device changes ports
- prevent duplicate Desktop instances and terminate the secondary native runner after forwarding
- include the already-reviewed v0.8.0 release metadata

## Verification

- Desktop: all 55 Flutter tests pass
- Desktop: `flutter analyze` passes
- Android focused `ConnectionMergeTest` passes
- tvOS build passes
- macOS two-instance manual test confirms the primary window is focused and the secondary process exits without a blank window

## Notes

This PR promotes the release branch into `main`; it does not introduce new product changes or version updates.