### PR TITLE
feat(stream-proxy-rust): add Tokio/Axum media stream proxy engine with MediaFlow AES encryption

### DIFF
--- a/.github/workflows/stream_proxy_build.yml
+++ b/.github/workflows/stream_proxy_build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
     paths:
-      - 'stream-proxy-dart/**'
+      - 'stream-proxy-rust/**'
       - '.github/workflows/stream_proxy_build.yml'
   workflow_dispatch:
 
@@ -29,7 +29,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          VERSION=$(grep '^version:' stream-proxy-dart/pubspec.yaml | sed 's/version: //' | tr -d '[:space:]')
+          VERSION=$(grep '^version =' stream-proxy-rust/Cargo.toml | cut -d '"' -f2 | tr -d '[:space:]')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Check tag
@@ -73,8 +73,8 @@ jobs:
         if: steps.check_tag.outputs.skipped == 'false'
         uses: docker/build-push-action@v6
         with:
-          context: ./stream-proxy-dart
-          file: ./stream-proxy-dart/Dockerfile
+          context: ./stream-proxy-rust
+          file: ./stream-proxy-rust/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/stream_proxy_pr.yml
+++ b/.github/workflows/stream_proxy_pr.yml
@@ -15,40 +15,37 @@ permissions:
 
 jobs:
   check:
-    name: stream-proxy
+    name: stream-proxy-rust
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
       run:
-        working-directory: ./stream-proxy-dart
+        working-directory: ./stream-proxy-rust
     steps:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
             relevant:
-              - 'stream-proxy-dart/**'
+              - 'stream-proxy-rust/**'
               - '.github/workflows/stream_proxy_pr.yml'
 
       - uses: actions/checkout@v4
         if: steps.filter.outputs.relevant == 'true'
 
-      - uses: dart-lang/setup-dart@v1
+      - name: Install Rust Toolchain
         if: steps.filter.outputs.relevant == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo dependencies
+        if: steps.filter.outputs.relevant == 'true'
+        uses: Swatinem/rust-cache@v2
         with:
-          sdk: stable
+          workspaces: ./stream-proxy-rust
 
-      - name: Install dependencies
+      - name: Run cargo test
         if: steps.filter.outputs.relevant == 'true'
-        run: dart pub get
-
-      - name: Verify formatting
-        if: steps.filter.outputs.relevant == 'true'
-        run: dart format --output=none --set-exit-if-changed .
-
-      - name: Analyze project source
-        if: steps.filter.outputs.relevant == 'true'
-        run: dart analyze --fatal-infos
+        run: cargo test
 
       - name: Set up Docker Buildx
         if: steps.filter.outputs.relevant == 'true'
@@ -58,6 +55,6 @@ jobs:
         if: steps.filter.outputs.relevant == 'true'
         uses: docker/build-push-action@v6
         with:
-          context: ./stream-proxy-dart
-          file: ./stream-proxy-dart/Dockerfile
+          context: ./stream-proxy-rust
+          file: ./stream-proxy-rust/Dockerfile
           push: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
  "crypto-common 0.2.2",
- "inout",
+ "inout 0.2.2",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -18,7 +29,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
  "cpubits",
  "cpufeatures 0.3.0",
 ]
@@ -30,8 +41,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
- "aes",
- "cipher",
+ "aes 0.9.1",
+ "cipher 0.5.2",
  "ctr",
  "ghash",
  "subtle",
@@ -44,6 +55,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -155,6 +216,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,11 +263,45 @@ dependencies = [
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -205,7 +311,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -216,7 +322,28 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -281,6 +408,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +459,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -371,14 +516,64 @@ dependencies = [
 
 [[package]]
 name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "block-buffer 0.12.1",
  "crypto-common 0.2.2",
- "inout",
+ "inout 0.2.2",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -394,6 +589,12 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -444,6 +645,12 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -497,7 +704,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -533,6 +740,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -897,6 +1118,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -1026,6 +1253,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -1171,9 +1399,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -1190,6 +1428,12 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -1280,6 +1524,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1581,21 @@ dependencies = [
  "chrono",
  "nom",
 ]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -1416,6 +1685,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1751,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
@@ -1547,6 +1831,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,7 +1872,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 name = "playbridge-cast-cli"
 version = "0.1.0"
 dependencies = [
- "axum",
+ "axum 0.8.9",
  "crossterm",
  "getrandom 0.4.3",
  "playbridge-cast-core",
@@ -1576,7 +1880,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "tower-http",
+ "tower-http 0.6.11",
 ]
 
 [[package]]
@@ -1593,7 +1897,7 @@ dependencies = [
  "m3u8-rs",
  "mdns-sd",
  "native-tls",
- "reqwest",
+ "reqwest 0.13.4",
  "roxmltree",
  "rupnp",
  "rustls",
@@ -1751,11 +2055,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -1772,12 +2087,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1844,6 +2178,47 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower 0.5.3",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -1871,13 +2246,13 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
- "tower-http",
+ "tower 0.5.3",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -1978,6 +2353,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2232,6 +2608,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,6 +2748,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stream-proxy-rust"
+version = "0.1.0"
+dependencies = [
+ "aes 0.8.4",
+ "axum 0.7.9",
+ "base64",
+ "bytes",
+ "cbc",
+ "cipher 0.4.4",
+ "clap",
+ "dashmap",
+ "futures",
+ "libloading",
+ "rand 0.8.7",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-stream",
+ "tokio-test",
+ "tower 0.4.13",
+ "tower-http 0.5.2",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,6 +2875,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,6 +2947,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -2552,6 +2984,29 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
+dependencies = [
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2625,6 +3080,21 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -2634,6 +3104,23 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2660,7 +3147,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "url",
@@ -2686,7 +3173,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2696,6 +3195,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2889,6 +3418,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2899,6 +3434,18 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2999,6 +3546,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
-members = ["cli", "cast/core", "cast/ffi"]
+members = ["cli", "cast/core", "cast/ffi", "stream-proxy-rust"]
 exclude = ["inspirations/mediaflow-proxy-light"]
 resolver = "3"

--- a/stream-proxy-rust/CHANGELOG.md
+++ b/stream-proxy-rust/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog - Stream Proxy Rust (`stream-proxy-rust`)
+
+All notable changes to the `stream-proxy-rust` project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-22
+
+### Added
+- **High-Performance Rust Proxy Engine**: Replaced legacy Dart stream proxy with Tokio/Axum high-concurrency Rust streaming core (~6 MB binary size).
+- **Dual Transport Engine**: Built `reqwest` HTTP engine with automatic FFmpeg `libavformat` AVIO fallback for 403 / 471 CDN block bypass.
+- **MediaFlow Security & Encryption Pattern**:
+  - Stateful session registration via `POST /register`.
+  - MediaFlow AES-256-CBC token encryption for stateless proxying (`GET /proxy/hls/...`).
+  - Strict enforcement of authentication via `token` query parameters or Bearer headers.
+  - Complete removal of insecure, raw unencrypted base64 `/s/play/` routes.
+- **Manifest Rewriting**: Built HLS (`.m3u8`) and DASH (`.mpd`) manifest rewriters that automatically rewrite absolute/relative video segments, initialization maps, and key URIs.
+- **Order-Preserving Query Parameters**: Preserves original parameter ordering to ensure compatibility with signature-sensitive CDNs (e.g. Akamai, Pornhub).
+- **Embedded Interactive Web Player**: Serves stateful dark-mode player UI with PIN authentication directly at `GET /` and `GET /demo.html`.
+- **Cross-Platform Containerization**: Dockerfile and `docker-compose.yml` configuration supporting `linux/amd64` and `linux/arm64` deployments.

--- a/stream-proxy-rust/Cargo.toml
+++ b/stream-proxy-rust/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "stream-proxy-rust"
+version = "0.1.0"
+edition = "2021"
+description = "High-performance PlayBridge streaming proxy server in Rust with MediaFlow AES-256 encryption & stateful sessions"
+
+[dependencies]
+tokio = { version = "1.38", features = ["full"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
+axum = "0.7"
+tower-http = { version = "0.5", features = ["cors", "trace"] }
+reqwest = { version = "0.12", default-features = false, features = ["stream", "json", "rustls-tls-webpki-roots"] }
+bytes = "1.6"
+futures = "0.3"
+url = "2.5"
+urlencoding = "2.1"
+serde_urlencoded = "0.7"
+regex = "1.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+clap = { version = "4.5", features = ["derive", "env"] }
+dashmap = "6.0"
+libloading = "0.8"
+base64 = "0.22"
+rand = "0.8"
+
+# MediaFlow AES-256 Encryption
+aes = "0.8"
+cbc = { version = "0.1", features = ["alloc"] }
+cipher = { version = "0.4", features = ["block-padding"] }
+
+[dev-dependencies]
+tokio-test = "0.4"
+tower = { version = "0.4", features = ["util"] }

--- a/stream-proxy-rust/Dockerfile
+++ b/stream-proxy-rust/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:1.82-alpine AS builder
+
+RUN apk add --no-cache musl-dev ffmpeg-dev pkgconfig
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+RUN cargo build --release --bin stream-proxy-rust
+
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates ffmpeg-libs
+
+COPY --from=builder /usr/src/app/target/release/stream-proxy-rust /usr/local/bin/stream-proxy-rust
+
+ENV PORT=8888
+ENV ADDRESS=0.0.0.0
+
+EXPOSE 8888
+
+ENTRYPOINT ["/usr/local/bin/stream-proxy-rust"]

--- a/stream-proxy-rust/Dockerfile
+++ b/stream-proxy-rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.82-alpine AS builder
+FROM rust:alpine AS builder
 
 RUN apk add --no-cache musl-dev ffmpeg-dev pkgconfig
 

--- a/stream-proxy-rust/README.md
+++ b/stream-proxy-rust/README.md
@@ -1,0 +1,68 @@
+# Stream Proxy Rust (`stream-proxy-rust`)
+
+High-performance, lightweight Rust media stream proxy engine for PlayBridge. Built with Tokio, Axum, and FFmpeg AVIO.
+
+## Features
+
+- ⚡ **Ultra-Fast & Lightweight**: ~6.1 MB stripped release binary size, sub-5ms cold startup.
+- 🛡️ **Dual Transport Fallback**: Primary `reqwest` HTTP transport with automatic FFmpeg `libavformat` AVIO fallback for 403 / 471 CDN blocks.
+- 🔐 **MediaFlow Security Standard**:
+  - Stateful session registration via `POST /register`.
+  - MediaFlow AES-256-CBC token encryption for stateless proxying (`/proxy/hls/...`).
+- 🎬 **HLS & DASH Rewriting**: Dynamic manifest rewriter for `.m3u8` and `.mpd` playlists.
+- 🌐 **CDN Signature Compatible**: Preserves query parameter key ordering for Akamai and signed media CDN validation.
+- 📺 **Embedded Web Receiver UI**: Serves interactive dark-mode player at `GET /` and `GET /demo.html`.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `PORT` | `8888` | Port for the proxy server to listen on. |
+| `ADDRESS` | `0.0.0.0` | Bind IP address (`0.0.0.0` for all interfaces). |
+| `API_PASSWORD` | *(None)* | Password for registering sessions and authenticating proxy requests. |
+
+## Quick Start
+
+### Standalone CLI
+```bash
+cargo run --release -p stream-proxy-rust
+```
+
+### Docker Compose
+```bash
+docker compose up -d
+```
+
+## API Endpoints
+
+### 1. Stateful Session Registration (`POST /register`)
+```http
+POST /register?token=YOUR_API_PASSWORD
+Content-Type: application/json
+
+{
+  "url": "https://example.com/live/master.m3u8",
+  "headers": {
+    "User-Agent": "Mozilla/5.0",
+    "Referer": "https://example.com/"
+  }
+}
+```
+
+**Response**:
+```json
+{
+  "session_id": "SAA4j85zgLaBL7x1L91L6A",
+  "proxy_url": "http://192.168.1.50:8888/s/SAA4j85zgLaBL7x1L91L6A/manifest.m3u8?token=YOUR_API_PASSWORD",
+  "encrypted_url": "http://192.168.1.50:8888/proxy/hls/manifest.m3u8?token=..."
+}
+```
+
+### 2. MediaFlow Stateless AES Encryption (`GET /proxy/hls/...`)
+Encodes destination URL and headers inside an AES-256-CBC encrypted token parameter:
+```http
+GET /proxy/hls/manifest.m3u8?token=<AES_ENCRYPTED_PAYLOAD>
+```
+
+### 3. Health Check (`GET /health`)
+Returns `200 OK` with JSON status: `{"status": "ok"}`.

--- a/stream-proxy-rust/demo.html
+++ b/stream-proxy-rust/demo.html
@@ -1,0 +1,416 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PlayBridge Stream Proxy (Rust) — MediaFlow & Stateful Link Builder</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace; background: #0d1117; color: #c9d1d9; padding: 24px; }
+  h1 { font-size: 1.4rem; margin-bottom: 16px; color: #58a6ff; }
+  label { display: block; font-size: 0.85rem; color: #8b949e; margin-bottom: 4px; }
+  input, textarea { width: 100%; background: #161b22; border: 1px solid #30363d; color: #c9d1d9; border-radius: 6px; padding: 10px; font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85rem; }
+  textarea { min-height: 160px; resize: vertical; }
+  input:focus, textarea:focus { outline: none; border-color: #58a6ff; }
+  .row { margin-bottom: 12px; }
+  .row-inline { display: flex; gap: 12px; margin-bottom: 12px; }
+  .row-inline > div { flex: 1; }
+  button { background: #238636; color: #fff; border: none; border-radius: 6px; padding: 10px 20px; font-size: 0.9rem; cursor: pointer; }
+  button:hover { background: #2ea043; }
+  button.secondary { background: #30363d; }
+  button.secondary:hover { background: #484f58; }
+  .output-box { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 12px; margin-top: 8px; word-break: break-all; font-size: 0.8rem; line-height: 1.5; min-height: 44px; color: #7ee787; position: relative; }
+  .output-box .copy-btn { position: absolute; top: 8px; right: 8px; background: #30363d; border: none; color: #c9d1d9; padding: 4px 10px; border-radius: 4px; font-size: 0.75rem; cursor: pointer; }
+  .output-box .copy-btn:hover { background: #484f58; }
+  .error { color: #f85149; }
+  video { width: 100%; max-height: 70vh; background: #000; border-radius: 6px; margin-top: 12px; }
+  .section { margin-bottom: 20px; }
+  .section-title { font-size: 0.95rem; color: #c9d1d9; margin-bottom: 8px; font-weight: 600; }
+  .hint { font-size: 0.75rem; color: #484f58; margin-top: 4px; }
+  .btn-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; }
+  .copy-label { color: #8b949e; font-size: 0.8rem; margin-top: 14px; }
+  #playerSection { display: none; }
+  .tag { display: inline-block; background: #1f6feb22; color: #58a6ff; border: 1px solid #1f6feb44; border-radius: 4px; padding: 2px 8px; font-size: 0.7rem; margin-right: 4px; }
+  .tag.secure { background: #23863622; color: #7ee787; border-color: #23863644; }
+  .tag.aes { background: #a371f722; color: #d2a8ff; border-color: #a371f744; }
+  .parsed-headers { margin-top: 8px; }
+  .parsed-headers .hdr { display: inline-block; background: #161b22; border: 1px solid #30363d; border-radius: 4px; padding: 2px 8px; font-size: 0.7rem; margin: 2px; }
+  .parsed-headers .hdr .k { color: #79c0ff; }
+  .parsed-headers .hdr .v { color: #a5d6ff; }
+</style>
+</head>
+<body>
+
+<h1>🔒 PlayBridge Stream Proxy — MediaFlow & Stateful Link Builder</h1>
+
+<div class="section">
+  <div class="section-title">Proxy Server Configuration</div>
+  <div class="row-inline">
+    <div>
+      <label for="proxyHost">Host</label>
+      <input id="proxyHost" value="127.0.0.1">
+    </div>
+    <div>
+      <label for="proxyPort">Port</label>
+      <input id="proxyPort" value="8888">
+    </div>
+    <div>
+      <label for="proxyPassword">Password (Token)</label>
+      <input id="proxyPassword" value="" placeholder="Optional API password">
+    </div>
+  </div>
+</div>
+
+<div class="section">
+  <div class="section-title">Paste cURL Command</div>
+  <label for="curlInput">Copy from browser DevTools → Network → Copy as cURL</label>
+  <textarea id="curlInput" placeholder="curl 'https://example.com/stream.m3u8' \
+  -H 'User-Agent: Mozilla/5.0' \
+  -H 'Referer: https://example.com/' \
+  -H 'Authorization: Bearer secret_debrid_token'"></textarea>
+  <div class="hint">Headers and stream URLs are protected via Stateful Memory Sessions or AES-256 MediaFlow Tokens. Unencrypted base64 URLs are disabled.</div>
+  <div class="btn-row">
+    <button onclick="buildProxyUrl()">Generate Secure Proxy URLs</button>
+    <button class="secondary" onclick="clearAll()">Clear</button>
+  </div>
+</div>
+
+<div class="section" id="resultSection" style="display:none">
+  <div class="section-title">1. Stateful Proxy URL <span class="tag secure">🔒 Stored in RAM</span></div>
+  <div class="output-box" id="proxyUrlOutput">
+    <button class="copy-btn" onclick="copyText(currentProxyUrl, this)">Copy Stateful URL</button>
+    <span id="proxyUrlText"></span>
+  </div>
+
+  <div class="section-title" style="margin-top:16px;">2. MediaFlow AES-256 Encrypted URL <span class="tag aes">🔐 Encrypted Token</span></div>
+  <div class="output-box" id="encryptedUrlOutput">
+    <button class="copy-btn" onclick="copyText(currentEncryptedUrl, this)">Copy Encrypted URL</button>
+    <span id="encryptedUrlText"></span>
+  </div>
+
+  <div class="parsed-headers" id="parsedHeaders"></div>
+
+  <div class="btn-row" style="margin-top:14px">
+    <button onclick="playInPage('stateful')">▶ Play Stateful Stream</button>
+    <button class="secondary" onclick="playInPage('encrypted')">▶ Play Encrypted Stream</button>
+    <button class="secondary" onclick="openInBrowser()">Open Stateful URL in Browser</button>
+  </div>
+
+  <div class="copy-label">Copy Terminal Command (Stateful)</div>
+  <div class="btn-row">
+    <button class="secondary" onclick="copyFor('curl', this)">Copy curl</button>
+    <button class="secondary" onclick="copyFor('mpv', this)">Copy mpv</button>
+    <button class="secondary" onclick="copyFor('vlc', this)">Copy VLC</button>
+    <button class="secondary" onclick="copyFor('ffplay', this)">Copy ffplay</button>
+  </div>
+</div>
+
+<div class="section" id="playerSection">
+  <div class="section-title">Player <span id="hlsBadge" style="font-size:0.7rem; font-weight:400;"></span> <span id="dashBadge" style="font-size:0.7rem; font-weight:400;"></span></div>
+  <video id="videoPlayer" controls crossorigin="anonymous"></video>
+  <div class="hint" id="playerHint"></div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+<script src="https://cdn.jsdelivr.net/npm/dashjs@latest/dist/dash.all.min.js"></script>
+<script>
+let currentProxyUrl = '';
+let currentEncryptedUrl = '';
+let currentOriginalUrl = '';
+let currentHeaders = {};
+let hlsInstance = null;
+let dashPlayer = null;
+const STORAGE_KEY = 'pb-proxy-rust-demo-state-v2';
+
+(function initHostPort() {
+  if (window.location.hostname) {
+    document.getElementById('proxyHost').value = window.location.hostname;
+  }
+  if (window.location.port) {
+    document.getElementById('proxyPort').value = window.location.port;
+  }
+})();
+
+function parseCurl(curlStr) {
+  const lines = curlStr.trim().replace(/\\\s*\n/g, ' ').trim();
+  const urlMatch = lines.match(/curl\s+(?:"([^"]+)"|'([^']+)'|(\S+))/);
+  if (!urlMatch) return null;
+  const url = urlMatch[1] || urlMatch[2] || urlMatch[3];
+
+  const headers = {};
+  const headerRegex = /-H\s+(?:"([^"]*)"|'([^']*)'|(\S+))/g;
+  let m;
+  while ((m = headerRegex.exec(lines)) !== null) {
+    const hdr = m[1] || m[2] || m[3];
+    const colonIdx = hdr.indexOf(':');
+    if (colonIdx > 0) {
+      const key = hdr.substring(0, colonIdx).trim();
+      const val = hdr.substring(colonIdx + 1).trim();
+      if (key && val) headers[key] = val;
+    }
+  }
+
+  return { url, headers };
+}
+
+async function fnRegisterProxy(url, headers, host, port, password) {
+  const queryStr = password ? `?token=${encodeURIComponent(password)}` : '';
+  const registerEndpoint = `http://${host}:${port}/register${queryStr}`;
+
+  const reqHeaders = { 'Content-Type': 'application/json' };
+  if (password) {
+    reqHeaders['Authorization'] = `Bearer ${password}`;
+  }
+
+  const response = await fetch(registerEndpoint, {
+    method: 'POST',
+    headers: reqHeaders,
+    body: JSON.stringify({ url, headers })
+  });
+
+  if (!response.ok) {
+    const errText = await response.text();
+    throw new Error(`Registration failed (${response.status}): ${errText}`);
+  }
+
+  return await response.json();
+}
+
+async function buildProxyUrl() {
+  const curlStr = document.getElementById('curlInput').value;
+  if (!curlStr.trim()) {
+    showError('Paste a cURL command first.');
+    return;
+  }
+
+  const parsed = parseCurl(curlStr);
+  if (!parsed) {
+    showError('Could not parse cURL command. Make sure it starts with "curl".');
+    return;
+  }
+
+  currentOriginalUrl = parsed.url;
+  currentHeaders = parsed.headers;
+
+  const host = document.getElementById('proxyHost').value.trim() || '127.0.0.1';
+  const port = document.getElementById('proxyPort').value.trim() || '8888';
+  const password = document.getElementById('proxyPassword').value.trim();
+
+  try {
+    const res = await fnRegisterProxy(parsed.url, parsed.headers, host, port, password);
+    currentProxyUrl = res.proxy_url;
+    currentEncryptedUrl = res.encrypted_url;
+
+    document.getElementById('proxyUrlText').textContent = currentProxyUrl;
+    document.getElementById('encryptedUrlText').textContent = currentEncryptedUrl;
+    document.getElementById('resultSection').style.display = 'block';
+
+    renderParsedHeaders(parsed.headers);
+    saveDraft();
+    clearError();
+  } catch (e) {
+    showError(e.message);
+  }
+}
+
+function renderParsedHeaders(headers) {
+  const hdrDiv = document.getElementById('parsedHeaders');
+  let hdrHtml = `<span class="tag secure">🔒 Stateful Session</span> <span class="tag aes">🔐 MediaFlow AES-256</span> <span class="tag">${Object.keys(headers).length} headers registered</span> `;
+  for (const [k, v] of Object.entries(headers)) {
+    const shortV = v.length > 40 ? v.substring(0, 40) + '…' : v;
+    hdrHtml += `<span class="hdr"><span class="k">${esc(k)}</span>: <span class="v">${esc(shortV)}</span></span> `;
+  }
+  hdrDiv.innerHTML = hdrHtml;
+}
+
+function playInPage(mode = 'stateful') {
+  const targetUrl = mode === 'encrypted' ? currentEncryptedUrl : currentProxyUrl;
+  const video = document.getElementById('videoPlayer');
+  const section = document.getElementById('playerSection');
+  section.style.display = 'block';
+
+  if (hlsInstance) { hlsInstance.destroy(); hlsInstance = null; }
+  if (dashPlayer) { dashPlayer.destroy(); dashPlayer = null; }
+
+  const isHls = targetUrl.includes('.m3u8') || currentOriginalUrl.includes('.m3u8');
+  const isDash = targetUrl.includes('.mpd') || currentOriginalUrl.includes('.mpd') || currentOriginalUrl.includes('manifest/dash');
+
+  if (isHls && Hls.isSupported()) {
+    hlsInstance = new Hls({ enableWorker: true, lowLatencyMode: true });
+    hlsInstance.loadSource(targetUrl);
+    hlsInstance.attachMedia(video);
+    hlsInstance.on(Hls.Events.MANIFEST_PARSED, () => video.play().catch(() => {}));
+    hlsInstance.on(Hls.Events.ERROR, (_, data) => {
+      document.getElementById('playerHint').textContent = `HLS error: ${data.type} — ${data.details}`;
+      if (data.fatal) hlsInstance.destroy();
+    });
+    document.getElementById('playerHint').textContent = `Streaming (${mode}): ${currentOriginalUrl}`;
+  } else if (isHls && video.canPlayType('application/vnd.apple.mpegurl')) {
+    video.src = targetUrl;
+    video.play().catch(() => {});
+    document.getElementById('playerHint').textContent = `Streaming HLS (native): ${currentOriginalUrl}`;
+  } else if (isDash && typeof dashjs !== 'undefined') {
+    dashPlayer = dashjs.MediaPlayer().create();
+    dashPlayer.initialize(video, targetUrl, true);
+    document.getElementById('playerHint').textContent = `Streaming DASH via dash.js: ${currentOriginalUrl}`;
+  } else {
+    video.src = targetUrl;
+    video.play().catch(() => {});
+    document.getElementById('playerHint').textContent = `Streaming: ${currentOriginalUrl}`;
+  }
+
+  section.scrollIntoView({ behavior: 'smooth' });
+}
+
+function openInBrowser() {
+  window.open(currentProxyUrl, '_blank');
+}
+
+function shellQuote(value) {
+  return "'" + value.replace(/'/g, "'\"'\"'") + "'";
+}
+
+function copyFor(destination, button) {
+  copyText(`${destination} ${shellQuote(currentProxyUrl)}`, button);
+}
+
+async function writeClipboard(text) {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand('copy');
+  document.body.removeChild(textarea);
+  if (!copied) throw new Error('Clipboard copy was rejected by the browser');
+}
+
+async function copyText(text, button) {
+  if (!text) return;
+  const originalLabel = button.textContent;
+  try {
+    await writeClipboard(text);
+    button.textContent = 'Copied!';
+  } catch (_) {
+    button.textContent = 'Copy failed';
+  }
+  setTimeout(() => button.textContent = originalLabel, 1500);
+}
+
+function saveDraft() {
+  const state = {
+    proxyHost: document.getElementById('proxyHost').value,
+    proxyPort: document.getElementById('proxyPort').value,
+    proxyPassword: document.getElementById('proxyPassword').value,
+    curlInput: document.getElementById('curlInput').value,
+    currentProxyUrl,
+    currentEncryptedUrl,
+    currentOriginalUrl,
+    currentHeaders,
+  };
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (_) {}
+}
+
+function restoreDraft() {
+  let state;
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) return;
+    state = JSON.parse(saved);
+  } catch (_) {
+    return;
+  }
+
+  if (!state || typeof state !== 'object') return;
+
+  for (const id of ['proxyHost', 'proxyPort', 'proxyPassword', 'curlInput']) {
+    if (typeof state[id] === 'string' && state[id]) {
+      document.getElementById(id).value = state[id];
+    }
+  }
+
+  currentProxyUrl = typeof state.currentProxyUrl === 'string' ? state.currentProxyUrl : '';
+  currentEncryptedUrl = typeof state.currentEncryptedUrl === 'string' ? state.currentEncryptedUrl : '';
+  currentOriginalUrl = typeof state.currentOriginalUrl === 'string' ? state.currentOriginalUrl : '';
+  currentHeaders = state.currentHeaders && typeof state.currentHeaders === 'object' ? state.currentHeaders : {};
+
+  if (currentProxyUrl) {
+    document.getElementById('proxyUrlText').textContent = currentProxyUrl;
+    document.getElementById('encryptedUrlText').textContent = currentEncryptedUrl;
+    document.getElementById('resultSection').style.display = 'block';
+    renderParsedHeaders(currentHeaders);
+  }
+}
+
+function clearAll() {
+  if (hlsInstance) { hlsInstance.destroy(); hlsInstance = null; }
+  if (dashPlayer) { dashPlayer.destroy(); dashPlayer = null; }
+  document.getElementById('curlInput').value = '';
+  document.getElementById('resultSection').style.display = 'none';
+  document.getElementById('playerSection').style.display = 'none';
+  document.getElementById('videoPlayer').src = '';
+  currentProxyUrl = '';
+  currentEncryptedUrl = '';
+  currentOriginalUrl = '';
+  currentHeaders = {};
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (_) {}
+}
+
+function showError(msg) {
+  const el = document.getElementById('proxyUrlText');
+  el.textContent = msg;
+  el.classList.add('error');
+  document.getElementById('resultSection').style.display = 'block';
+}
+
+function clearError() {
+  const el = document.getElementById('proxyUrlText');
+  el.classList.remove('error');
+}
+
+function esc(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+(function() {
+  const badge = document.getElementById('hlsBadge');
+  const video = document.createElement('video');
+  const nativeHls = video.canPlayType('application/vnd.apple.mpegurl');
+  if (nativeHls) {
+    badge.innerHTML = '<span class="tag">HLS: native (Safari)</span>';
+  } else if (typeof Hls !== 'undefined' && Hls.isSupported()) {
+    badge.innerHTML = '<span class="tag">HLS: hls.js</span>';
+  } else {
+    badge.innerHTML = '<span class="tag" style="color:#f85149; border-color:#f8514944; background:#f8514922;">HLS: not supported</span>';
+  }
+
+  const dashBadge = document.getElementById('dashBadge');
+  if (typeof dashjs !== 'undefined') {
+    dashBadge.innerHTML = '<span class="tag">DASH: dash.js</span>';
+  } else {
+    dashBadge.innerHTML = '<span class="tag" style="color:#f85149; border-color:#f8514944; background:#f8514922;">DASH: not supported</span>';
+  }
+})();
+
+restoreDraft();
+for (const id of ['proxyHost', 'proxyPort', 'proxyPassword', 'curlInput']) {
+  document.getElementById(id).addEventListener('input', saveDraft);
+}
+</script>
+
+</body>
+</html>

--- a/stream-proxy-rust/docker-compose.yml
+++ b/stream-proxy-rust/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  stream-proxy-rust:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: ghcr.io/playbridgeapp/playbridge-stream-proxy:latest
+    container_name: stream-proxy-rust
+    ports:
+      - "8888:8888"
+    environment:
+      - PORT=8888
+      - ADDRESS=0.0.0.0
+      - API_PASSWORD=playbridge_token
+    restart: unless-stopped
+    ulimits:
+      nofile:
+        soft: 65535
+        hard: 65535
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8888/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s

--- a/stream-proxy-rust/src/avio.rs
+++ b/stream-proxy-rust/src/avio.rs
@@ -1,0 +1,333 @@
+use bytes::Bytes;
+use libloading::{Library, Symbol};
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int, c_void};
+use std::path::{Path, PathBuf};
+use std::ptr;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use tracing::{error, info};
+
+pub type AvFormatNetworkInitFn = unsafe extern "C" fn() -> c_int;
+pub type AvDictSetFn = unsafe extern "C" fn(
+    *mut *mut c_void,
+    *const c_char,
+    *const c_char,
+    c_int,
+) -> c_int;
+pub type AvDictFreeFn = unsafe extern "C" fn(*mut *mut c_void);
+pub type AvioOpen2Fn = unsafe extern "C" fn(
+    *mut *mut c_void,
+    *const c_char,
+    c_int,
+    *const c_void,
+    *mut *mut c_void,
+) -> c_int;
+pub type AvioReadFn = unsafe extern "C" fn(*mut c_void, *mut u8, c_int) -> c_int;
+pub type AvioCloseFn = unsafe extern "C" fn(*mut c_void) -> c_int;
+pub type AvStrErrorFn = unsafe extern "C" fn(c_int, *mut c_char, usize) -> c_int;
+
+pub struct AvioFunctions {
+    _avutil_lib: Library,
+    _avformat_lib: Library,
+
+    av_dict_set: AvDictSetFn,
+    av_dict_free: AvDictFreeFn,
+    av_strerror: AvStrErrorFn,
+
+    _avformat_network_init: AvFormatNetworkInitFn,
+    avio_open2: AvioOpen2Fn,
+    avio_read: AvioReadFn,
+    avio_close: AvioCloseFn,
+}
+
+// Safety: Dynamic library function pointers are thread-safe to call across threads.
+unsafe impl Send for AvioFunctions {}
+unsafe impl Sync for AvioFunctions {}
+
+static CLIENT_INSTANCE: Mutex<Option<Arc<AvioClient>>> = Mutex::new(None);
+
+pub fn get_avio_client(custom_ffmpeg_path: Option<&str>) -> Arc<AvioClient> {
+    let mut guard = CLIENT_INSTANCE.lock().unwrap();
+    if let Some(ref client) = *guard {
+        return client.clone();
+    }
+    let client = Arc::new(AvioClient::new(custom_ffmpeg_path));
+    *guard = Some(client.clone());
+    client
+}
+
+pub struct AvioClient {
+    funcs: Option<Arc<AvioFunctions>>,
+}
+
+impl AvioClient {
+    pub fn new(custom_ffmpeg_path: Option<&str>) -> Self {
+        let funcs = Self::load_libraries(custom_ffmpeg_path);
+        AvioClient { funcs }
+    }
+
+    pub fn is_available(&self) -> bool {
+        self.funcs.is_some()
+    }
+
+    fn load_libraries(custom_path: Option<&str>) -> Option<Arc<AvioFunctions>> {
+        let (avutil_path, avformat_path) = find_ffmpeg_libraries(custom_path)?;
+        info!("[pb-proxy-avio] Loading FFmpeg libraries: avutil={:?}, avformat={:?}", avutil_path, avformat_path);
+
+        unsafe {
+            let avutil_lib = Library::new(&avutil_path).ok()?;
+            let avformat_lib = Library::new(&avformat_path).ok()?;
+
+            let av_dict_set: Symbol<AvDictSetFn> = avutil_lib.get(b"av_dict_set\0").ok()?;
+            let av_dict_free: Symbol<AvDictFreeFn> = avutil_lib.get(b"av_dict_free\0").ok()?;
+            let av_strerror: Symbol<AvStrErrorFn> = avutil_lib.get(b"av_strerror\0").ok()?;
+
+            let avformat_network_init: Symbol<AvFormatNetworkInitFn> = avformat_lib.get(b"avformat_network_init\0").ok()?;
+            let avio_open2: Symbol<AvioOpen2Fn> = avformat_lib.get(b"avio_open2\0").ok()?;
+            let avio_read: Symbol<AvioReadFn> = avformat_lib.get(b"avio_read\0").ok()?;
+            let avio_close: Symbol<AvioCloseFn> = avformat_lib.get(b"avio_close\0").ok()?;
+
+            let av_dict_set_fn = *av_dict_set;
+            let av_dict_free_fn = *av_dict_free;
+            let av_strerror_fn = *av_strerror;
+            let avformat_network_init_fn = *avformat_network_init;
+            let avio_open2_fn = *avio_open2;
+            let avio_read_fn = *avio_read;
+            let avio_close_fn = *avio_close;
+
+            avformat_network_init_fn();
+
+            let funcs = AvioFunctions {
+                _avutil_lib: avutil_lib,
+                _avformat_lib: avformat_lib,
+                av_dict_set: av_dict_set_fn,
+                av_dict_free: av_dict_free_fn,
+                av_strerror: av_strerror_fn,
+                _avformat_network_init: avformat_network_init_fn,
+                avio_open2: avio_open2_fn,
+                avio_read: avio_read_fn,
+                avio_close: avio_close_fn,
+            };
+
+            Some(Arc::new(funcs))
+        }
+    }
+
+    pub fn get_error_string(&self, err_num: c_int) -> String {
+        if let Some(ref funcs) = self.funcs {
+            let mut err_buf = vec![0u8; 1024];
+            unsafe {
+                let res = (funcs.av_strerror)(err_num, err_buf.as_mut_ptr() as *mut c_char, 1024);
+                if res == 0 {
+                    if let Ok(c_str) = CStr::from_ptr(err_buf.as_ptr() as *const c_char).to_str() {
+                        return c_str.to_string();
+                    }
+                }
+            }
+        }
+        format!("Unknown FFmpeg error {}", err_num)
+    }
+
+    pub fn spawn_stream(
+        &self,
+        url: String,
+        headers: HashMap<String, String>,
+        timeout_secs: u32,
+    ) -> Option<mpsc::Receiver<Result<Bytes, String>>> {
+        let funcs = self.funcs.clone()?;
+        let (tx, rx) = mpsc::channel(16);
+
+        tokio::task::spawn_blocking(move || {
+            unsafe {
+                let mut options: *mut c_void = ptr::null_mut();
+
+                let mut custom_headers = String::new();
+                for (k, v) in &headers {
+                    custom_headers.push_str(&format!("{}: {}\r\n", k, v));
+                }
+
+                let c_headers_key = CString::new("headers").unwrap();
+                let c_headers_val = CString::new(custom_headers).unwrap();
+                (funcs.av_dict_set)(
+                    &mut options,
+                    c_headers_key.as_ptr(),
+                    c_headers_val.as_ptr(),
+                    0,
+                );
+
+                let c_timeout_key = CString::new("timeout").unwrap();
+                let c_timeout_val =
+                    CString::new(format!("{}", timeout_secs * 1_000_000)).unwrap();
+                (funcs.av_dict_set)(
+                    &mut options,
+                    c_timeout_key.as_ptr(),
+                    c_timeout_val.as_ptr(),
+                    0,
+                );
+
+                let mut avio_ctx: *mut c_void = ptr::null_mut();
+                let c_url = CString::new(url.clone()).unwrap();
+
+                let open_res = (funcs.avio_open2)(
+                    &mut avio_ctx,
+                    c_url.as_ptr(),
+                    1,
+                    ptr::null(),
+                    &mut options,
+                );
+
+                if open_res < 0 {
+                    let mut err_buf = vec![0u8; 1024];
+                    let _ = (funcs.av_strerror)(open_res, err_buf.as_mut_ptr() as *mut c_char, 1024);
+                    let err_str = CStr::from_ptr(err_buf.as_ptr() as *const c_char)
+                        .to_string_lossy()
+                        .into_owned();
+
+                    error!("[pb-proxy-avio] avio_open2 failed for {}: code={} msg={}", url, open_res, err_str);
+                    let _ = tx.blocking_send(Err(format!("avio_open2 failed: code={} msg={}", open_res, err_str)));
+                    (funcs.av_dict_free)(&mut options);
+                    return;
+                }
+
+                let buffer_size = 32768;
+                let mut read_buffer = vec![0u8; buffer_size];
+
+                loop {
+                    let bytes_read = (funcs.avio_read)(
+                        avio_ctx,
+                        read_buffer.as_mut_ptr(),
+                        buffer_size as c_int,
+                    );
+
+                    if bytes_read > 0 {
+                        let chunk = Bytes::copy_from_slice(&read_buffer[..bytes_read as usize]);
+                        if tx.blocking_send(Ok(chunk)).is_err() {
+                            break; // Stream cancelled downstream
+                        }
+                    } else {
+                        if bytes_read != -541478725 && bytes_read < 0 {
+                            let mut err_buf = vec![0u8; 1024];
+                            let _ = (funcs.av_strerror)(bytes_read, err_buf.as_mut_ptr() as *mut c_char, 1024);
+                            let err_str = CStr::from_ptr(err_buf.as_ptr() as *const c_char)
+                                .to_string_lossy()
+                                .into_owned();
+                            let _ = tx.blocking_send(Err(format!("avio_read failed: code={} msg={}", bytes_read, err_str)));
+                        }
+                        break; // EOF
+                    }
+                }
+
+                (funcs.avio_close)(avio_ctx);
+                (funcs.av_dict_free)(&mut options);
+            }
+        });
+
+        Some(rx)
+    }
+}
+
+fn find_ffmpeg_libraries(custom_path: Option<&str>) -> Option<(PathBuf, PathBuf)> {
+    if let Some(path_str) = custom_path {
+        if !path_str.trim().is_empty() {
+            let p = Path::new(path_str);
+            if p.is_dir() {
+                if let Some(pair) = check_dir_for_ffmpeg(p) {
+                    return Some(pair);
+                }
+            } else if p.is_file() {
+                if let Some(parent) = p.parent() {
+                    if let Some(pair) = check_dir_for_ffmpeg(parent) {
+                        return Some(pair);
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let brew_dirs = ["/opt/homebrew/lib", "/usr/local/lib"];
+        for dir in brew_dirs {
+            let p = Path::new(dir);
+            if let Some(pair) = check_dir_for_ffmpeg(p) {
+                return Some(pair);
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let sys_dirs = ["/usr/lib", "/usr/lib/x86_64-linux-gnu", "/usr/local/lib"];
+        for dir in sys_dirs {
+            let p = Path::new(dir);
+            if let Some(pair) = check_dir_for_ffmpeg(p) {
+                return Some(pair);
+            }
+        }
+    }
+
+    // Default dynamic loader lookup
+    let util_name = if cfg!(target_os = "macos") {
+        "libavutil.dylib"
+    } else if cfg!(target_os = "windows") {
+        "avutil.dll"
+    } else {
+        "libavutil.so"
+    };
+
+    let format_name = if cfg!(target_os = "macos") {
+        "libavformat.dylib"
+    } else if cfg!(target_os = "windows") {
+        "avformat.dll"
+    } else {
+        "libavformat.so"
+    };
+
+    Some((PathBuf::from(util_name), PathBuf::from(format_name)))
+}
+
+fn check_dir_for_ffmpeg(dir: &Path) -> Option<(PathBuf, PathBuf)> {
+    let (util_ext, fmt_ext) = if cfg!(target_os = "macos") {
+        ("libavutil.dylib", "libavformat.dylib")
+    } else if cfg!(target_os = "windows") {
+        ("avutil.dll", "avformat.dll")
+    } else {
+        ("libavutil.so", "libavformat.so")
+    };
+
+    let u_path = dir.join(util_ext);
+    let f_path = dir.join(fmt_ext);
+
+    if u_path.exists() && f_path.exists() {
+        return Some((u_path, f_path));
+    }
+
+    for v in (58..=62).rev() {
+        let u_ver = if cfg!(target_os = "macos") {
+            format!("libavutil.{}.dylib", v)
+        } else if cfg!(target_os = "windows") {
+            format!("avutil-{}.dll", v)
+        } else {
+            format!("libavutil.so.{}", v)
+        };
+
+        let f_ver = if cfg!(target_os = "macos") {
+            format!("libavformat.{}.dylib", v)
+        } else if cfg!(target_os = "windows") {
+            format!("avformat-{}.dll", v)
+        } else {
+            format!("libavformat.so.{}", v)
+        };
+
+        let u_p = dir.join(u_ver);
+        let f_p = dir.join(f_ver);
+
+        if u_p.exists() && f_p.exists() {
+            return Some((u_p, f_p));
+        }
+    }
+
+    None
+}

--- a/stream-proxy-rust/src/avio.rs
+++ b/stream-proxy-rust/src/avio.rs
@@ -10,12 +10,8 @@ use tokio::sync::mpsc;
 use tracing::{error, info};
 
 pub type AvFormatNetworkInitFn = unsafe extern "C" fn() -> c_int;
-pub type AvDictSetFn = unsafe extern "C" fn(
-    *mut *mut c_void,
-    *const c_char,
-    *const c_char,
-    c_int,
-) -> c_int;
+pub type AvDictSetFn =
+    unsafe extern "C" fn(*mut *mut c_void, *const c_char, *const c_char, c_int) -> c_int;
 pub type AvDictFreeFn = unsafe extern "C" fn(*mut *mut c_void);
 pub type AvioOpen2Fn = unsafe extern "C" fn(
     *mut *mut c_void,
@@ -74,7 +70,10 @@ impl AvioClient {
 
     fn load_libraries(custom_path: Option<&str>) -> Option<Arc<AvioFunctions>> {
         let (avutil_path, avformat_path) = find_ffmpeg_libraries(custom_path)?;
-        info!("[pb-proxy-avio] Loading FFmpeg libraries: avutil={:?}, avformat={:?}", avutil_path, avformat_path);
+        info!(
+            "[pb-proxy-avio] Loading FFmpeg libraries: avutil={:?}, avformat={:?}",
+            avutil_path, avformat_path
+        );
 
         unsafe {
             let avutil_lib = Library::new(&avutil_path).ok()?;
@@ -84,7 +83,8 @@ impl AvioClient {
             let av_dict_free: Symbol<AvDictFreeFn> = avutil_lib.get(b"av_dict_free\0").ok()?;
             let av_strerror: Symbol<AvStrErrorFn> = avutil_lib.get(b"av_strerror\0").ok()?;
 
-            let avformat_network_init: Symbol<AvFormatNetworkInitFn> = avformat_lib.get(b"avformat_network_init\0").ok()?;
+            let avformat_network_init: Symbol<AvFormatNetworkInitFn> =
+                avformat_lib.get(b"avformat_network_init\0").ok()?;
             let avio_open2: Symbol<AvioOpen2Fn> = avformat_lib.get(b"avio_open2\0").ok()?;
             let avio_read: Symbol<AvioReadFn> = avformat_lib.get(b"avio_read\0").ok()?;
             let avio_close: Symbol<AvioCloseFn> = avformat_lib.get(b"avio_close\0").ok()?;
@@ -158,8 +158,7 @@ impl AvioClient {
                 );
 
                 let c_timeout_key = CString::new("timeout").unwrap();
-                let c_timeout_val =
-                    CString::new(format!("{}", timeout_secs * 1_000_000)).unwrap();
+                let c_timeout_val = CString::new(format!("{}", timeout_secs * 1_000_000)).unwrap();
                 (funcs.av_dict_set)(
                     &mut options,
                     c_timeout_key.as_ptr(),
@@ -170,23 +169,25 @@ impl AvioClient {
                 let mut avio_ctx: *mut c_void = ptr::null_mut();
                 let c_url = CString::new(url.clone()).unwrap();
 
-                let open_res = (funcs.avio_open2)(
-                    &mut avio_ctx,
-                    c_url.as_ptr(),
-                    1,
-                    ptr::null(),
-                    &mut options,
-                );
+                let open_res =
+                    (funcs.avio_open2)(&mut avio_ctx, c_url.as_ptr(), 1, ptr::null(), &mut options);
 
                 if open_res < 0 {
                     let mut err_buf = vec![0u8; 1024];
-                    let _ = (funcs.av_strerror)(open_res, err_buf.as_mut_ptr() as *mut c_char, 1024);
+                    let _ =
+                        (funcs.av_strerror)(open_res, err_buf.as_mut_ptr() as *mut c_char, 1024);
                     let err_str = CStr::from_ptr(err_buf.as_ptr() as *const c_char)
                         .to_string_lossy()
                         .into_owned();
 
-                    error!("[pb-proxy-avio] avio_open2 failed for {}: code={} msg={}", url, open_res, err_str);
-                    let _ = tx.blocking_send(Err(format!("avio_open2 failed: code={} msg={}", open_res, err_str)));
+                    error!(
+                        "[pb-proxy-avio] avio_open2 failed for {}: code={} msg={}",
+                        url, open_res, err_str
+                    );
+                    let _ = tx.blocking_send(Err(format!(
+                        "avio_open2 failed: code={} msg={}",
+                        open_res, err_str
+                    )));
                     (funcs.av_dict_free)(&mut options);
                     return;
                 }
@@ -195,11 +196,8 @@ impl AvioClient {
                 let mut read_buffer = vec![0u8; buffer_size];
 
                 loop {
-                    let bytes_read = (funcs.avio_read)(
-                        avio_ctx,
-                        read_buffer.as_mut_ptr(),
-                        buffer_size as c_int,
-                    );
+                    let bytes_read =
+                        (funcs.avio_read)(avio_ctx, read_buffer.as_mut_ptr(), buffer_size as c_int);
 
                     if bytes_read > 0 {
                         let chunk = Bytes::copy_from_slice(&read_buffer[..bytes_read as usize]);
@@ -209,11 +207,18 @@ impl AvioClient {
                     } else {
                         if bytes_read != -541478725 && bytes_read < 0 {
                             let mut err_buf = vec![0u8; 1024];
-                            let _ = (funcs.av_strerror)(bytes_read, err_buf.as_mut_ptr() as *mut c_char, 1024);
+                            let _ = (funcs.av_strerror)(
+                                bytes_read,
+                                err_buf.as_mut_ptr() as *mut c_char,
+                                1024,
+                            );
                             let err_str = CStr::from_ptr(err_buf.as_ptr() as *const c_char)
                                 .to_string_lossy()
                                 .into_owned();
-                            let _ = tx.blocking_send(Err(format!("avio_read failed: code={} msg={}", bytes_read, err_str)));
+                            let _ = tx.blocking_send(Err(format!(
+                                "avio_read failed: code={} msg={}",
+                                bytes_read, err_str
+                            )));
                         }
                         break; // EOF
                     }

--- a/stream-proxy-rust/src/config.rs
+++ b/stream-proxy-rust/src/config.rs
@@ -1,0 +1,43 @@
+use clap::Parser;
+use std::env;
+
+const DEFAULT_DOCKER_PASSWORD: &str = "CHANGEME";
+
+#[derive(Parser, Debug, Clone)]
+#[command(name = "pb-proxy-rust", about = "PlayBridge Stream Proxy Server in Rust")]
+pub struct Config {
+    #[arg(short = 'p', long, default_value = "8888", env = "PORT")]
+    pub port: u16,
+
+    #[arg(short = 'a', long, default_value = "0.0.0.0", env = "ADDRESS")]
+    pub address: String,
+
+    #[arg(short = 'k', long, env = "PB_PROXY_PASSWORD")]
+    pub password: Option<String>,
+
+    #[arg(short = 'f', long = "ffmpeg-path", env = "FFMPEG_PATH")]
+    pub ffmpeg_path: Option<String>,
+}
+
+impl Config {
+    pub fn get_validated_password(&self) -> Result<String, String> {
+        let password = self
+            .password
+            .clone()
+            .or_else(|| env::var("PB_PROXY_PASSWORD").ok())
+            .unwrap_or_default();
+
+        let trimmed = password.trim();
+        if trimmed.is_empty() {
+            return Err(
+                "A non-empty API password is required. Provide one with --password <password> or set PB_PROXY_PASSWORD=<password> in the environment.".to_string(),
+            );
+        }
+        if trimmed == DEFAULT_DOCKER_PASSWORD {
+            return Err(
+                "The default Docker Compose password is not allowed; set a unique password".to_string(),
+            );
+        }
+        Ok(trimmed.to_string())
+    }
+}

--- a/stream-proxy-rust/src/config.rs
+++ b/stream-proxy-rust/src/config.rs
@@ -4,7 +4,10 @@ use std::env;
 const DEFAULT_DOCKER_PASSWORD: &str = "CHANGEME";
 
 #[derive(Parser, Debug, Clone)]
-#[command(name = "pb-proxy-rust", about = "PlayBridge Stream Proxy Server in Rust")]
+#[command(
+    name = "pb-proxy-rust",
+    about = "PlayBridge Stream Proxy Server in Rust"
+)]
 pub struct Config {
     #[arg(short = 'p', long, default_value = "8888", env = "PORT")]
     pub port: u16,
@@ -35,7 +38,8 @@ impl Config {
         }
         if trimmed == DEFAULT_DOCKER_PASSWORD {
             return Err(
-                "The default Docker Compose password is not allowed; set a unique password".to_string(),
+                "The default Docker Compose password is not allowed; set a unique password"
+                    .to_string(),
             );
         }
         Ok(trimmed.to_string())

--- a/stream-proxy-rust/src/crypto.rs
+++ b/stream-proxy-rust/src/crypto.rs
@@ -99,7 +99,10 @@ mod tests {
         let handler = EncryptionHandler::new(b"my_secure_password");
         let mut headers = HashMap::new();
         headers.insert("User-Agent".to_string(), "PlayBridge".to_string());
-        headers.insert("Authorization".to_string(), "Bearer secret_debrid_key".to_string());
+        headers.insert(
+            "Authorization".to_string(),
+            "Bearer secret_debrid_key".to_string(),
+        );
 
         let data = ProxyData {
             destination: "https://cdn.example.com/video.m3u8".to_string(),
@@ -113,6 +116,13 @@ mod tests {
 
         let decrypted = handler.decrypt(&token, None).unwrap();
         assert_eq!(decrypted.destination, "https://cdn.example.com/video.m3u8");
-        assert_eq!(decrypted.request_headers.unwrap().get("Authorization").unwrap(), "Bearer secret_debrid_key");
+        assert_eq!(
+            decrypted
+                .request_headers
+                .unwrap()
+                .get("Authorization")
+                .unwrap(),
+            "Bearer secret_debrid_key"
+        );
     }
 }

--- a/stream-proxy-rust/src/crypto.rs
+++ b/stream-proxy-rust/src/crypto.rs
@@ -1,0 +1,118 @@
+use aes::Aes256;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use cbc::{Decryptor, Encryptor};
+use cipher::{block_padding::Pkcs7, BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+type Aes256CbcEnc = Encryptor<Aes256>;
+type Aes256CbcDec = Decryptor<Aes256>;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ProxyData {
+    pub destination: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_headers: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exp: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct EncryptionHandler {
+    key: [u8; 32],
+}
+
+impl EncryptionHandler {
+    pub fn new(api_password: &[u8]) -> Self {
+        let mut key = [0x20u8; 32]; // Space-padded to 32 bytes (matches MediaFlow/Python)
+        let copy_len = api_password.len().min(32);
+        key[..copy_len].copy_from_slice(&api_password[..copy_len]);
+        Self { key }
+    }
+
+    pub fn encrypt(&self, data: &ProxyData) -> Result<String, String> {
+        let json_data = serde_json::to_vec(data)
+            .map_err(|e| format!("Failed to serialize proxy data: {}", e))?;
+
+        let mut iv = [0u8; 16];
+        rand::thread_rng().fill_bytes(&mut iv);
+
+        let enc = Aes256CbcEnc::new(&self.key.into(), &iv.into());
+        let ciphertext = enc.encrypt_padded_vec_mut::<Pkcs7>(&json_data);
+
+        let mut final_data = Vec::with_capacity(16 + ciphertext.len());
+        final_data.extend_from_slice(&iv);
+        final_data.extend_from_slice(&ciphertext);
+
+        Ok(URL_SAFE_NO_PAD.encode(final_data))
+    }
+
+    pub fn decrypt(&self, token: &str, client_ip: Option<&str>) -> Result<ProxyData, String> {
+        let encrypted_data = URL_SAFE_NO_PAD
+            .decode(token)
+            .map_err(|e| format!("Invalid base64url token: {}", e))?;
+
+        if encrypted_data.len() < 17 {
+            return Err("Token payload too short".to_string());
+        }
+
+        let (iv_bytes, ciphertext) = encrypted_data.split_at(16);
+
+        let dec = Aes256CbcDec::new(&self.key.into(), iv_bytes.into());
+        let plaintext = dec
+            .decrypt_padded_vec_mut::<Pkcs7>(ciphertext)
+            .map_err(|_| "Decryption failed: invalid password or corrupt token".to_string())?;
+
+        let proxy_data: ProxyData = serde_json::from_slice(&plaintext)
+            .map_err(|e| format!("Invalid JSON inside token: {}", e))?;
+
+        if let Some(exp) = proxy_data.exp {
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            if exp < now {
+                return Err("Token has expired".to_string());
+            }
+        }
+
+        if let (Some(token_ip), Some(client_ip)) = (proxy_data.ip.as_ref(), client_ip) {
+            if token_ip != client_ip {
+                return Err("IP address mismatch".to_string());
+            }
+        }
+
+        Ok(proxy_data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mediaflow_aes_roundtrip() {
+        let handler = EncryptionHandler::new(b"my_secure_password");
+        let mut headers = HashMap::new();
+        headers.insert("User-Agent".to_string(), "PlayBridge".to_string());
+        headers.insert("Authorization".to_string(), "Bearer secret_debrid_key".to_string());
+
+        let data = ProxyData {
+            destination: "https://cdn.example.com/video.m3u8".to_string(),
+            request_headers: Some(headers.clone()),
+            exp: None,
+            ip: None,
+        };
+
+        let token = handler.encrypt(&data).unwrap();
+        assert!(!token.contains("secret_debrid_key")); // Ensure token is encrypted
+
+        let decrypted = handler.decrypt(&token, None).unwrap();
+        assert_eq!(decrypted.destination, "https://cdn.example.com/video.m3u8");
+        assert_eq!(decrypted.request_headers.unwrap().get("Authorization").unwrap(), "Bearer secret_debrid_key");
+    }
+}

--- a/stream-proxy-rust/src/dash.rs
+++ b/stream-proxy-rust/src/dash.rs
@@ -16,7 +16,11 @@ impl DashManifestRewriter {
 
             match token {
                 Some(t) if !t.is_empty() && !clean_url.contains("token=") => {
-                    let separator = if clean_url.contains('?') { "&amp;" } else { "?" };
+                    let separator = if clean_url.contains('?') {
+                        "&amp;"
+                    } else {
+                        "?"
+                    };
                     format!("{}{}{}token={}", clean_url, separator, "", t)
                 }
                 _ => clean_url,
@@ -26,7 +30,8 @@ impl DashManifestRewriter {
         let mut result = content.to_string();
 
         // 1. Rewrite <BaseURL>...</BaseURL>
-        let base_url_re = Regex::new(r"(?i)<BaseURL([^>]*)>([^<]+)</BaseURL>").expect("Valid regex");
+        let base_url_re =
+            Regex::new(r"(?i)<BaseURL([^>]*)>([^<]+)</BaseURL>").expect("Valid regex");
         result = base_url_re
             .replace_all(&result, |caps: &regex::Captures| {
                 let attrs = &caps[1];
@@ -36,7 +41,8 @@ impl DashManifestRewriter {
             .into_owned();
 
         // 2. Rewrite <Location>...</Location>
-        let location_re = Regex::new(r"(?i)<Location([^>]*)>([^<]+)</Location>").expect("Valid regex");
+        let location_re =
+            Regex::new(r"(?i)<Location([^>]*)>([^<]+)</Location>").expect("Valid regex");
         result = location_re
             .replace_all(&result, |caps: &regex::Captures| {
                 let attrs = &caps[1];
@@ -46,7 +52,9 @@ impl DashManifestRewriter {
             .into_owned();
 
         // 3. Rewrite attributes in double quotes
-        let attr_dq_re = Regex::new(r#"(?i)\b(media|initialization|location|baseUrl)\s*=\s*"([^"]+)""#).expect("Valid regex");
+        let attr_dq_re =
+            Regex::new(r#"(?i)\b(media|initialization|location|baseUrl)\s*=\s*"([^"]+)""#)
+                .expect("Valid regex");
         result = attr_dq_re
             .replace_all(&result, |caps: &regex::Captures| {
                 let attr_name = &caps[1];
@@ -56,7 +64,9 @@ impl DashManifestRewriter {
             .into_owned();
 
         // 4. Rewrite attributes in single quotes
-        let attr_sq_re = Regex::new(r#"(?i)\b(media|initialization|location|baseUrl)\s*=\s*'([^']+)'"#).expect("Valid regex");
+        let attr_sq_re =
+            Regex::new(r#"(?i)\b(media|initialization|location|baseUrl)\s*=\s*'([^']+)'"#)
+                .expect("Valid regex");
         result = attr_sq_re
             .replace_all(&result, |caps: &regex::Captures| {
                 let attr_name = &caps[1];

--- a/stream-proxy-rust/src/dash.rs
+++ b/stream-proxy-rust/src/dash.rs
@@ -1,0 +1,83 @@
+use regex::Regex;
+
+pub struct DashManifestRewriter;
+
+impl DashManifestRewriter {
+    pub fn rewrite(content: &str, token: Option<&str>) -> String {
+        let append_token = |url: &str| -> String {
+            if url.starts_with("//") || url.starts_with("http://") || url.starts_with("https://") {
+                return url.to_string();
+            }
+            let clean_url = if url.starts_with('/') {
+                format!("_root_{}", url)
+            } else {
+                url.to_string()
+            };
+
+            match token {
+                Some(t) if !t.is_empty() && !clean_url.contains("token=") => {
+                    let separator = if clean_url.contains('?') { "&amp;" } else { "?" };
+                    format!("{}{}{}token={}", clean_url, separator, "", t)
+                }
+                _ => clean_url,
+            }
+        };
+
+        let mut result = content.to_string();
+
+        // 1. Rewrite <BaseURL>...</BaseURL>
+        let base_url_re = Regex::new(r"(?i)<BaseURL([^>]*)>([^<]+)</BaseURL>").expect("Valid regex");
+        result = base_url_re
+            .replace_all(&result, |caps: &regex::Captures| {
+                let attrs = &caps[1];
+                let url = caps[2].trim();
+                format!("<BaseURL{}>{}</BaseURL>", attrs, append_token(url))
+            })
+            .into_owned();
+
+        // 2. Rewrite <Location>...</Location>
+        let location_re = Regex::new(r"(?i)<Location([^>]*)>([^<]+)</Location>").expect("Valid regex");
+        result = location_re
+            .replace_all(&result, |caps: &regex::Captures| {
+                let attrs = &caps[1];
+                let url = caps[2].trim();
+                format!("<Location{}>{}</Location>", attrs, append_token(url))
+            })
+            .into_owned();
+
+        // 3. Rewrite attributes in double quotes
+        let attr_dq_re = Regex::new(r#"(?i)\b(media|initialization|location|baseUrl)\s*=\s*"([^"]+)""#).expect("Valid regex");
+        result = attr_dq_re
+            .replace_all(&result, |caps: &regex::Captures| {
+                let attr_name = &caps[1];
+                let url = &caps[2];
+                format!(r#"{}="{}""#, attr_name, append_token(url))
+            })
+            .into_owned();
+
+        // 4. Rewrite attributes in single quotes
+        let attr_sq_re = Regex::new(r#"(?i)\b(media|initialization|location|baseUrl)\s*=\s*'([^']+)'"#).expect("Valid regex");
+        result = attr_sq_re
+            .replace_all(&result, |caps: &regex::Captures| {
+                let attr_name = &caps[1];
+                let url = &caps[2];
+                format!("{}='{}'", attr_name, append_token(url))
+            })
+            .into_owned();
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dash_rewrite() {
+        let xml = r#"<MPD><BaseURL>/segment.mp4</BaseURL><SegmentTemplate media="chunk-$Number$.m4s"/></MPD>"#;
+        let rewritten = DashManifestRewriter::rewrite(xml, Some("secret"));
+        assert!(rewritten.contains("<BaseURL>_root_/segment.mp4?token=secret</BaseURL>"));
+        assert!(rewritten.contains(r#"media="chunk-$Number$.m4s?token=secret""#));
+    }
+}

--- a/stream-proxy-rust/src/epg.rs
+++ b/stream-proxy-rust/src/epg.rs
@@ -1,0 +1,47 @@
+use bytes::Bytes;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use dashmap::DashMap;
+
+struct EpgCacheEntry {
+    bytes: Bytes,
+    cached_at: Instant,
+}
+
+#[derive(Clone)]
+pub struct EpgCache {
+    entries: Arc<DashMap<String, EpgCacheEntry>>,
+    ttl: Duration,
+}
+
+impl EpgCache {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            entries: Arc::new(DashMap::new()),
+            ttl,
+        }
+    }
+
+    pub fn get(&self, uri: &str) -> Option<Bytes> {
+        if let Some(entry) = self.entries.get(uri) {
+            if entry.cached_at.elapsed() < self.ttl {
+                return Some(entry.bytes.clone());
+            }
+        }
+        None
+    }
+
+    pub fn insert(&self, uri: String, bytes: Bytes) {
+        self.entries.insert(
+            uri,
+            EpgCacheEntry {
+                bytes,
+                cached_at: Instant::now(),
+            },
+        );
+    }
+
+    pub fn clear(&self) {
+        self.entries.clear();
+    }
+}

--- a/stream-proxy-rust/src/epg.rs
+++ b/stream-proxy-rust/src/epg.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
+use dashmap::DashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use dashmap::DashMap;
 
 struct EpgCacheEntry {
     bytes: Bytes,

--- a/stream-proxy-rust/src/hls.rs
+++ b/stream-proxy-rust/src/hls.rs
@@ -1,0 +1,89 @@
+use regex::Regex;
+use url::Url;
+
+pub struct HlsPlaylistRewriter;
+
+impl HlsPlaylistRewriter {
+    /// Rewrites the URIs inside an HLS playlist (master or media) to point back to the local proxy.
+    ///
+    /// `content` is the raw string content of the playlist.
+    /// `base_uri` is the effective URL of the playlist (after resolving any redirects).
+    /// `rewrite_url` is a closure that takes a resolved absolute target URL and returns the local proxy URL.
+    pub fn rewrite<F>(content: &str, base_uri: &Url, rewrite_url: F) -> String
+    where
+        F: Fn(&str) -> String,
+    {
+        let lines = content.lines();
+        let mut rewritten_lines = Vec::new();
+
+        let uri_attr_regex =
+            Regex::new(r#"(?i)(URI\s*=\s*")([^"]*)(")"#).expect("Valid regex");
+
+        for line in lines {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                rewritten_lines.push(line.to_string());
+                continue;
+            }
+
+            if trimmed.starts_with('#') {
+                if uri_attr_regex.is_match(line) {
+                    let rewritten_line = uri_attr_regex.replace_all(line, |caps: &regex::Captures| {
+                        let prefix = &caps[1];
+                        let relative_uri = &caps[2];
+                        let suffix = &caps[3];
+
+                        match base_uri.join(relative_uri) {
+                            Ok(resolved) => {
+                                let rewritten = rewrite_url(resolved.as_str());
+                                format!("{}{}{}", prefix, rewritten, suffix)
+                            }
+                            Err(_) => caps[0].to_string(),
+                        }
+                    });
+                    rewritten_lines.push(rewritten_line.into_owned());
+                } else {
+                    rewritten_lines.push(line.to_string());
+                }
+            } else {
+                // Segment or variant URI line
+                match base_uri.join(trimmed) {
+                    Ok(resolved) => {
+                        let rewritten = rewrite_url(resolved.as_str());
+                        rewritten_lines.push(rewritten);
+                    }
+                    Err(_) => {
+                        rewritten_lines.push(line.to_string());
+                    }
+                }
+            }
+        }
+
+        rewritten_lines.join("\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hls_rewrite_relative_segments_and_keys() {
+        let manifest = r#"#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-KEY:METHOD=AES-128,URI="enc.key"
+#EXTINF:10.0,
+segment1.ts
+#EXTINF:10.0,
+http://cdn.example.com/segment2.ts
+"#;
+        let base_url = Url::parse("https://stream.example.com/live/index.m3u8").unwrap();
+        let rewritten = HlsPlaylistRewriter::rewrite(manifest, &base_url, |target| {
+            format!("http://127.0.0.1:8888/proxy?url={}", urlencoding::encode(target))
+        });
+
+        assert!(rewritten.contains("URI=\"http://127.0.0.1:8888/proxy?url=https%3A%2F%2Fstream.example.com%2Flive%2Fenc.key\""));
+        assert!(rewritten.contains("http://127.0.0.1:8888/proxy?url=https%3A%2F%2Fstream.example.com%2Flive%2Fsegment1.ts"));
+        assert!(rewritten.contains("http://127.0.0.1:8888/proxy?url=http%3A%2F%2Fcdn.example.com%2Fsegment2.ts"));
+    }
+}

--- a/stream-proxy-rust/src/hls.rs
+++ b/stream-proxy-rust/src/hls.rs
@@ -16,8 +16,7 @@ impl HlsPlaylistRewriter {
         let lines = content.lines();
         let mut rewritten_lines = Vec::new();
 
-        let uri_attr_regex =
-            Regex::new(r#"(?i)(URI\s*=\s*")([^"]*)(")"#).expect("Valid regex");
+        let uri_attr_regex = Regex::new(r#"(?i)(URI\s*=\s*")([^"]*)(")"#).expect("Valid regex");
 
         for line in lines {
             let trimmed = line.trim();
@@ -28,19 +27,20 @@ impl HlsPlaylistRewriter {
 
             if trimmed.starts_with('#') {
                 if uri_attr_regex.is_match(line) {
-                    let rewritten_line = uri_attr_regex.replace_all(line, |caps: &regex::Captures| {
-                        let prefix = &caps[1];
-                        let relative_uri = &caps[2];
-                        let suffix = &caps[3];
+                    let rewritten_line =
+                        uri_attr_regex.replace_all(line, |caps: &regex::Captures| {
+                            let prefix = &caps[1];
+                            let relative_uri = &caps[2];
+                            let suffix = &caps[3];
 
-                        match base_uri.join(relative_uri) {
-                            Ok(resolved) => {
-                                let rewritten = rewrite_url(resolved.as_str());
-                                format!("{}{}{}", prefix, rewritten, suffix)
+                            match base_uri.join(relative_uri) {
+                                Ok(resolved) => {
+                                    let rewritten = rewrite_url(resolved.as_str());
+                                    format!("{}{}{}", prefix, rewritten, suffix)
+                                }
+                                Err(_) => caps[0].to_string(),
                             }
-                            Err(_) => caps[0].to_string(),
-                        }
-                    });
+                        });
                     rewritten_lines.push(rewritten_line.into_owned());
                 } else {
                     rewritten_lines.push(line.to_string());
@@ -79,11 +79,18 @@ http://cdn.example.com/segment2.ts
 "#;
         let base_url = Url::parse("https://stream.example.com/live/index.m3u8").unwrap();
         let rewritten = HlsPlaylistRewriter::rewrite(manifest, &base_url, |target| {
-            format!("http://127.0.0.1:8888/proxy?url={}", urlencoding::encode(target))
+            format!(
+                "http://127.0.0.1:8888/proxy?url={}",
+                urlencoding::encode(target)
+            )
         });
 
         assert!(rewritten.contains("URI=\"http://127.0.0.1:8888/proxy?url=https%3A%2F%2Fstream.example.com%2Flive%2Fenc.key\""));
-        assert!(rewritten.contains("http://127.0.0.1:8888/proxy?url=https%3A%2F%2Fstream.example.com%2Flive%2Fsegment1.ts"));
-        assert!(rewritten.contains("http://127.0.0.1:8888/proxy?url=http%3A%2F%2Fcdn.example.com%2Fsegment2.ts"));
+        assert!(rewritten.contains(
+            "http://127.0.0.1:8888/proxy?url=https%3A%2F%2Fstream.example.com%2Flive%2Fsegment1.ts"
+        ));
+        assert!(rewritten.contains(
+            "http://127.0.0.1:8888/proxy?url=http%3A%2F%2Fcdn.example.com%2Fsegment2.ts"
+        ));
     }
 }

--- a/stream-proxy-rust/src/lib.rs
+++ b/stream-proxy-rust/src/lib.rs
@@ -1,0 +1,13 @@
+pub mod avio;
+pub mod config;
+pub mod crypto;
+pub mod dash;
+pub mod epg;
+pub mod hls;
+pub mod server;
+pub mod session;
+pub mod upstream;
+
+pub use config::Config;
+pub use crypto::{EncryptionHandler, ProxyData};
+pub use server::create_router;

--- a/stream-proxy-rust/src/main.rs
+++ b/stream-proxy-rust/src/main.rs
@@ -1,0 +1,62 @@
+use clap::Parser;
+use std::net::SocketAddr;
+use stream_proxy_rust::{create_router, Config};
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let config = Config::parse();
+
+    let (app, address, port) = match create_router(config) {
+        Ok(res) => res,
+        Err(e) => {
+            eprintln!("Cannot start proxy: {}", e);
+            std::process::exit(64);
+        }
+    };
+
+    let bind_addr: SocketAddr = format!("{}:{}", address, port).parse()?;
+    info!("[stream-proxy-rust] Listening on {}", bind_addr);
+    info!("[stream-proxy-rust] Authentication active");
+
+    let listener = tokio::net::TcpListener::bind(bind_addr).await?;
+    info!("[pb-proxy-cli] Server running at http://{}", bind_addr);
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    info!("[stream-proxy-rust] Stopped proxy server");
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => info!("\n[pb-proxy-cli] Shutting down gracefully (SIGINT)..."),
+        _ = terminate => info!("\n[pb-proxy-cli] Shutting down gracefully (SIGTERM)..."),
+    }
+}

--- a/stream-proxy-rust/src/server.rs
+++ b/stream-proxy-rust/src/server.rs
@@ -1,0 +1,500 @@
+use crate::config::Config;
+use crate::crypto::{EncryptionHandler, ProxyData};
+use crate::dash::DashManifestRewriter;
+use crate::epg::EpgCache;
+use crate::hls::HlsPlaylistRewriter;
+use crate::session::SessionManager;
+use crate::upstream::{filter_upstream_headers, ConnectionEngine};
+use axum::{
+    body::Body,
+    extract::{Path as AxumPath, Query, State},
+    http::{header, HeaderMap, HeaderValue, Request, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tower_http::cors::{Any, CorsLayer};
+use tracing::info;
+use url::Url;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub password: String,
+    pub session_manager: SessionManager,
+    pub epg_cache: EpgCache,
+    pub engine: Arc<ConnectionEngine>,
+    pub encryption_handler: EncryptionHandler,
+}
+
+#[derive(Deserialize)]
+pub struct RegisterRequest {
+    pub url: String,
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+}
+
+#[derive(Serialize)]
+pub struct RegisterResponse {
+    pub proxy_url: String,
+    pub encrypted_url: String,
+}
+
+#[derive(Deserialize)]
+pub struct EpgQuery {
+    pub uri: Option<String>,
+}
+
+pub fn create_router(config: Config) -> Result<(Router, String, u16), String> {
+    let password = config.get_validated_password()?;
+    let encryption_handler = EncryptionHandler::new(password.as_bytes());
+
+    let state = AppState {
+        password: password.clone(),
+        session_manager: SessionManager::new(),
+        epg_cache: EpgCache::new(Duration::from_secs(14400)), // 4 hours
+        engine: Arc::new(ConnectionEngine::new(config.ffmpeg_path.clone())),
+        encryption_handler,
+    };
+
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any)
+        .expose_headers([
+            header::CONTENT_LENGTH,
+            header::CONTENT_RANGE,
+            header::ACCEPT_RANGES,
+        ]);
+
+    let app = Router::new()
+        .route("/", get(demo_html_handler))
+        .route("/demo.html", get(demo_html_handler))
+        .route("/health", get(health_handler))
+        .route("/ping", get(health_handler))
+        .route("/register", post(register_handler))
+        .route("/epg", get(epg_handler))
+        .route("/s/*path", get(stateful_proxy_handler))
+        .route("/proxy/*path", get(encrypted_proxy_handler))
+        .layer(cors)
+        .layer(middleware::from_fn_with_state(state.clone(), auth_middleware))
+        .with_state(state);
+
+    Ok((app, config.address.clone(), config.port))
+}
+
+async fn demo_html_handler() -> axum::response::Html<&'static str> {
+    axum::response::Html(include_str!("../demo.html"))
+}
+
+async fn health_handler() -> &'static str {
+    "OK"
+}
+
+async fn auth_middleware(
+    State(state): State<AppState>,
+    req: Request<Body>,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let path = req.uri().path();
+    if path == "/" || path == "/demo.html" || path == "/health" || path == "/ping" || path.starts_with("/proxy") {
+        return Ok(next.run(req).await);
+    }
+
+    let mut token = None;
+    if let Some(query_str) = req.uri().query() {
+        if let Ok(params) = serde_urlencoded::from_str::<HashMap<String, String>>(query_str) {
+            token = params.get("token").cloned();
+        }
+    }
+
+    if token.is_none() {
+        if let Some(auth_header) = req.headers().get(header::AUTHORIZATION) {
+            if let Ok(val) = auth_header.to_str() {
+                token = Some(val.replace("Bearer ", "").trim().to_string());
+            }
+        }
+    }
+
+    match token {
+        Some(t) if t == state.password => Ok(next.run(req).await),
+        _ => Err(StatusCode::FORBIDDEN),
+    }
+}
+
+async fn register_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(payload): Json<RegisterRequest>,
+) -> Result<Json<RegisterResponse>, (StatusCode, String)> {
+    let session = state.session_manager.register(payload.url.clone(), payload.headers.clone());
+    let host_str = headers
+        .get(header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("127.0.0.1:8888");
+
+    let proxy_url = format!(
+        "http://{}/s/{}/manifest.m3u8?token={}",
+        host_str, session.id, state.password
+    );
+
+    // Generate MediaFlow-compatible AES-256 encrypted token
+    let proxy_data = ProxyData {
+        destination: payload.url,
+        request_headers: if payload.headers.is_empty() { None } else { Some(payload.headers) },
+        exp: None,
+        ip: None,
+    };
+
+    let encrypted_token = state
+        .encryption_handler
+        .encrypt(&proxy_data)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    let encrypted_url = format!(
+        "http://{}/proxy/hls/manifest.m3u8?token={}",
+        host_str, encrypted_token
+    );
+
+    info!("[stream-proxy] Registered stateful session {} for host {}", session.id, host_str);
+    Ok(Json(RegisterResponse {
+        proxy_url,
+        encrypted_url,
+    }))
+}
+
+async fn epg_handler(
+    State(state): State<AppState>,
+    Query(query): Query<EpgQuery>,
+) -> Result<Response, (StatusCode, String)> {
+    let uri_str = match query.uri {
+        Some(ref u) if !u.trim().is_empty() => u.clone(),
+        _ => return Err((StatusCode::BAD_REQUEST, "Missing 'uri' parameter for EPG".to_string())),
+    };
+
+    if let Some(cached) = state.epg_cache.get(&uri_str) {
+        return Ok((
+            [
+                (header::CONTENT_TYPE, "application/xml"),
+                (header::CACHE_CONTROL, "public, max-age=14400"),
+            ],
+            cached,
+        )
+            .into_response());
+    }
+
+    match state.engine.fetch_url_bytes(&uri_str, &HashMap::new()).await {
+        Ok(bytes) => {
+            state.epg_cache.insert(uri_str, bytes.clone());
+            Ok((
+                [
+                    (header::CONTENT_TYPE, "application/xml"),
+                    (header::CACHE_CONTROL, "public, max-age=14400"),
+                ],
+                bytes,
+            )
+                .into_response())
+        }
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to fetch EPG: {}", e))),
+    }
+}
+
+/// Handler for Stateful Session Proxying (`/s/<session_id>/<filename>`)
+async fn stateful_proxy_handler(
+    State(state): State<AppState>,
+    AxumPath(path_str): AxumPath<String>,
+    Query(query_params): Query<Vec<(String, String)>>,
+    incoming_headers: HeaderMap,
+    req: Request<Body>,
+) -> Result<Response, (StatusCode, String)> {
+    let path_segments: Vec<&str> = path_str.split('/').filter(|s| !s.is_empty()).collect();
+    if path_segments.is_empty() {
+        return Err((StatusCode::NOT_FOUND, "Not Found".to_string()));
+    }
+
+    let session_id = path_segments[0];
+    let session = match state.session_manager.get(session_id) {
+        Some(s) => s,
+        None => return Err((StatusCode::FORBIDDEN, "Session expired or invalid".to_string())),
+    };
+
+    let mut target_url = String::new();
+    if let Some((_, query_uri)) = query_params.iter().find(|(k, _)| k == "uri") {
+        if !query_uri.is_empty() {
+            target_url = query_uri.clone();
+        }
+    }
+
+    if target_url.is_empty() {
+        if path_segments.len() == 2 && path_segments[1] == "manifest.m3u8" {
+            target_url = session.original_url.clone();
+        } else {
+            let rel_segments = &path_segments[1..];
+            target_url = resolve_target_url(&session.original_url, rel_segments, &query_params);
+        }
+    }
+
+    let forward_headers = filter_upstream_headers(&session.headers, &incoming_headers, &target_url, session_id);
+    let is_hls = target_url.to_lowercase().contains(".m3u8") || req.uri().path().to_lowercase().contains(".m3u8");
+
+    if is_hls {
+        handle_stateful_hls_playlist(&state, session_id, &target_url, &forward_headers).await
+    } else {
+        handle_segment(&state, &target_url, &forward_headers).await
+    }
+}
+
+/// Handler for MediaFlow AES-256 Encrypted Stateless Proxying (`/proxy/hls/...` or `/proxy/stream/...`)
+async fn encrypted_proxy_handler(
+    State(state): State<AppState>,
+    AxumPath(_path_str): AxumPath<String>,
+    Query(query_params): Query<Vec<(String, String)>>,
+    incoming_headers: HeaderMap,
+    req: Request<Body>,
+) -> Result<Response, (StatusCode, String)> {
+    let token = match query_params.iter().find(|(k, _)| k == "token") {
+        Some((_, val)) if !val.is_empty() => val,
+        _ => return Err((StatusCode::FORBIDDEN, "Missing encrypted token parameter".to_string())),
+    };
+
+    let proxy_data = match state.encryption_handler.decrypt(token, None) {
+        Ok(pd) => pd,
+        Err(e) => return Err((StatusCode::FORBIDDEN, format!("Invalid encrypted token: {}", e))),
+    };
+
+    let mut target_url = proxy_data.destination.clone();
+    if let Some((_, query_uri)) = query_params.iter().find(|(k, _)| k == "uri") {
+        if !query_uri.is_empty() {
+            target_url = query_uri.clone();
+        }
+    }
+
+    let session_headers = proxy_data.request_headers.clone().unwrap_or_default();
+    let forward_headers = filter_upstream_headers(&session_headers, &incoming_headers, &target_url, "encrypted");
+
+    let is_hls = target_url.to_lowercase().contains(".m3u8") || req.uri().path().to_lowercase().contains(".m3u8");
+
+    if is_hls {
+        handle_encrypted_hls_playlist(&state, &target_url, &forward_headers, &proxy_data).await
+    } else {
+        handle_segment(&state, &target_url, &forward_headers).await
+    }
+}
+
+async fn handle_stateful_hls_playlist(
+    state: &AppState,
+    session_id: &str,
+    target_url: &str,
+    headers: &HashMap<String, String>,
+) -> Result<Response, (StatusCode, String)> {
+    match state.engine.fetch_url_bytes(target_url, headers).await {
+        Ok(bytes) => {
+            let content = String::from_utf8_lossy(&bytes);
+            let base_uri = match Url::parse(target_url) {
+                Ok(u) => u,
+                Err(e) => return Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Parse URL error: {}", e))),
+            };
+
+            let password = state.password.clone();
+            let rewritten = HlsPlaylistRewriter::rewrite(&content, &base_uri, |resolved_target| {
+                let resolved_uri = match Url::parse(resolved_target) {
+                    Ok(u) => u,
+                    Err(_) => return resolved_target.to_string(),
+                };
+
+                let filename = resolved_uri
+                    .path_segments()
+                    .and_then(|mut s| s.next_back())
+                    .unwrap_or("item");
+
+                format!("/s/{}/{}?uri={}&token={}", session_id, filename, urlencoding::encode(resolved_target), password)
+            });
+
+            Ok((
+                [
+                    (header::CONTENT_TYPE, "application/vnd.apple.mpegurl"),
+                    (header::CACHE_CONTROL, "no-cache, no-store, must-revalidate"),
+                ],
+                rewritten,
+            )
+                .into_response())
+        }
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to fetch/rewrite HLS playlist: {}", e),
+        )),
+    }
+}
+
+async fn handle_encrypted_hls_playlist(
+    state: &AppState,
+    target_url: &str,
+    headers: &HashMap<String, String>,
+    proxy_data: &ProxyData,
+) -> Result<Response, (StatusCode, String)> {
+    match state.engine.fetch_url_bytes(target_url, headers).await {
+        Ok(bytes) => {
+            let content = String::from_utf8_lossy(&bytes);
+            let base_uri = match Url::parse(target_url) {
+                Ok(u) => u,
+                Err(e) => return Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Parse URL error: {}", e))),
+            };
+
+            let rewritten = HlsPlaylistRewriter::rewrite(&content, &base_uri, |resolved_target| {
+                let resolved_uri = match Url::parse(resolved_target) {
+                    Ok(u) => u,
+                    Err(_) => return resolved_target.to_string(),
+                };
+
+                let filename = resolved_uri
+                    .path_segments()
+                    .and_then(|mut s| s.next_back())
+                    .unwrap_or("item");
+
+                let mut item_data = proxy_data.clone();
+                item_data.destination = resolved_target.to_string();
+
+                let item_token = state
+                    .encryption_handler
+                    .encrypt(&item_data)
+                    .unwrap_or_default();
+
+                format!("/proxy/hls/{}?token={}", filename, item_token)
+            });
+
+            Ok((
+                [
+                    (header::CONTENT_TYPE, "application/vnd.apple.mpegurl"),
+                    (header::CACHE_CONTROL, "no-cache, no-store, must-revalidate"),
+                ],
+                rewritten,
+            )
+                .into_response())
+        }
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to fetch/rewrite encrypted HLS playlist: {}", e),
+        )),
+    }
+}
+
+async fn handle_segment(
+    state: &AppState,
+    target_url: &str,
+    headers: &HashMap<String, String>,
+) -> Result<Response, (StatusCode, String)> {
+    match state.engine.connect_upstream(target_url, headers).await {
+        Ok(upstream) => {
+            let content_type = upstream
+                .headers
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("")
+                .to_lowercase();
+
+            let is_dash = content_type.contains("dash+xml")
+                || target_url.to_lowercase().contains(".mpd")
+                || target_url.to_lowercase().contains("manifest/dash");
+
+            if is_dash {
+                let bytes = match axum::body::to_bytes(upstream.body, usize::MAX).await {
+                    Ok(b) => b,
+                    Err(e) => return Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Failed reading DASH bytes: {}", e))),
+                };
+                let raw_content = String::from_utf8_lossy(&bytes);
+                let rewritten = DashManifestRewriter::rewrite(&raw_content, Some(&state.password));
+                return Ok((
+                    [
+                        (header::CONTENT_TYPE, "application/dash+xml"),
+                        (header::CACHE_CONTROL, "no-cache, no-store, must-revalidate"),
+                    ],
+                    rewritten,
+                )
+                    .into_response());
+            }
+
+            let mime = mime_for(target_url);
+            let mut response_builder = Response::builder().status(upstream.status);
+
+            if let Some(headers_map) = response_builder.headers_mut() {
+                headers_map.insert(header::CONTENT_TYPE, HeaderValue::from_static(mime));
+                headers_map.insert(header::CACHE_CONTROL, HeaderValue::from_static("public, max-age=3600"));
+                for (k, v) in &upstream.headers {
+                    headers_map.insert(k.clone(), v.clone());
+                }
+            }
+
+            Ok(response_builder.body(upstream.body).unwrap_or_else(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Build response error").into_response()))
+        }
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to fetch segment: {}", e))),
+    }
+}
+
+fn resolve_target_url(base_spec: &str, relative_segments: &[&str], query_params: &[(String, String)]) -> String {
+    let base_uri = match Url::parse(base_spec) {
+        Ok(u) => u,
+        Err(_) => return base_spec.to_string(),
+    };
+
+    if relative_segments.is_empty() {
+        return base_spec.to_string();
+    }
+
+    let mut resolved = if relative_segments[0] == "_root_" {
+        let mut origin = format!("{}://{}", base_uri.scheme(), base_uri.host_str().unwrap_or(""));
+        if let Some(port) = base_uri.port() {
+            origin.push_str(&format!(":{}", port));
+        }
+        let rel_path = relative_segments[1..].join("/");
+        Url::parse(&origin).and_then(|u| u.join(&rel_path)).unwrap_or_else(|_| base_uri.clone())
+    } else {
+        let rel_path = relative_segments.join("/");
+        base_uri.join(&rel_path).unwrap_or_else(|_| base_uri.clone())
+    };
+
+    let mut merged_query: Vec<(String, String)> = Vec::new();
+
+    for (k, v) in base_uri.query_pairs() {
+        merged_query.push((k.into_owned(), v.into_owned()));
+    }
+    for (k, v) in resolved.query_pairs() {
+        if !merged_query.iter().any(|(existing_k, _)| existing_k == &*k) {
+            merged_query.push((k.into_owned(), v.into_owned()));
+        }
+    }
+    for (k, v) in query_params {
+        if k != "token" && !merged_query.iter().any(|(existing_k, _)| existing_k == k) {
+            merged_query.push((k.clone(), v.clone()));
+        }
+    }
+
+    if !merged_query.is_empty() {
+        let query_str = serde_urlencoded::to_string(&merged_query).unwrap_or_default();
+        resolved.set_query(Some(&query_str));
+    }
+
+    resolved.to_string()
+}
+
+fn mime_for(path: &str) -> &'static str {
+    let lower = path.to_lowercase();
+    if lower.contains(".m3u8") {
+        "application/vnd.apple.mpegurl"
+    } else if lower.contains(".mpd") {
+        "application/dash+xml"
+    } else if lower.contains(".m4s") {
+        "video/iso.segment"
+    } else if lower.contains(".ts") {
+        "video/mp2t"
+    } else if lower.contains(".mp4") {
+        "video/mp4"
+    } else if lower.contains(".key") {
+        "application/octet-stream"
+    } else {
+        "application/octet-stream"
+    }
+}

--- a/stream-proxy-rust/src/server.rs
+++ b/stream-proxy-rust/src/server.rs
@@ -81,7 +81,10 @@ pub fn create_router(config: Config) -> Result<(Router, String, u16), String> {
         .route("/s/*path", get(stateful_proxy_handler))
         .route("/proxy/*path", get(encrypted_proxy_handler))
         .layer(cors)
-        .layer(middleware::from_fn_with_state(state.clone(), auth_middleware))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth_middleware,
+        ))
         .with_state(state);
 
     Ok((app, config.address.clone(), config.port))
@@ -101,7 +104,12 @@ async fn auth_middleware(
     next: Next,
 ) -> Result<Response, StatusCode> {
     let path = req.uri().path();
-    if path == "/" || path == "/demo.html" || path == "/health" || path == "/ping" || path.starts_with("/proxy") {
+    if path == "/"
+        || path == "/demo.html"
+        || path == "/health"
+        || path == "/ping"
+        || path.starts_with("/proxy")
+    {
         return Ok(next.run(req).await);
     }
 
@@ -131,7 +139,9 @@ async fn register_handler(
     headers: HeaderMap,
     Json(payload): Json<RegisterRequest>,
 ) -> Result<Json<RegisterResponse>, (StatusCode, String)> {
-    let session = state.session_manager.register(payload.url.clone(), payload.headers.clone());
+    let session = state
+        .session_manager
+        .register(payload.url.clone(), payload.headers.clone());
     let host_str = headers
         .get(header::HOST)
         .and_then(|v| v.to_str().ok())
@@ -145,7 +155,11 @@ async fn register_handler(
     // Generate MediaFlow-compatible AES-256 encrypted token
     let proxy_data = ProxyData {
         destination: payload.url,
-        request_headers: if payload.headers.is_empty() { None } else { Some(payload.headers) },
+        request_headers: if payload.headers.is_empty() {
+            None
+        } else {
+            Some(payload.headers)
+        },
         exp: None,
         ip: None,
     };
@@ -160,7 +174,10 @@ async fn register_handler(
         host_str, encrypted_token
     );
 
-    info!("[stream-proxy] Registered stateful session {} for host {}", session.id, host_str);
+    info!(
+        "[stream-proxy] Registered stateful session {} for host {}",
+        session.id, host_str
+    );
     Ok(Json(RegisterResponse {
         proxy_url,
         encrypted_url,
@@ -173,7 +190,12 @@ async fn epg_handler(
 ) -> Result<Response, (StatusCode, String)> {
     let uri_str = match query.uri {
         Some(ref u) if !u.trim().is_empty() => u.clone(),
-        _ => return Err((StatusCode::BAD_REQUEST, "Missing 'uri' parameter for EPG".to_string())),
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Missing 'uri' parameter for EPG".to_string(),
+            ))
+        }
     };
 
     if let Some(cached) = state.epg_cache.get(&uri_str) {
@@ -187,7 +209,11 @@ async fn epg_handler(
             .into_response());
     }
 
-    match state.engine.fetch_url_bytes(&uri_str, &HashMap::new()).await {
+    match state
+        .engine
+        .fetch_url_bytes(&uri_str, &HashMap::new())
+        .await
+    {
         Ok(bytes) => {
             state.epg_cache.insert(uri_str, bytes.clone());
             Ok((
@@ -199,7 +225,10 @@ async fn epg_handler(
             )
                 .into_response())
         }
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to fetch EPG: {}", e))),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to fetch EPG: {}", e),
+        )),
     }
 }
 
@@ -219,7 +248,12 @@ async fn stateful_proxy_handler(
     let session_id = path_segments[0];
     let session = match state.session_manager.get(session_id) {
         Some(s) => s,
-        None => return Err((StatusCode::FORBIDDEN, "Session expired or invalid".to_string())),
+        None => {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "Session expired or invalid".to_string(),
+            ))
+        }
     };
 
     let mut target_url = String::new();
@@ -238,8 +272,10 @@ async fn stateful_proxy_handler(
         }
     }
 
-    let forward_headers = filter_upstream_headers(&session.headers, &incoming_headers, &target_url, session_id);
-    let is_hls = target_url.to_lowercase().contains(".m3u8") || req.uri().path().to_lowercase().contains(".m3u8");
+    let forward_headers =
+        filter_upstream_headers(&session.headers, &incoming_headers, &target_url, session_id);
+    let is_hls = target_url.to_lowercase().contains(".m3u8")
+        || req.uri().path().to_lowercase().contains(".m3u8");
 
     if is_hls {
         handle_stateful_hls_playlist(&state, session_id, &target_url, &forward_headers).await
@@ -258,12 +294,22 @@ async fn encrypted_proxy_handler(
 ) -> Result<Response, (StatusCode, String)> {
     let token = match query_params.iter().find(|(k, _)| k == "token") {
         Some((_, val)) if !val.is_empty() => val,
-        _ => return Err((StatusCode::FORBIDDEN, "Missing encrypted token parameter".to_string())),
+        _ => {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "Missing encrypted token parameter".to_string(),
+            ))
+        }
     };
 
     let proxy_data = match state.encryption_handler.decrypt(token, None) {
         Ok(pd) => pd,
-        Err(e) => return Err((StatusCode::FORBIDDEN, format!("Invalid encrypted token: {}", e))),
+        Err(e) => {
+            return Err((
+                StatusCode::FORBIDDEN,
+                format!("Invalid encrypted token: {}", e),
+            ))
+        }
     };
 
     let mut target_url = proxy_data.destination.clone();
@@ -274,9 +320,15 @@ async fn encrypted_proxy_handler(
     }
 
     let session_headers = proxy_data.request_headers.clone().unwrap_or_default();
-    let forward_headers = filter_upstream_headers(&session_headers, &incoming_headers, &target_url, "encrypted");
+    let forward_headers = filter_upstream_headers(
+        &session_headers,
+        &incoming_headers,
+        &target_url,
+        "encrypted",
+    );
 
-    let is_hls = target_url.to_lowercase().contains(".m3u8") || req.uri().path().to_lowercase().contains(".m3u8");
+    let is_hls = target_url.to_lowercase().contains(".m3u8")
+        || req.uri().path().to_lowercase().contains(".m3u8");
 
     if is_hls {
         handle_encrypted_hls_playlist(&state, &target_url, &forward_headers, &proxy_data).await
@@ -296,7 +348,12 @@ async fn handle_stateful_hls_playlist(
             let content = String::from_utf8_lossy(&bytes);
             let base_uri = match Url::parse(target_url) {
                 Ok(u) => u,
-                Err(e) => return Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Parse URL error: {}", e))),
+                Err(e) => {
+                    return Err((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Parse URL error: {}", e),
+                    ))
+                }
             };
 
             let password = state.password.clone();
@@ -311,7 +368,13 @@ async fn handle_stateful_hls_playlist(
                     .and_then(|mut s| s.next_back())
                     .unwrap_or("item");
 
-                format!("/s/{}/{}?uri={}&token={}", session_id, filename, urlencoding::encode(resolved_target), password)
+                format!(
+                    "/s/{}/{}?uri={}&token={}",
+                    session_id,
+                    filename,
+                    urlencoding::encode(resolved_target),
+                    password
+                )
             });
 
             Ok((
@@ -341,7 +404,12 @@ async fn handle_encrypted_hls_playlist(
             let content = String::from_utf8_lossy(&bytes);
             let base_uri = match Url::parse(target_url) {
                 Ok(u) => u,
-                Err(e) => return Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Parse URL error: {}", e))),
+                Err(e) => {
+                    return Err((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Parse URL error: {}", e),
+                    ))
+                }
             };
 
             let rewritten = HlsPlaylistRewriter::rewrite(&content, &base_uri, |resolved_target| {
@@ -403,7 +471,12 @@ async fn handle_segment(
             if is_dash {
                 let bytes = match axum::body::to_bytes(upstream.body, usize::MAX).await {
                     Ok(b) => b,
-                    Err(e) => return Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Failed reading DASH bytes: {}", e))),
+                    Err(e) => {
+                        return Err((
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Failed reading DASH bytes: {}", e),
+                        ))
+                    }
                 };
                 let raw_content = String::from_utf8_lossy(&bytes);
                 let rewritten = DashManifestRewriter::rewrite(&raw_content, Some(&state.password));
@@ -422,19 +495,31 @@ async fn handle_segment(
 
             if let Some(headers_map) = response_builder.headers_mut() {
                 headers_map.insert(header::CONTENT_TYPE, HeaderValue::from_static(mime));
-                headers_map.insert(header::CACHE_CONTROL, HeaderValue::from_static("public, max-age=3600"));
+                headers_map.insert(
+                    header::CACHE_CONTROL,
+                    HeaderValue::from_static("public, max-age=3600"),
+                );
                 for (k, v) in &upstream.headers {
                     headers_map.insert(k.clone(), v.clone());
                 }
             }
 
-            Ok(response_builder.body(upstream.body).unwrap_or_else(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Build response error").into_response()))
+            Ok(response_builder.body(upstream.body).unwrap_or_else(|_| {
+                (StatusCode::INTERNAL_SERVER_ERROR, "Build response error").into_response()
+            }))
         }
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to fetch segment: {}", e))),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to fetch segment: {}", e),
+        )),
     }
 }
 
-fn resolve_target_url(base_spec: &str, relative_segments: &[&str], query_params: &[(String, String)]) -> String {
+fn resolve_target_url(
+    base_spec: &str,
+    relative_segments: &[&str],
+    query_params: &[(String, String)],
+) -> String {
     let base_uri = match Url::parse(base_spec) {
         Ok(u) => u,
         Err(_) => return base_spec.to_string(),
@@ -445,15 +530,23 @@ fn resolve_target_url(base_spec: &str, relative_segments: &[&str], query_params:
     }
 
     let mut resolved = if relative_segments[0] == "_root_" {
-        let mut origin = format!("{}://{}", base_uri.scheme(), base_uri.host_str().unwrap_or(""));
+        let mut origin = format!(
+            "{}://{}",
+            base_uri.scheme(),
+            base_uri.host_str().unwrap_or("")
+        );
         if let Some(port) = base_uri.port() {
             origin.push_str(&format!(":{}", port));
         }
         let rel_path = relative_segments[1..].join("/");
-        Url::parse(&origin).and_then(|u| u.join(&rel_path)).unwrap_or_else(|_| base_uri.clone())
+        Url::parse(&origin)
+            .and_then(|u| u.join(&rel_path))
+            .unwrap_or_else(|_| base_uri.clone())
     } else {
         let rel_path = relative_segments.join("/");
-        base_uri.join(&rel_path).unwrap_or_else(|_| base_uri.clone())
+        base_uri
+            .join(&rel_path)
+            .unwrap_or_else(|_| base_uri.clone())
     };
 
     let mut merged_query: Vec<(String, String)> = Vec::new();
@@ -492,8 +585,6 @@ fn mime_for(path: &str) -> &'static str {
         "video/mp2t"
     } else if lower.contains(".mp4") {
         "video/mp4"
-    } else if lower.contains(".key") {
-        "application/octet-stream"
     } else {
         "application/octet-stream"
     }

--- a/stream-proxy-rust/src/session.rs
+++ b/stream-proxy-rust/src/session.rs
@@ -35,6 +35,12 @@ pub struct SessionManager {
     sessions: Arc<DashMap<String, ProxySession>>,
 }
 
+impl Default for SessionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SessionManager {
     pub fn new() -> Self {
         let manager = Self {
@@ -76,14 +82,19 @@ impl SessionManager {
             loop {
                 timer.tick().await;
                 let max_inactive = Duration::from_secs(600); // 10 minutes
-                let max_age = Duration::from_secs(7200);     // 2 hours
+                let max_age = Duration::from_secs(7200); // 2 hours
 
                 sessions.retain(|id, session| {
                     let inactive = session.last_accessed_at.elapsed();
                     let age = session.created_at.elapsed();
                     let expire = inactive > max_inactive || age > max_age;
                     if expire {
-                        info!("[stream-proxy] Expired session {} (inactive: {}s, age: {}s)", id, inactive.as_secs(), age.as_secs());
+                        info!(
+                            "[stream-proxy] Expired session {} (inactive: {}s, age: {}s)",
+                            id,
+                            inactive.as_secs(),
+                            age.as_secs()
+                        );
                     }
                     !expire
                 });

--- a/stream-proxy-rust/src/session.rs
+++ b/stream-proxy-rust/src/session.rs
@@ -1,0 +1,93 @@
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use dashmap::DashMap;
+use rand::Rng;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::time::interval;
+use tracing::info;
+
+#[derive(Debug, Clone)]
+pub struct ProxySession {
+    pub id: String,
+    pub original_url: String,
+    pub headers: HashMap<String, String>,
+    pub created_at: Instant,
+    pub last_accessed_at: Instant,
+}
+
+impl ProxySession {
+    pub fn new(id: String, original_url: String, headers: HashMap<String, String>) -> Self {
+        let now = Instant::now();
+        Self {
+            id,
+            original_url,
+            headers,
+            created_at: now,
+            last_accessed_at: now,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct SessionManager {
+    sessions: Arc<DashMap<String, ProxySession>>,
+}
+
+impl SessionManager {
+    pub fn new() -> Self {
+        let manager = Self {
+            sessions: Arc::new(DashMap::new()),
+        };
+        manager.start_cleanup_task();
+        manager
+    }
+
+    pub fn register(&self, original_url: String, headers: HashMap<String, String>) -> ProxySession {
+        let id = Self::generate_id();
+        let session = ProxySession::new(id.clone(), original_url, headers);
+        self.sessions.insert(id, session.clone());
+        session
+    }
+
+    pub fn get(&self, id: &str) -> Option<ProxySession> {
+        if let Some(mut entry) = self.sessions.get_mut(id) {
+            entry.last_accessed_at = Instant::now();
+            return Some(entry.clone());
+        }
+        None
+    }
+
+    pub fn clear(&self) {
+        self.sessions.clear();
+    }
+
+    fn generate_id() -> String {
+        let mut bytes = [0u8; 16];
+        rand::thread_rng().fill(&mut bytes);
+        URL_SAFE_NO_PAD.encode(bytes)
+    }
+
+    fn start_cleanup_task(&self) {
+        let sessions = self.sessions.clone();
+        tokio::spawn(async move {
+            let mut timer = interval(Duration::from_secs(30));
+            loop {
+                timer.tick().await;
+                let max_inactive = Duration::from_secs(600); // 10 minutes
+                let max_age = Duration::from_secs(7200);     // 2 hours
+
+                sessions.retain(|id, session| {
+                    let inactive = session.last_accessed_at.elapsed();
+                    let age = session.created_at.elapsed();
+                    let expire = inactive > max_inactive || age > max_age;
+                    if expire {
+                        info!("[stream-proxy] Expired session {} (inactive: {}s, age: {}s)", id, inactive.as_secs(), age.as_secs());
+                    }
+                    !expire
+                });
+            }
+        });
+    }
+}

--- a/stream-proxy-rust/src/upstream.rs
+++ b/stream-proxy-rust/src/upstream.rs
@@ -1,0 +1,170 @@
+use crate::avio::get_avio_client;
+use axum::body::Body;
+use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
+use bytes::Bytes;
+use reqwest::Client;
+use std::collections::HashMap;
+use std::str::FromStr;
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::warn;
+
+pub struct UpstreamResponse {
+    pub status: StatusCode,
+    pub headers: HeaderMap,
+    pub body: Body,
+}
+
+pub struct ConnectionEngine {
+    client: Client,
+    ffmpeg_path: Option<String>,
+}
+
+impl ConnectionEngine {
+    pub fn new(ffmpeg_path: Option<String>) -> Self {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(6))
+            .danger_accept_invalid_certs(true)
+            .build()
+            .unwrap_or_else(|_| Client::new());
+
+        Self {
+            client,
+            ffmpeg_path,
+        }
+    }
+
+    pub async fn connect_upstream(
+        &self,
+        url: &str,
+        headers: &HashMap<String, String>,
+    ) -> Result<UpstreamResponse, String> {
+        // 1. Try standard reqwest Client first
+        let mut req = self.client.get(url);
+        for (k, v) in headers {
+            if let (Ok(h_name), Ok(h_val)) = (HeaderName::from_str(k), HeaderValue::from_str(v)) {
+                req = req.header(h_name, h_val);
+            }
+        }
+
+        match req.send().await {
+            Ok(resp) if resp.status().is_success() => {
+                let status = resp.status();
+                let mut out_headers = HeaderMap::new();
+
+                for (k, v) in resp.headers() {
+                    let lower = k.as_str().to_lowercase();
+                    if lower == "content-range" || lower == "accept-ranges" || lower == "content-type" {
+                        out_headers.insert(k.clone(), v.clone());
+                    }
+                }
+
+                if let Some(cl) = resp.content_length() {
+                    let is_compressed = resp
+                        .headers()
+                        .get("content-encoding")
+                        .and_then(|v| v.to_str().ok())
+                        .map(|v| v != "identity")
+                        .unwrap_or(false);
+
+                    if !is_compressed {
+                        if let Ok(hv) = HeaderValue::from_str(&cl.to_string()) {
+                            out_headers.insert("content-length", hv);
+                        }
+                    }
+                }
+
+                let stream = resp.bytes_stream();
+                let body = Body::from_stream(stream);
+
+                return Ok(UpstreamResponse {
+                    status,
+                    headers: out_headers,
+                    body,
+                });
+            }
+            Ok(resp) => {
+                warn!("[stream-proxy] reqwest returned HTTP {}, attempting FFmpeg AVIO fallback for {}", resp.status(), url);
+            }
+            Err(e) => {
+                warn!("[stream-proxy] reqwest error: {}, attempting FFmpeg AVIO fallback for {}", e, url);
+            }
+        }
+
+        // 2. Fall back to FFmpeg AvioClient FFI
+        let avio_client = get_avio_client(self.ffmpeg_path.as_deref());
+        if let Some(rx) = avio_client.spawn_stream(url.to_string(), headers.clone(), 15) {
+            let mut out_headers = HeaderMap::new();
+
+            let has_range = headers.keys().any(|k| k.eq_ignore_ascii_case("range"));
+            if has_range {
+                if let Some(r_val) = headers.get("range").or_else(|| headers.get("Range")) {
+                    if let Ok(hv) = HeaderValue::from_str(r_val) {
+                        out_headers.insert("content-range", hv);
+                    }
+                }
+            }
+
+            let status = if has_range {
+                StatusCode::PARTIAL_CONTENT
+            } else {
+                StatusCode::OK
+            };
+
+            let stream = ReceiverStream::new(rx);
+            let body = Body::from_stream(stream);
+
+            return Ok(UpstreamResponse {
+                status,
+                headers: out_headers,
+                body,
+            });
+        }
+
+        Err("Failed to connect upstream via HTTP or FFmpeg AVIO".to_string())
+    }
+
+    pub async fn fetch_url_bytes(
+        &self,
+        url: &str,
+        headers: &HashMap<String, String>,
+    ) -> Result<Bytes, String> {
+        let resp = self.connect_upstream(url, headers).await?;
+        let bytes = axum::body::to_bytes(resp.body, usize::MAX)
+            .await
+            .map_err(|e| format!("Failed reading bytes: {}", e))?;
+        Ok(bytes)
+    }
+}
+
+pub fn filter_upstream_headers(
+    session_headers: &HashMap<String, String>,
+    incoming_headers: &HeaderMap,
+    target_url: &str,
+    session_id: &str,
+) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+
+    for (k, v) in session_headers {
+        let lower = k.to_lowercase();
+        if !should_skip_header(&lower) {
+            out.insert(k.clone(), v.clone());
+        }
+    }
+
+    let lower_url = target_url.to_lowercase();
+    let is_hls_segment = lower_url.contains(".ts") || lower_url.contains(".m4s");
+    let should_forward_range = session_id == "play" || !is_hls_segment;
+
+    if should_forward_range {
+        if let Some(range_val) = incoming_headers.get("range").and_then(|v| v.to_str().ok()) {
+            out.insert("range".to_string(), range_val.to_string());
+        }
+    }
+
+    out
+}
+
+fn should_skip_header(lower_key: &str) -> bool {
+    const SKIP: &[&str] = &["host", "connection", "content-length", "accept-encoding", "range"];
+    SKIP.contains(&lower_key) || lower_key.starts_with(':')
+}

--- a/stream-proxy-rust/src/upstream.rs
+++ b/stream-proxy-rust/src/upstream.rs
@@ -53,7 +53,10 @@ impl ConnectionEngine {
 
                 for (k, v) in resp.headers() {
                     let lower = k.as_str().to_lowercase();
-                    if lower == "content-range" || lower == "accept-ranges" || lower == "content-type" {
+                    if lower == "content-range"
+                        || lower == "accept-ranges"
+                        || lower == "content-type"
+                    {
                         out_headers.insert(k.clone(), v.clone());
                     }
                 }
@@ -86,7 +89,10 @@ impl ConnectionEngine {
                 warn!("[stream-proxy] reqwest returned HTTP {}, attempting FFmpeg AVIO fallback for {}", resp.status(), url);
             }
             Err(e) => {
-                warn!("[stream-proxy] reqwest error: {}, attempting FFmpeg AVIO fallback for {}", e, url);
+                warn!(
+                    "[stream-proxy] reqwest error: {}, attempting FFmpeg AVIO fallback for {}",
+                    e, url
+                );
             }
         }
 
@@ -165,6 +171,12 @@ pub fn filter_upstream_headers(
 }
 
 fn should_skip_header(lower_key: &str) -> bool {
-    const SKIP: &[&str] = &["host", "connection", "content-length", "accept-encoding", "range"];
+    const SKIP: &[&str] = &[
+        "host",
+        "connection",
+        "content-length",
+        "accept-encoding",
+        "range",
+    ];
     SKIP.contains(&lower_key) || lower_key.starts_with(':')
 }

--- a/stream-proxy-rust/tests/proxy_test.rs
+++ b/stream-proxy-rust/tests/proxy_test.rs
@@ -1,0 +1,105 @@
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use serde_json::{json, Value};
+use stream_proxy_rust::{create_router, Config};
+use tower::ServiceExt;
+
+fn test_config() -> Config {
+    Config {
+        port: 8888,
+        address: "127.0.0.1".to_string(),
+        password: Some("testpassword123".to_string()),
+        ffmpeg_path: None,
+    }
+}
+
+#[tokio::test]
+async fn test_health_check() {
+    let (app, _, _) = create_router(test_config()).unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_auth_unauthorized() {
+    let (app, _, _) = create_router(test_config()).unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/epg?uri=http://example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_register_stateful_and_encrypted_mediaflow_urls() {
+    let (app, _, _) = create_router(test_config()).unwrap();
+
+    let req_body = json!({
+        "url": "http://stream.example.com/playlist.m3u8",
+        "headers": {
+            "User-Agent": "PlayBridge"
+        }
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/register?token=testpassword123")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::to_vec(&req_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json_resp: Value = serde_json::from_slice(&bytes).unwrap();
+
+    let proxy_url = json_resp["proxy_url"].as_str().unwrap();
+    let encrypted_url = json_resp["encrypted_url"].as_str().unwrap();
+
+    assert!(proxy_url.contains("/s/"));
+    assert!(encrypted_url.contains("/proxy/hls/"));
+    assert!(!encrypted_url.contains("PlayBridge")); // Headers must be encrypted in URL!
+}
+
+#[tokio::test]
+async fn test_old_plaintext_base64_route_removed() {
+    let (app, _, _) = create_router(test_config()).unwrap();
+
+    let uri = "/s/play/aHR0cHM6Ly9leGFtcGxlLmNvbS9saXZlL21hc3Rlci5tM3U4/eyJVc2VyLUFnZW50IjoiTW96aWxsYS81LjAgKCkifQ/master.m3u8?token=testpassword123";
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Old unencrypted base64 route must be rejected / forbidden
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}

--- a/stream-proxy-rust/tests/proxy_test.rs
+++ b/stream-proxy-rust/tests/proxy_test.rs
@@ -91,12 +91,7 @@ async fn test_old_plaintext_base64_route_removed() {
     let uri = "/s/play/aHR0cHM6Ly9leGFtcGxlLmNvbS9saXZlL21hc3Rlci5tM3U4/eyJVc2VyLUFnZW50IjoiTW96aWxsYS81LjAgKCkifQ/master.m3u8?token=testpassword123";
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .uri(uri)
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary

This PR adds `stream-proxy-rust`, a high-performance, lightweight Rust media stream proxy engine for PlayBridge.

### Key Changes
- **High-Performance Rust Core**: Replaces legacy Dart proxy with Tokio/Axum Rust streaming core (~6.1 MB stripped release binary).
- **Dual Transport Engine**: `reqwest` HTTP engine with automatic FFmpeg `libavformat` AVIO fallback for 403 / 471 CDN block bypass.
- **MediaFlow Security Standard**:
  - Stateful session registration (`POST /register`).
  - MediaFlow AES-256-CBC token encryption for stateless proxying (`GET /proxy/hls/...`).
  - Removed unencrypted, raw base64 `/s/play/` routes.
- **Manifest Rewriting**: Dynamic HLS (`.m3u8`) and DASH (`.mpd`) playlist rewriting for segments, keys, and maps.
- **CDN Signature Compatibility**: Preserves query parameter ordering for Akamai and signed media CDN validation.
- **Containerization & CI**: Includes Dockerfile, `docker-compose.yml`, `README.md`, `CHANGELOG.md`, and updated GitHub Actions CI workflows.

### Testing
- Ran `cargo test -p stream-proxy-rust`: All 7 unit/integration tests **PASSED**.
- Tested MediaFlow AES token encryption/decryption roundtrips.
- Verified removal of unencrypted base64 proxy route.