### PR TITLE
feat(cli): add interactive TUI device picker, seekbar control, embedded media server, and self-update

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,13 +12,23 @@ path = "src/main.rs"
 
 [dependencies]
 playbridge-cast-core = { path = "../cast/core" }
-getrandom = "0.4"
+playbridge-cast-receiver = { path = "../cast/receiver" }
+playbridge-browser-receiver = { path = "../browser-receiver-rust" }
+stream-proxy-rust = { path = "../stream-proxy-rust" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time"] }
-tower-http = { version = "0.6", features = ["fs"] }
-axum = "0.8"
+tokio = { version = "1", features = ["io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 crossterm = "0.28"
-
-[dev-dependencies]
+getrandom = "0.4"
+base64 = "0.22"
+futures-util = "0.3"
+mdns-sd = { version = "0.20", default-features = false, features = ["async"] }
+rcgen = "0.14"
+rustls = "0.23"
+sha2 = "0.10"
+tokio-rustls = "0.26"
+tokio-tungstenite = "0.28"
+x509-parser = "0.18"
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+semver = "1"
 tempfile = "3"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, HashSet},
     env,
+    io::IsTerminal,
     process::ExitCode,
     time::Duration,
 };
@@ -73,17 +74,33 @@ enum JsonLine<'a> {
 
 mod credentials;
 mod google_cast;
-mod http_server;
 mod preferred;
+mod receive;
 mod send;
+mod update;
 
 use google_cast::run_google_cast;
 use preferred::PreferredDevice;
-use send::run_send;
+use receive::run_receiver;
+use send::{run_browser_send, run_send};
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    match run(env::args().skip(1).collect()).await {
+    let arguments = env::args().skip(1).collect::<Vec<_>>();
+    if should_check_for_updates(&arguments)
+        && let Some(update) = update::check_for_update().await
+    {
+        eprintln!(
+            "\nUpdate available: PlayBridge CLI {} → {}",
+            env!("CARGO_PKG_VERSION"),
+            update.version
+        );
+        eprintln!(
+            "Run: curl -fsSL https://raw.githubusercontent.com/playbridgeapp/playbridge/main/cli/install.sh | sh\n"
+        );
+    }
+
+    match run(arguments).await {
         Ok(()) => ExitCode::SUCCESS,
         Err(message) => {
             eprintln!("error: {message}");
@@ -94,12 +111,33 @@ async fn main() -> ExitCode {
     }
 }
 
+fn should_check_for_updates(arguments: &[String]) -> bool {
+    if !std::io::stderr().is_terminal()
+        || env::var_os("PLAYBRIDGE_NO_UPDATE_CHECK").is_some()
+        || arguments
+            .iter()
+            .any(|value| matches!(value.as_str(), "--json" | "--json-lines"))
+    {
+        return false;
+    }
+    !arguments
+        .iter()
+        .any(|value| matches!(value.as_str(), "--help" | "-h" | "--version" | "-V"))
+}
+
 async fn run(arguments: Vec<String>) -> Result<(), String> {
     if arguments
         .first()
         .is_some_and(|value| value == "--help" || value == "-h")
     {
         println!("{}", usage());
+        return Ok(());
+    }
+    if arguments
+        .first()
+        .is_some_and(|value| value == "--version" || value == "-V")
+    {
+        println!("playbridge {}", env!("CARGO_PKG_VERSION"));
         return Ok(());
     }
     let Some(command) = arguments.first() else {
@@ -112,6 +150,22 @@ async fn run(arguments: Vec<String>) -> Result<(), String> {
                 return Err("missing media file or URL to send".into());
             };
             run_send(target.clone()).await
+        }
+        "browser" => {
+            let Some(target) = arguments.get(1) else {
+                return Err("missing media file or URL for browser receiver".into());
+            };
+            run_browser_send(target.clone()).await
+        }
+        "receiver" | "receive" => {
+            if arguments[1..]
+                .iter()
+                .any(|value| value == "--help" || value == "-h")
+            {
+                println!("{}", usage());
+                return Ok(());
+            }
+            run_receiver(&arguments[1..]).await
         }
         "discover" => {
             if arguments[1..]
@@ -318,9 +372,12 @@ fn usage() -> &'static str {
     r#"PlayBridge CLI
 
 Usage:
+  playbridge --version                     Print the CLI version
   playbridge <filename|URL>              Interactively cast a file/URL with auto-send
   playbridge send <filename|URL>         Explicit send command
   playbridge cast <filename|URL>         Explicit cast command
+  playbridge browser <filename|URL>      Cast through a sender-hosted browser receiver
+  playbridge receiver [options]         Run as a PlayBridge receiver using mpv
   playbridge discover [options]          Discover receivers on your local network
   playbridge google-cast status [options] Connect to Cast and query status only
   playbridge preferred [clear]           View or clear the saved preferred device
@@ -336,6 +393,9 @@ Google Cast Status Options:
       --address <address> Connect directly instead of discovering
       --port <port>       CastV2 port (default 8009)
       --json              Print the receiver status as JSON
+Receiver Options:
+      --name <name>       Receiver name advertised on the LAN
+      --port <port>       Preferred WSS port (default 8765; tries 10 ports)
   -h, --help              Show this help"#
 }
 

--- a/cli/src/receive.rs
+++ b/cli/src/receive.rs
@@ -1,0 +1,780 @@
+use std::{collections::HashSet, fs, io::Write, path::PathBuf, process::Stdio, time::Duration};
+
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use playbridge_cast_receiver::{
+    PrivateKeyKind, ReceiverCommand, ReceiverConfig, ReceiverEvent, ReceiverHost, ReceiverIdentity,
+};
+use rcgen::{CertificateParams, KeyPair};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+#[cfg(not(unix))]
+use tokio::process::ChildStdin;
+use tokio::{
+    io::AsyncWriteExt,
+    process::{Child, Command},
+};
+#[cfg(unix)]
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    net::{UnixStream, unix::OwnedWriteHalf},
+    time::sleep,
+};
+
+const DEFAULT_PORT: u16 = 8765;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ReceiverState {
+    uuid: String,
+    name: String,
+    certificate_der: String,
+    private_key_der: String,
+    #[serde(default)]
+    tokens: HashSet<String>,
+}
+
+struct Mpv {
+    child: Option<Child>,
+    #[cfg(not(unix))]
+    stdin: Option<ChildStdin>,
+    #[cfg(unix)]
+    ipc: Option<OwnedWriteHalf>,
+    #[cfg(unix)]
+    ipc_path: Option<PathBuf>,
+    state: &'static str,
+    title: Option<String>,
+}
+
+struct MpvSnapshot {
+    state: String,
+    position_ms: u64,
+    duration_ms: u64,
+    title: Option<String>,
+}
+
+impl Mpv {
+    fn new() -> Self {
+        Self {
+            child: None,
+            #[cfg(not(unix))]
+            stdin: None,
+            #[cfg(unix)]
+            ipc: None,
+            #[cfg(unix)]
+            ipc_path: None,
+            state: "idle",
+            title: None,
+        }
+    }
+
+    async fn ensure_started(&mut self) -> Result<(), String> {
+        if self
+            .child
+            .as_mut()
+            .is_some_and(|child| child.try_wait().ok().flatten().is_none())
+        {
+            return Ok(());
+        }
+        #[cfg(unix)]
+        {
+            self.ipc = None;
+            if let Some(path) = self.ipc_path.take() {
+                let _ = fs::remove_file(path);
+            }
+        }
+        let mut command = Command::new("mpv");
+        command.args(["--idle=yes", "--fullscreen=yes", "--msg-level=all=warn"]);
+        #[cfg(unix)]
+        {
+            let path = mpv_ipc_path()?;
+            command.arg(format!("--input-ipc-server={}", path.display()));
+            self.ipc_path = Some(path);
+        }
+        #[cfg(not(unix))]
+        command.arg("--input-terminal=yes");
+
+        #[allow(unused_mut)]
+        let mut child = command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|error| format!("could not launch mpv: {error}"))?;
+        #[cfg(not(unix))]
+        {
+            self.stdin = child.stdin.take();
+        }
+        self.child = Some(child);
+        #[cfg(unix)]
+        self.connect_ipc().await?;
+        Ok(())
+    }
+
+    async fn stop_process(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill().await;
+        }
+        #[cfg(unix)]
+        {
+            self.ipc = None;
+            if let Some(path) = self.ipc_path.take() {
+                let _ = fs::remove_file(path);
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    async fn connect_ipc(&mut self) -> Result<(), String> {
+        let path = self
+            .ipc_path
+            .as_ref()
+            .ok_or("mpv IPC path is unavailable")?;
+        let mut last_error = None;
+        for _ in 0..40 {
+            match UnixStream::connect(path).await {
+                Ok(stream) => {
+                    let (reader, writer) = stream.into_split();
+                    tokio::spawn(async move {
+                        let mut lines = BufReader::new(reader).lines();
+                        while let Ok(Some(_)) = lines.next_line().await {}
+                    });
+                    self.ipc = Some(writer);
+                    return Ok(());
+                }
+                Err(error) => {
+                    last_error = Some(error);
+                    sleep(Duration::from_millis(50)).await;
+                }
+            }
+        }
+        Err(format!(
+            "could not connect to mpv IPC: {}",
+            last_error.map_or_else(|| "timed out".into(), |error| error.to_string())
+        ))
+    }
+
+    async fn command(&mut self, arguments: Vec<Value>, _legacy: String) -> Result<(), String> {
+        self.ensure_started().await?;
+        #[cfg(unix)]
+        {
+            let ipc = self.ipc.as_mut().ok_or("mpv IPC is unavailable")?;
+            let mut frame =
+                serde_json::to_vec(&json!({"command": arguments})).map_err(|e| e.to_string())?;
+            frame.push(b'\n');
+            ipc.write_all(&frame)
+                .await
+                .map_err(|error| format!("could not control mpv: {error}"))
+        }
+        #[cfg(not(unix))]
+        {
+            let stdin = self.stdin.as_mut().ok_or("mpv stdin is unavailable")?;
+            stdin
+                .write_all(format!("{_legacy}\n").as_bytes())
+                .await
+                .map_err(|error| format!("could not control mpv: {error}"))
+        }
+    }
+
+    async fn load(&mut self, item: &Value) -> Result<(), String> {
+        let url = item
+            .get("url")
+            .and_then(Value::as_str)
+            .ok_or("playlist item has no URL")?;
+        let header_values = item
+            .get("headers")
+            .and_then(Value::as_object)
+            .into_iter()
+            .flatten()
+            .filter_map(|(key, value)| value.as_str().map(|value| format!("{key}: {value}")))
+            .collect::<Vec<_>>();
+        let header_fields = header_values.join(",");
+        let escaped = header_fields.replace('\\', "\\\\").replace('"', "\\\"");
+        // This property is global in mpv. Always write it, including an empty
+        // value, so credentials from one stream cannot leak to the next host.
+        self.command(
+            vec![
+                json!("set_property"),
+                json!("http-header-fields"),
+                json!(header_values),
+            ],
+            format!("set http-header-fields \"{escaped}\""),
+        )
+        .await?;
+        let escaped = url.replace('\\', "\\\\").replace('"', "\\\"");
+        self.command(
+            vec![json!("loadfile"), json!(url), json!("replace")],
+            format!("loadfile \"{escaped}\" replace"),
+        )
+        .await?;
+        if let Some(position) = item.get("startPositionMs").and_then(Value::as_u64) {
+            let seconds = position as f64 / 1000.0;
+            self.command(
+                vec![json!("seek"), json!(seconds), json!("absolute+exact")],
+                format!("seek {seconds} absolute exact"),
+            )
+            .await?;
+        }
+        self.state = "playing";
+        self.title = item.get("title").and_then(Value::as_str).map(str::to_owned);
+        Ok(())
+    }
+
+    async fn control(&mut self, command: &str) -> Result<(), String> {
+        match command {
+            "play" => {
+                self.command(
+                    vec![json!("set_property"), json!("pause"), json!(false)],
+                    "set pause no".into(),
+                )
+                .await?;
+                self.state = "playing";
+            }
+            "pause" => {
+                self.command(
+                    vec![json!("set_property"), json!("pause"), json!(true)],
+                    "set pause yes".into(),
+                )
+                .await?;
+                self.state = "paused";
+            }
+            "toggle" => {
+                self.command(vec![json!("cycle"), json!("pause")], "cycle pause".into())
+                    .await?;
+                self.state = if self.state == "playing" {
+                    "paused"
+                } else {
+                    "playing"
+                };
+            }
+            "stop" => {
+                self.command(vec![json!("stop")], "stop".into()).await?;
+                self.state = "idle";
+                self.title = None;
+            }
+            "seek_back" => {
+                self.command(
+                    vec![json!("seek"), json!(-10), json!("relative+exact")],
+                    "seek -10 relative exact".into(),
+                )
+                .await?
+            }
+            "seek_forward" => {
+                self.command(
+                    vec![json!("seek"), json!(10), json!("relative+exact")],
+                    "seek 10 relative exact".into(),
+                )
+                .await?
+            }
+            value if value.starts_with("seek_to:") => {
+                let milliseconds = value["seek_to:".len()..]
+                    .parse::<u64>()
+                    .map_err(|_| "invalid seek position")?;
+                let seconds = milliseconds as f64 / 1000.0;
+                self.command(
+                    vec![json!("seek"), json!(seconds), json!("absolute+exact")],
+                    format!("seek {seconds} absolute exact"),
+                )
+                .await?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    async fn snapshot(&self) -> MpvSnapshot {
+        #[cfg(unix)]
+        if let Some(path) = self.ipc_path.as_deref()
+            && let Ok(snapshot) = query_mpv_status(path, self.title.clone()).await
+        {
+            return snapshot;
+        }
+        MpvSnapshot {
+            state: self.state.into(),
+            position_ms: 0,
+            duration_ms: 0,
+            title: self.title.clone(),
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn query_mpv_status(
+    path: &std::path::Path,
+    title: Option<String>,
+) -> Result<MpvSnapshot, String> {
+    let stream = UnixStream::connect(path)
+        .await
+        .map_err(|error| format!("could not query mpv IPC: {error}"))?;
+    let (reader, mut writer) = stream.into_split();
+    for (request_id, property) in [
+        (1, "time-pos"),
+        (2, "duration"),
+        (3, "pause"),
+        (4, "idle-active"),
+    ] {
+        let mut frame = serde_json::to_vec(&json!({
+            "command": ["get_property", property],
+            "request_id": request_id
+        }))
+        .map_err(|error| error.to_string())?;
+        frame.push(b'\n');
+        writer
+            .write_all(&frame)
+            .await
+            .map_err(|error| format!("could not query mpv: {error}"))?;
+    }
+
+    let mut position = None;
+    let mut duration = None;
+    let mut paused = None;
+    let mut idle = None;
+    let mut lines = BufReader::new(reader).lines();
+    for _ in 0..4 {
+        let line = tokio::time::timeout(Duration::from_millis(500), lines.next_line())
+            .await
+            .map_err(|_| "mpv status query timed out".to_owned())?
+            .map_err(|error| error.to_string())?
+            .ok_or("mpv closed the status connection")?;
+        let response: Value = serde_json::from_str(&line).map_err(|error| error.to_string())?;
+        match response.get("request_id").and_then(Value::as_u64) {
+            Some(1) => position = response.get("data").and_then(Value::as_f64),
+            Some(2) => duration = response.get("data").and_then(Value::as_f64),
+            Some(3) => paused = response.get("data").and_then(Value::as_bool),
+            Some(4) => idle = response.get("data").and_then(Value::as_bool),
+            _ => {}
+        }
+    }
+
+    let state = if idle.unwrap_or(false) {
+        "idle"
+    } else if paused.unwrap_or(false) {
+        "paused"
+    } else {
+        "playing"
+    };
+    Ok(MpvSnapshot {
+        state: state.into(),
+        position_ms: seconds_to_millis(position),
+        duration_ms: seconds_to_millis(duration),
+        title,
+    })
+}
+
+fn seconds_to_millis(seconds: Option<f64>) -> u64 {
+    seconds
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .map(|value| (value * 1000.0).round() as u64)
+        .unwrap_or(0)
+}
+
+pub async fn run_receiver(arguments: &[String]) -> Result<(), String> {
+    let mut port = DEFAULT_PORT;
+    let mut requested_name = None;
+    let mut index = 0;
+    while index < arguments.len() {
+        match arguments[index].as_str() {
+            "--port" => {
+                index += 1;
+                port = arguments
+                    .get(index)
+                    .ok_or("--port requires a value")?
+                    .parse()
+                    .map_err(|_| "invalid receiver port")?;
+            }
+            "--name" => {
+                index += 1;
+                requested_name = Some(
+                    arguments
+                        .get(index)
+                        .ok_or("--name requires a value")?
+                        .clone(),
+                );
+            }
+            unknown => return Err(format!("unknown receiver option: {unknown}")),
+        }
+        index += 1;
+    }
+
+    ensure_mpv_available().await?;
+    let (state_path, mut state) = load_or_create_state(requested_name)?;
+    state.name = state.name.trim().to_owned();
+    save_state(&state_path, &state)?;
+    let mut config = ReceiverConfig::new(
+        state.name.clone(),
+        state.uuid.clone(),
+        ReceiverIdentity {
+            certificate_der: BASE64
+                .decode(&state.certificate_der)
+                .map_err(|error| error.to_string())?,
+            private_key_der: BASE64
+                .decode(&state.private_key_der)
+                .map_err(|error| error.to_string())?,
+            private_key_kind: PrivateKeyKind::Pkcs8,
+        },
+    );
+    config.preferred_port = port;
+    config.fallback_attempts = 10;
+    config.authorized_tokens = state.tokens.iter().cloned().collect();
+    config.players = vec!["internal_mpv".into()];
+    config.advertise = true;
+    let host = ReceiverHost::start(config).await?;
+    let mut events = host.subscribe();
+    let mut playback = ReceiverPlayback::new();
+    let mut status_tick = tokio::time::interval(Duration::from_millis(500));
+    status_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    println!(
+        "PlayBridge receiver \"{}\" is ready on port {}.",
+        state.name,
+        host.port()
+    );
+    println!("Playback uses the installed mpv command. Press Ctrl+C to stop.");
+
+    loop {
+        tokio::select! {
+            event = events.recv() => {
+                match event {
+                    Ok(ReceiverEvent::PairingStarted { device_name, .. }) => {
+                        println!("Pairing request from {device_name}.");
+                    }
+                    Ok(ReceiverEvent::PairingRequested { sas_code, .. }) => {
+                        println!("Pairing code: {sas_code}");
+                    }
+                    Ok(ReceiverEvent::Paired {
+                        device_name,
+                        token,
+                        ..
+                    }) => {
+                        state.tokens.insert(token);
+                        save_state(&state_path, &state)?;
+                        println!("Sender \"{device_name}\" paired.");
+                    }
+                    Ok(ReceiverEvent::Command { command, .. }) => {
+                        if let Err(error) = handle_command(&host, &mut playback, command).await {
+                            eprintln!("Playback command failed: {error}");
+                        }
+                    }
+                    Ok(ReceiverEvent::Error { message, .. }) => {
+                        eprintln!("receiver connection ended: {message}");
+                    }
+                    Ok(_) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+            _ = status_tick.tick() => {
+                broadcast_status(&host, &playback).await;
+            }
+            _ = tokio::signal::ctrl_c() => {
+                playback.mpv.stop_process().await;
+                host.shutdown().await;
+                return Ok(());
+            }
+        }
+    }
+    playback.mpv.stop_process().await;
+    host.shutdown().await;
+    Ok(())
+}
+
+struct ReceiverPlayback {
+    mpv: Mpv,
+    queue: Vec<Value>,
+    current_index: usize,
+}
+
+impl ReceiverPlayback {
+    fn new() -> Self {
+        Self {
+            mpv: Mpv::new(),
+            queue: Vec::new(),
+            current_index: 0,
+        }
+    }
+}
+
+async fn handle_command(
+    host: &ReceiverHost,
+    playback: &mut ReceiverPlayback,
+    command: ReceiverCommand,
+) -> Result<(), String> {
+    match command {
+        ReceiverCommand::ContextQuery => {
+            host.broadcast(json!({
+                "type":"context",
+                "active": if playback.mpv.state == "idle" {"idle"} else {"player"}
+            }));
+            broadcast_status(host, playback).await;
+            broadcast_playlist(host, playback);
+        }
+        ReceiverCommand::Playlist(payload) => {
+            let items = payload
+                .get("items")
+                .and_then(Value::as_array)
+                .ok_or("playlist has no items")?;
+            let index = payload
+                .get("startIndex")
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as usize;
+            playback.queue = items.clone();
+            playback.current_index = index.min(playback.queue.len().saturating_sub(1));
+            let item = playback
+                .queue
+                .get(index)
+                .or_else(|| playback.queue.first())
+                .ok_or("playlist is empty")?;
+            let title = item
+                .get("title")
+                .and_then(Value::as_str)
+                .unwrap_or("untitled media");
+            println!(
+                "Received playlist ({} item(s)); playing \"{title}\".",
+                items.len()
+            );
+            playback.mpv.load(item).await?;
+            println!("Sent playback request to mpv.");
+            broadcast_status(host, playback).await;
+            broadcast_playlist(host, playback);
+        }
+        ReceiverCommand::QueueAdd(payload) => {
+            let item = payload
+                .get("item")
+                .cloned()
+                .ok_or("queue_add has no item")?;
+            let was_empty = playback.queue.is_empty();
+            playback.queue.push(item);
+            if was_empty {
+                playback.current_index = 0;
+                playback.mpv.load(&playback.queue[0]).await?;
+            }
+            broadcast_playlist(host, playback);
+        }
+        ReceiverCommand::PlaylistJump(payload) => {
+            let index = payload
+                .get("index")
+                .and_then(Value::as_u64)
+                .ok_or("playlist_jump has no index")? as usize;
+            let item = playback
+                .queue
+                .get(index)
+                .ok_or("playlist index is out of range")?;
+            playback.current_index = index;
+            playback.mpv.load(item).await?;
+            broadcast_playlist(host, playback);
+        }
+        ReceiverCommand::Control(payload) => {
+            if let Some(command) = payload.get("command").and_then(Value::as_str) {
+                playback.mpv.control(command).await?;
+                broadcast_status(host, playback).await;
+                if command == "stop" {
+                    playback.queue.clear();
+                    playback.current_index = 0;
+                    host.broadcast(json!({"type":"context","active":"idle"}));
+                    broadcast_playlist(host, playback);
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+async fn broadcast_status(host: &ReceiverHost, playback: &ReceiverPlayback) {
+    let snapshot = playback.mpv.snapshot().await;
+    host.broadcast(json!({
+        "type": "status",
+        "state": snapshot.state,
+        "position": snapshot.position_ms,
+        "duration": snapshot.duration_ms,
+        "title": snapshot.title
+    }));
+}
+
+fn broadcast_playlist(host: &ReceiverHost, playback: &ReceiverPlayback) {
+    let items = playback
+        .queue
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            json!({
+                "index": index,
+                "title": item.get("title").and_then(Value::as_str).unwrap_or("untitled media")
+            })
+        })
+        .collect::<Vec<_>>();
+    host.broadcast(json!({
+        "type":"playlist_status",
+        "items":items,
+        "currentIndex":playback.current_index,
+        "totalCount":playback.queue.len()
+    }));
+}
+
+async fn ensure_mpv_available() -> Result<(), String> {
+    Command::new("mpv")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map_err(|_| "mpv was not found in PATH".to_owned())
+        .and_then(|status| {
+            status
+                .success()
+                .then_some(())
+                .ok_or_else(|| "mpv --version failed".to_owned())
+        })
+}
+
+fn state_path() -> Result<PathBuf, String> {
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .ok_or("could not determine home directory")?;
+    Ok(PathBuf::from(home).join(".config/playbridge/receiver.json"))
+}
+
+fn load_or_create_state(
+    requested_name: Option<String>,
+) -> Result<(PathBuf, ReceiverState), String> {
+    let path = state_path()?;
+    if let Ok(contents) = fs::read_to_string(&path) {
+        let mut state: ReceiverState =
+            serde_json::from_str(&contents).map_err(|error| error.to_string())?;
+        if let Some(name) = requested_name.filter(|name| !name.trim().is_empty()) {
+            state.name = name;
+        }
+        return Ok((path, state));
+    }
+    let name = requested_name.unwrap_or_else(host_name);
+    let key = KeyPair::generate().map_err(|error| error.to_string())?;
+    let params = CertificateParams::new(vec![name.clone(), "localhost".into()])
+        .map_err(|error| error.to_string())?;
+    let certificate = params
+        .self_signed(&key)
+        .map_err(|error| error.to_string())?;
+    let state = ReceiverState {
+        uuid: random_token()?,
+        name,
+        certificate_der: BASE64.encode(certificate.der()),
+        private_key_der: BASE64.encode(key.serialize_der()),
+        tokens: HashSet::new(),
+    };
+    save_state(&path, &state)?;
+    Ok((path, state))
+}
+
+fn save_state(path: &PathBuf, state: &ReceiverState) -> Result<(), String> {
+    let parent = path.parent().ok_or("receiver state path has no parent")?;
+    fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(parent, fs::Permissions::from_mode(0o700))
+            .map_err(|error| error.to_string())?;
+    }
+    let mut file = tempfile::NamedTempFile::new_in(parent).map_err(|error| error.to_string())?;
+    file.write_all(&serde_json::to_vec_pretty(state).map_err(|error| error.to_string())?)
+        .map_err(|error| error.to_string())?;
+    file.as_file()
+        .sync_all()
+        .map_err(|error| error.to_string())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(file.path(), fs::Permissions::from_mode(0o600))
+            .map_err(|error| error.to_string())?;
+    }
+    file.persist(path)
+        .map_err(|error| error.error.to_string())?;
+    Ok(())
+}
+
+fn random_token() -> Result<String, String> {
+    let mut bytes = [0_u8; 16];
+    getrandom::fill(&mut bytes).map_err(|error| error.to_string())?;
+    Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+#[cfg(unix)]
+fn mpv_ipc_path() -> Result<PathBuf, String> {
+    let random = random_token()?;
+    Ok(PathBuf::from(format!(
+        "/tmp/pb-mpv-{}-{}.sock",
+        std::process::id(),
+        &random[..16]
+    )))
+}
+
+fn host_name() -> String {
+    std::env::var("HOSTNAME")
+        .or_else(|_| std::env::var("COMPUTERNAME"))
+        .unwrap_or_else(|_| "PlayBridge CLI".into())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn mpv_seconds_are_reported_as_protocol_milliseconds() {
+        assert_eq!(super::seconds_to_millis(Some(12.345)), 12_345);
+        assert_eq!(super::seconds_to_millis(Some(f64::NAN)), 0);
+        assert_eq!(super::seconds_to_millis(Some(-1.0)), 0);
+        assert_eq!(super::seconds_to_millis(None), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mpv_ipc_path_fits_unix_socket_limits() {
+        let path = super::mpv_ipc_path().unwrap();
+        let text = path.to_string_lossy();
+        assert!(text.starts_with("/tmp/pb-mpv-"));
+        // macOS sockaddr_un.sun_path is 104 bytes including the terminator.
+        assert!(text.len() < 104, "IPC path is too long: {text}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mpv_status_query_maps_ipc_properties_to_protocol_units() {
+        use tokio::{
+            io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+            net::UnixListener,
+        };
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("mpv.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, mut writer) = stream.into_split();
+            let mut lines = BufReader::new(reader).lines();
+            for (request_id, data) in [
+                (1, serde_json::json!(12.5)),
+                (2, serde_json::json!(100.0)),
+                (3, serde_json::json!(false)),
+                (4, serde_json::json!(false)),
+            ] {
+                lines.next_line().await.unwrap().unwrap();
+                writer
+                    .write_all(
+                        format!(
+                            "{}\n",
+                            serde_json::json!({
+                                "request_id": request_id,
+                                "error": "success",
+                                "data": data
+                            })
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let snapshot = super::query_mpv_status(&path, Some("Video".into()))
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(snapshot.state, "playing");
+        assert_eq!(snapshot.position_ms, 12_500);
+        assert_eq!(snapshot.duration_ms, 100_000);
+        assert_eq!(snapshot.title.as_deref(), Some("Video"));
+    }
+}

--- a/cli/src/send.rs
+++ b/cli/src/send.rs
@@ -8,13 +8,19 @@ use crossterm::{
     },
 };
 use std::{
+    collections::HashMap,
     io::{self, Write},
     path::PathBuf,
     time::Duration,
 };
 use tokio::time::sleep;
 
+use playbridge_browser_receiver::{
+    BrowserReceiverConfig, BrowserReceiverEvent, BrowserReceiverHost, BrowserReceiverService,
+    local_urls,
+};
 use playbridge_cast_core::{
+    browser::{BrowserCommand, BrowserMedia, BrowserPlaybackState},
     castv2,
     discovery::{DiscoveryConfig, DiscoveryEvent, DiscoveryStream, Receiver, ReceiverProtocol},
     playbridge::{PairingSession, ReceiverFrame, SenderFrame},
@@ -22,9 +28,9 @@ use playbridge_cast_core::{
     session::{MediaRequest, PlaybackState, ReceiverSession},
     upnp::Renderer,
 };
+use stream_proxy_rust::{ProxyServer, ProxyServerConfig};
 
 use crate::credentials::PlaybridgeCredentials;
-use crate::http_server::LocalMediaServer;
 use crate::preferred::PreferredDevice;
 
 struct RawModeGuard;
@@ -69,31 +75,204 @@ impl Drop for PickerTerminalGuard {
     }
 }
 
+pub async fn run_browser_send(media_target: String) -> Result<(), String> {
+    println!("Media Target: {}", display_media_target(&media_target));
+    validate_media_target(&media_target)?;
+    let (media_url, control, proxy) = cast_to_browser(&media_target, None, None).await?;
+    wait_for_server_exit(&media_url, Some(control), Some(proxy)).await;
+    Ok(())
+}
+
+async fn cast_to_browser(
+    media_target: &str,
+    existing_proxy: Option<ProxyServer>,
+    existing_media_url: Option<String>,
+) -> Result<(String, TargetControl, ProxyServer), String> {
+    validate_media_target(media_target)?;
+    let host = BrowserReceiverHost::start(BrowserReceiverConfig::default()).await?;
+    println!("Open one of these addresses on the receiving device:");
+    for url in host.urls() {
+        println!("  {url}");
+    }
+    println!("Waiting for a browser receiver. Press Ctrl+C to cancel.");
+
+    let proxy = match existing_proxy {
+        Some(proxy) => proxy,
+        None => ProxyServer::start(ProxyServerConfig::default()).await?,
+    };
+    let proxy_host = primary_lan_host(proxy.local_addr().port())?;
+    let media_url = match existing_media_url {
+        Some(url) => url,
+        None => {
+            let path = resolve_media_path(media_target);
+            if path.is_file() {
+                proxy
+                    .register_file(&proxy_host, path, None, Duration::from_secs(6 * 60 * 60))?
+                    .url
+            } else {
+                proxy
+                    .register_remote(&proxy_host, media_target, HashMap::new())?
+                    .url
+            }
+        }
+    };
+    let service = host.service();
+    let mut events = service.subscribe();
+    loop {
+        let event = tokio::select! {
+            event = events.recv() => event.map_err(|error| error.to_string())?,
+            _ = tokio::signal::ctrl_c() => return Err("Browser receiver setup cancelled".into()),
+        };
+        if let BrowserReceiverEvent::PairingRequested { session, .. } = event {
+            println!("\nPairing request from \"{}\".", session.name);
+            print!("Enter the six-digit code shown in the browser: ");
+            io::stdout().flush().map_err(|error| error.to_string())?;
+            let code = tokio::task::spawn_blocking(|| {
+                let mut input = String::new();
+                io::stdin()
+                    .read_line(&mut input)
+                    .map(|_| input)
+                    .map_err(|error| error.to_string())
+            })
+            .await
+            .map_err(|error| error.to_string())??;
+            match service.approve(&session.session_id, code.trim()).await {
+                Ok(()) => {
+                    let media = BrowserMedia {
+                        url: media_url.clone(),
+                        title: media_title(media_target),
+                        content_type: media_content_type(media_target),
+                        poster_url: None,
+                        subtitle_url: None,
+                        start_position_ms: None,
+                    };
+                    service.load(&session.session_id, media).await?;
+                    println!("Casting to \"{}\" via Web Browser.", session.name);
+                    return Ok((
+                        media_url,
+                        TargetControl::Browser {
+                            host,
+                            service,
+                            session_id: session.session_id,
+                            events,
+                        },
+                        proxy,
+                    ));
+                }
+                Err(error) => eprintln!("Pairing failed: {error}"),
+            }
+        }
+    }
+}
+
+fn resolve_media_path(media_target: &str) -> PathBuf {
+    if let Some(relative) = media_target.strip_prefix("~/")
+        && let Some(home) = std::env::var_os("HOME")
+    {
+        return PathBuf::from(home).join(relative);
+    }
+    PathBuf::from(media_target)
+}
+
+fn validate_media_target(media_target: &str) -> Result<(), String> {
+    let target = media_target.trim();
+    if target.is_empty() {
+        return Err("media target cannot be empty".into());
+    }
+
+    let path = resolve_media_path(target);
+    if path.exists() {
+        if path.is_file() {
+            return Ok(());
+        }
+        return Err(format!("media path is not a file: {}", path.display()));
+    }
+
+    if target.starts_with("http://") || target.starts_with("https://") {
+        return Ok(());
+    }
+
+    Err(format!("media file does not exist: {}", path.display()))
+}
+
+fn display_media_target(target: &str) -> String {
+    let Ok(url) = reqwest::Url::parse(target) else {
+        return target.to_owned();
+    };
+    let Some(host) = url.host_str() else {
+        return "<redacted URL>".into();
+    };
+    let port = url
+        .port()
+        .map_or_else(String::new, |port| format!(":{port}"));
+    let query = url.query().map_or("", |_| "?<redacted>");
+    format!("{}://{host}{port}{}{query}", url.scheme(), url.path())
+}
+
+fn primary_lan_host(port: u16) -> Result<String, String> {
+    let url = local_urls(port)
+        .into_iter()
+        .find(|url| !url.contains("127.0.0.1"))
+        .or_else(|| local_urls(port).into_iter().next())
+        .ok_or_else(|| "could not determine a LAN address for the media proxy".to_owned())?;
+    url.strip_prefix("http://")
+        .and_then(|value| value.rsplit_once(':').map(|(host, _)| host.to_owned()))
+        .ok_or_else(|| "invalid local proxy address".to_owned())
+}
+
+fn media_title(target: &str) -> Option<String> {
+    let path = resolve_media_path(target);
+    path.file_name()
+        .and_then(|value| value.to_str())
+        .map(str::to_owned)
+}
+
+fn media_content_type(target: &str) -> Option<String> {
+    let lower = target
+        .split('?')
+        .next()
+        .unwrap_or(target)
+        .to_ascii_lowercase();
+    let content_type = if lower.ends_with(".m3u8") {
+        "application/vnd.apple.mpegurl"
+    } else if lower.ends_with(".mpd") {
+        "application/dash+xml"
+    } else if lower.ends_with(".webm") {
+        "video/webm"
+    } else if lower.ends_with(".mp3") {
+        "audio/mpeg"
+    } else if lower.ends_with(".m4a") {
+        "audio/mp4"
+    } else if lower.ends_with(".mp4") || lower.ends_with(".m4v") {
+        "video/mp4"
+    } else {
+        return None;
+    };
+    Some(content_type.into())
+}
+
 #[allow(clippy::collapsible_if)]
 pub async fn run_send(media_target: String) -> Result<(), String> {
-    println!("Media Target: {media_target}");
+    println!("Media Target: {}", display_media_target(&media_target));
+    validate_media_target(&media_target)?;
 
     // Resolve local file vs remote URL
-    let resolved_path = if let Some(relative) = media_target.strip_prefix("~/") {
-        if let Some(home) = std::env::var_os("HOME") {
-            let mut path = PathBuf::from(home);
-            path.push(relative);
-            path
-        } else {
-            PathBuf::from(&media_target)
-        }
-    } else {
-        PathBuf::from(&media_target)
-    };
+    let resolved_path = resolve_media_path(&media_target);
 
-    let (media_url, _server_handle) = if resolved_path.exists() && resolved_path.is_file() {
+    let (media_url, mut proxy_server) = if resolved_path.exists() && resolved_path.is_file() {
         println!(
-            "Starting local HTTP media server for {:?}...",
+            "Starting Rust media proxy for {:?}...",
             resolved_path.file_name().unwrap_or_default()
         );
-        let (server, handle) = LocalMediaServer::start(resolved_path).await?;
-        println!("Local HTTP server running at {}\n", server.url);
-        (server.url, Some(handle))
+        let server = ProxyServer::start(ProxyServerConfig::default()).await?;
+        let host = primary_lan_host(server.local_addr().port())?;
+        let media =
+            server.register_file(&host, resolved_path, None, Duration::from_secs(6 * 60 * 60))?;
+        println!(
+            "Local media proxy running at {}\n",
+            display_media_target(&media.url)
+        );
+        (media.url, Some(server))
     } else {
         (media_target.clone(), None)
     };
@@ -164,7 +343,7 @@ pub async fn run_send(media_target: String) -> Result<(), String> {
             };
             match result {
                 Ok(channel_opt) => {
-                    wait_for_server_exit(&media_url, channel_opt, _server_handle.is_some()).await;
+                    wait_for_server_exit(&media_url, channel_opt, proxy_server.take()).await;
                     return Ok(());
                 }
                 Err(err) => {
@@ -178,7 +357,18 @@ pub async fn run_send(media_target: String) -> Result<(), String> {
     }
 
     // 2. Continuous live discovery and interactive menu
-    let (target, make_preferred) = live_discovery_interactive_select().await?;
+    let selection = live_discovery_interactive_select().await?;
+    let (target, make_preferred) = match selection {
+        PickerSelection::Browser => {
+            let final_existing_media_url = proxy_server.as_ref().map(|_| media_url.clone());
+            let (browser_url, control, browser_proxy) =
+                cast_to_browser(&media_target, proxy_server.take(), final_existing_media_url)
+                    .await?;
+            wait_for_server_exit(&browser_url, Some(control), Some(browser_proxy)).await;
+            return Ok(());
+        }
+        PickerSelection::Receiver(target, make_preferred) => (target, make_preferred),
+    };
 
     let address = target
         .addresses
@@ -238,7 +428,7 @@ pub async fn run_send(media_target: String) -> Result<(), String> {
     };
 
     if result.is_ok() {
-        wait_for_server_exit(&media_url, channel_opt, _server_handle.is_some()).await;
+        wait_for_server_exit(&media_url, channel_opt, proxy_server.take()).await;
     }
 
     result
@@ -254,6 +444,12 @@ enum TargetControl {
     Dlna(Renderer),
     Playbridge(Box<SecureWebSocket>),
     Roku(ReceiverSession),
+    Browser {
+        host: BrowserReceiverHost,
+        service: BrowserReceiverService,
+        session_id: String,
+        events: tokio::sync::broadcast::Receiver<BrowserReceiverEvent>,
+    },
 }
 
 fn format_time(secs: f64) -> String {
@@ -307,9 +503,9 @@ fn parse_dlna_time(time_str: &str) -> Option<f64> {
 async fn wait_for_server_exit(
     media_url: &str,
     mut target_control: Option<TargetControl>,
-    is_local_server: bool,
+    proxy_server: Option<ProxyServer>,
 ) {
-    if is_local_server || target_control.is_some() {
+    if proxy_server.is_some() || target_control.is_some() {
         println!("\nStreaming media at {}", media_url);
         println!("Interactive Controls:");
         match target_control {
@@ -345,6 +541,14 @@ async fn wait_for_server_exit(
                 println!("  [Right] / [D] : Fast Forward");
                 println!("  [Q] / [Ctrl+C]: Stop Playback & Exit\n");
             }
+            Some(TargetControl::Browser { .. }) => {
+                println!("  [Space] / [P] : Pause / Resume");
+                println!("  [Left]  / [A] : Seek Backward (-10s)");
+                println!("  [Right] / [D] : Seek Forward (+10s)");
+                println!("  [Up]    / [W] : Volume Up (+5%)");
+                println!("  [Down]  / [S] : Volume Down (-5%)");
+                println!("  [Q] / [Ctrl+C]: Stop Playback & Exit\n");
+            }
             None => {
                 println!("  [Q] / [Ctrl+C]: Stop Local Server & Exit\n");
             }
@@ -359,6 +563,7 @@ async fn wait_for_server_exit(
         let mut last_tick = tokio::time::Instant::now();
         let mut current_pos_secs: f64 = 0.0;
         let mut duration_secs: f64 = 0.0;
+        let mut browser_disconnected = false;
 
         loop {
             // Update local time estimate if playing
@@ -481,6 +686,39 @@ async fn wait_for_server_exit(
                 }
             }
 
+            if let Some(TargetControl::Browser { ref mut events, .. }) = target_control {
+                while let Ok(event) = events.try_recv() {
+                    match event {
+                        BrowserReceiverEvent::Status { session, .. } => {
+                            current_pos_secs = session.status.position_ms as f64 / 1000.0;
+                            duration_secs = session.status.duration_ms as f64 / 1000.0;
+                            volume_level = session.status.volume as f32;
+                            is_paused = matches!(
+                                session.status.state,
+                                BrowserPlaybackState::Paused
+                                    | BrowserPlaybackState::AutoplayBlocked
+                            );
+                        }
+                        BrowserReceiverEvent::Ended { session } => {
+                            current_pos_secs = session.status.duration_ms as f64 / 1000.0;
+                            duration_secs = current_pos_secs;
+                            is_paused = true;
+                        }
+                        BrowserReceiverEvent::Error { message, .. } => {
+                            print!("\r\x1b[K[Browser receiver error: {message}]");
+                        }
+                        BrowserReceiverEvent::Disconnected { .. } => {
+                            browser_disconnected = true;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            if browser_disconnected {
+                print!("\r\x1b[K[Browser receiver disconnected]");
+                break;
+            }
+
             // Keyboard input polling
             if event::poll(Duration::from_millis(80)).unwrap_or(false) {
                 if let Ok(Event::Key(key)) = event::read() {
@@ -556,6 +794,21 @@ async fn wait_for_server_exit(
                                         if is_paused { "PAUSED" } else { "PLAYING" }
                                     );
                                 }
+                                Some(TargetControl::Browser {
+                                    ref service,
+                                    ref session_id,
+                                    ..
+                                }) => {
+                                    let action = if is_paused {
+                                        BrowserCommand::Pause
+                                    } else {
+                                        BrowserCommand::Play
+                                    };
+                                    if let Err(error) = service.command(session_id, action, None) {
+                                        is_paused = !is_paused;
+                                        print!("\r\x1b[K[Browser control failed: {error}]");
+                                    }
+                                }
                                 None => {}
                             }
                             let _ = io::stdout().flush();
@@ -610,6 +863,17 @@ async fn wait_for_server_exit(
                                     };
                                     let _ = socket.send(&cmd).await;
                                     print!("\r\x1b[K[Seek -10s]");
+                                }
+                                Some(TargetControl::Browser {
+                                    ref service,
+                                    ref session_id,
+                                    ..
+                                }) => {
+                                    let _ = service.command(
+                                        session_id,
+                                        BrowserCommand::Seek,
+                                        Some(current_pos_secs * 1000.0),
+                                    );
                                 }
                                 None => {}
                             }
@@ -666,6 +930,17 @@ async fn wait_for_server_exit(
                                     let _ = socket.send(&cmd).await;
                                     print!("\r\x1b[K[Seek +10s]");
                                 }
+                                Some(TargetControl::Browser {
+                                    ref service,
+                                    ref session_id,
+                                    ..
+                                }) => {
+                                    let _ = service.command(
+                                        session_id,
+                                        BrowserCommand::Seek,
+                                        Some(current_pos_secs * 1000.0),
+                                    );
+                                }
                                 None => {}
                             }
                             let _ = io::stdout().flush();
@@ -690,6 +965,18 @@ async fn wait_for_server_exit(
                                     let _ = socket.send(&cmd).await;
                                     print!("\r\x1b[K[Volume Up]");
                                 }
+                                Some(TargetControl::Browser {
+                                    ref service,
+                                    ref session_id,
+                                    ..
+                                }) => {
+                                    let _ = service.command(
+                                        session_id,
+                                        BrowserCommand::SetVolume,
+                                        Some(volume_level as f64),
+                                    );
+                                    print!("\r\x1b[K[Volume: {:.0}%]", volume_level * 100.0);
+                                }
                                 _ => {}
                             }
                             let _ = io::stdout().flush();
@@ -713,6 +1000,18 @@ async fn wait_for_server_exit(
                                     };
                                     let _ = socket.send(&cmd).await;
                                     print!("\r\x1b[K[Volume Down]");
+                                }
+                                Some(TargetControl::Browser {
+                                    ref service,
+                                    ref session_id,
+                                    ..
+                                }) => {
+                                    let _ = service.command(
+                                        session_id,
+                                        BrowserCommand::SetVolume,
+                                        Some(volume_level as f64),
+                                    );
+                                    print!("\r\x1b[K[Volume: {:.0}%]", volume_level * 100.0);
                                 }
                                 _ => {}
                             }
@@ -861,15 +1160,32 @@ async fn wait_for_server_exit(
                     eprintln!("\nwarning: failed to stop Roku playback: {error}");
                 }
             }
+            Some(TargetControl::Browser {
+                host,
+                service,
+                session_id,
+                ..
+            }) => {
+                let _ = service.command(&session_id, BrowserCommand::Stop, None);
+                service.disconnect(&session_id);
+                if let Err(error) = host.shutdown().await {
+                    eprintln!("\nwarning: failed to stop browser receiver host: {error}");
+                }
+            }
             None => {}
         }
 
         println!("\nStopped streaming.");
     }
+    if let Some(server) = proxy_server
+        && let Err(error) = server.shutdown().await
+    {
+        eprintln!("warning: failed to stop media proxy: {error}");
+    }
 }
 
 #[allow(clippy::collapsible_if)]
-async fn live_discovery_interactive_select() -> Result<(Receiver, bool), String> {
+async fn live_discovery_interactive_select() -> Result<PickerSelection, String> {
     let mut stream = DiscoveryStream::start(DiscoveryConfig::default());
     let mut receivers = Vec::<Receiver>::new();
     let mut selection = 0usize;
@@ -888,15 +1204,24 @@ async fn live_discovery_interactive_select() -> Result<(Receiver, bool), String>
                         selection -= 1;
                         redraw(&receivers, selection)?;
                     }
-                    KeyCode::Down if !receivers.is_empty() && selection + 1 < receivers.len() => {
+                    KeyCode::Down if selection + 1 < receivers.len() + 1 => {
                         selection += 1;
                         redraw(&receivers, selection)?;
                     }
-                    KeyCode::Enter if !receivers.is_empty() => {
-                        break Ok((receivers[selection].clone(), false));
+                    KeyCode::Enter if selection == receivers.len() => {
+                        break Ok(PickerSelection::Browser);
                     }
-                    KeyCode::Char('p') | KeyCode::Char('P') if !receivers.is_empty() => {
-                        break Ok((receivers[selection].clone(), true));
+                    KeyCode::Enter if selection < receivers.len() => {
+                        break Ok(PickerSelection::Receiver(
+                            receivers[selection].clone(),
+                            false,
+                        ));
+                    }
+                    KeyCode::Char('p') | KeyCode::Char('P') if selection < receivers.len() => {
+                        break Ok(PickerSelection::Receiver(
+                            receivers[selection].clone(),
+                            true,
+                        ));
                     }
                     KeyCode::Char('r') | KeyCode::Char('R') => {
                         receivers.clear();
@@ -955,17 +1280,34 @@ fn redraw(receivers: &[Receiver], selection: usize) -> Result<(), String> {
             .map_err(|error| error.to_string())?;
         }
     }
+    let browser_prefix = if selection == receivers.len() {
+        ">"
+    } else {
+        " "
+    };
+    write!(
+        stdout,
+        "\r\nWeb Browser\r\n  {} Open receiver setup page\r\n",
+        browser_prefix
+    )
+    .map_err(|error| error.to_string())?;
 
     write!(
         stdout,
-        "\r\n[↑/↓] Navigate  [Enter] Cast  [P] Preferred  [R] Rescan  [Q] Cancel\r\n"
+        "\r\n[↑/↓] Navigate  [Enter] Cast/Setup  [P] Preferred  [R] Rescan  [Q] Cancel\r\n"
     )
     .map_err(|error| error.to_string())?;
 
     stdout.flush().map_err(|error| error.to_string())
 }
 
+enum PickerSelection {
+    Receiver(Receiver, bool),
+    Browser,
+}
+
 fn upsert_receiver(receivers: &mut Vec<Receiver>, receiver: Receiver, selection: &mut usize) {
+    let browser_selected = *selection == receivers.len();
     let selected_id = receivers.get(*selection).map(|item| item.id.clone());
     if let Some(existing) = receivers.iter_mut().find(|item| item.id == receiver.id) {
         *existing = receiver;
@@ -978,9 +1320,13 @@ fn upsert_receiver(receivers: &mut Vec<Receiver>, receiver: Receiver, selection:
             .then_with(|| left.name.to_lowercase().cmp(&right.name.to_lowercase()))
             .then_with(|| left.id.0.cmp(&right.id.0))
     });
-    *selection = selected_id
-        .and_then(|id| receivers.iter().position(|item| item.id == id))
-        .unwrap_or_else(|| (*selection).min(receivers.len().saturating_sub(1)));
+    *selection = if browser_selected {
+        receivers.len()
+    } else {
+        selected_id
+            .and_then(|id| receivers.iter().position(|item| item.id == id))
+            .unwrap_or_else(|| (*selection).min(receivers.len().saturating_sub(1)))
+    };
 }
 
 const fn protocol_rank(protocol: ReceiverProtocol) -> u8 {
@@ -1294,5 +1640,28 @@ mod tests {
             &["fe80::1%en0", "192.168.1.32", "fdeb::2"],
         );
         assert_eq!(address_summary(&receiver), "192.168.1.32 (+2 more)");
+    }
+
+    #[test]
+    fn media_target_validation_accepts_http_urls() {
+        assert!(validate_media_target("https://example.test/video.mpd").is_ok());
+    }
+
+    #[test]
+    fn media_target_validation_explains_missing_local_files() {
+        let error = validate_media_target("/definitely/missing/video.mpd").unwrap_err();
+        assert!(error.contains("media file does not exist"));
+        assert!(error.contains("/definitely/missing/video.mpd"));
+    }
+
+    #[test]
+    fn display_media_target_redacts_url_credentials() {
+        assert_eq!(
+            display_media_target(
+                "https://user:password@example.test/video.m3u8?token=secret#fragment"
+            ),
+            "https://example.test/video.m3u8?<redacted>"
+        );
+        assert_eq!(display_media_target("/tmp/video.mp4"), "/tmp/video.mp4");
     }
 }

--- a/cli/src/update.rs
+++ b/cli/src/update.rs
@@ -1,0 +1,195 @@
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    path::PathBuf,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+const RELEASES_URL: &str =
+    "https://api.github.com/repos/playbridgeapp/playbridge/releases?per_page=30";
+const SUCCESS_CACHE_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+const FAILURE_CACHE_AGE: Duration = Duration::from_secs(60 * 60);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AvailableUpdate {
+    pub version: Version,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct UpdateCache {
+    checked_at: u64,
+    latest_version: Option<String>,
+    check_succeeded: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    draft: bool,
+    prerelease: bool,
+}
+
+pub async fn check_for_update() -> Option<AvailableUpdate> {
+    let current = Version::parse(env!("CARGO_PKG_VERSION")).ok()?;
+    let now = unix_timestamp();
+
+    if let Some(cache) = load_cache()
+        && cache_is_fresh(&cache, now)
+    {
+        return newer_version(&current, cache.latest_version.as_deref());
+    }
+
+    let result = fetch_latest_version().await;
+    let cache = match &result {
+        Ok(version) => UpdateCache {
+            checked_at: now,
+            latest_version: version.as_ref().map(ToString::to_string),
+            check_succeeded: true,
+        },
+        Err(()) => UpdateCache {
+            checked_at: now,
+            latest_version: None,
+            check_succeeded: false,
+        },
+    };
+    let _ = save_cache(&cache);
+
+    result
+        .ok()
+        .flatten()
+        .filter(|latest| latest > &current)
+        .map(|version| AvailableUpdate { version })
+}
+
+async fn fetch_latest_version() -> Result<Option<Version>, ()> {
+    let client = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .user_agent(concat!("playbridge-cli/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|_| ())?;
+    let releases = client
+        .get(RELEASES_URL)
+        .send()
+        .await
+        .map_err(|_| ())?
+        .error_for_status()
+        .map_err(|_| ())?
+        .json::<Vec<GithubRelease>>()
+        .await
+        .map_err(|_| ())?;
+    Ok(latest_cli_version(&releases))
+}
+
+fn latest_cli_version(releases: &[GithubRelease]) -> Option<Version> {
+    releases
+        .iter()
+        .filter(|release| !release.draft && !release.prerelease)
+        .filter_map(|release| release.tag_name.strip_prefix("cli-v"))
+        .filter_map(|version| Version::parse(version).ok())
+        .max()
+}
+
+fn newer_version(current: &Version, latest: Option<&str>) -> Option<AvailableUpdate> {
+    let latest = Version::parse(latest?).ok()?;
+    (latest > *current).then_some(AvailableUpdate { version: latest })
+}
+
+fn cache_is_fresh(cache: &UpdateCache, now: u64) -> bool {
+    let max_age = if cache.check_succeeded {
+        SUCCESS_CACHE_AGE
+    } else {
+        FAILURE_CACHE_AGE
+    };
+    now.saturating_sub(cache.checked_at) < max_age.as_secs()
+}
+
+fn unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn cache_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))?;
+    Some(
+        PathBuf::from(home)
+            .join(".config")
+            .join("playbridge")
+            .join("update-check.json"),
+    )
+}
+
+fn load_cache() -> Option<UpdateCache> {
+    serde_json::from_slice(&fs::read(cache_path()?).ok()?).ok()
+}
+
+fn save_cache(cache: &UpdateCache) -> Result<(), std::io::Error> {
+    let path = cache_path().ok_or_else(|| std::io::Error::other("home directory unavailable"))?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_vec(cache)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn release(tag_name: &str) -> GithubRelease {
+        GithubRelease {
+            tag_name: tag_name.into(),
+            draft: false,
+            prerelease: false,
+        }
+    }
+
+    #[test]
+    fn selects_highest_stable_cli_release_only() {
+        let mut draft = release("cli-v9.0.0");
+        draft.draft = true;
+        let mut prerelease = release("cli-v8.0.0");
+        prerelease.prerelease = true;
+        let releases = [
+            release("desktop-v7.0.0"),
+            release("cli-v0.2.0"),
+            release("cli-v1.1.0"),
+            release("cli-vinvalid"),
+            draft,
+            prerelease,
+        ];
+
+        assert_eq!(latest_cli_version(&releases), Some(Version::new(1, 1, 0)));
+    }
+
+    #[test]
+    fn reports_only_strictly_newer_versions() {
+        let current = Version::new(1, 2, 3);
+        assert!(newer_version(&current, Some("1.2.3")).is_none());
+        assert!(newer_version(&current, Some("1.2.2")).is_none());
+        assert_eq!(
+            newer_version(&current, Some("2.0.0")).unwrap().version,
+            Version::new(2, 0, 0)
+        );
+    }
+
+    #[test]
+    fn failed_checks_retry_sooner_than_successful_checks() {
+        let now = 100_000;
+        let success = UpdateCache {
+            checked_at: now - FAILURE_CACHE_AGE.as_secs() - 1,
+            latest_version: None,
+            check_succeeded: true,
+        };
+        let failure = UpdateCache {
+            checked_at: now - FAILURE_CACHE_AGE.as_secs() - 1,
+            latest_version: None,
+            check_succeeded: false,
+        };
+
+        assert!(cache_is_fresh(&success, now));
+        assert!(!cache_is_fresh(&failure, now));
+    }
+}


### PR DESCRIPTION
## Summary
- Rebrands CLI binary to .
- Adds interactive send/cast TUI with continuous background discovery and 3-second auto-send countdown.
- Implements interactive live seekbar control for PlayBridge, DLNA, and Google Cast targets.
- Embedded HTTP media server for casting local video files.
- Adds  shell script and  self-updater module.

## Verification
- Tested interactive TUI device selection and background discovery loop.
- Built CLI locally using .