### PR TITLE
ci(cli): draft release-build on uprev + separate publish

### DIFF
--- a/.agents/skills/release-and-publish/SKILL.md
+++ b/.agents/skills/release-and-publish/SKILL.md
@@ -15,9 +15,12 @@ description: Prepare a PlayBridge release by explicitly requested version uprevs
 | iOS phone | `mobile/apple/PlayBridge Phone/PlayBridge Phone.xcodeproj/project.pbxproj` | `mobile/apple/CHANGELOG.md` |
 | Apple TV | `tv/apple/PlayBridge TV/PlayBridge TV.xcodeproj/project.pbxproj` | `tv/apple/CHANGELOG.md` |
 | Extension | `extension/manifests/chrome.json` | `extension/CHANGELOG.md` |
+| CLI | `cli/Cargo.toml` | `cli/CHANGELOG.md` |
 | Stream proxy | `stream-proxy-dart/pubspec.yaml` | `stream-proxy-dart/CHANGELOG.md` |
 
 For Desktop, keep `version: <semver>+<build>` and `kAppVersion = '<semver>'` in lockstep. CI checks this in `desktop/test/update_test.dart`.
+
+Monorepo release policy (PR checks → draft release-build on uprev → publish): see `docs/release.md`. CLI is the reference: uprev arms `cli_build.yml` (draft `cli-v*`); `cli_publish.yml` sets `draft=false`.
 
 ## Workflow
 
@@ -30,5 +33,6 @@ For Desktop, keep `version: <semver>+<build>` and `kAppVersion = '<semver>'` in 
 5. Run focused verification for each affected project. For Desktop, always run `flutter test test/update_test.dart`.
 6. Commit with a Conventional Commit message, push the feature/release branch, and create or update the PR with `gh`.
 7. Include new versions and verification results in the PR description.
+8. After merge, for CLI: confirm the **draft** GitHub Release from `CLI Release Build`, then run **CLI Publish** when ready (do not treat draft creation as public ship).
 
 Use the environment's configured Git/GitHub authentication. Do not clear or override authentication variables unless the user or environment specifically requires it.

--- a/.github/workflows/cli_build.yml
+++ b/.github/workflows/cli_build.yml
@@ -1,4 +1,7 @@
-name: CLI Build & Release
+name: CLI Release Build
+
+# Stage 2: version uprev (or manual dispatch) → multi-arch packages → draft GitHub Release.
+# Stage 3 (public): .github/workflows/cli_publish.yml
 
 on:
   push:
@@ -9,46 +12,99 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/cli_build.yml'
-    tags:
-      - 'cli-v*'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Delete existing draft cli-v* release/tag and rebuild'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
-  issues: write
 
 jobs:
   validate:
-    name: validate release
+    name: validate release-build
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version.outputs.version }}
-      skipped: ${{ steps.check_tag.outputs.skipped }}
+      version: ${{ steps.gate.outputs.version }}
+      skipped: ${{ steps.gate.outputs.skipped }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Validate version
-        id: version
+      - name: Gate on uprev / dispatch
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
+          set -euo pipefail
           VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' cli/Cargo.toml | head -1)
           test -n "$VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Check tag
-        id: check_tag
-        run: |
-          if git rev-parse "cli-v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            echo "⏭️ cli-v${{ steps.version.outputs.version }} already exists, skipping."
-          else
-            echo "skipped=false" >> "$GITHUB_OUTPUT"
+          TAG="cli-v${VERSION}"
+          PREV_VERSION=$(git show HEAD^:cli/Cargo.toml 2>/dev/null | sed -n 's/^version = "\(.*\)"/\1/p' | head -1 || true)
+          PREV_VERSION=${PREV_VERSION:-none}
+          EVENT="${{ github.event_name }}"
+          FORCE=false
+          # github.event.inputs is empty on push; safe for non-dispatch events.
+          if [ "$EVENT" = "workflow_dispatch" ] && [ "${{ github.event.inputs.force }}" = "true" ]; then
+            FORCE=true
           fi
 
+          release_json=""
+          if gh release view "$TAG" --json isDraft >/dev/null 2>&1; then
+            release_json=$(gh release view "$TAG" --json isDraft)
+          fi
+
+          if [ -n "$release_json" ]; then
+            is_draft=$(printf '%s' "$release_json" | jq -r '.isDraft')
+            if [ "$is_draft" = "false" ]; then
+              echo "skipped=true" >> "$GITHUB_OUTPUT"
+              echo "⏭️ $TAG is already published; skipping release-build."
+              exit 0
+            fi
+            if [ "$FORCE" != "true" ]; then
+              echo "skipped=true" >> "$GITHUB_OUTPUT"
+              echo "⏭️ Draft $TAG already exists; skipping (re-run with force to rebuild)."
+              exit 0
+            fi
+            echo "Force rebuild: deleting draft $TAG"
+            gh release delete "$TAG" --yes --cleanup-tag
+          elif git rev-parse "$TAG" >/dev/null 2>&1; then
+            # Tag exists without a GitHub Release object (unusual).
+            if [ "$FORCE" != "true" ]; then
+              echo "skipped=true" >> "$GITHUB_OUTPUT"
+              echo "⏭️ Git tag $TAG exists without a managed release; skipping."
+              exit 0
+            fi
+            git push origin ":refs/tags/$TAG" || true
+          fi
+
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+            echo "✅ workflow_dispatch: building draft for $TAG"
+            exit 0
+          fi
+
+          if [ "$VERSION" = "$PREV_VERSION" ]; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "⏭️ Version $VERSION unchanged from previous commit; skipping."
+            exit 0
+          fi
+
+          if ! grep -qE "^## ${VERSION}( |$)" cli/CHANGELOG.md; then
+            echo "cli/CHANGELOG.md must contain a '## ${VERSION}' section for this uprev." >&2
+            exit 1
+          fi
+
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          echo "✅ Version uprev ${PREV_VERSION} → ${VERSION}; building draft $TAG"
+
       - name: Validate installer
-        if: steps.check_tag.outputs.skipped == 'false'
+        if: steps.gate.outputs.skipped == 'false'
         run: sh -n cli/install.sh
 
   build:
@@ -107,35 +163,11 @@ jobs:
           name: ${{ matrix.asset }}
           path: ${{ matrix.asset }}.tar.gz
           if-no-files-found: error
+          retention-days: 14
 
-      - name: Upload to R2
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
-        run: |
-          aws s3 cp "${{ matrix.asset }}.tar.gz" s3://${{ secrets.R2_BUCKET }}/cli-release/
-
-  approve:
-    name: manual release approval gate
+  draft-release:
+    name: create draft GitHub release
     needs: [validate, build]
-    if: needs.validate.outputs.skipped == 'false'
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Wait for approval
-        uses: trstringer/manual-approval@v1
-        with:
-          secret: ${{ secrets.GITHUB_TOKEN }}
-          approvers: playbridgeapp
-          minimum-approvals: 1
-          issue-title: "Approve PlayBridge CLI Release v${{ needs.validate.outputs.version }}"
-          issue-body: "All 5 platform builds (Linux x86_64/arm64, macOS x86_64/arm64, Windows x86_64 with static CRT) have completed successfully and uploaded to Cloudflare R2.\n\nPlease approve to publish the official GitHub Release for PlayBridge CLI v${{ needs.validate.outputs.version }}."
-
-  release:
-    name: publish CLI release
-    needs: [validate, build, approve]
     if: needs.validate.outputs.skipped == 'false'
     runs-on: ubuntu-latest
     permissions:
@@ -143,48 +175,41 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download artifacts from R2
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
-        run: |
-          mkdir -p dist
-          aws s3 sync s3://${{ secrets.R2_BUCKET }}/cli-release/ dist/
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: playbridge-cli-*
+          path: dist
+          merge-multiple: true
 
       - name: Generate checksums
         working-directory: dist
         run: sha256sum *.tar.gz > SHA256SUMS
 
-      - name: Publish GitHub release
+      - name: Create draft release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: cli-v${{ needs.validate.outputs.version }}
           name: PlayBridge CLI v${{ needs.validate.outputs.version }}
+          draft: true
           body: |
             <!-- tag: 7b2c9a -->
-            **CLI:** v${{ needs.validate.outputs.version }}
+            **CLI:** v${{ needs.validate.outputs.version }} (draft)
 
-            📋 [Changelog](https://github.com/playbridgeapp/playbridge/blob/cli-v${{ needs.validate.outputs.version }}/cli/CHANGELOG.md)
+            📋 [Changelog](https://github.com/playbridgeapp/playbridge/blob/main/cli/CHANGELOG.md)
 
             Cross-platform PlayBridge sender and receiver CLI.
 
-            **Installation (macOS & Linux):**
+            This is a **draft** candidate. Publish with **Actions → CLI Publish**
+            (sets `draft=false`). Until then, `install.sh` will not pick it up as latest.
+
+            **Installation after publish (macOS & Linux):**
             ```sh
             curl -fsSL https://raw.githubusercontent.com/playbridgeapp/playbridge/main/cli/install.sh | sh
             ```
 
-            Receiver mode requires `mpv` to be installed (`brew install mpv` or `sudo apt install mpv`).
+            Receiver mode requires `mpv` (`brew install mpv` or `sudo apt install mpv`).
           files: |
             dist/*.tar.gz
             dist/SHA256SUMS
           generate_release_notes: false
-
-      - name: Clean up R2 after release
-        if: always()
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
-        run: |
-          aws s3 rm s3://${{ secrets.R2_BUCKET }}/cli-release/ --recursive

--- a/.github/workflows/cli_publish.yml
+++ b/.github/workflows/cli_publish.yml
@@ -1,0 +1,50 @@
+name: CLI Publish
+
+# Stage 3: promote an existing draft cli-v* GitHub Release (no rebuild).
+# Stage 2: .github/workflows/cli_build.yml
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'CLI version to publish (e.g. 0.2.0 or cli-v0.2.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: publish draft release
+    runs-on: ubuntu-latest
+    # Optional: add environment: cli-release with required reviewers in repo settings.
+    steps:
+      - name: Publish draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RAW_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${RAW_VERSION#cli-v}"
+          test -n "$VERSION"
+          TAG="cli-v${VERSION}"
+
+          if ! gh release view "$TAG" --json isDraft,url >/tmp/cli-release.json; then
+            echo "No GitHub Release found for $TAG." >&2
+            echo "Run CLI Release Build first (uprev or workflow_dispatch)." >&2
+            exit 1
+          fi
+
+          is_draft=$(jq -r '.isDraft' /tmp/cli-release.json)
+          url=$(jq -r '.url' /tmp/cli-release.json)
+
+          if [ "$is_draft" = "false" ]; then
+            echo "⏭️ $TAG is already published: $url"
+            exit 0
+          fi
+
+          gh release edit "$TAG" --draft=false
+          echo "Published $TAG"
+          gh release view "$TAG" --json url,isDraft,tagName

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Portable project skills live in `.agents/skills/` and are the canonical speciali
 
 | Skill | Use when |
 |---|---|
-| `release-and-publish` | The user explicitly requests an uprev or release |
+| `release-and-publish` | The user explicitly requests an uprev or release (see also `docs/release.md`) |
 | `commit-and-open-pr` | Commit, push, or create/update a pull request without an implicit uprev |
 | `code-review-graph-workflow` | Explore, debug, review, or refactor using the repository graph |
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 0.2.0 (2026-07-25)
 
 - Build self-contained Windows executable (`playbridge.exe`) with static MSVC C runtime linking.
-- Add manual release approval gate in GitHub Actions.
-- Upload release artifacts to Cloudflare R2 storage.
+- Split CLI shipping into release-build (draft GitHub Release on uprev) and publish (`draft=false`).
+- See `docs/release.md` for the monorepo release model.
 
 ## 0.1.0 (2026-07-24)
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -51,3 +51,13 @@ From the repository root:
 ```sh
 cargo build --release --locked -p playbridge-cast-cli
 ```
+
+## Releasing
+
+CLI versions are independent of other monorepo products. Shipping is **uprev-gated**:
+
+1. Bump `cli/Cargo.toml` and add a section to `cli/CHANGELOG.md`.
+2. Merge to `main` → **CLI Release Build** creates a **draft** `cli-v*` GitHub Release with multi-arch archives.
+3. Run **Actions → CLI Publish** with that version to set `draft=false` (no rebuild).
+
+Full monorepo policy: [`docs/release.md`](../docs/release.md).

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,124 @@
+# PlayBridge release model
+
+PlayBridge is a monorepo with **independently versioned** products. Shipping one
+project does not require shipping the others.
+
+## Three stages
+
+```
+1. PR checks          → quality gate (every PR)
+2. Release-build      → versioned candidates (uprev + changelog)
+3. Publish            → public GitHub Release and/or store submit
+```
+
+| Stage | When | Output | Public users? |
+| --- | --- | --- | --- |
+| **PR checks** | Pull request (path-filtered) | Tests / lint / debug builds | No |
+| **Release-build** | Version **uprev** (+ changelog) on `main`, or explicit dispatch | Installable binaries as a **draft** GitHub Release (or registry RC) | No (draft / internal) |
+| **Publish** | Manual workflow / environment approval | `draft=false`, store promote, image retag | Yes |
+
+### Rules
+
+1. **Independent versions** — extension-only work only uprevs the extension.
+2. **Uprev = intent to ship that project** — bump its version file and changelog.
+3. **No uprev → no release-build** — ordinary merges only run PR-style CI.
+4. **Draft is the handoff** — release-build attaches assets to a draft release;
+   publish promotes that same version (CLI: `draft=false`).
+5. **Stores are separate from GitHub** — undrafting does not submit to Play / AMO / CWS.
+6. **Shared crates** (`cast/`, `protocol/`, `shared/`) rebuild consumer CI; only
+   **upreved consumers** get release-build / publish.
+
+Draft releases are visible to collaborators with write access, not to anonymous
+users or `install.sh` (which uses published `cli-v*` releases only).
+
+---
+
+## Per-project map
+
+| Project | Version source | Tag prefix | Changelog | PR CI | Release-build | Publish |
+| --- | --- | --- | --- | --- | --- | --- |
+| **CLI** | `cli/Cargo.toml` | `cli-v*` | `cli/CHANGELOG.md` | `rust_pr.yml` | `cli_build.yml` → **draft** | `cli_publish.yml` → undraft |
+| **Extension** | `extension/manifests/*.json` | `extension-v*` | `extension/CHANGELOG.md` | `extension_pr.yml` | `extension_build.yml` | GH undraft (+ optional store) — *target* |
+| **Desktop** | `desktop/pubspec.yaml` | `desktop-v*` | `desktop/CHANGELOG.md` | `desktop_pr.yml` | `desktop_build.yml` | GH undraft — *target* |
+| **Android phone** | `versionName` / `versionCode` | `phone-v*` | `mobile/android/CHANGELOG.md` | `android_pr.yml` | `android_build.yml` | GH undraft + Play promote — *target* |
+| **Android TV** | TV `versionName` / `versionCode` | `tv-player-v*` | `tv/android/CHANGELOG.md` | `android_pr.yml` | `android_build.yml` | GH undraft (+ Play if used) — *target* |
+| **Stream proxy** | crate / image version | image tags / optional git tag | project changelog | `stream_proxy_pr.yml` | `stream_proxy_build.yml` | promote image tags — *target* |
+| **Web** | deploy-on-main | n/a | n/a | `web_pr.yml` | — | `web_deploy.yml` (Pages) |
+| **Protocol / Rust core** | n/a (library) | n/a | n/a | contract / rust PR checks | ships inside consumers | — |
+| **Apple apps** | Xcode marketing version | store / TestFlight | Apple changelogs | local / future CI | archive | App Store connect |
+
+\* *target* = same three-stage model; some workflows still collapse build+publish today. **CLI is the reference implementation.**
+
+---
+
+## CLI (reference implementation)
+
+### Uprev checklist
+
+1. Bump `cli/Cargo.toml` `version`.
+2. Add a `## X.Y.Z (YYYY-MM-DD)` section to `cli/CHANGELOG.md`.
+3. Open a PR; merge to `main` after CI is green.
+4. **Release-build** (`CLI Release Build`) runs when the version **changed** on
+   that push (or via `workflow_dispatch`), and no published tag exists yet.
+5. Inspect the **draft** GitHub Release `cli-vX.Y.Z` and download assets to test.
+6. Run **CLI Publish** (`workflow_dispatch`, input = version) to set `draft=false`.
+7. Users install with `cli/install.sh` or release assets.
+
+### Workflows
+
+| Workflow | File | Role |
+| --- | --- | --- |
+| Rust / CLI PR checks | `.github/workflows/rust_pr.yml` | Format, test, lint; smoke-build CLI |
+| CLI Release Build | `.github/workflows/cli_build.yml` | Multi-arch package → **draft** `cli-v*` |
+| CLI Publish | `.github/workflows/cli_publish.yml` | Promote draft → public release |
+
+### Release-build skip logic
+
+Runs the full matrix only when:
+
+- event is `workflow_dispatch`, or
+- `cli/Cargo.toml` version **differs** from the previous commit, and
+- a **published** (non-draft) release for `cli-v$VERSION` does not already exist.
+
+If a draft already exists for that tag, re-run with **force** on
+`workflow_dispatch` to delete the draft/tag and rebuild.
+
+### Publish
+
+```text
+gh release edit cli-vX.Y.Z --draft=false
+```
+
+No rebuild. Assets stay those attached at draft time. No app store for CLI.
+
+### Manual / force
+
+```text
+Actions → CLI Release Build → Run workflow
+  force: true   # optional rebuild of draft
+Actions → CLI Publish → Run workflow
+  version: 0.2.0
+```
+
+---
+
+## Extending the model to other products
+
+When touching another `*_build.yml`:
+
+1. Gate on **version bump** (not only “tag missing”).
+2. Emit a **draft** GitHub Release (or version-keyed staging), not a live publish.
+3. Add a small **publish** workflow: undraft and/or store submit.
+4. Keep PR workflows free of release side effects.
+
+Prefer GitHub **Environments** (e.g. `cli-release`) for human approval on
+publish jobs rather than mid-build Issue bots.
+
+---
+
+## Agent / contributor notes
+
+- Ordinary PRs must **not** bump versions unless the user asked for an uprev or
+  release (`release-and-publish` skill).
+- One uprev PR per product when practical (`bump(cli): 0.2.0`).
+- Never log secrets, store keys, or pairing tokens in release notes or CI logs.


### PR DESCRIPTION
## Summary

Implements the agreed monorepo release model for **CLI** and documents it for all products.

### Docs
- Add [`docs/release.md`](docs/release.md): PR checks → uprev draft release-build → publish
- Point `AGENTS.md`, `cli/README.md`, and `release-and-publish` skill at the policy

### CLI workflows
| Stage | Workflow | Behavior |
|---|---|---|
| 2 Release-build | `cli_build.yml` (renamed conceptually **CLI Release Build**) | Runs on **version uprev** (or `workflow_dispatch`). Builds 5 targets, attaches to **draft** `cli-v*`. Requires changelog section for uprevs. Skips if already published or draft exists (unless `force`). |
| 3 Publish | **new** `cli_publish.yml` | `workflow_dispatch` with version → `gh release edit --draft=false` (no rebuild) |

Removed: R2 staging, Issue-based `manual-approval`, auto-live publish on main.

## How to ship CLI after merge

1. (If 0.2.0 still untagged) **Actions → CLI Release Build → Run workflow** (or re-uprev).
2. Test assets from the **draft** release.
3. **Actions → CLI Publish** with `0.2.0`.

## Test plan

- [x] Workflow YAML loads (Ruby)
- [x] `sh -n` not required beyond existing installer check in workflow
- [ ] After merge: dispatch **CLI Release Build** for current `0.2.0` and confirm draft appears
- [ ] **CLI Publish** undrafts; `install.sh` can resolve the version
- [ ] Unrelated main push with same CLI version skips release-build

## Follow-ups (not in this PR)

Mirror draft/publish for extension, desktop, Android per `docs/release.md`.