### PR TITLE
docs: update monorepo documentation, store badges, and agent skills

### DIFF
--- a/.agents/skills/playbridge-rust-core/SKILL.md
+++ b/.agents/skills/playbridge-rust-core/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: playbridge-rust-core
+description: Work on the PlayBridge Rust casting core, reusable receiver runtime, FFI bindings, and CLI. Use for discovery and protocol sessions, receiver TLS/WSS and SAS pairing, authentication, UniFFI/C/JNI/Dart bindings, command-line sender or receiver behavior, or changes under cast/core/, cast/receiver/, cast/ffi/, packages/playbridge_cast_core_dart/, and cli/.
+---
+
+# PlayBridge Rust Core
+
+## Establish ownership
+
+- Treat `cast/core/`, `cast/receiver/`, `cast/ffi/`, and `cli/` as the portable Rust casting layer.
+- Keep discovery (mDNS, UPnP), SAS pairing, security (X25519, HKDF, AES-GCM), and stream metadata logic inside `cast/core/`.
+- Keep TLS/WSS serving, pairing orchestration, authentication, connection limits, and typed receiver command delivery inside `cast/receiver/`. Keep playback, UI, discovery lifecycle, and platform services in the consumer.
+- Keep UniFFI, C, and JNI exported bindings in `cast/ffi/`. Ensure language binding definitions stay compatible across platform targets.
+- Keep the Dart C-ABI façade in `packages/playbridge_cast_core_dart/`.
+- Keep command-line behavior and the external-mpv playback adapter in `cli/`; do not duplicate receiver networking there.
+- Coordinate FFI or protocol model changes with platform specialist owners (`playbridge-android`, `playbridge-apple`, `playbridge-desktop-proxy`).
+
+## Work safely
+
+1. Follow the root `AGENTS.md` rules and preserve unrelated working-tree edits.
+2. Keep sensitive cryptographic keys, SAS session secrets, authenticated URLs, and the raw token in `ReceiverEvent::Paired` out of logs.
+3. Preserve persisted TLS identities and SPKI pins. Accept legacy raw tokens and `sha256:<hex>` records during credential migrations.
+4. Keep receiver connection, message, and outbound-queue limits bounded. Credential removal must terminate sessions authenticated by the removed token.
+5. Ensure FFI bindings remain thread-safe and panic-safe. Keep the receiver ABI version separate and bump it for incompatible C/Dart changes.
+6. Maintain compatibility with AGPL-3.0 licensing constraints across all core components.
+
+## Verify
+
+From the repository root:
+
+```bash
+cargo test -p playbridge-cast-core -p playbridge-cast-receiver \
+  -p playbridge-cast-core-ffi -p playbridge-cast-cli \
+  --features playbridge-cast-core-ffi/sender-services --locked
+cargo clippy -p playbridge-cast-core -p playbridge-cast-receiver \
+  -p playbridge-cast-core-ffi -p playbridge-cast-cli --all-targets \
+  --features playbridge-cast-core-ffi/sender-services --locked -- -D warnings
+```
+
+When the receiver ABI or Desktop-facing Rust code changes, rebuild the native
+artifacts from the repository root and validate the Dart consumer:
+
+```bash
+sh cast/build-desktop.sh
+cd desktop
+flutter test test/rust_receiver_runtime_test.dart
+```
+
+Run specific examples when testing core discovery or pairing workflows:
+
+```bash
+cargo run --example discover -p playbridge-cast-core
+cargo run --example pair -p playbridge-cast-core
+```

--- a/.agents/skills/playbridge-stream-proxy-rust/SKILL.md
+++ b/.agents/skills/playbridge-stream-proxy-rust/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: playbridge-stream-proxy-rust
+description: Work on the PlayBridge Rust stream proxy server. Use for stream proxying, HLS rewriting, AES-256 MediaFlow encryption/decryption, debrid link resolution, Tokio/Axum web server logic, Docker packaging, or changes under stream-proxy-rust/.
+---
+
+# PlayBridge Rust Stream Proxy
+
+## Establish ownership
+
+- Treat `stream-proxy-rust/` as a high-performance standalone Rust proxy service.
+- Keep proxy routing, HTTP streaming, HLS rewriting, debrid link resolution, and MediaFlow AES-256 encryption within `stream-proxy-rust/`.
+- Coordinate changes that affect Desktop proxy integration with the `playbridge-desktop-proxy` owner.
+- Load `playbridge-protocol` for any cross-platform wire payload or message contract changes.
+
+## Work safely
+
+1. Follow the root `AGENTS.md` rules and preserve unrelated working-tree edits.
+2. Never log Debrid tokens, authentication credentials, private keys, or full authenticated stream URLs.
+3. Preserve HTTP header forwarding and HLS manifest rewriting without leaking user session tokens in logs or errors.
+4. Ensure non-blocking async IO using Tokio and Axum for high-concurrency stream forwarding.
+
+## Verify
+
+From the repository root or `stream-proxy-rust/`:
+
+```bash
+cargo test -p stream-proxy-rust
+cargo check -p stream-proxy-rust
+```
+
+Build the Docker image when container configuration or dependencies are updated:
+
+```bash
+docker build -t playbridge-stream-proxy-rust -f stream-proxy-rust/Dockerfile .
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,12 @@ Portable project skills live in `.agents/skills/` and are the canonical speciali
 |---|---|
 | `playbridge-android` | Android phone, Android TV, shared Kotlin, and shared Android dependencies |
 | `playbridge-apple` | Apple phone and Apple TV applications |
-| `playbridge-desktop-proxy` | Flutter Desktop and the Dart stream proxy |
+| `playbridge-desktop-proxy` | Flutter Desktop, its Rust-backed receiver adapter, and the Dart stream proxy |
 | `playbridge-extension` | Browser extension and native-messaging integration |
 | `playbridge-web` | Svelte website and static web assets |
 | `playbridge-protocol` | Protocol schema, generated bindings, and consumer compatibility |
+| `playbridge-rust-core` | Portable Rust casting and receiver engines, UniFFI/C/JNI bindings, and Rust CLI |
+| `playbridge-stream-proxy-rust` | High-performance Rust streaming proxy and MediaFlow encryption |
 
 Before working in a project, load the matching specialist skill. For cross-project work, load each affected specialist or delegate non-overlapping consumers to subagents using those skills. Keep shared contracts and files with one designated writer, and keep the primary agent responsible for integration and final verification.
 
@@ -43,7 +45,13 @@ If `SUBAGENTS.local.md` exists at the repository root, read and follow it for op
 | Apple phone | `mobile/apple/` | Swift/Xcode project |
 | Apple TV | `tv/apple/` | Swift/Xcode project |
 | Desktop | `desktop/` | Flutter receiver for macOS, Windows, and Linux |
-| Stream proxy | `stream-proxy-dart/` | Standalone Dart proxy, embedded by Desktop and released as a Docker image |
+| Stream proxy (Dart) | `stream-proxy-dart/` | Standalone Dart proxy, embedded by Desktop and released as a Docker image |
+| Stream proxy (Rust) | `stream-proxy-rust/` | High-performance Rust streaming proxy with MediaFlow AES-256 encryption |
+| Rust Cast Core | `cast/core/` | Portable discovery, protocol clients, pairing primitives, and casting sessions |
+| Rust Receiver | `cast/receiver/` | Secure reusable PlayBridge WSS receiver runtime; consumers provide playback and platform lifecycle |
+| Rust FFI | `cast/ffi/` | UniFFI plus stable C/JNI bindings for Cast Core and the receiver runtime |
+| Dart Cast bindings | `packages/playbridge_cast_core_dart/` | Dart FFI wrappers consumed by Flutter Desktop and standalone Dart applications |
+| Rust CLI | `cli/` | Command-line client binary (`playbridge`) for Rust Core |
 | Extension | `extension/` | Browser extension, JavaScript/TypeScript |
 | Web | `web/` | Svelte site |
 | Protocol assets | `protocol/` | In-repository AsyncAPI contract, protocol documentation, and generated artifacts |
@@ -91,6 +99,25 @@ Changes to `shared/src/commonMain/kotlin/com/playbridge/shared/protocol/Message.
 - `mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt`
 - `tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt`
 - `extension/src/background.ts`, which manually handles protocol JSON
+
+### Native receiver runtime ripple
+
+Changes to the PlayBridge receiver wire behavior, `cast/receiver/` public API, or
+the receiver C ABI must be checked across:
+
+- `cast/core/src/playbridge.rs`
+- `cast/ffi/src/receiver_runtime.rs` and `cast/ffi/include/playbridge_cast_core.h`
+- `packages/playbridge_cast_core_dart/lib/src/receiver_runtime.dart`
+- `desktop/lib/receiver_server.dart`, `desktop/lib/cert_manager.dart`, and `desktop/lib/pairing_store.dart`
+- `cli/src/receive.rs`
+
+Rust owns TLS/WSS, pairing, authentication, resource limits, and typed command
+delivery. Consumer applications own playback, UI, discovery lifecycle, and
+platform services. Preserve existing TLS identities/SPKI pins, accept compatible
+raw and SHA-256 token records during migrations, and never log the raw token
+emitted by a successful pairing. Bump the receiver ABI version for incompatible
+C/Dart changes, rebuild Desktop libraries with `cast/build-desktop.sh`, and run
+the native receiver smoke test.
 
 ### Shared dependency versions
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,12 @@ PlayBridge is an open-source casting suite: browse on your phone, play on the bi
 
 ## Table of Contents
 
+- [Installation & Store Listings](#installation--store-listings)
+- [How to Connect & Cast](#how-to-connect--cast)
 - [Screenshots](#screenshots)
 - [Features](#features)
-- [Sender feature matrix](#sender-feature-matrix)
-- [Receiver feature matrix](#receiver-feature-matrix)
-- [Installation](#installation)
-  - [Google Play](#google-play)
-- [How to connect & cast](#how-to-connect--cast)
+- [Sender Feature Matrix](#sender-feature-matrix)
+- [Receiver Feature Matrix](#receiver-feature-matrix)
 - [Components](#components)
 - [Documentation](#documentation)
 - [Build Instructions](#build-instructions)
@@ -34,6 +33,63 @@ PlayBridge is an open-source casting suite: browse on your phone, play on the bi
 - [Acknowledgments](#acknowledgments)
 - [License](#license)
 - [Contact](#contact)
+
+## Installation & Store Listings
+
+### Official Store Listings
+
+The PlayBridge senders and extensions are available on official store registries:
+
+* **Android Phone (Sender)**:
+  * <a href="https://play.google.com/store/apps/details?id=com.playbridge.sender"><img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get PlayBridge on Google Play" height="80"></a>
+  * Or download the latest `phone` APK from [GitHub Releases](https://github.com/playbridgeapp/PlayBridge/releases?q=5c9b2f&expanded=true).
+* **Browser Extension (Sender — Firefox & Chrome)**:
+  * **Firefox Add-ons**: <a href="https://addons.mozilla.org/en-US/firefox/addon/playbridge-video-detector/"><img src="https://img.shields.io/badge/Firefox_Add--ons-FF7139?style=for-the-badge&logo=firefox-browser&logoColor=white" alt="Firefox Add-ons" height="44"></a>
+  * **Chrome Web Store**: <a href="https://chromewebstore.google.com/detail/playbridge-video-detector/gofdcnocpnieoonficfnfccolcocoaim?hl=en"><img src="https://img.shields.io/badge/Chrome_Web_Store-4285F4?style=for-the-badge&logo=google-chrome&logoColor=white" alt="Chrome Web Store" height="44"></a>
+* **Android TV (Player) — Closed Testing**:
+  * **Group invite**: [pbtvclosedtesters Google Group](https://groups.google.com/g/pbtvclosedtesters)
+  * **Apply to be a tester**: [Google Play Opt-in](https://play.google.com/apps/testing/com.playbridge.player)
+  * **Download app**: [Google Play Store](https://play.google.com/store/apps/details?id=com.playbridge.player)
+
+### Receiver & Manual Installation
+
+- **Android TV / Fire TV (receiver)**:
+  - Open the **Downloader** app on your TV and enter code `9557748` to install the TV Player directly, or
+  - download the latest `tv-player` APK from [GitHub Releases](https://github.com/playbridgeapp/PlayBridge/releases?q=8d2a1c&expanded=true) and sideload it.
+  - *Note:* on first launch the TV app asks for "Display over other apps" — required for the receiver to come to the foreground when a cast arrives.
+  - Optional: the ad-blocked **TV Browser** APK (GeckoView + uBlock Origin) extends the player with web browsing (download from [TV Browser Releases](https://github.com/playbridgeapp/PlayBridge/releases?q=3e7f9a&expanded=true)).
+- **Apple TV (receiver)**: no prebuilt binary yet — build and deploy from Xcode; see the [TV README](tv/).
+- **Desktop (receiver)**: download the build for your OS from [GitHub Releases](https://github.com/playbridgeapp/PlayBridge/releases?q=1a4b6c&expanded=true) (`playbridge-desktop-windows-*.zip`, `-linux-*.tar.gz`, `-macos-*.zip`). Linux needs `libmpv2`; the macOS build is unsigned (right-click → Open on first launch).
+- **CLI (sender & receiver)**: on macOS or Linux, run `curl -fsSL https://raw.githubusercontent.com/playbridgeapp/playbridge/main/cli/install.sh | sh`. Windows and manual archives are on [GitHub Releases](https://github.com/playbridgeapp/playbridge/releases).
+- **DLNA TVs**: nothing to install — the phone discovers renderers on your network automatically.
+- **Staying up to date**: the phone and TV apps can check for new releases and install updates from within the app, so sideloaded builds don't go stale.
+
+## How to connect & cast
+
+PlayBridge provides multiple ways to discover receivers and cast media — using your phone, browser extension, Desktop app, or command-line CLI.
+
+### 1. Connect on the same Wi-Fi
+
+Ensure your sender device (Phone, Desktop app, Browser Extension, or Rust CLI) and target receiver (Android TV, Apple TV, Desktop app, or DLNA Smart TV) are connected to the **same local Wi-Fi network**.
+
+### 2. Discover & Pair Receivers
+
+- **Automatic Discovery**: Open PlayBridge on your phone or Desktop app. Tap the **device chip** to see automatically discovered receivers on your network (via mDNS & UPnP).
+- **Manual IP Connect**: If a receiver isn't listed automatically, enter the receiver's IP address (displayed on its home screen).
+- **Secure 6-Digit Pairing**: On your first connection to a PlayBridge receiver (Android TV, Apple TV, Desktop), a **6-digit pairing PIN** appears on the receiver screen. Enter it on your sender to establish a secure, encrypted connection (`wss://`). Paired devices auto-reconnect on future sessions.
+- **DLNA / UPnP Smart TVs**: Discovered automatically on your local network without requiring a pairing PIN.
+
+### 3. Choose your Sender
+
+- 📱 **Phone App (Android / iOS)**: Browse video sites in the built-in ad-blocked browser, cast movies/episodes from your Stremio library and add-ons, load IPTV playlists, or stream local phone files.
+- 🖥️ **Desktop App (Receiver & Sender)**: Plays incoming casts from phone and extension senders. Also acts as a sender to cast local video files (with drag-and-drop) or stream URLs to TVs.
+- 🧩 **Browser Extension (Firefox & Chrome)**: Detects streams in active browser tabs and casts them to your TV via the Desktop app.
+- 💻 **Rust CLI (`playbridge`)**: Discover receivers and send local files or URLs directly from your terminal:
+  ```bash
+  playbridge discover               # Discover local network receivers
+  playbridge send video.mp4         # Send a local file or stream URL to a receiver
+  playbridge receiver               # Receive casts using the installed mpv
+  ```
 
 ## Screenshots
 
@@ -183,14 +239,17 @@ The PlayBridge senders and extensions are available on official store registries
 
 ## Components
 
-PlayBridge is a monorepo; each component has its own README:
+PlayBridge is a monorepo; each component has its own documentation:
 
-1.  **[Phone App](mobile/)** (`mobile/`) — the sender: browser, library, video detection, remote. [Changelog](mobile/android/CHANGELOG.md)
-2.  **[TV Apps](tv/)** (`tv/`) — receivers for Android TV (player + browser APKs) and Apple TV. [Changelog](tv/android/CHANGELOG.md) · [tvOS changelog](tv/apple/CHANGELOG.md)
-3.  **[Desktop App](desktop/)** (`desktop/`) — a Flutter desktop receiver that plays casts via libmpv. [Changelog](desktop/CHANGELOG.md)
-4.  **[Browser Extension](extension/)** (`extension/`) — a Firefox extension that casts media from desktop browser tabs.
-5.  **[Shared Module](shared/)** (`shared/`) — Kotlin Multiplatform logic, player engines, and protocol bindings.
-6.  **[Protocol](protocol/)** (`protocol/`) — AsyncAPI WSS contract, detailed connection flow, and retained protobuf bindings.
+1. **[Phone App](mobile/)** (`mobile/`) — The sender: browser, library, video detection, remote. [Changelog](mobile/android/CHANGELOG.md)
+2. **[TV Apps](tv/)** (`tv/`) — Receivers for Android TV (player + browser APKs) and Apple TV. [Changelog](tv/android/CHANGELOG.md) · [tvOS changelog](tv/apple/CHANGELOG.md)
+3. **[Desktop App](desktop/)** (`desktop/`) — A Flutter desktop receiver that plays casts via libmpv. [Changelog](desktop/CHANGELOG.md)
+4. **[Browser Extension](extension/)** (`extension/`) — A Firefox and Chromium extension that casts media from desktop browser tabs.
+5. **[Rust Cast](cast/)** (`cast/core/`, `cast/receiver/`, `cast/ffi/`) — Portable discovery/casting core, secure reusable receiver runtime, and UniFFI/C/JNI/Dart bindings.
+6. **[Rust Stream Proxy](stream-proxy-rust/)** (`stream-proxy-rust/`) — High-performance Rust streaming proxy and MediaFlow AES-256 encryption.
+7. **[Rust CLI](cli/)** (`cli/`) — Command-line client binary (`playbridge`) for Rust Core.
+8. **[Shared Module](shared/)** (`shared/`) — Kotlin Multiplatform logic, player engines, and protocol bindings.
+9. **[Protocol](protocol/)** (`protocol/`) — AsyncAPI WSS contract, detailed connection flow, and retained protobuf bindings.
 
 ## Documentation
 
@@ -215,6 +274,8 @@ phone browser. Source: [`web/site/static/cast-demo/`](web/site/static/cast-demo/
 - **Android apps**: Android Studio Ladybug or later, JDK 17+, Android SDK 26+
 - **Desktop**: Flutter SDK (Dart `^3.6`) and libmpv
 - **Apple TV**: Xcode with CocoaPods (see [tv/](tv/))
+- **Browser Extension**: Node.js and `pnpm`
+- **Rust Core & Proxy**: Rust 1.85+ (`cargo`)
 
 ### Building
 
@@ -222,14 +283,18 @@ phone browser. Source: [`web/site/static/cast-demo/`](web/site/static/cast-demo/
 # Phone app
 cd mobile/android && ./gradlew :app:assembleDebug
 
-# TV player
-cd tv/android && ./gradlew :player:app:assembleDebug
-
-# TV browser
-cd tv/android && ./gradlew :browser:app:assembleDebug
+# TV player & browser
+cd tv/android && ./gradlew :player:app:assembleDebug :browser:app:assembleDebug
 
 # Desktop
 cd desktop && flutter pub get && flutter run    # -d macos | windows | linux
+
+# Browser extension
+cd extension && pnpm install && pnpm build
+
+# Rust core & stream proxy
+cargo build --workspace
+cargo test --workspace
 ```
 
 ## Contributing

--- a/cast/README.md
+++ b/cast/README.md
@@ -6,8 +6,11 @@ independent of Android, Apple, Flutter, and desktop UI lifecycles.
 ## Crates
 
 - `core`: discovery plus a unified PlayBridge, DLNA, Roku, and Google Cast session API.
+- `receiver`: secure PlayBridge WSS receiver runtime with typed command events.
 - `ffi`: UniFFI bindings for Kotlin and Swift plus a stable C ABI for Dart consumers.
 - `../cli`: cross-platform CLI built directly on `core`.
+- `../stream-proxy-rust`: embeddable and standalone media proxy.
+- `../browser-receiver-rust`: sender-hosted web receiver library and binary.
 
 Discovery is caller-owned and time-boxed. A caller chooses one or more protocols,
 reads events, and cancels or drops the scanner when its screen or command ends. The
@@ -42,9 +45,34 @@ with the matching static or dynamic library for each Apple target.
 ## C ABI
 
 `cast/ffi/include/playbridge_cast_core.h` is the stable surface intended for
-Dart FFI and other languages that do not need generated bindings. Discovery events
-are UTF-8 JSON. Strings returned by `pb_discovery_next_json` must be released with
-`pb_string_free`; scanner handles must be cancelled and released.
+Dart FFI and other languages that do not need generated bindings. Discovery and
+session events are UTF-8 JSON. Strings returned by either `next_json` function
+must be released with `pb_string_free`; handles must be cancelled and released.
+Consumers must check `pb_cast_core_abi_version` before resolving the rest of the
+session API.
+
+Desktop builds enable the optional `sender-services` feature. Its separate
+`pb_sender_services_*` ABI owns the Rust proxy for the app lifetime and starts
+the web-browser receiver only on request. Keeping this lifecycle ABI separate
+allows phone builds to ship the protocol core without pulling in either server.
+
+The `pb_receiver_runtime_*` ABI exposes the shared native PlayBridge receiver.
+It accepts a caller-owned TLS identity and authorized token digests, then emits
+pairing, connection, and authenticated command events. Playback snapshots and
+other receiver responses are submitted by the host application, keeping Flutter
+and mobile player lifecycles outside Rust.
+
+A session target selects exactly one protocol and retains all known addresses:
+
+```json
+{"protocol":"roku","addresses":["192.168.1.20"],"port":8060}
+```
+
+DLNA targets use `location`; Google Cast defaults to port 8009. Every queued
+command has a scalar `request_id`, which is echoed by its `operation`, `status`,
+or `error` event. Supported commands are `load`, `play`, `pause`, `stop`, `seek`,
+`relative_seek`, `status`, and `disconnect`. Session command/event queues are
+bounded and the worker exists only for the lifetime of an active connection.
 
 Protocol mask values are stable:
 
@@ -54,9 +82,10 @@ Protocol mask values are stable:
 - DIAL: `8`
 - Google Cast: `16`
 
-Build the native library for the current desktop OS with
-`cast/build-desktop.sh`. The macOS build is universal; Linux and Windows builds
-are produced on their native operating systems.
+The reusable Dart wrapper lives in `../packages/playbridge_cast_core_dart`. Build
+the native library for the current desktop OS with `cast/build-desktop.sh`. The
+macOS build is universal; Linux and Windows builds are produced by their native
+Desktop CI jobs and packaged by Flutter's platform build files.
 
 ## Desktop CLI
 
@@ -73,14 +102,15 @@ playbridge discover --protocol all --json-lines
 `--json` emits one deduplicated report after the scan. `--json-lines` streams
 stable started, found, updated, error, and finished event objects for scripts.
 
-## Android libraries
+## Android packaging status
 
-Build and copy the two supported Android libraries with:
+The phone uses a thin JNI adapter rather than JNA. Build and copy the two supported
+Android libraries with:
 
 ```sh
 cd mobile/android
 ./gradlew :app:buildRustCastCore
 ```
 
-Platform applications remain responsible for their lifecycle, multicast locks,
-permissions, and UI integration.
+The phone uses Rust as its primary PlayBridge, DLNA, and Roku discovery engine;
+Android retains the platform lifecycle, multicast lock, and UI integration.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,53 @@
+# PlayBridge CLI
+
+`playbridge` is a cross-platform sender and receiver built on PlayBridge's Rust
+casting core. It can discover receivers, cast local files or URLs, host a browser
+receiver, or receive PlayBridge casts through an installed `mpv`.
+
+## Install
+
+On macOS or Linux:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/playbridgeapp/playbridge/main/cli/install.sh | sh
+```
+
+The installer downloads the latest `cli-v*` GitHub release, verifies its SHA-256
+checksum, and installs `playbridge` to `~/.local/bin`. Override the defaults with:
+
+```sh
+PLAYBRIDGE_VERSION=0.1.0 PLAYBRIDGE_INSTALL_DIR=/usr/local/bin \
+  sh cli/install.sh
+```
+
+Windows binaries and manual archives for every supported platform are available
+from [GitHub Releases](https://github.com/playbridgeapp/playbridge/releases).
+
+Receiver mode requires [`mpv`](https://mpv.io/) to be installed and available on
+`PATH`. Its TLS/WSS, pairing, authentication, limits, queue commands, and status
+transport use the same `playbridge-cast-receiver` crate as Flutter Desktop;
+only the external-mpv playback adapter remains CLI-specific.
+
+## Examples
+
+```sh
+playbridge discover
+playbridge send video.mp4
+playbridge receiver --name "My Computer"
+playbridge browser video.mp4
+```
+
+Run `playbridge --help` for all commands and options.
+
+When started interactively, the CLI checks for a newer `cli-v*` release at most
+once per day and prints the install command when an update is available. Network
+failures are silent and retried after one hour. Set `PLAYBRIDGE_NO_UPDATE_CHECK=1`
+to disable the check.
+
+## Build from source
+
+From the repository root:
+
+```sh
+cargo build --release --locked -p playbridge-cast-cli
+```

--- a/packages/playbridge_cast_core_dart/README.md
+++ b/packages/playbridge_cast_core_dart/README.md
@@ -1,0 +1,52 @@
+# PlayBridge Cast Core for Dart
+
+Reusable `dart:ffi` bindings for the PlayBridge Rust casting core. The package
+works in Flutter Desktop and standalone Dart executables on macOS, Windows, and
+Linux.
+
+```dart
+final core = CastCoreLibrary.open();
+final scanner = core.discover(
+  protocols: {ReceiverProtocol.playBridge, ReceiverProtocol.dlna},
+);
+scanner.events.listen(print);
+```
+
+Discovery uses non-blocking native polls on a 50 ms timer. Always call
+`scanner.dispose()` when the owning screen or command exits; a native finalizer
+is retained as a process-exit safety net.
+
+Desktop consumers can also use `SenderServices` when the native library was
+built with the `sender-services` feature:
+
+```dart
+final services = SenderServices.start();
+final media = await services.registerFile(
+  host: '192.168.1.20',
+  path: '/path/to/video.mp4',
+);
+final browser = await services.startBrowser();
+```
+
+`SenderServices` owns one embedded Rust stream proxy. The browser host is
+on-demand and pairing/status events are exposed through `services.events`.
+Dispose the service during application shutdown.
+
+Native receiver applications can use `ReceiverRuntime`. Rust owns the secure
+network and pairing boundary while the Dart application handles command events
+with its platform player:
+
+```dart
+final receiver = ReceiverRuntime.start(
+  ReceiverRuntimeConfig(
+    name: 'My Computer',
+    uuid: deviceId,
+    certificateDer: certificateDerBase64,
+    privateKeyDer: privateKeyDerBase64,
+    privateKeyKind: 'pkcs1',
+    authorizedTokens: storedTokenDigests,
+  ),
+);
+receiver.events.listen(handleReceiverEvent);
+final port = await receiver.started;
+```


### PR DESCRIPTION
## Summary
- Restructures  layout for fast installation flow and monorepo overview.
- Adds Firefox Add-ons and Chrome Web Store links and badges.
- Updates desktop, TV, and phone connection & release documentation.
- Introduces agent skill definitions for  and  under .

## Verification
- Verified Markdown syntax and rendered links across updated docs.
- Checked  against PlayBridge specialist guidelines.