### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Local Content Provider Access Vulnerability in TV App

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The Android TV app's `SystemWebViewEngine` had `mixedContentMode` set to `WebSettings.MIXED_CONTENT_ALWAYS_ALLOW`. This is a critical security risk as it permits the loading of insecure active content (like scripts and iframes) over HTTP within a secure HTTPS context, exposing the app to Man-In-The-Middle (MITM) attacks and XSS.
 **Learning:** `MIXED_CONTENT_ALWAYS_ALLOW` should never be used in a WebView that loads remote, untrusted content, as it completely disables the browser's mixed content protections.
 **Prevention:** Always use `WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE` (or `MIXED_CONTENT_NEVER_ALLOW`) for WebViews to ensure the browser blocks active insecure content from loading on secure origins.
+
+## 2026-07-21 - Local Content Provider Access Vulnerability in TV App
+**Vulnerability:** The Android TV app's `SystemWebViewEngine` had `allowContentAccess` set to `true`. This is a critical security misconfiguration because it allows the arbitrary web content loaded into the system WebView to access and read local content provider data via `content://` URIs on the device, potentially exposing sensitive application data or internal processes (e.g. `PlayerProcessBridgeProvider`).
+**Learning:** Just as `allowFileAccess` is dangerous, `allowContentAccess` is equally risky when a WebView acts as a browser to navigate to untrusted arbitrary URLs. It unnecessarily expands the attack surface.
+**Prevention:** Explicitly configure `allowContentAccess = false` on all WebViews that handle remote, untrusted content to prevent access to the application's ContentProviders.

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
@@ -656,7 +656,7 @@ class SystemWebViewEngine(
                 setSupportZoom(true)
                 mediaPlaybackRequiresUserGesture = false
                 allowFileAccess = false
-                allowContentAccess = true
+                allowContentAccess = false
                 mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
 
                 // User agent. A literal [userAgentOverride] (picked from the phone's User Agent


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The Android TV app's `SystemWebViewEngine` had `allowContentAccess` set to `true`.
🎯 Impact: This allows arbitrary web content loaded into the system WebView to access and read local content provider data via `content://` URIs on the device, potentially exposing sensitive application data or internal processes.
🔧 Fix: Explicitly configure `allowContentAccess = false` on the WebView.
✅ Verification: Tested via `./gradlew test` in `tv/android/player`.

---
*PR created automatically by Jules for task [16169281496001618164](https://jules.google.com/task/16169281496001618164) started by @playbridgeapp*