### PR TITLE
chore: import safe leftovers from rust-core discovery branch

### DIFF
--- a/.agents/skills/playbridge-desktop-proxy/SKILL.md
+++ b/.agents/skills/playbridge-desktop-proxy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playbridge-desktop-proxy
-description: Work on the PlayBridge Flutter desktop receiver and its Dart stream proxy. Use for Flutter/Dart receiver UI, playback engines, libmpv/media_kit, desktop sender behavior, extension bridge integration, local proxy routing, HLS rewriting, FFmpeg AVIO, proxy authentication, Docker packaging, or changes under desktop/ and stream-proxy-dart/.
+description: Work on PlayBridge Flutter Desktop, its Rust-backed receiver adapter, and the Dart stream proxy. Use for receiver UI and playback adapters, Dart FFI lifecycle, libmpv/media_kit, desktop sender behavior, extension bridge integration, local proxy routing, HLS rewriting, FFmpeg AVIO, proxy authentication, Docker packaging, or changes under desktop/ and stream-proxy-dart/.
 ---
 
 # PlayBridge Desktop and Stream Proxy
@@ -8,9 +8,12 @@ description: Work on the PlayBridge Flutter desktop receiver and its Dart stream
 ## Establish ownership
 
 - Treat `desktop/` and `stream-proxy-dart/` as separate build and release units.
+- Treat `desktop/lib/receiver_server.dart` as the production PlayBridge receiver adapter. Rust owns TLS/WSS, pairing, authentication, limits, and command decoding; Dart owns `PlayerController`, UI, certificate/token persistence, discovery publishing, and application lifecycle.
+- Treat `desktop/lib/server.dart` as legacy/test-only until an explicit cleanup removes it. Do not implement production receiver behavior there.
 - Keep small in-process proxy adaptations with the Desktop owner. Split out a proxy owner for API, authentication, networking, HLS rewriting, FFmpeg, Docker, or standalone release work.
 - Give shared Desktop/proxy interfaces one writer while the other consumer reviews compatibility.
 - Load `playbridge-extension` for native-messaging or browser-to-Desktop bridge changes.
+- Load `playbridge-rust-core` for receiver runtime, C ABI, bundled native library, or `packages/playbridge_cast_core_dart/` changes.
 - Load `playbridge-protocol` for cast envelopes, pairing, authentication, or generated Dart binding changes.
 
 ## Work safely
@@ -18,7 +21,8 @@ description: Work on the PlayBridge Flutter desktop receiver and its Dart stream
 1. Follow the root `AGENTS.md` and preserve unrelated Desktop working-tree edits.
 2. Keep proxy credentials and session authorization out of logs.
 3. Preserve authenticated headers without exposing full stream URLs or tokens in diagnostics.
-4. Keep platform-specific Desktop behavior compatible with macOS, Windows, and Linux where practical.
+4. Preserve the persisted receiver TLS identity and SPKI pin across the Rust migration. Store paired credentials as SHA-256 token digests and refresh the runtime after forgetting devices so active credentials are revoked.
+5. Keep platform-specific Desktop behavior compatible with macOS, Windows, and Linux where practical.
 
 ## Verify
 
@@ -27,6 +31,15 @@ From `desktop/`:
 ```bash
 flutter test
 flutter analyze
+```
+
+When the Rust receiver, C ABI, Dart wrapper, or bundled library changes, run from
+the repository root before the Desktop checks:
+
+```bash
+sh cast/build-desktop.sh
+cd packages/playbridge_cast_core_dart && dart analyze --fatal-infos
+cd ../../desktop && flutter test test/rust_receiver_runtime_test.dart
 ```
 
 From `stream-proxy-dart/`:

--- a/.agents/skills/playbridge-protocol/SKILL.md
+++ b/.agents/skills/playbridge-protocol/SKILL.md
@@ -20,11 +20,19 @@ Inspect all affected consumers, including:
 - `shared/src/commonMain/kotlin/com/playbridge/shared/protocol/Message.kt`
 - `shared/src/androidMain/kotlin/com/playbridge/shared/protocol/IncomingMessage.kt`
 - Android sender and TV server call sites
+- `cast/core/src/playbridge.rs` and the network-facing behavior in `cast/receiver/`
 - `desktop/lib/protocol.dart` and the generated Dart dependency
 - Apple phone and TV message handling
 - `extension/src/background.ts` and related bridge code
 
 Load the corresponding PlayBridge specialist skills for consumer implementation.
+
+The `pb_receiver_runtime_*` C API and its Dart event JSON are an internal host
+ABI, not the PlayBridge WSS contract. A change limited to that ABI does not
+require an AsyncAPI change, but it must update the C header, Rust FFI worker,
+Dart wrapper, receiver ABI version when incompatible, and affected consumers
+together. Any change to frames sent over WSS still requires the normal protocol
+contract review.
 
 ## Preserve security invariants
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "cast/receiver",
     "cast/ffi",
     "stream-proxy-rust",
+    "browser-receiver-rust",
 ]
 exclude = ["inspirations/mediaflow-proxy-light"]
 resolver = "3"

--- a/cast/build-desktop.sh
+++ b/cast/build-desktop.sh
@@ -7,7 +7,16 @@ output_root=${1:-"$repo_dir/desktop/native/cast_core"}
 
 add_target() {
     if command -v rustup >/dev/null 2>&1; then
-        rustup target add "$1"
+        rustup target add --toolchain stable "$1"
+    fi
+}
+
+cargo_build() {
+    if command -v rustup >/dev/null 2>&1; then
+        stable_rustc=$(rustup which --toolchain stable rustc)
+        RUSTC="$stable_rustc" rustup run stable cargo build "$@"
+    else
+        cargo build "$@"
     fi
 }
 
@@ -15,11 +24,15 @@ case "$(uname -s)" in
     Darwin)
         add_target aarch64-apple-darwin
         add_target x86_64-apple-darwin
-        cargo build --manifest-path "$repo_dir/Cargo.toml" \
-            --package playbridge-cast-core-ffi --package playbridge-cast-cli --release \
+        cargo_build --manifest-path "$repo_dir/Cargo.toml" \
+            --package playbridge-cast-core-ffi \
+            --features playbridge-cast-core-ffi/sender-services \
+            --package playbridge-cast-cli --release \
             --target aarch64-apple-darwin
-        cargo build --manifest-path "$repo_dir/Cargo.toml" \
-            --package playbridge-cast-core-ffi --package playbridge-cast-cli --release \
+        cargo_build --manifest-path "$repo_dir/Cargo.toml" \
+            --package playbridge-cast-core-ffi \
+            --features playbridge-cast-core-ffi/sender-services \
+            --package playbridge-cast-cli --release \
             --target x86_64-apple-darwin
         mkdir -p "$output_root/macos"
         lipo -create \
@@ -37,8 +50,10 @@ case "$(uname -s)" in
         ;;
     Linux)
         add_target x86_64-unknown-linux-gnu
-        cargo build --manifest-path "$repo_dir/Cargo.toml" \
-            --package playbridge-cast-core-ffi --package playbridge-cast-cli --release \
+        cargo_build --manifest-path "$repo_dir/Cargo.toml" \
+            --package playbridge-cast-core-ffi \
+            --features playbridge-cast-core-ffi/sender-services \
+            --package playbridge-cast-cli --release \
             --target x86_64-unknown-linux-gnu
         mkdir -p "$output_root/linux"
         cp "$repo_dir/target/x86_64-unknown-linux-gnu/release/libplaybridge_cast_core_ffi.so" \
@@ -50,8 +65,10 @@ case "$(uname -s)" in
         ;;
     MINGW*|MSYS*|CYGWIN*)
         add_target x86_64-pc-windows-msvc
-        cargo build --manifest-path "$repo_dir/Cargo.toml" \
-            --package playbridge-cast-core-ffi --package playbridge-cast-cli --release \
+        cargo_build --manifest-path "$repo_dir/Cargo.toml" \
+            --package playbridge-cast-core-ffi \
+            --features playbridge-cast-core-ffi/sender-services \
+            --package playbridge-cast-cli --release \
             --target x86_64-pc-windows-msvc
         mkdir -p "$output_root/windows"
         cp "$repo_dir/target/x86_64-pc-windows-msvc/release/playbridge_cast_core_ffi.dll" \

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -499,7 +499,7 @@ function castVideo(
   titleHint?: string | null,
 ): Promise<{ ok: boolean; error?: string }> {
   return resolveStreamTitle(video.tabId, video.url, titleHint).then((title) =>
-    bridge.cast(video.url, video.headers ?? {}, title),
+    bridge.cast(video.url, video.headers ?? {}, title, video.contentType),
   );
 }
 


### PR DESCRIPTION
## Summary

Ports four low-risk leftovers that were still unique to `refactor/use-rust-core-for-cast-discovery` after the bulk of that work landed on `main` via #153–#161. Does **not** merge that branch (CLI release CI, version, and other main-ahead work stay intact).

1. **`cast/build-desktop.sh`** — Build FFI with `--features playbridge-cast-core-ffi/sender-services` and prefer stable rustc via rustup. Aligns local Desktop native builds with Desktop PR CI and with runtime use of `SenderServices`.
2. **`Cargo.toml`** — Add `browser-receiver-rust` as a workspace member (crate already existed as a path dependency of `cast/ffi`).
3. **`extension/src/background.ts`** — Pass `video.contentType` through `bridge.cast(...)`. Native bridge and Desktop already accept it.
4. **Agent skills** — Update `playbridge-desktop-proxy` and `playbridge-protocol` guidance for Rust receiver ownership and the internal receiver-runtime ABI vs WSS contract.

## Test plan

- [x] `sh -n cast/build-desktop.sh`
- [x] `cargo metadata` resolves workspace including `playbridge-browser-receiver`
- [ ] (optional) rebuild Desktop FFI with `sh cast/build-desktop.sh` and confirm `SenderServices` symbols are present
- [ ] Manual: cast a media URL from the extension and confirm MIME/content type is available on Desktop when provided by detection

## Risks

- Low. No CLI release workflow or version changes. Prebuilt Desktop dylib is unchanged until someone re-runs `build-desktop.sh`; the script change is required for correct local rebuilds.