### PR TITLE
feat(cast): add reusable secure receiver runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,6 +1834,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +1948,27 @@ dependencies = [
  "thiserror",
  "tokio",
  "uniffi",
+]
+
+[[package]]
+name = "playbridge-cast-receiver"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "futures-util",
+ "getrandom 0.4.3",
+ "mdns-sd",
+ "playbridge-cast-core",
+ "rcgen",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "tokio",
+ "tokio-rustls",
+ "tokio-tungstenite",
+ "x509-parser",
 ]
 
 [[package]]
@@ -2136,6 +2176,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -3817,8 +3871,19 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
+ "ring",
  "rusticata-macros",
  "thiserror",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,10 @@
 [workspace]
-members = ["cli", "cast/core", "cast/ffi", "stream-proxy-rust"]
+members = [
+    "cli",
+    "cast/core",
+    "cast/receiver",
+    "cast/ffi",
+    "stream-proxy-rust",
+]
 exclude = ["inspirations/mediaflow-proxy-light"]
 resolver = "3"

--- a/cast/core/src/playbridge.rs
+++ b/cast/core/src/playbridge.rs
@@ -26,7 +26,9 @@ pub enum SenderFrame {
     #[serde(rename = "pairing_commit", rename_all = "camelCase")]
     PairingCommit {
         commit: String,
+        #[serde(alias = "device_name")]
         device_name: String,
+        #[serde(rename = "deviceUUID", alias = "deviceUuid", alias = "device_uuid")]
         device_uuid: String,
     },
     #[serde(rename = "pairing_reveal", rename_all = "camelCase")]
@@ -42,6 +44,8 @@ pub enum SenderFrame {
         #[serde(skip_serializing_if = "Option::is_none")]
         payload: Option<Value>,
     },
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -69,6 +73,8 @@ pub enum ReceiverFrame {
     },
     #[serde(rename = "status")]
     Status {
+        #[serde(default)]
+        state: String,
         #[serde(default)]
         position: u64,
         #[serde(default)]
@@ -101,6 +107,120 @@ pub struct PairingSession {
     #[zeroize(skip)]
     transcript: Option<Vec<u8>>,
     shared_secret: Option<[u8; 32]>,
+}
+
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct ReceiverPairingSession {
+    private_key: [u8; 32],
+    public_key: [u8; 32],
+    nonce_t: [u8; 16],
+    commit: [u8; 32],
+    #[zeroize(skip)]
+    transcript: Option<Vec<u8>>,
+    shared_secret: Option<[u8; 32]>,
+}
+
+impl ReceiverPairingSession {
+    pub fn start(commit: &str) -> Result<(Self, ReceiverFrame)> {
+        let commit = decode_array::<32>(commit, "commit")?;
+        let secret = StaticSecret::random();
+        let public_key = PublicKey::from(&secret).to_bytes();
+        let private_key = secret.to_bytes();
+        let mut nonce_t = [0_u8; 16];
+        getrandom::fill(&mut nonce_t).map_err(|_| CastError::Crypto)?;
+        Ok((
+            Self {
+                private_key,
+                public_key,
+                nonce_t,
+                commit,
+                transcript: None,
+                shared_secret: None,
+            },
+            ReceiverFrame::PairingChallenge {
+                tv_eph_pub: BASE64.encode(public_key),
+                nonce_t: BASE64.encode(nonce_t),
+            },
+        ))
+    }
+
+    pub fn accept_reveal(&mut self, sender_eph_pub: &str, nonce_s: &str) -> Result<String> {
+        let sender_public = decode_array::<32>(sender_eph_pub, "senderEphPub")?;
+        let nonce_s = decode_array::<16>(nonce_s, "nonceS")?;
+        if sha256(&[sender_public.as_slice(), nonce_s.as_slice()].concat())
+            .ct_eq(&self.commit)
+            .unwrap_u8()
+            != 1
+        {
+            return Err(CastError::Protocol("pairing commitment mismatch".into()));
+        }
+        let secret = StaticSecret::from(self.private_key);
+        let shared = secret
+            .diffie_hellman(&PublicKey::from(sender_public))
+            .to_bytes();
+        let transcript = [
+            self.commit.as_slice(),
+            self.public_key.as_slice(),
+            self.nonce_t.as_slice(),
+            sender_public.as_slice(),
+            nonce_s.as_slice(),
+        ]
+        .concat();
+        let sas = generate_sas(&shared, &transcript);
+        self.shared_secret = Some(shared);
+        self.transcript = Some(transcript);
+        Ok(sas)
+    }
+
+    pub fn approve(
+        &self,
+        confirmation_mac: &str,
+        credentials: &CredentialBundle,
+    ) -> Result<ReceiverFrame> {
+        let (shared, transcript) = self.secrets()?;
+        let submitted = BASE64
+            .decode(confirmation_mac)
+            .map_err(|_| CastError::Protocol("invalid confirmation MAC".into()))?;
+        let key = hkdf_expand(shared, b"confirmationKey")?;
+        let mut mac = <HmacSha256 as Mac>::new_from_slice(&key).map_err(|_| CastError::Crypto)?;
+        mac.update(transcript);
+        let expected = mac.finalize().into_bytes();
+        if submitted.as_slice().ct_eq(expected.as_slice()).unwrap_u8() != 1 {
+            return Err(CastError::Protocol("pairing confirmation mismatch".into()));
+        }
+
+        let key = hkdf_expand(shared, b"playbridgeCredentialKey-v1")?;
+        let cipher = Aes256Gcm::new_from_slice(&key).map_err(|_| CastError::Crypto)?;
+        let mut nonce = [0_u8; 12];
+        getrandom::fill(&mut nonce).map_err(|_| CastError::Crypto)?;
+        let plaintext = serde_json::to_vec(credentials)
+            .map_err(|error| CastError::Protocol(error.to_string()))?;
+        let nonce_ref = Nonce::try_from(nonce.as_slice()).map_err(|_| CastError::Crypto)?;
+        let ciphertext = cipher
+            .encrypt(
+                &nonce_ref,
+                Payload {
+                    msg: &plaintext,
+                    aad: &sha256(transcript),
+                },
+            )
+            .map_err(|_| CastError::Crypto)?;
+        Ok(ReceiverFrame::PairingApproved {
+            nonce: BASE64.encode(nonce),
+            ciphertext: BASE64.encode(ciphertext),
+        })
+    }
+
+    fn secrets(&self) -> Result<(&[u8; 32], &[u8])> {
+        Ok((
+            self.shared_secret
+                .as_ref()
+                .ok_or(CastError::MissingField("pairing shared secret"))?,
+            self.transcript
+                .as_deref()
+                .ok_or(CastError::MissingField("pairing transcript"))?,
+        ))
+    }
 }
 
 impl PairingSession {
@@ -291,6 +411,44 @@ mod tests {
         })
         .unwrap();
         assert!(!playlist.contains(r#""startIndex""#));
+
+        let pairing = encode_text(&SenderFrame::PairingCommit {
+            commit: "commit".into(),
+            device_name: "Phone".into(),
+            device_uuid: "phone-id".into(),
+        })
+        .unwrap();
+        assert_eq!(
+            pairing,
+            r#"{"type":"pairing_commit","commit":"commit","deviceName":"Phone","deviceUUID":"phone-id"}"#
+        );
+    }
+
+    #[test]
+    fn pairing_commit_accepts_established_and_legacy_identity_spellings() {
+        for json in [
+            r#"{"type":"pairing_commit","commit":"value","deviceName":"Phone","deviceUUID":"id"}"#,
+            r#"{"type":"pairing_commit","commit":"value","deviceName":"Phone","deviceUuid":"id"}"#,
+            r#"{"type":"pairing_commit","commit":"value","device_name":"Phone","device_uuid":"id"}"#,
+        ] {
+            assert!(matches!(
+                serde_json::from_str::<SenderFrame>(json).unwrap(),
+                SenderFrame::PairingCommit {
+                    device_name,
+                    device_uuid,
+                    ..
+                } if device_name == "Phone" && device_uuid == "id"
+            ));
+        }
+    }
+
+    #[test]
+    fn sender_parser_tolerates_unknown_message_types() {
+        assert_eq!(
+            serde_json::from_str::<SenderFrame>(r#"{"type":"future_sender_message","value":1}"#)
+                .unwrap(),
+            SenderFrame::Unknown
+        );
     }
 
     #[test]
@@ -373,5 +531,55 @@ mod tests {
                 Some("sha256/other"),
             )
             .is_err());
+    }
+
+    #[test]
+    fn sender_and_receiver_pairing_sessions_interoperate() {
+        let (mut sender, commit) =
+            PairingSession::start("sender".into(), "sender-id".into()).unwrap();
+        let SenderFrame::PairingCommit { commit, .. } = commit else {
+            panic!("expected commit");
+        };
+        let (mut receiver, challenge) = ReceiverPairingSession::start(&commit).unwrap();
+        let ReceiverFrame::PairingChallenge {
+            tv_eph_pub,
+            nonce_t,
+        } = challenge
+        else {
+            panic!("expected challenge");
+        };
+        let (sas, reveal) = sender.accept_challenge(&tv_eph_pub, &nonce_t).unwrap();
+        let SenderFrame::PairingReveal {
+            sender_eph_pub,
+            nonce_s,
+        } = reveal
+        else {
+            panic!("expected reveal");
+        };
+        assert_eq!(
+            receiver.accept_reveal(&sender_eph_pub, &nonce_s).unwrap(),
+            sas
+        );
+        let SenderFrame::PairingConfirmation { mac } = sender.confirmation(&sas, &sas).unwrap()
+        else {
+            panic!("expected confirmation");
+        };
+        let credentials = CredentialBundle {
+            token: "token".into(),
+            cert_fingerprint: Some("sha256/test".into()),
+            players: vec!["mpv".into()],
+            browsers: vec![],
+        };
+        let ReceiverFrame::PairingApproved { nonce, ciphertext } =
+            receiver.approve(&mac, &credentials).unwrap()
+        else {
+            panic!("expected approval");
+        };
+        assert_eq!(
+            sender
+                .decrypt_credentials(&nonce, &ciphertext, Some("sha256/test"))
+                .unwrap(),
+            credentials
+        );
     }
 }

--- a/cast/core/src/roku.rs
+++ b/cast/core/src/roku.rs
@@ -15,6 +15,12 @@ pub struct RokuStatus {
     pub duration_ms: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RokuApp {
+    pub id: String,
+    pub name: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct RokuClient {
     http: Client,
@@ -85,6 +91,27 @@ impl RokuClient {
             });
         }
         parse_device_name(&response_text_limited(response).await?)
+    }
+
+    pub async fn apps(&self) -> Result<Vec<RokuApp>> {
+        let url = self.base_url.join("query/apps")?;
+        let response = self.http.get(url).send().await?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(CastError::ReceiverHttp {
+                operation: "Roku installed apps",
+                status,
+            });
+        }
+        parse_apps(&response_text_limited(response).await?)
+    }
+
+    pub async fn has_play_on_roku(&self) -> Result<bool> {
+        Ok(self
+            .apps()
+            .await?
+            .iter()
+            .any(|app| app.id == PLAY_ON_ROKU_APP_ID))
     }
 
     async fn expect_success(
@@ -161,6 +188,25 @@ fn parse_device_name(xml: &str) -> Result<String> {
     Err(CastError::MissingField("Roku device name"))
 }
 
+fn parse_apps(xml: &str) -> Result<Vec<RokuApp>> {
+    let document = roxmltree::Document::parse(xml)
+        .map_err(|error| CastError::Protocol(format!("invalid Roku apps XML: {error}")))?;
+    Ok(document
+        .descendants()
+        .filter(|node| node.has_tag_name("app"))
+        .filter_map(|node| {
+            let id = node.attribute("id")?.trim();
+            if id.is_empty() {
+                return None;
+            }
+            Some(RokuApp {
+                id: id.to_owned(),
+                name: node.text().unwrap_or("").trim().to_owned(),
+            })
+        })
+        .collect())
+}
+
 fn parse_roku_time_ms(value: &str) -> Option<u64> {
     let trimmed = value.trim();
     let number = trimmed.split_whitespace().next()?.trim_end_matches("ms");
@@ -220,5 +266,16 @@ mod tests {
             .unwrap(),
             "Living Room Roku"
         );
+    }
+
+    #[test]
+    fn parses_roku_apps_and_receiver_capability() {
+        let apps = parse_apps(
+            r#"<apps><app id="12">Netflix</app><app id="15985" version="2.0">Play on Roku</app></apps>"#,
+        )
+        .unwrap();
+        assert_eq!(apps.len(), 2);
+        assert_eq!(apps[1].id, PLAY_ON_ROKU_APP_ID);
+        assert_eq!(apps[1].name, "Play on Roku");
     }
 }

--- a/cast/core/src/session.rs
+++ b/cast/core/src/session.rs
@@ -31,6 +31,20 @@ impl MediaRequest {
             metadata: None,
         }
     }
+
+    fn dlna_metadata(&self) -> String {
+        if let Some(metadata) = &self.metadata {
+            return metadata.clone();
+        }
+        let title = self.title.as_deref().unwrap_or("PlayBridge media");
+        let content_type = castv2::media_format(&self.url).0;
+        format!(
+            r#"<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="0" parentID="0" restricted="1"><dc:title>{}</dc:title><upnp:class>object.item.videoItem</upnp:class><res protocolInfo="http-get:*:{}:*">{}</res></item></DIDL-Lite>"#,
+            escape_xml(title),
+            content_type,
+            escape_xml(&self.url),
+        )
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -89,7 +103,7 @@ impl ReceiverSession {
     pub async fn connect_dlna(location: &str, media: &MediaRequest) -> Result<Self> {
         let renderer = timeout(Renderer::load(location), "DLNA renderer connection").await??;
         timeout(
-            renderer.set_media_uri(&media.url, media.metadata.as_deref().unwrap_or("")),
+            renderer.set_media_uri(&media.url, &media.dlna_metadata()),
             "DLNA media load",
         )
         .await??;
@@ -128,7 +142,7 @@ impl ReceiverSession {
             }
             Self::Dlna(renderer) => {
                 renderer
-                    .set_media_uri(&media.url, media.metadata.as_deref().unwrap_or(""))
+                    .set_media_uri(&media.url, &media.dlna_metadata())
                     .await?;
                 renderer.play().await
             }
@@ -315,10 +329,13 @@ impl ReceiverSession {
                         .map_err(|_| CastError::Protocol("PlayBridge status timed out".into()))??
                     {
                         Some(ReceiverFrame::Status {
-                            position, duration, ..
+                            state,
+                            position,
+                            duration,
+                            ..
                         }) => {
                             return Ok(PlaybackStatus {
-                                state: PlaybackState::Unknown,
+                                state: state_from_text(&state),
                                 position_seconds: position as f64 / 1000.0,
                                 duration_seconds: duration as f64 / 1000.0,
                             });
@@ -350,8 +367,9 @@ impl ReceiverSession {
 }
 
 impl GoogleCastSession {
-    async fn send_media(&mut self, mut payload: serde_json::Value) -> Result<()> {
-        payload["requestId"] = json!(self.request_ids.next());
+    async fn send_media(&mut self, mut payload: serde_json::Value) -> Result<u32> {
+        let request_id = self.request_ids.next();
+        payload["requestId"] = json!(request_id);
         payload["mediaSessionId"] = json!(self.details.media_session_id);
         self.details
             .channel
@@ -361,14 +379,18 @@ impl GoogleCastSession {
                 payload.to_string(),
             ))
             .await
-            .map_err(CastError::Protocol)
+            .map_err(CastError::Protocol)?;
+        Ok(request_id)
     }
     async fn media_command(&mut self, command: &str) -> Result<()> {
-        self.send_media(json!({ "type": command })).await
+        let request_id = self.send_media(json!({ "type": command })).await?;
+        self.wait_for_media_status(request_id).await.map(|_| ())
     }
     async fn seek(&mut self, seconds: f64) -> Result<()> {
-        self.send_media(json!({ "type": "SEEK", "currentTime": seconds.max(0.0) }))
-            .await
+        let request_id = self
+            .send_media(json!({ "type": "SEEK", "currentTime": seconds.max(0.0) }))
+            .await?;
+        self.wait_for_media_status(request_id).await.map(|_| ())
     }
     async fn receiver_command(&mut self, mut payload: serde_json::Value) -> Result<()> {
         payload["requestId"] = json!(self.request_ids.next());
@@ -392,7 +414,11 @@ impl GoogleCastSession {
         Ok(())
     }
     async fn status(&mut self) -> Result<PlaybackStatus> {
-        self.send_media(json!({ "type": "GET_STATUS" })).await?;
+        let request_id = self.send_media(json!({ "type": "GET_STATUS" })).await?;
+        self.wait_for_media_status(request_id).await
+    }
+
+    async fn wait_for_media_status(&mut self, request_id: u32) -> Result<PlaybackStatus> {
         let deadline = tokio::time::Instant::now() + OPERATION_TIMEOUT;
         loop {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
@@ -414,6 +440,29 @@ impl GoogleCastSession {
             if message.namespace == NS_MEDIA {
                 let payload: serde_json::Value = serde_json::from_str(&message.payload_utf8)
                     .map_err(|error| CastError::Protocol(error.to_string()))?;
+                if payload["requestId"]
+                    .as_u64()
+                    .is_some_and(|id| id != u64::from(request_id))
+                {
+                    continue;
+                }
+                if matches!(
+                    payload["type"].as_str(),
+                    Some("INVALID_REQUEST" | "LOAD_FAILED")
+                ) {
+                    return Err(CastError::Protocol(format!(
+                        "Google Cast rejected request: {}",
+                        payload["reason"].as_str().unwrap_or("unknown reason")
+                    )));
+                }
+                if payload["type"] == "MEDIA_STATUS"
+                    && payload["status"].as_array().is_some_and(Vec::is_empty)
+                {
+                    return Ok(PlaybackStatus {
+                        state: PlaybackState::Finished,
+                        ..PlaybackStatus::default()
+                    });
+                }
                 if let Some(status) = payload["status"].as_array().and_then(|items| items.first()) {
                     if let Some(id) = status["mediaSessionId"].as_i64() {
                         self.details.media_session_id = id;
@@ -471,6 +520,15 @@ fn format_dlna_time(seconds: f64) -> String {
     )
 }
 
+fn escape_xml(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
 async fn timeout<T, E>(
     future: impl std::future::Future<Output = std::result::Result<T, E>>,
     operation: &'static str,
@@ -491,5 +549,15 @@ mod tests {
     #[test]
     fn formats_dlna_seek_time() {
         assert_eq!(format_dlna_time(3661.9), "01:01:01");
+    }
+
+    #[test]
+    fn generates_dlna_metadata_when_the_caller_does_not_supply_it() {
+        let mut media = MediaRequest::new("https://example.test/video.mp4?x=1&y=2");
+        media.title = Some("One & <Two>".into());
+        let metadata = media.dlna_metadata();
+        assert!(metadata.contains("One &amp; &lt;Two&gt;"));
+        assert!(metadata.contains("video/mp4"));
+        assert!(metadata.contains("x=1&amp;y=2"));
     }
 }

--- a/cast/receiver/Cargo.toml
+++ b/cast/receiver/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "playbridge-cast-receiver"
+version = "0.1.0"
+edition = "2024"
+publish = false
+license = "AGPL-3.0-or-later"
+description = "Reusable PlayBridge secure receiver runtime"
+
+[dependencies]
+playbridge-cast-core = { path = "../core" }
+base64 = "0.22"
+futures-util = "0.3"
+getrandom = "0.4"
+mdns-sd = { version = "0.20", default-features = false, features = ["async"] }
+rustls = "0.23"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+subtle = "2"
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-rustls = "0.26"
+tokio-tungstenite = "0.28"
+x509-parser = "0.18"
+
+[dev-dependencies]
+rcgen = "0.14"

--- a/cast/receiver/README.md
+++ b/cast/receiver/README.md
@@ -1,0 +1,32 @@
+# PlayBridge Cast Receiver
+
+Reusable secure receiver runtime for native PlayBridge connections.
+
+The crate owns TLS/WSS, SAS pairing, bearer-token authentication, connection and
+message limits, command decoding, and receiver event delivery. Consumers provide
+the TLS identity, authorized token records, capabilities, playback implementation,
+and platform lifecycle.
+
+The CLI consumes the crate directly. Flutter Desktop consumes the same runtime
+through `cast/ffi` and keeps its existing `PlayerController` as the playback
+adapter. Android and Apple receivers can adopt the FFI event API without moving
+foreground services, NSD, activities, or platform media engines into Rust.
+
+The optional built-in mDNS advertisement is intended for native binaries such as
+the CLI. Mobile applications should normally use their platform discovery API.
+
+## Runtime guarantees
+
+The defaults allow 32 concurrent connections, 1 MiB WebSocket messages, 64
+queued outbound messages per connection, and a 60-second pairing window. Slow
+clients cannot grow an unbounded response queue.
+
+Authorized credentials may be supplied as legacy raw tokens or
+`sha256:<hex>` digests. Successful pairing emits the raw token exactly once for
+the consumer to persist securely. Replacing the authorized-token set immediately
+disconnects sessions authenticated by credentials that are no longer present.
+
+The receiver identity is caller-owned and must remain stable across restarts so
+existing senders retain a valid SPKI pin. The receiver crate never owns playback:
+the CLI adapts events to external mpv, while Flutter Desktop adapts them to
+`PlayerController`.

--- a/cast/receiver/src/lib.rs
+++ b/cast/receiver/src/lib.rs
@@ -1,0 +1,1023 @@
+//! Secure, reusable PlayBridge receiver runtime.
+//!
+//! This crate owns the network-facing receiver boundary: TLS/WSS, pairing,
+//! authentication, connection limits, and authenticated command decoding.
+//! Playback and platform lifecycle remain with the consuming application.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use futures_util::{SinkExt, StreamExt};
+use mdns_sd::{ServiceDaemon, ServiceInfo};
+use playbridge_cast_core::playbridge::{CredentialBundle, ReceiverPairingSession, SenderFrame};
+use rustls::{
+    ServerConfig,
+    pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs1KeyDer, PrivatePkcs8KeyDer},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::{Semaphore, broadcast, mpsc, watch},
+};
+use tokio_rustls::TlsAcceptor;
+use tokio_tungstenite::{
+    WebSocketStream, accept_async_with_config,
+    tungstenite::{Message, protocol::WebSocketConfig},
+};
+use x509_parser::parse_x509_certificate;
+
+const DEFAULT_MAX_CONNECTIONS: usize = 32;
+const DEFAULT_MAX_MESSAGE_BYTES: usize = 1024 * 1024;
+const OUTBOUND_QUEUE_CAPACITY: usize = 64;
+const DEFAULT_PAIRING_TIMEOUT: Duration = Duration::from_secs(60);
+const TLS_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrivateKeyKind {
+    Pkcs1,
+    Pkcs8,
+}
+
+#[derive(Clone)]
+pub struct ReceiverIdentity {
+    pub certificate_der: Vec<u8>,
+    pub private_key_der: Vec<u8>,
+    pub private_key_kind: PrivateKeyKind,
+}
+
+#[derive(Clone)]
+pub struct ReceiverConfig {
+    pub preferred_port: u16,
+    pub fallback_attempts: u16,
+    pub name: String,
+    pub uuid: String,
+    pub identity: ReceiverIdentity,
+    /// Raw legacy tokens and `sha256:<hex>` token digests are both accepted.
+    pub authorized_tokens: Vec<String>,
+    pub players: Vec<String>,
+    pub browsers: Vec<String>,
+    pub advertise: bool,
+    pub max_connections: usize,
+    pub max_message_bytes: usize,
+    pub pairing_timeout: Duration,
+}
+
+impl ReceiverConfig {
+    pub fn new(name: String, uuid: String, identity: ReceiverIdentity) -> Self {
+        Self {
+            preferred_port: 8765,
+            fallback_attempts: 10,
+            name,
+            uuid,
+            identity,
+            authorized_tokens: Vec::new(),
+            players: Vec::new(),
+            browsers: Vec::new(),
+            advertise: false,
+            max_connections: DEFAULT_MAX_CONNECTIONS,
+            max_message_bytes: DEFAULT_MAX_MESSAGE_BYTES,
+            pairing_timeout: DEFAULT_PAIRING_TIMEOUT,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "action", content = "payload", rename_all = "snake_case")]
+pub enum ReceiverCommand {
+    ContextQuery,
+    Playlist(Value),
+    QueueAdd(Value),
+    PlaylistJump(Value),
+    Control(Value),
+    Remote(Value),
+    Mouse(Value),
+    Browser(Value),
+    BrowserControl(Value),
+    Unknown { action: String, payload: Value },
+}
+
+impl ReceiverCommand {
+    fn decode(action: String, payload: Option<Value>) -> Self {
+        let payload = payload.unwrap_or(Value::Null);
+        match action.as_str() {
+            "context_query" => Self::ContextQuery,
+            "playlist" => Self::Playlist(payload),
+            "queue_add" => Self::QueueAdd(payload),
+            "playlist_jump" => Self::PlaylistJump(payload),
+            "control" => Self::Control(payload),
+            "remote" => Self::Remote(payload),
+            "mouse" => Self::Mouse(payload),
+            "browser" => Self::Browser(payload),
+            "browser_control" => Self::BrowserControl(payload),
+            _ => Self::Unknown { action, payload },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum ReceiverEvent {
+    Started {
+        port: u16,
+        fingerprint: String,
+    },
+    ClientCount {
+        total: usize,
+        authenticated: usize,
+    },
+    PairingStarted {
+        connection_id: u64,
+        device_name: String,
+        device_uuid: String,
+    },
+    PairingRequested {
+        connection_id: u64,
+        device_name: String,
+        device_uuid: String,
+        sas_code: String,
+    },
+    Paired {
+        connection_id: u64,
+        device_name: String,
+        device_uuid: String,
+        /// Consumers must persist this securely and must not log it.
+        token: String,
+    },
+    Authenticated {
+        connection_id: u64,
+        token_digest: String,
+    },
+    Command {
+        connection_id: u64,
+        command: ReceiverCommand,
+        raw: String,
+    },
+    Error {
+        connection_id: Option<u64>,
+        message: String,
+    },
+    Finished,
+}
+
+enum Outbound {
+    Json(Value),
+}
+
+struct ConnectionHandle {
+    outbound: mpsc::Sender<Outbound>,
+    close: watch::Sender<bool>,
+}
+
+struct ConnectionIo {
+    outbound: mpsc::Receiver<Outbound>,
+    close: watch::Receiver<bool>,
+}
+
+struct Shared {
+    fingerprint: String,
+    players: Vec<String>,
+    browsers: Vec<String>,
+    authorized_tokens: Mutex<HashSet<String>>,
+    connections: Mutex<HashMap<u64, ConnectionHandle>>,
+    authenticated: Mutex<HashMap<u64, String>>,
+    pairing_owner: Mutex<Option<u64>>,
+    failed_attempts: Mutex<HashMap<String, (u8, Instant)>>,
+    events: broadcast::Sender<ReceiverEvent>,
+}
+
+impl Shared {
+    fn emit(&self, event: ReceiverEvent) {
+        let _ = self.events.send(event);
+    }
+
+    fn emit_counts(&self) {
+        let total = self.connections.lock().map_or(0, |items| items.len());
+        let authenticated = self.authenticated.lock().map_or(0, |items| items.len());
+        self.emit(ReceiverEvent::ClientCount {
+            total,
+            authenticated,
+        });
+    }
+
+    fn is_authorized(&self, token: &str) -> bool {
+        let digest = token_digest(token);
+        self.authorized_tokens.lock().is_ok_and(|tokens| {
+            tokens.iter().any(|stored| {
+                stored.as_bytes().ct_eq(token.as_bytes()).unwrap_u8() == 1
+                    || stored.as_bytes().ct_eq(digest.as_bytes()).unwrap_u8() == 1
+            })
+        })
+    }
+
+    fn record_pairing_failure(&self, ip: &str) {
+        if let Ok(mut attempts) = self.failed_attempts.lock() {
+            let entry = attempts.entry(ip.to_owned()).or_insert((0, Instant::now()));
+            entry.0 = entry.0.saturating_add(1);
+            if entry.0 >= 3 {
+                *entry = (0, Instant::now() + Duration::from_secs(60));
+            }
+        }
+    }
+
+    fn is_locked_out(&self, ip: &str) -> bool {
+        self.failed_attempts.lock().is_ok_and(|attempts| {
+            attempts
+                .get(ip)
+                .is_some_and(|(count, until)| *count == 0 && Instant::now() < *until)
+        })
+    }
+}
+
+pub struct ReceiverHost {
+    port: u16,
+    fingerprint: String,
+    shared: Arc<Shared>,
+    events: broadcast::Sender<ReceiverEvent>,
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl ReceiverHost {
+    pub async fn start(config: ReceiverConfig) -> Result<Self, String> {
+        validate_config(&config)?;
+        let (tls, fingerprint) = tls_config(&config.identity)?;
+        let listener =
+            bind_next_port(config.preferred_port, config.fallback_attempts.max(1)).await?;
+        let port = listener
+            .local_addr()
+            .map_err(|error| error.to_string())?
+            .port();
+        let (events, _) = broadcast::channel(256);
+        let shared = Arc::new(Shared {
+            fingerprint: fingerprint.clone(),
+            players: config.players.clone(),
+            browsers: config.browsers.clone(),
+            authorized_tokens: Mutex::new(config.authorized_tokens.iter().cloned().collect()),
+            connections: Mutex::new(HashMap::new()),
+            authenticated: Mutex::new(HashMap::new()),
+            pairing_owner: Mutex::new(None),
+            failed_attempts: Mutex::new(HashMap::new()),
+            events: events.clone(),
+        });
+        let mdns = if config.advertise {
+            Some(advertise(&config.name, &config.uuid, port)?)
+        } else {
+            None
+        };
+        let acceptor = TlsAcceptor::from(Arc::new(tls));
+        let semaphore = Arc::new(Semaphore::new(config.max_connections));
+        let next_id = Arc::new(AtomicU64::new(1));
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
+        let task_shared = shared.clone();
+        let task_events = events.clone();
+        let task = tokio::spawn(async move {
+            task_shared.emit(ReceiverEvent::Started {
+                port,
+                fingerprint: task_shared.fingerprint.clone(),
+            });
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_rx => break,
+                    accepted = listener.accept() => {
+                        let Ok((stream, address)) = accepted else {
+                            task_shared.emit(ReceiverEvent::Error {
+                                connection_id: None,
+                                message: "receiver listener failed".into(),
+                            });
+                            continue;
+                        };
+                        let Ok(permit) = semaphore.clone().try_acquire_owned() else {
+                            drop(stream);
+                            continue;
+                        };
+                        let id = next_id.fetch_add(1, Ordering::Relaxed);
+                        let shared = task_shared.clone();
+                        let acceptor = acceptor.clone();
+                        let ip = address.ip().to_string();
+                        let pairing_timeout = config.pairing_timeout;
+                        let max_message_bytes = config.max_message_bytes;
+                        tokio::spawn(async move {
+                            let _permit = permit;
+                            if let Err(message) = serve_connection(
+                                id,
+                                ip,
+                                stream,
+                                acceptor,
+                                shared.clone(),
+                                pairing_timeout,
+                                max_message_bytes,
+                            )
+                            .await
+                            {
+                                shared.emit(ReceiverEvent::Error {
+                                    connection_id: Some(id),
+                                    message,
+                                });
+                            }
+                            cleanup_connection(id, &shared);
+                        });
+                    }
+                }
+            }
+            if let Some(mdns) = mdns {
+                let _ = mdns.shutdown();
+            }
+            for sender in task_shared
+                .connections
+                .lock()
+                .map(|items| {
+                    items
+                        .values()
+                        .map(|connection| connection.close.clone())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+            {
+                let _ = sender.send(true);
+            }
+            task_shared.emit(ReceiverEvent::Finished);
+            drop(task_events);
+        });
+        Ok(Self {
+            port,
+            fingerprint,
+            shared,
+            events,
+            shutdown: Some(shutdown_tx),
+            task: Some(task),
+        })
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<ReceiverEvent> {
+        self.events.subscribe()
+    }
+
+    pub fn broadcast(&self, value: Value) {
+        let authenticated = self
+            .shared
+            .authenticated
+            .lock()
+            .map(|items| items.clone())
+            .unwrap_or_default();
+        for sender in self
+            .shared
+            .connections
+            .lock()
+            .map(|items| {
+                items
+                    .iter()
+                    .filter(|(id, _)| authenticated.contains_key(id))
+                    .map(|(_, connection)| connection.outbound.clone())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+        {
+            let _ = sender.try_send(Outbound::Json(value.clone()));
+        }
+    }
+
+    pub fn send_to(&self, connection_id: u64, value: Value) -> bool {
+        self.shared
+            .connections
+            .lock()
+            .ok()
+            .and_then(|items| {
+                items
+                    .get(&connection_id)
+                    .map(|connection| connection.outbound.clone())
+            })
+            .is_some_and(|sender| sender.try_send(Outbound::Json(value)).is_ok())
+    }
+
+    pub fn deny_pairing(&self, connection_id: u64) {
+        let _ = self.send_to(connection_id, json!({"type":"pairing_denied"}));
+        if let Ok(connections) = self.shared.connections.lock()
+            && let Some(connection) = connections.get(&connection_id)
+        {
+            let _ = connection.close.send(true);
+        }
+    }
+
+    pub fn disconnect_all(&self) {
+        for close in self
+            .shared
+            .connections
+            .lock()
+            .map(|items| {
+                items
+                    .values()
+                    .map(|connection| connection.close.clone())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+        {
+            let _ = close.send(true);
+        }
+    }
+
+    pub fn replace_authorized_tokens(&self, tokens: impl IntoIterator<Item = String>) {
+        let tokens = tokens.into_iter().collect::<HashSet<_>>();
+        let accepted_digests = tokens
+            .iter()
+            .map(|token| {
+                if token.starts_with("sha256:") {
+                    token.clone()
+                } else {
+                    token_digest(token)
+                }
+            })
+            .collect::<HashSet<_>>();
+        if let Ok(mut authorized) = self.shared.authorized_tokens.lock() {
+            *authorized = tokens;
+        }
+        let revoked = self
+            .shared
+            .authenticated
+            .lock()
+            .map(|authenticated| {
+                authenticated
+                    .iter()
+                    .filter(|(_, digest)| !accepted_digests.contains(*digest))
+                    .map(|(id, _)| *id)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        if let Ok(connections) = self.shared.connections.lock() {
+            for id in revoked {
+                if let Some(connection) = connections.get(&id) {
+                    let _ = connection.close.send(true);
+                }
+            }
+        }
+    }
+
+    pub async fn shutdown(mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(task) = self.task.take() {
+            let _ = task.await;
+        }
+    }
+}
+
+impl Drop for ReceiverHost {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+async fn serve_connection(
+    id: u64,
+    ip: String,
+    stream: TcpStream,
+    acceptor: TlsAcceptor,
+    shared: Arc<Shared>,
+    pairing_timeout: Duration,
+    max_message_bytes: usize,
+) -> Result<(), String> {
+    let tls = tokio::time::timeout(TLS_TIMEOUT, acceptor.accept(stream))
+        .await
+        .map_err(|_| "TLS handshake timed out".to_owned())?
+        .map_err(|_| "TLS handshake failed".to_owned())?;
+    let mut websocket_config = WebSocketConfig::default();
+    websocket_config.max_message_size = Some(max_message_bytes);
+    websocket_config.max_frame_size = Some(max_message_bytes);
+    let socket = accept_async_with_config(tls, Some(websocket_config))
+        .await
+        .map_err(|_| "WebSocket handshake failed".to_owned())?;
+    let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
+    let (close_tx, close_rx) = watch::channel(false);
+    shared
+        .connections
+        .lock()
+        .map_err(|_| "receiver connection registry failed")?
+        .insert(
+            id,
+            ConnectionHandle {
+                outbound: outbound_tx,
+                close: close_tx,
+            },
+        );
+    shared.emit_counts();
+    run_socket(
+        id,
+        ip,
+        socket,
+        ConnectionIo {
+            outbound: outbound_rx,
+            close: close_rx,
+        },
+        shared,
+        pairing_timeout,
+        max_message_bytes,
+    )
+    .await
+}
+
+async fn run_socket<S>(
+    id: u64,
+    ip: String,
+    mut socket: WebSocketStream<S>,
+    mut io: ConnectionIo,
+    shared: Arc<Shared>,
+    pairing_timeout: Duration,
+    max_message_bytes: usize,
+) -> Result<(), String>
+where
+    WebSocketStream<S>: SinkExt<Message>
+        + StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>>
+        + Unpin,
+{
+    let mut authenticated = false;
+    let mut pairing: Option<(ReceiverPairingSession, String, String, Instant)> = None;
+    let mut timeout_tick = tokio::time::interval(Duration::from_secs(1));
+    timeout_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            changed = io.close.changed() => {
+                if changed.is_err() || *io.close.borrow() {
+                    break;
+                }
+            }
+            _ = timeout_tick.tick(), if !authenticated && pairing.is_some() => {
+                if pairing.as_ref().is_some_and(|(_, _, _, started)| started.elapsed() >= pairing_timeout) {
+                    shared.record_pairing_failure(&ip);
+                    let _ = socket.send(Message::Text(r#"{"type":"pairing_denied"}"#.into())).await;
+                    break;
+                }
+            }
+            outbound = io.outbound.recv() => {
+                match outbound {
+                    Some(Outbound::Json(value)) => {
+                        send_value(&mut socket, value).await?;
+                    }
+                    None => break,
+                }
+            }
+            incoming = socket.next() => {
+                let Some(incoming) = incoming else { break };
+                let incoming = incoming.map_err(|_| "WebSocket connection failed".to_owned())?;
+                let Message::Text(text) = incoming else { continue };
+                if text.len() > max_message_bytes {
+                    return Err("receiver message exceeded size limit".into());
+                }
+                let frame = match serde_json::from_str::<SenderFrame>(&text) {
+                    Ok(frame) => frame,
+                    Err(_) => continue,
+                };
+                match frame {
+                    SenderFrame::Ping => send_value(&mut socket, json!({"type":"pong"})).await?,
+                    SenderFrame::Auth { token } if !authenticated => {
+                        authenticated = shared.is_authorized(&token);
+                        send_value(
+                            &mut socket,
+                            json!({
+                                "type":"auth_response",
+                                "success":authenticated,
+                                "certFingerprint":shared.fingerprint,
+                                "players":shared.players,
+                                "browsers":shared.browsers,
+                            }),
+                        ).await?;
+                        if authenticated {
+                            let digest = token_digest(&token);
+                            shared.authenticated.lock().map_err(|_| "authentication registry failed")?.insert(id, digest.clone());
+                            shared.emit(ReceiverEvent::Authenticated {
+                                connection_id: id,
+                                token_digest: digest,
+                            });
+                            shared.emit_counts();
+                        } else {
+                            break;
+                        }
+                    }
+                    SenderFrame::PairingCommit { commit, device_name, device_uuid }
+                        if !authenticated =>
+                    {
+                        if shared.is_locked_out(&ip)
+                            || device_name.is_empty()
+                            || device_name.len() > 128
+                            || device_uuid.is_empty()
+                            || device_uuid.len() > 128
+                        {
+                            send_value(&mut socket, json!({"type":"pairing_denied"})).await?;
+                            break;
+                        }
+                        let pairing_busy = {
+                            let mut owner = shared.pairing_owner.lock().map_err(|_| "pairing registry failed")?;
+                            if owner.is_some_and(|owner| owner != id) {
+                                true
+                            } else {
+                                *owner = Some(id);
+                                false
+                            }
+                        };
+                        if pairing_busy {
+                            send_value(&mut socket, json!({"type":"pairing_denied"})).await?;
+                            break;
+                        }
+                        let (session, challenge) = ReceiverPairingSession::start(&commit)
+                            .map_err(|_| "invalid pairing commitment".to_owned())?;
+                        pairing = Some((
+                            session,
+                            device_name.clone(),
+                            device_uuid.clone(),
+                            Instant::now(),
+                        ));
+                        shared.emit(ReceiverEvent::PairingStarted {
+                            connection_id: id,
+                            device_name,
+                            device_uuid,
+                        });
+                        send_frame(&mut socket, &challenge).await?;
+                    }
+                    SenderFrame::PairingReveal { sender_eph_pub, nonce_s }
+                        if !authenticated =>
+                    {
+                        let (_, device_name, device_uuid, _) = pairing
+                            .as_ref()
+                            .ok_or_else(|| "pairing reveal arrived without a commit".to_owned())?;
+                        let device_name = device_name.clone();
+                        let device_uuid = device_uuid.clone();
+                        let sas = pairing
+                            .as_mut()
+                            .expect("checked pairing session")
+                            .0
+                            .accept_reveal(&sender_eph_pub, &nonce_s)
+                            .map_err(|_| "pairing reveal was invalid".to_owned())?;
+                        shared.emit(ReceiverEvent::PairingRequested {
+                            connection_id: id,
+                            device_name,
+                            device_uuid,
+                            sas_code: sas,
+                        });
+                    }
+                    SenderFrame::PairingConfirmation { mac } if !authenticated => {
+                        let (session, device_name, device_uuid, _) = pairing
+                            .as_ref()
+                            .ok_or_else(|| "pairing confirmation arrived without a reveal".to_owned())?;
+                        let token = random_token()?;
+                        let approval = session
+                            .approve(
+                                &mac,
+                                &CredentialBundle {
+                                    token: token.clone(),
+                                    cert_fingerprint: Some(shared.fingerprint.clone()),
+                                    players: shared.players.clone(),
+                                    browsers: shared.browsers.clone(),
+                                },
+                            )
+                            .map_err(|_| "pairing confirmation was invalid".to_owned())?;
+                        shared
+                            .authorized_tokens
+                            .lock()
+                            .map_err(|_| "credential registry failed")?
+                            .insert(token.clone());
+                        authenticated = true;
+                        shared.authenticated.lock().map_err(|_| "authentication registry failed")?.insert(id, token_digest(&token));
+                        send_frame(&mut socket, &approval).await?;
+                        shared.emit(ReceiverEvent::Paired {
+                            connection_id: id,
+                            device_name: device_name.clone(),
+                            device_uuid: device_uuid.clone(),
+                            token,
+                        });
+                        shared.emit_counts();
+                        if let Ok(mut owner) = shared.pairing_owner.lock() {
+                            *owner = None;
+                        }
+                        pairing = None;
+                    }
+                    SenderFrame::Command { action, payload } if authenticated => {
+                        let command = ReceiverCommand::decode(action, payload);
+                        shared.emit(ReceiverEvent::Command {
+                            connection_id: id,
+                            command,
+                            raw: text.to_string(),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn cleanup_connection(id: u64, shared: &Shared) {
+    if let Ok(mut connections) = shared.connections.lock() {
+        connections.remove(&id);
+    }
+    if let Ok(mut authenticated) = shared.authenticated.lock() {
+        authenticated.remove(&id);
+    }
+    if let Ok(mut owner) = shared.pairing_owner.lock()
+        && owner.is_some_and(|owner| owner == id)
+    {
+        *owner = None;
+    }
+    shared.emit_counts();
+}
+
+async fn send_frame<S, T>(socket: &mut WebSocketStream<S>, value: &T) -> Result<(), String>
+where
+    WebSocketStream<S>: SinkExt<Message> + Unpin,
+    T: Serialize,
+{
+    let value = serde_json::to_value(value).map_err(|error| error.to_string())?;
+    send_value(socket, value).await
+}
+
+async fn send_value<S>(socket: &mut WebSocketStream<S>, value: Value) -> Result<(), String>
+where
+    WebSocketStream<S>: SinkExt<Message> + Unpin,
+{
+    let text = serde_json::to_string(&value).map_err(|error| error.to_string())?;
+    socket
+        .send(Message::Text(text.into()))
+        .await
+        .map_err(|_| "could not send receiver WebSocket frame".to_owned())
+}
+
+async fn bind_next_port(start: u16, attempts: u16) -> Result<TcpListener, String> {
+    for offset in 0..attempts {
+        let port = start
+            .checked_add(offset)
+            .ok_or("receiver port range overflow")?;
+        match TcpListener::bind(("0.0.0.0", port)).await {
+            Ok(listener) => return Ok(listener),
+            Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => continue,
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+    Err(format!(
+        "ports {start} through {} are unavailable",
+        start.saturating_add(attempts.saturating_sub(1))
+    ))
+}
+
+fn advertise(name: &str, uuid: &str, port: u16) -> Result<ServiceDaemon, String> {
+    let daemon = ServiceDaemon::new().map_err(|error| error.to_string())?;
+    let port_text = port.to_string();
+    let properties = [("uuid", uuid), ("wss_port", port_text.as_str())];
+    let service = ServiceInfo::new(
+        "_playbridge._tcp.local.",
+        name,
+        &format!("{uuid}.local."),
+        "",
+        port,
+        &properties[..],
+    )
+    .map_err(|error| error.to_string())?
+    .enable_addr_auto();
+    daemon
+        .register(service)
+        .map_err(|error| error.to_string())?;
+    Ok(daemon)
+}
+
+fn validate_config(config: &ReceiverConfig) -> Result<(), String> {
+    if config.name.trim().is_empty() || config.name.len() > 128 {
+        return Err("receiver name must contain 1-128 characters".into());
+    }
+    if config.uuid.trim().is_empty() || config.uuid.len() > 128 {
+        return Err("receiver UUID must contain 1-128 characters".into());
+    }
+    if config.max_connections == 0 || config.max_message_bytes < 1024 {
+        return Err("receiver resource limits are invalid".into());
+    }
+    Ok(())
+}
+
+fn tls_config(identity: &ReceiverIdentity) -> Result<(ServerConfig, String), String> {
+    let (_, parsed) =
+        parse_x509_certificate(&identity.certificate_der).map_err(|error| error.to_string())?;
+    let fingerprint = format!(
+        "sha256/{}",
+        BASE64.encode(Sha256::digest(parsed.public_key().raw))
+    );
+    let key = match identity.private_key_kind {
+        PrivateKeyKind::Pkcs1 => {
+            PrivateKeyDer::Pkcs1(PrivatePkcs1KeyDer::from(identity.private_key_der.clone()))
+        }
+        PrivateKeyKind::Pkcs8 => {
+            PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(identity.private_key_der.clone()))
+        }
+    };
+    let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+    let config = ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|error| error.to_string())?
+        .with_no_client_auth()
+        .with_single_cert(
+            vec![CertificateDer::from(identity.certificate_der.clone())],
+            key,
+        )
+        .map_err(|error| error.to_string())?;
+    Ok((config, fingerprint))
+}
+
+fn random_token() -> Result<String, String> {
+    let mut bytes = [0_u8; 32];
+    getrandom::fill(&mut bytes).map_err(|error| error.to_string())?;
+    Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+pub fn token_digest(token: &str) -> String {
+    format!("sha256:{:x}", Sha256::digest(token.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use playbridge_cast_core::{
+        playbridge::{PairingSession, ReceiverFrame, SenderFrame},
+        secure_ws::SecureWebSocket,
+    };
+    use rcgen::{CertificateParams, KeyPair};
+
+    fn identity() -> ReceiverIdentity {
+        let key = KeyPair::generate().unwrap();
+        let certificate = CertificateParams::new(vec!["localhost".into()])
+            .unwrap()
+            .self_signed(&key)
+            .unwrap();
+        ReceiverIdentity {
+            certificate_der: certificate.der().to_vec(),
+            private_key_der: key.serialize_der(),
+            private_key_kind: PrivateKeyKind::Pkcs8,
+        }
+    }
+
+    #[test]
+    fn receiver_commands_are_typed_without_rejecting_future_actions() {
+        assert_eq!(
+            ReceiverCommand::decode("control".into(), Some(json!({"command":"pause"}))),
+            ReceiverCommand::Control(json!({"command":"pause"}))
+        );
+        assert!(matches!(
+            ReceiverCommand::decode("future".into(), Some(json!({"value":1}))),
+            ReceiverCommand::Unknown { action, .. } if action == "future"
+        ));
+    }
+
+    #[test]
+    fn token_digest_is_stable_and_distinct_from_plaintext() {
+        let digest = token_digest("secret");
+        assert_eq!(
+            digest,
+            "sha256:2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b"
+        );
+        assert_ne!(digest, "secret");
+    }
+
+    #[tokio::test]
+    async fn receiver_uses_next_available_port() {
+        let mut selected = None;
+        for port in 40_000..50_000 {
+            let Ok(occupied) = TcpListener::bind(("0.0.0.0", port)).await else {
+                continue;
+            };
+            let Ok(next) = TcpListener::bind(("0.0.0.0", port + 1)).await else {
+                continue;
+            };
+            drop(next);
+            selected = Some((occupied, port));
+            break;
+        }
+        let (occupied, port) = selected.expect("could not find two consecutive test ports");
+        let mut config = ReceiverConfig::new("Test".into(), "test-id".into(), identity());
+        config.preferred_port = port;
+        config.fallback_attempts = 2;
+        let host = ReceiverHost::start(config).await.unwrap();
+        assert_eq!(host.port(), port + 1);
+        host.shutdown().await;
+        drop(occupied);
+    }
+
+    #[tokio::test]
+    async fn receiver_pairs_authenticates_and_emits_typed_commands() {
+        let mut config = ReceiverConfig::new("Test".into(), "test-id".into(), identity());
+        config.preferred_port = 0;
+        config.fallback_attempts = 1;
+        config.players = vec!["internal_mpv".into()];
+        let host = ReceiverHost::start(config).await.unwrap();
+        let mut events = host.subscribe();
+        let endpoint = format!("wss://127.0.0.1:{}/", host.port());
+
+        let mut socket = SecureWebSocket::connect_for_pairing(&endpoint)
+            .await
+            .unwrap();
+        let pin = socket.served_spki_pin().to_owned();
+        let (mut pairing, commit) =
+            PairingSession::start("Phone".into(), "phone-id".into()).unwrap();
+        socket.send(&commit).await.unwrap();
+        let challenge = socket.receive().await.unwrap().unwrap();
+        let ReceiverFrame::PairingChallenge {
+            tv_eph_pub,
+            nonce_t,
+        } = challenge
+        else {
+            panic!("expected pairing challenge");
+        };
+        let (sas, reveal) = pairing.accept_challenge(&tv_eph_pub, &nonce_t).unwrap();
+        socket.send(&reveal).await.unwrap();
+
+        let requested = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let ReceiverEvent::PairingRequested {
+                    sas_code,
+                    device_uuid,
+                    ..
+                } = events.recv().await.unwrap()
+                {
+                    break (sas_code, device_uuid);
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(requested, (sas.clone(), "phone-id".into()));
+
+        socket
+            .send(&pairing.confirmation(&sas, &sas).unwrap())
+            .await
+            .unwrap();
+        let approval = socket.receive().await.unwrap().unwrap();
+        let ReceiverFrame::PairingApproved { nonce, ciphertext } = approval else {
+            panic!("expected pairing approval");
+        };
+        let credentials = pairing
+            .decrypt_credentials(&nonce, &ciphertext, Some(&pin))
+            .unwrap();
+        socket
+            .send(&SenderFrame::Command {
+                action: "control".into(),
+                payload: Some(json!({"command":"pause"})),
+            })
+            .await
+            .unwrap();
+        let command = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let ReceiverEvent::Command { command, .. } = events.recv().await.unwrap() {
+                    break command;
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            command,
+            ReceiverCommand::Control(json!({"command":"pause"}))
+        );
+        socket.close().await.unwrap();
+
+        let mut authenticated = SecureWebSocket::connect_pinned(&endpoint, &pin)
+            .await
+            .unwrap();
+        authenticated
+            .send(&SenderFrame::Auth {
+                token: credentials.token.clone(),
+            })
+            .await
+            .unwrap();
+        assert!(matches!(
+            authenticated.receive().await.unwrap(),
+            Some(ReceiverFrame::AuthResponse { success: true, .. })
+        ));
+        host.replace_authorized_tokens(Vec::new());
+        let revoked = tokio::time::timeout(Duration::from_secs(2), authenticated.receive())
+            .await
+            .expect("revoked connection did not close");
+        assert!(
+            !matches!(revoked, Ok(Some(_))),
+            "revoked connection received another frame"
+        );
+        host.shutdown().await;
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable TLS/WSS PlayBridge receiver runtime with pairing and authenticated sessions
- harden PlayBridge frame parsing and receiver-side pairing state
- improve protocol session state mapping, DLNA metadata, Roku capability parsing, and Google Cast request handling
- add receiver and Cast Core coverage for the new behavior

## Verification
- cargo test -p playbridge-cast-core -p playbridge-cast-receiver
- cargo fmt --all -- --check
- cargo clippy -p playbridge-cast-core -p playbridge-cast-receiver --all-targets --locked -- -D warnings

This PR is independently mergeable and excludes CLI, Desktop, FFI, and browser receiver integration.