### PR TITLE
feat(protocol): define browser receiver contract

### DIFF
--- a/protocol/asyncapi.yaml
+++ b/protocol/asyncapi.yaml
@@ -24,6 +24,16 @@ servers:
         description: >-
           Preferred receiver port. Receivers may select another available port;
           mDNS discovery supplies the active endpoint.
+  browserReceiverHost:
+    host: '{host}:{port}'
+    pathname: /v1/browser/ws
+    protocol: ws
+    description: Local sender-hosted endpoint opened by an ordinary web browser.
+    variables:
+      host:
+        default: 192.0.2.2
+      port:
+        default: '8770'
 channels:
   receiverSocket:
     address: /
@@ -35,6 +45,14 @@ channels:
         $ref: '#/components/messages/ReceiverTextFrame'
       pointerBinary:
         $ref: '#/components/messages/PointerBinaryFrame'
+  browserReceiverSocket:
+    address: /v1/browser/ws
+    description: One browser page connected to a sender-hosted receiver service.
+    messages:
+      browserHostText:
+        $ref: '#/components/messages/BrowserHostTextFrame'
+      browserClientText:
+        $ref: '#/components/messages/BrowserClientTextFrame'
 operations:
   sendToReceiver:
     action: send
@@ -51,6 +69,20 @@ operations:
     summary: Frames sent by a receiver to a sender.
     messages:
       - $ref: '#/channels/receiverSocket/messages/receiverText'
+  sendToBrowserReceiver:
+    action: send
+    channel:
+      $ref: '#/channels/browserReceiverSocket'
+    summary: Pairing and playback frames sent by the local host to a browser.
+    messages:
+      - $ref: '#/channels/browserReceiverSocket/messages/browserHostText'
+  receiveFromBrowserReceiver:
+    action: receive
+    channel:
+      $ref: '#/channels/browserReceiverSocket'
+    summary: Identity, capabilities, and playback events sent by a browser.
+    messages:
+      - $ref: '#/channels/browserReceiverSocket/messages/browserClientText'
 components:
   messages:
     SenderTextFrame:
@@ -74,7 +106,173 @@ components:
       payload:
         type: string
         format: binary
+    BrowserHostTextFrame:
+      name: BrowserHostTextFrame
+      title: Sender host to browser receiver JSON frame
+      payload:
+        $ref: '#/components/schemas/BrowserHostFrame'
+    BrowserClientTextFrame:
+      name: BrowserClientTextFrame
+      title: Browser receiver to sender host JSON frame
+      payload:
+        $ref: '#/components/schemas/BrowserClientFrame'
   schemas:
+    BrowserHostFrame:
+      oneOf:
+        - $ref: '#/components/schemas/BrowserPairingRequired'
+        - $ref: '#/components/schemas/BrowserPairingApproved'
+        - $ref: '#/components/schemas/BrowserPairingDenied'
+        - $ref: '#/components/schemas/BrowserDisconnect'
+        - $ref: '#/components/schemas/BrowserLoad'
+        - $ref: '#/components/schemas/BrowserControl'
+        - $ref: '#/components/schemas/BrowserPing'
+    BrowserClientFrame:
+      oneOf:
+        - $ref: '#/components/schemas/BrowserHello'
+        - $ref: '#/components/schemas/BrowserCapabilitiesFrame'
+        - $ref: '#/components/schemas/BrowserReady'
+        - $ref: '#/components/schemas/BrowserStatus'
+        - $ref: '#/components/schemas/BrowserEnded'
+        - $ref: '#/components/schemas/BrowserError'
+        - $ref: '#/components/schemas/BrowserPong'
+    BrowserPairingRequired:
+      type: object
+      required: [type, sessionId, code, expiresInMs]
+      properties:
+        type: { const: pairing_required }
+        sessionId: { type: string, minLength: 1 }
+        code: { type: string, pattern: '^[0-9]{6}$', writeOnly: true }
+        expiresInMs: { type: integer, minimum: 1 }
+      additionalProperties: false
+    BrowserPairingApproved:
+      type: object
+      required: [type, sessionId]
+      properties:
+        type: { const: pairing_approved }
+        sessionId: { type: string, minLength: 1 }
+      additionalProperties: false
+    BrowserPairingDenied:
+      type: object
+      required: [type, sessionId, reason]
+      properties:
+        type: { const: pairing_denied }
+        sessionId: { type: string, minLength: 1 }
+        reason: { type: string }
+      additionalProperties: false
+    BrowserDisconnect:
+      type: object
+      required: [type, reason]
+      properties:
+        type: { const: disconnect }
+        reason: { type: string }
+      additionalProperties: false
+    BrowserLoad:
+      type: object
+      required: [type, requestId, media]
+      properties:
+        type: { const: load }
+        requestId: { type: string, minLength: 1 }
+        media: { $ref: '#/components/schemas/BrowserMedia' }
+      additionalProperties: false
+    BrowserControl:
+      type: object
+      required: [type, requestId, action]
+      properties:
+        type: { const: command }
+        requestId: { type: string, minLength: 1 }
+        action: { enum: [play, pause, stop, seek, set_volume] }
+        value: { type: number }
+      additionalProperties: false
+    BrowserPing:
+      type: object
+      required: [type, requestId]
+      properties:
+        type: { const: ping }
+        requestId: { type: string, minLength: 1 }
+      additionalProperties: false
+    BrowserHello:
+      type: object
+      required: [type, protocolVersion, receiverId, name]
+      properties:
+        type: { const: hello }
+        protocolVersion: { const: 1 }
+        receiverId: { type: string, minLength: 1 }
+        name: { type: string, minLength: 1 }
+      additionalProperties: false
+    BrowserCapabilitiesFrame:
+      type: object
+      required: [type, capabilities]
+      properties:
+        type: { const: capabilities }
+        capabilities: { $ref: '#/components/schemas/BrowserCapabilities' }
+      additionalProperties: false
+    BrowserReady:
+      type: object
+      required: [type, requestId]
+      properties:
+        type: { const: ready }
+        requestId: { type: string, minLength: 1 }
+      additionalProperties: false
+    BrowserStatus:
+      type: object
+      required: [type, state, positionMs, durationMs, volume, muted]
+      properties:
+        type: { const: status }
+        requestId: { type: string }
+        state:
+          enum: [idle, buffering, playing, paused, stopped, ended, error, autoplay_blocked, unknown]
+        positionMs: { type: integer, minimum: 0 }
+        durationMs: { type: integer, minimum: 0 }
+        volume: { type: number, minimum: 0, maximum: 1 }
+        muted: { type: boolean }
+        title: { type: [string, 'null'] }
+      additionalProperties: false
+    BrowserEnded:
+      type: object
+      required: [type]
+      properties:
+        type: { const: ended }
+      additionalProperties: false
+    BrowserError:
+      type: object
+      required: [type, message]
+      properties:
+        type: { const: error }
+        requestId: { type: string }
+        message: { type: string }
+      additionalProperties: false
+    BrowserPong:
+      type: object
+      required: [type, requestId]
+      properties:
+        type: { const: pong }
+        requestId: { type: string, minLength: 1 }
+      additionalProperties: false
+    BrowserMedia:
+      type: object
+      required: [url]
+      properties:
+        url: { type: string, minLength: 1 }
+        title: { type: [string, 'null'] }
+        contentType: { type: [string, 'null'] }
+        posterUrl: { type: [string, 'null'] }
+        subtitleUrl: { type: [string, 'null'] }
+        startPositionMs: { type: [integer, 'null'], minimum: 0 }
+      additionalProperties: false
+    BrowserCapabilities:
+      type: object
+      required: [nativeHls, mediaSource, hlsJs, dashJs, webVtt, volumeControl, mimeTypes]
+      properties:
+        nativeHls: { type: boolean }
+        mediaSource: { type: boolean }
+        hlsJs: { type: boolean }
+        dashJs: { type: boolean }
+        webVtt: { type: boolean }
+        volumeControl: { type: boolean }
+        mimeTypes:
+          type: array
+          items: { type: string }
+      additionalProperties: false
     SenderFrame:
       oneOf:
         - $ref: '#/components/schemas/Ping'

--- a/protocol/docs/WSS_FLOW.md
+++ b/protocol/docs/WSS_FLOW.md
@@ -21,6 +21,15 @@ schema disagree, the schema defines JSON shape and this document defines sequenc
 - Receivers use a locally generated TLS identity. Paired senders validate its SPKI pin on every
   connection. A changed key is a hard failure and requires explicit re-pairing.
 
+The fallback web-browser receiver uses a separate, reversed local transport documented by the
+`browserReceiverSocket` channel in `asyncapi.yaml`. An ordinary browser opens a page served by the
+sender and connects back to `/v1/browser/ws` over the same LAN. It is never advertised or found by
+mDNS/SSDP. Each page session displays a short-lived six-digit code that must be approved by the
+sender; v1 deliberately stores no browser credential and requires approval for every new page
+session. After approval the host sends `load` and `command` frames while the page returns
+capabilities, status, completion, and errors. Unknown fields and message types remain
+forward-compatible.
+
 The first connection cannot authenticate the receiver's self-signed certificate from a public
 CA or a previously stored pin. The TLS channel still provides encryption, while the SAS exchange
 below authenticates the endpoints and protects the credential bundle containing the pin.

--- a/protocol/scripts/check-spec.rb
+++ b/protocol/scripts/check-spec.rb
@@ -17,11 +17,15 @@ required_schemas = %w[
   SenderFrame ReceiverFrame PairingCommit PairingChallenge PairingReveal
   PairingConfirmation PairingApproved CredentialBundle Auth AuthResponse
   PlayPayload PlaylistPayload Status Context PlaylistStatus Tracks PlayerSettings
+  BrowserHostFrame BrowserClientFrame BrowserMedia BrowserCapabilities
 ]
 missing_schemas = required_schemas.reject { |name| schemas.key?(name) }
 abort "missing required schemas: #{missing_schemas.join(', ')}" unless missing_schemas.empty?
 
-required_messages = %w[SenderTextFrame ReceiverTextFrame PointerBinaryFrame]
+required_messages = %w[
+  SenderTextFrame ReceiverTextFrame PointerBinaryFrame
+  BrowserHostTextFrame BrowserClientTextFrame
+]
 missing_messages = required_messages.reject { |name| messages.key?(name) }
 abort "missing required messages: #{missing_messages.join(', ')}" unless missing_messages.empty?
 


### PR DESCRIPTION
## Summary
- define browser receiver session commands, events, state, and errors in AsyncAPI
- document the browser receiver WebSocket flow
- extend the protocol integrity check for the new contract

## Verification
- ruby protocol/scripts/check-spec.rb

This is a contract-only PR and has no dependency on the implementation PRs.