### PR TITLE
🛡️ Sentinel: [HIGH] Fix Local File Access in TV WebView

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability in `extension/src/ui/popup.js` where user-controlled connection properties (`ip`, `pin`) were rendered directly into the DOM using `item.innerHTML = \`<span class="saved-connection-ip">${conn.ip}</span>\``.
 **Learning:** The extension builds some DOM views manually without a UI framework, increasing the risk of DOM-based XSS when interpolating variables into HTML strings.
 **Prevention:** Always use safe DOM API methods (`document.createElement` and `textContent`) or a sanitization library instead of interpolating untrusted input into `innerHTML`.
+
+## 2026-07-21 - Local File Access Vulnerability in TV App
+**Vulnerability:** The Android TV app's `SystemWebViewEngine` had `allowFileAccess` set to `true`. This is a high-risk security misconfiguration because it allows the arbitrary web content loaded into the system WebView to access and read local files on the device filesystem.
+**Learning:** The WebView should be treated as untrusted, especially since it's used as a browser to navigate to arbitrary URLs. Giving it file system access unnecessarily expands the attack surface for potential XSS or path traversal attacks to access sensitive application data.
+**Prevention:** Explicitly configure `allowFileAccess = false` on all WebViews that handle remote, untrusted content unless there is a verified, strict requirement for local file access (and even then, restrict it securely).

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
@@ -655,7 +655,7 @@ class SystemWebViewEngine(
                 displayZoomControls = false
                 setSupportZoom(true)
                 mediaPlaybackRequiresUserGesture = false
-                allowFileAccess = true
+                allowFileAccess = false
                 allowContentAccess = true
                 mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Local File Access in TV WebView

🚨 Severity: HIGH
💡 Vulnerability: The Android TV app's `SystemWebViewEngine` explicitly enabled local file access (`allowFileAccess = true`) on its WebView. Since this WebView is used to browse arbitrary, untrusted remote URLs, this configuration could allow malicious scripts (via XSS) to read sensitive local files on the user's device.
🎯 Impact: An attacker could potentially access local application data or other files on the device filesystem.
🔧 Fix: Changed the WebView configuration in `tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt` to explicitly disable local file access (`allowFileAccess = false`).
✅ Verification: Ensure the app builds properly and the test suite passes (`./gradlew test`). Tested that `allowFileAccess` is now disabled.

---
*PR created automatically by Jules for task [7310126320827316535](https://jules.google.com/task/7310126320827316535) started by @playbridgeapp*