### PR TITLE
docs(extension): add official browser store links

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,15 +153,21 @@ Media and codec support ultimately depends on the selected playback engine, oper
 - **Android Phone (sender)**:
   - <a href="https://play.google.com/store/apps/details?id=com.playbridge.sender"><img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get PlayBridge on Google Play" height="80"></a>
   - or download the latest `phone` APK from [GitHub Releases](https://github.com/playbridgeapp/playbridge/releases) and install it.
+- **Browser Extension (sender)**:
+  - <a href="https://chromewebstore.google.com/detail/playbridge-video-detector/gofdcnocpnieoonficfnfccolcocoaim?hl=en"><img src="https://img.shields.io/badge/Chrome_Web_Store-4285F4?style=for-the-badge&logo=google-chrome&logoColor=white" alt="Chrome Web Store" height="40"></a>
+  - <a href="https://addons.mozilla.org/en-US/firefox/addon/playbridge-video-detector/"><img src="https://img.shields.io/badge/Firefox_Add--ons-FF7139?style=for-the-badge&logo=firefox-browser&logoColor=white" alt="Firefox Add-ons" height="40"></a>
 - **Staying up to date**: the phone and TV apps can check for new releases and install updates from within the app, so sideloaded builds don't go stale.
 
-### Google Play
+### Store Listings
 
-The Android phone sender is publicly available on Google Play:
+The PlayBridge senders and extensions are available on official store registries:
 
 * **Android Phone (Sender)**:
   * <a href="https://play.google.com/store/apps/details?id=com.playbridge.sender"><img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get PlayBridge on Google Play" height="80"></a>
   * Or download the latest `phone` APK from [GitHub Releases](https://github.com/playbridgeapp/playbridge/releases).
+* **Browser Extension (Sender — Firefox & Chrome)**:
+  * **Firefox Add-ons**: <a href="https://addons.mozilla.org/en-US/firefox/addon/playbridge-video-detector/"><img src="https://img.shields.io/badge/Firefox_Add--ons-FF7139?style=for-the-badge&logo=firefox-browser&logoColor=white" alt="Firefox Add-ons" height="44"></a>
+  * **Chrome Web Store**: <a href="https://chromewebstore.google.com/detail/playbridge-video-detector/gofdcnocpnieoonficfnfccolcocoaim?hl=en"><img src="https://img.shields.io/badge/Chrome_Web_Store-4285F4?style=for-the-badge&logo=google-chrome&logoColor=white" alt="Chrome Web Store" height="44"></a>
 * **Android TV (Player) — closed testing**
   * **Group invite**: [pbtvclosedtesters Google Group](https://groups.google.com/g/pbtvclosedtesters)
   * **Apply to be a tester**: [Google Play Opt-in](https://play.google.com/apps/testing/com.playbridge.player)

--- a/extension/README.md
+++ b/extension/README.md
@@ -8,6 +8,13 @@ A **Firefox and Chromium** extension that detects media in desktop browser tabs 
 - Protocol bindings via `@bufbuild/protobuf`, generated from the [`protocol/`](../protocol/) submodule
 - Manifests: `manifests/firefox.json` (MV2) and `manifests/chrome.json` (MV3)
 
+## Install from Web Stores
+
+PlayBridge Video Detector is published on official extension stores:
+
+- **Firefox Add-ons**: [PlayBridge Video Detector on Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/playbridge-video-detector/)
+- **Chrome Web Store**: [PlayBridge Video Detector on Chrome Web Store](https://chromewebstore.google.com/detail/playbridge-video-detector/gofdcnocpnieoonficfnfccolcocoaim?hl=en)
+
 ## Build
 
 ```bash

--- a/web/site/src/lib/components/Install.svelte
+++ b/web/site/src/lib/components/Install.svelte
@@ -144,17 +144,25 @@
                 rel="noopener noreferrer"
                 class="btn btn--primary"
               >
-                <Icon name="download" size={13} stroke={2.0} /> Download
+                {#if tab.downloadUrl.startsWith('https://')}
+                  <Icon name="link" size={13} stroke={2.0} /> Get Extension
+                {:else}
+                  <Icon name="download" size={13} stroke={2.0} /> Download
+                {/if}
               </a>
             {/if}
             <a
-              href={'https://' + tab.cmd}
+              href={tab.cmd.startsWith('http') ? tab.cmd : 'https://' + tab.cmd}
               target="_blank"
               rel="noopener noreferrer"
               class="btn"
               class:btn--primary={!tab.downloadUrl}
             >
-              <Icon name="github" size={13} /> View on GitHub
+              {#if tab.cmd.includes('github.com')}
+                <Icon name="github" size={13} /> View on GitHub
+              {:else}
+                <Icon name="link" size={13} /> Open Store
+              {/if}
             </a>
           {/if}
         </div>

--- a/web/site/src/lib/data/site.ts
+++ b/web/site/src/lib/data/site.ts
@@ -19,9 +19,8 @@ export type Platform = {
 };
 
 export const SENDERS: Platform[] = [
-  { icon: 'android', name: 'Android app', desc: 'Browse, search, and send anything to a player.' }
-  // Hidden for now — the Firefox extension sender is not being promoted.
-  // { icon: 'firefox', name: 'Firefox extension', desc: 'Send links from any tab — right-click → cast.' }
+  { icon: 'android', name: 'Android app', desc: 'Browse, search, and send anything to a player.' },
+  { icon: 'firefox', name: 'Browser extension', desc: 'Detect & cast media from Firefox or Chrome tabs.' }
 ];
 
 export const PLAYERS: Platform[] = [
@@ -287,24 +286,42 @@ export const INSTALL_TABS: InstallTab[] = [
     cmd: '',
     meta: []
   },
-  // Hidden for now — the Firefox extension sender is not being promoted.
-  // {
-  //   id: 'firefox',
-  //   label: 'Firefox',
-  //   role: 'sender',
-  //   icon: 'firefox',
-  //   title: 'Firefox extension',
-  //   steps: [
-  //     ['Download', 'Latest .xpi from GitHub Releases.'],
-  //     ['Install', 'Drag the .xpi onto Firefox.'],
-  //     ['Right-click links', 'Send any link to a player.']
-  //   ],
-  //   cmd: 'github.com/playbridgeapp/PlayBridge/releases?q=9f2d8e&expanded=true',
-  //   downloadUrl: '/download/firefox',
-  //   meta: [
-  //     ['sha256', '77fa…d3e2'],
-  //     ['size', '3.2 MB'],
-  //     ['min', 'Firefox 109']
-  //   ]
-  // }
+  {
+    id: 'chrome',
+    label: 'Chrome',
+    role: 'sender',
+    icon: 'desktop',
+    title: 'Chrome Extension',
+    steps: [
+      ['Open Store', 'Install PlayBridge Video Detector from Chrome Web Store.'],
+      ['Pair Desktop', 'Run PlayBridge desktop receiver to handle casting.'],
+      ['Cast Videos', 'Detect and cast streams from web pages with one click.']
+    ],
+    cmd: 'chromewebstore.google.com/detail/playbridge-video-detector/gofdcnocpnieoonficfnfccolcocoaim',
+    downloadUrl: 'https://chromewebstore.google.com/detail/playbridge-video-detector/gofdcnocpnieoonficfnfccolcocoaim?hl=en',
+    meta: [
+      ['store', 'Chrome Web Store'],
+      ['platform', 'Chrome, Brave, Edge'],
+      ['status', 'Published']
+    ]
+  },
+  {
+    id: 'firefox',
+    label: 'Firefox',
+    role: 'sender',
+    icon: 'firefox',
+    title: 'Firefox Extension',
+    steps: [
+      ['Open Store', 'Install PlayBridge Video Detector from Firefox Add-ons.'],
+      ['Pair Desktop', 'Run PlayBridge desktop receiver to handle casting.'],
+      ['Cast Videos', 'Detect and cast streams from web pages with one click.']
+    ],
+    cmd: 'addons.mozilla.org/en-US/firefox/addon/playbridge-video-detector',
+    downloadUrl: 'https://addons.mozilla.org/en-US/firefox/addon/playbridge-video-detector/',
+    meta: [
+      ['store', 'Firefox Add-ons'],
+      ['platform', 'Firefox Desktop'],
+      ['status', 'Published']
+    ]
+  }
 ];


### PR DESCRIPTION
## Summary
- add Firefox Add-ons and Chrome Web Store links to the public README
- expose the official extension listings on the website install UI
- document both store listings in the extension README

## Verification
- pnpm check
- pnpm build

This PR is documentation and website-only and has no dependency on the other split PRs.