### PR TITLE
bump(cli): 0.1.1 for next draft release

### DIFF
--- a/.github/workflows/cli_publish.yml
+++ b/.github/workflows/cli_publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'CLI version to publish (e.g. 0.2.0 or cli-v0.2.0)'
+        description: 'CLI version to publish (e.g. 0.1.1 or cli-v0.1.1)'
         required: true
         type: string
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "playbridge-cast-cli"
-version = "0.2.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "crossterm",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PlayBridge CLI Changelog
 
-## 0.2.0 (2026-07-25)
+## 0.1.1 (2026-07-25)
 
 - Build self-contained Windows executable (`playbridge.exe`) with static MSVC C runtime linking.
 - Split CLI shipping into release-build (draft GitHub Release on uprev) and publish (`draft=false`).

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playbridge-cast-cli"
-version = "0.2.0"
+version = "0.1.1"
 edition = "2024"
 publish = false
 license = "AGPL-3.0-or-later"

--- a/docs/release.md
+++ b/docs/release.md
@@ -97,7 +97,7 @@ No rebuild. Assets stay those attached at draft time. No app store for CLI.
 Actions → CLI Release Build → Run workflow
   force: true   # optional rebuild of draft
 Actions → CLI Publish → Run workflow
-  version: 0.2.0
+  version: 0.1.1
 ```
 
 ---
@@ -120,5 +120,5 @@ publish jobs rather than mid-build Issue bots.
 
 - Ordinary PRs must **not** bump versions unless the user asked for an uprev or
   release (`release-and-publish` skill).
-- One uprev PR per product when practical (`bump(cli): 0.2.0`).
+- One uprev PR per product when practical (`bump(cli): 0.1.1`).
 - Never log secrets, store keys, or pairing tokens in release notes or CI logs.


### PR DESCRIPTION
## Summary

- **No published `cli-v0.2.0`** existed; any remote `cli-v0.2.0` tag was deleted so it cannot block draft/publish.
- Renamed the unreleased line to **`0.1.1`** (patch over public `0.1.0`): Windows static CRT + draft/publish pipeline — not a feature minor.

## After merge

1. **CLI Release Build** should arm (version change + changelog section).
2. Test the **draft** `cli-v0.1.1` assets.
3. **CLI Publish** with `0.1.1` when ready.

## Why not keep 0.2.0?

Nothing was shipped as 0.2.0. Semver-wise these are packaging/CI fixes on top of 0.1.0 → **0.1.1**.