### PR TITLE
Require explicit proxy passwords

### DIFF
--- a/desktop/lib/stream_proxy_server.dart
+++ b/desktop/lib/stream_proxy_server.dart
@@ -29,12 +29,13 @@ class StreamProxyServer {
     // 2. Generate a secure random token for the proxy session
     final rng = Random.secure();
     final randomBytes = List<int>.generate(16, (_) => rng.nextInt(256));
-    _sessionToken = base64Url.encode(randomBytes).replaceAll('=', '');
+    final sessionToken = base64Url.encode(randomBytes).replaceAll('=', '');
+    _sessionToken = sessionToken;
 
     // 3. Start the Shelf server directly in-process
     stdout
         .writeln('[stream-proxy] Starting in-process proxy on port $_port...');
-    _server = proxy.StreamProxyServer(password: _sessionToken);
+    _server = proxy.StreamProxyServer(password: sessionToken);
 
     // Bind to 0.0.0.0 to allow connection from external TV receivers in the same network
     await _server!.start(host: '0.0.0.0', port: _port!);

--- a/stream-proxy-dart/README.md
+++ b/stream-proxy-dart/README.md
@@ -49,13 +49,13 @@ services:
     environment:
       - PORT=8888
       - ADDRESS=0.0.0.0
-      - PASSWORD=my_secure_proxy_token # Optional: Set to enforce token authorization
+      - PB_PROXY_PASSWORD=replace_with_a_unique_proxy_password # Required
     restart: unless-stopped
 ```
 
 - **`PORT`**: The internal port the server binds to (default: `8888`).
 - **`ADDRESS`**: The interface address to bind to. Use `0.0.0.0` for Docker.
-- **`PASSWORD`**: If set, requests must include a `token` query parameter or `Authorization: Bearer <password>` header matching this value.
+- **`PB_PROXY_PASSWORD`**: Required. The proxy refuses to start unless this is a unique, non-empty password. Requests must include a `token` query parameter or `Authorization: Bearer <password>` header matching this value.
 
 ---
 
@@ -65,7 +65,7 @@ To run or compile the proxy locally without Docker, make sure you have the [Dart
 
 ### Run Directly
 ```bash
-dart run bin/stream_proxy.dart -p 8888
+dart run bin/stream_proxy.dart -p 8888 -k replace_with_a_unique_proxy_password
 ```
 
 ### Compile to Standalone Native Binary

--- a/stream-proxy-dart/bin/stream_proxy.dart
+++ b/stream-proxy-dart/bin/stream_proxy.dart
@@ -38,8 +38,8 @@ void main(List<String> args) async {
       Platform.environment['ADDRESS'] ?? parsed['address'] as String;
   final ffmpegPath =
       Platform.environment['FFMPEG_PATH'] ?? parsed['ffmpeg-path'] as String?;
-  final password =
-      Platform.environment['PASSWORD'] ?? parsed['password'] as String?;
+  final password = Platform.environment['PB_PROXY_PASSWORD'] ??
+      parsed['password'] as String?;
 
   if (ffmpegPath != null && ffmpegPath.isNotEmpty) {
     AvioClient.dyldFrameworkPathOverride = ffmpegPath;
@@ -47,7 +47,13 @@ void main(List<String> args) async {
         .writeln('[pb-proxy-cli] Custom FFmpeg library path set: $ffmpegPath');
   }
 
-  final server = StreamProxyServer(password: password);
+  final StreamProxyServer server;
+  try {
+    server = StreamProxyServer(password: password ?? '');
+  } on ArgumentError catch (e) {
+    stderr.writeln('Cannot start proxy: ${e.message}');
+    exit(64);
+  }
 
   // Handle system signals for graceful shutdown
   ProcessSignal.sigint.watch().listen((_) async {

--- a/stream-proxy-dart/demo.html
+++ b/stream-proxy-dart/demo.html
@@ -27,7 +27,8 @@
   .section { margin-bottom: 20px; }
   .section-title { font-size: 0.95rem; color: #c9d1d9; margin-bottom: 8px; font-weight: 600; }
   .hint { font-size: 0.75rem; color: #484f58; margin-top: 4px; }
-  .btn-row { display: flex; gap: 8px; margin-top: 8px; }
+  .btn-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; }
+  .copy-label { color: #8b949e; font-size: 0.8rem; margin-top: 14px; }
   #playerSection { display: none; }
   .tag { display: inline-block; background: #1f6feb22; color: #58a6ff; border: 1px solid #1f6feb44; border-radius: 4px; padding: 2px 8px; font-size: 0.7rem; margin-right: 4px; }
   .parsed-headers { margin-top: 8px; }
@@ -75,14 +76,20 @@
 <div class="section" id="resultSection" style="display:none">
   <div class="section-title">Generated Proxy URL</div>
   <div class="output-box" id="proxyUrlOutput">
-    <button class="copy-btn" onclick="copyProxyUrl()">Copy</button>
+    <button class="copy-btn" onclick="copyFor('url', this)">Copy URL</button>
     <span id="proxyUrlText"></span>
   </div>
   <div class="parsed-headers" id="parsedHeaders"></div>
   <div class="btn-row" style="margin-top:12px">
     <button onclick="playInPage()">▶ Play in Page</button>
-    <button class="secondary" onclick="openInExternal()">Open in External Player</button>
-    <button class="secondary" onclick="copyCurlForProxy()">Copy curl for Proxy</button>
+    <button class="secondary" onclick="openInBrowser()">Open URL in Browser</button>
+  </div>
+  <div class="copy-label">Copy for terminal</div>
+  <div class="btn-row">
+    <button class="secondary" onclick="copyFor('curl', this)">Copy curl</button>
+    <button class="secondary" onclick="copyFor('mpv', this)">Copy mpv</button>
+    <button class="secondary" onclick="copyFor('vlc', this)">Copy VLC</button>
+    <button class="secondary" onclick="copyFor('ffplay', this)">Copy ffplay</button>
   </div>
 </div>
 
@@ -100,6 +107,7 @@ let currentOriginalUrl = '';
 let currentHeaders = {};
 let hlsInstance = null;
 let dashPlayer = null;
+const STORAGE_KEY = 'pb-proxy-demo-state-v1';
 
 function parseCurl(curlStr) {
   const lines = curlStr.trim().replace(/\\\s*\n/g, ' ').trim();
@@ -173,16 +181,19 @@ function buildProxyUrl() {
   document.getElementById('proxyUrlText').textContent = currentProxyUrl;
   document.getElementById('resultSection').style.display = 'block';
 
-  // Show parsed headers
+  renderParsedHeaders(parsed.headers);
+  saveDraft();
+  clearError();
+}
+
+function renderParsedHeaders(headers) {
   const hdrDiv = document.getElementById('parsedHeaders');
-  let hdrHtml = `<span class="tag">${Object.keys(parsed.headers).length} headers</span> `;
-  for (const [k, v] of Object.entries(parsed.headers)) {
+  let hdrHtml = `<span class="tag">${Object.keys(headers).length} headers</span> `;
+  for (const [k, v] of Object.entries(headers)) {
     const shortV = v.length > 40 ? v.substring(0, 40) + '…' : v;
     hdrHtml += `<span class="hdr"><span class="k">${esc(k)}</span>: <span class="v">${esc(shortV)}</span></span> `;
   }
   hdrDiv.innerHTML = hdrHtml;
-
-  clearError();
 }
 
 function playInPage() {
@@ -227,26 +238,101 @@ function playInPage() {
   section.scrollIntoView({ behavior: 'smooth' });
 }
 
-function openInExternal() {
-  // Opens in default browser (useful for mpv:// or just new tab)
+function openInBrowser() {
   window.open(currentProxyUrl, '_blank');
 }
 
-function copyProxyUrl() {
-  navigator.clipboard.writeText(currentProxyUrl).then(() => {
-    const btn = document.querySelector('#proxyUrlOutput .copy-btn');
-    btn.textContent = 'Copied!';
-    setTimeout(() => btn.textContent = 'Copy', 1500);
-  });
+function shellQuote(value) {
+  return "'" + value.replace(/'/g, "'\"'\"'") + "'";
 }
 
-function copyCurlForProxy() {
-  const curlCmd = `curl '${currentProxyUrl}'`;
-  navigator.clipboard.writeText(curlCmd).then(() => {
-    const btn = document.querySelector('#proxyUrlOutput .copy-btn');
-    btn.textContent = 'Copied curl!';
-    setTimeout(() => btn.textContent = 'Copy', 1500);
-  });
+function copyTextFor(destination) {
+  if (destination === 'url') return currentProxyUrl;
+  return `${destination} ${shellQuote(currentProxyUrl)}`;
+}
+
+async function writeClipboard(text) {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand('copy');
+  document.body.removeChild(textarea);
+  if (!copied) throw new Error('Clipboard copy was rejected by the browser');
+}
+
+async function copyFor(destination, button) {
+  if (!currentProxyUrl) return;
+
+  const originalLabel = button.textContent;
+  try {
+    await writeClipboard(copyTextFor(destination));
+    button.textContent = 'Copied!';
+  } catch (_) {
+    button.textContent = 'Copy failed';
+  }
+  setTimeout(() => button.textContent = originalLabel, 1500);
+}
+
+function saveDraft() {
+  const state = {
+    proxyHost: document.getElementById('proxyHost').value,
+    proxyPort: document.getElementById('proxyPort').value,
+    proxyPassword: document.getElementById('proxyPassword').value,
+    curlInput: document.getElementById('curlInput').value,
+    currentProxyUrl,
+    currentOriginalUrl,
+    currentHeaders,
+  };
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (_) {
+    // Storage can be unavailable for file:// pages or private browsing.
+  }
+}
+
+function restoreDraft() {
+  let state;
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) return;
+    state = JSON.parse(saved);
+  } catch (_) {
+    return;
+  }
+
+  if (!state || typeof state !== 'object') return;
+
+  for (const id of ['proxyHost', 'proxyPort', 'proxyPassword', 'curlInput']) {
+    if (typeof state[id] === 'string') {
+      document.getElementById(id).value = state[id];
+    }
+  }
+
+  currentProxyUrl = typeof state.currentProxyUrl === 'string'
+    ? state.currentProxyUrl
+    : '';
+  currentOriginalUrl = typeof state.currentOriginalUrl === 'string'
+    ? state.currentOriginalUrl
+    : '';
+  currentHeaders = state.currentHeaders && typeof state.currentHeaders === 'object'
+    ? state.currentHeaders
+    : {};
+
+  if (currentProxyUrl) {
+    document.getElementById('proxyUrlText').textContent = currentProxyUrl;
+    document.getElementById('resultSection').style.display = 'block';
+    renderParsedHeaders(currentHeaders);
+  }
 }
 
 function clearAll() {
@@ -259,6 +345,9 @@ function clearAll() {
   currentProxyUrl = '';
   currentOriginalUrl = '';
   currentHeaders = {};
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (_) {}
 }
 
 function showError(msg) {
@@ -299,6 +388,11 @@ function esc(s) {
     dashBadge.innerHTML = '<span class="tag" style="color:#f85149; border-color:#f8514944; background:#f8514922;">DASH: not supported</span>';
   }
 })();
+
+restoreDraft();
+for (const id of ['proxyHost', 'proxyPort', 'proxyPassword', 'curlInput']) {
+  document.getElementById(id).addEventListener('input', saveDraft);
+}
 </script>
 
 </body>

--- a/stream-proxy-dart/docker-compose.yml
+++ b/stream-proxy-dart/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - PORT=8888
       - ADDRESS=0.0.0.0
-      - PASSWORD=my_secure_proxy_token # Set to enable token auth
+      - PB_PROXY_PASSWORD=CHANGEME
       # - FFMPEG_PATH=/usr/lib/x86_64-linux-gnu # Auto-detected usually
     restart: unless-stopped
     ulimits:

--- a/stream-proxy-dart/lib/stream_proxy_server.dart
+++ b/stream-proxy-dart/lib/stream_proxy_server.dart
@@ -30,6 +30,8 @@ class ProxySession {
 }
 
 class StreamProxyServer {
+  static const defaultDockerComposePassword = 'CHANGEME';
+
   final String password;
   HttpServer? _server;
   final Map<String, ProxySession> _sessions = {};
@@ -37,15 +39,21 @@ class StreamProxyServer {
   Timer? _cleanupTimer;
   final _rng = Random.secure();
 
-  StreamProxyServer({String? password})
-      : password = (password != null && password.isNotEmpty)
-            ? password
-            : _generateSecureToken();
+  StreamProxyServer({required String password})
+      : password = _validatePassword(password);
 
-  static String _generateSecureToken() {
-    final rng = Random.secure();
-    final bytes = List<int>.generate(16, (_) => rng.nextInt(256));
-    return base64Url.encode(bytes).replaceAll('=', '');
+  static String _validatePassword(String password) {
+    if (password.trim().isEmpty) {
+      throw ArgumentError(
+          'A non-empty API password is required. Provide one with '
+          '--password <password> or set PB_PROXY_PASSWORD=<password> in the '
+          'environment.');
+    }
+    if (password.trim() == defaultDockerComposePassword) {
+      throw ArgumentError(
+          'The default Docker Compose password is not allowed; set a unique password');
+    }
+    return password;
   }
 
   int get port => _server?.port ?? 0;

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
@@ -500,6 +500,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
     }
 
     override fun onDestroy() {
+        MPVLib.removeObserver(this)
         if (receiverRegistered) {
             unregisterReceiver(remoteReceiver)
             receiverRegistered = false


### PR DESCRIPTION
## Summary

- Require a non-empty password for standalone stream-proxy startup.
- Reject the insecure CHANGEME Docker Compose placeholder.
- Use PB_PROXY_PASSWORD for environment-based configuration and document the CLI alternative.
- Keep Desktop in-process proxy startup working with its generated session token.
- Preserve the demo and TV MPV observer cleanup changes.

## Verification

- flutter analyze — passed
- flutter test — all 64 tests passed
- Dart analyze --fatal-infos — passed
- Dart formatting — passed
- Missing-password and CHANGEME startup checks — rejected with actionable errors
- git diff --check — passed

Docker Compose validation was unavailable because Docker Compose is not installed in the environment.