### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix mixed content policy in WebView

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The Android TV app's `SystemWebViewEngine` had `allowFileAccess` set to `true`. This is a high-risk security misconfiguration because it allows the arbitrary web content loaded into the system WebView to access and read local files on the device filesystem.
 **Learning:** The WebView should be treated as untrusted, especially since it's used as a browser to navigate to arbitrary URLs. Giving it file system access unnecessarily expands the attack surface for potential XSS or path traversal attacks to access sensitive application data.
 **Prevention:** Explicitly configure `allowFileAccess = false` on all WebViews that handle remote, untrusted content unless there is a verified, strict requirement for local file access (and even then, restrict it securely).
+
+## 2025-02-09 - Insecure Mixed Content Policy in TV App WebView
+**Vulnerability:** The Android TV app's `SystemWebViewEngine` had `mixedContentMode` set to `WebSettings.MIXED_CONTENT_ALWAYS_ALLOW`. This is a critical security risk as it permits the loading of insecure active content (like scripts and iframes) over HTTP within a secure HTTPS context, exposing the app to Man-In-The-Middle (MITM) attacks and XSS.
+**Learning:** `MIXED_CONTENT_ALWAYS_ALLOW` should never be used in a WebView that loads remote, untrusted content, as it completely disables the browser's mixed content protections.
+**Prevention:** Always use `WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE` (or `MIXED_CONTENT_NEVER_ALLOW`) for WebViews to ensure the browser blocks active insecure content from loading on secure origins.

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
@@ -657,7 +657,7 @@ class SystemWebViewEngine(
                 mediaPlaybackRequiresUserGesture = false
                 allowFileAccess = false
                 allowContentAccess = true
-                mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+                mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
 
                 // User agent. A literal [userAgentOverride] (picked from the phone's User Agent
                 // manager) wins outright. Otherwise, in mobile mode use the WebView's OWN


### PR DESCRIPTION
Severity: CRITICAL
Vulnerability: `WebSettings.MIXED_CONTENT_ALWAYS_ALLOW` was used in `SystemWebViewEngine.kt`.
Impact: Permits secure HTTPS sites to load insecure HTTP active content (like scripts), exposing the app to MITM and XSS attacks.
Fix: Changed `mixedContentMode` to `WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE`.
Verification: Verified by running `./gradlew test` in `tv/android/player`.

Added entry to `.jules/sentinel.md` documenting the learning.

---
*PR created automatically by Jules for task [3708482294818754514](https://jules.google.com/task/3708482294818754514) started by @playbridgeapp*