### PR TITLE
fix(tv): comply with Android 15 boot service rules

### DIFF
--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,11 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [0.10.1] — 2026-07-22 (versionCode 225)
+
+### Fixed
+- **Android 15 Boot Compatibility**: Kept the boot-started receiver server limited to the `connectedDevice` foreground-service type, preventing restricted `mediaPlayback` startup from `BOOT_COMPLETED` while preserving automatic discovery and background casting.
+
 ## Player [0.10.0] — 2026-07-19 (versionCode 224)
 
 ### Added

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 224
-        versionName = "0.10.0"
+        versionCode = 225
+        versionName = "0.10.1"
 
         ndk {
             abiFilters.add("armeabi-v7a")

--- a/tv/android/player/app/src/main/AndroidManifest.xml
+++ b/tv/android/player/app/src/main/AndroidManifest.xml
@@ -12,7 +12,6 @@
     <!-- Foreground service permission -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <!-- Allows showing a tiny invisible overlay window while phone is connected so that
          startActivity() from the background service is not blocked by Android 14+ BAL rules -->
@@ -213,7 +212,7 @@
         <service
             android:name=".server.ServerService"
             android:exported="false"
-            android:foregroundServiceType="connectedDevice|mediaPlayback" />
+            android:foregroundServiceType="connectedDevice" />
 
         <service
             android:name=".player.ExoRendererService"

--- a/tv/android/player/app/src/main/java/com/playbridge/player/BootReceiver.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/BootReceiver.kt
@@ -9,9 +9,10 @@ import com.playbridge.player.server.ServerService
 /**
  * Starts the PlayBridge server service automatically after device boot.
  *
- * The service runs in the background (foreground service with notification) so the TV is
- * immediately ready to receive commands from the phone without the user having to manually
- * open the app after a reboot.
+ * The service runs as a connected-device foreground service so the TV is immediately ready to
+ * receive commands from the phone without the user having to manually open the app after a
+ * reboot. Keeping the boot-started service limited to the connected-device type is required on
+ * Android 15+, where BOOT_COMPLETED receivers cannot launch media-playback foreground services.
  *
  * Requires: RECEIVE_BOOT_COMPLETED permission (already declared in manifest).
  */

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
@@ -196,8 +196,7 @@ class ServerService : Service() {
             startForeground(
                 NOTIFICATION_ID,
                 createNotification(),
-                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or
-                    android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
             )
         } else {
             startForeground(NOTIFICATION_ID, createNotification())
@@ -877,13 +876,13 @@ class ServerService : Service() {
      * Launches an activity from the background (e.g. when the app is not in the foreground).
      *
      * Strategy:
-     * 1. startActivity() — works because we have a `mediaPlayback` foreground service, which
-     *    qualifies for the Android 10+ background-launch exemption.
+     * 1. startActivity() — while a phone is connected, [OverlayWindowHelper] keeps a tiny
+     *    application-overlay window visible so Android permits the background activity launch.
      * 2. fullScreenIntent notification — belt-and-suspenders fallback for strict OEMs that
      *    ignore the exemption. Android pops this as an overlay over whatever is on screen.
      */
     private fun launchActivityFromBackground(intent: Intent, description: String) {
-        // Attempt 1: direct startActivity (requires mediaPlayback foreground service type)
+        // Attempt 1: direct startActivity using the visible-overlay BAL exemption.
         try {
             startActivity(intent)
             FileLogger.i(TAG, "startActivity succeeded for: $description")


### PR DESCRIPTION
## Summary

- keep the boot-started TV receiver server on the connectedDevice foreground-service type
- remove the restricted mediaPlayback type and unused permission while preserving boot discovery, START_STICKY recovery, and overlay-based background casting
- release Android TV player 0.10.1 with versionCode 225 and update the changelog

## Verification

- zsh -c "source ~/.zshrc && ./gradlew test :player:app:assembleDebug :player:app:lint :player:app:processPlayReleaseMainManifest"
- verified the Play release merged manifest retains BOOT_COMPLETED and connectedDevice
- verified the Play release merged manifest contains no mediaPlayback foreground-service type or permission

## Manual verification

- On an Android 15 or newer TV, reboot with PlayBridge installed, confirm the receiver becomes discoverable without opening it, then cast media while another app is foregrounded.