### PR TITLE
feat(web): CLI install + dual-role Desktop/CLI

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -38,6 +38,22 @@ users or `install.sh` (which uses published `cli-v*` releases only).
 | Project | Version source | Tag prefix | Changelog | PR CI | Release-build | Publish |
 | --- | --- | --- | --- | --- | --- | --- |
 | **CLI** | `cli/Cargo.toml` | `cli-v*` | `cli/CHANGELOG.md` | `rust_pr.yml` | `cli_build.yml` → **draft** | `cli_publish.yml` → undraft |
+
+### GitHub release search markers
+
+Each GitHub Release body includes a stable HTML comment so the site and README can
+deep-link to that product’s releases (`?q=<marker>&expanded=true`):
+
+| Product | Marker | Example |
+| --- | --- | --- |
+| Desktop | `1a4b6c` | [releases?q=1a4b6c](https://github.com/playbridgeapp/PlayBridge/releases?q=1a4b6c&expanded=true) |
+| Phone | `5c9b2f` | [releases?q=5c9b2f](https://github.com/playbridgeapp/PlayBridge/releases?q=5c9b2f&expanded=true) |
+| TV player | `8d2a1c` | [releases?q=8d2a1c](https://github.com/playbridgeapp/PlayBridge/releases?q=8d2a1c&expanded=true) |
+| TV GeckoView plugin | `3e7f9a` | [releases?q=3e7f9a](https://github.com/playbridgeapp/PlayBridge/releases?q=3e7f9a&expanded=true) |
+| Extension | `9f2d8e` | [releases?q=9f2d8e](https://github.com/playbridgeapp/PlayBridge/releases?q=9f2d8e&expanded=true) |
+| CLI | `7b2c9a` | [releases?q=7b2c9a](https://github.com/playbridgeapp/PlayBridge/releases?q=7b2c9a&expanded=true) |
+
+Keep the marker in every draft/publish body for that product. Do not reuse markers across products.
 | **Extension** | `extension/manifests/*.json` | `extension-v*` | `extension/CHANGELOG.md` | `extension_pr.yml` | `extension_build.yml` | GH undraft (+ optional store) — *target* |
 | **Desktop** | `desktop/pubspec.yaml` | `desktop-v*` | `desktop/CHANGELOG.md` | `desktop_pr.yml` | `desktop_build.yml` | GH undraft — *target* |
 | **Android phone** | `versionName` / `versionCode` | `phone-v*` | `mobile/android/CHANGELOG.md` | `android_pr.yml` | `android_build.yml` | GH undraft + Play promote — *target* |

--- a/web/site/src/lib/components/Install.svelte
+++ b/web/site/src/lib/components/Install.svelte
@@ -39,8 +39,9 @@
       : (INSTALL_TABS.find((t) => t.id === active) ?? INSTALL_TABS[0])
   );
 
-  const senderTabs = INSTALL_TABS.filter((t) => t.role === 'sender' && !t.hidden);
-  const playerTabs = INSTALL_TABS.filter((t) => t.role === 'player' && !t.hidden);
+  const senderTabs = INSTALL_TABS.filter((t) => t.roles.includes('sender') && !t.hidden);
+  const playerTabs = INSTALL_TABS.filter((t) => t.roles.includes('player') && !t.hidden);
+  const dualRole = $derived(tab.roles.includes('sender') && tab.roles.includes('player'));
 
   // The ad-blocked TV browser is presented as a GeckoView plugin of the Android TV
   // player rather than a standalone player tab.
@@ -90,6 +91,14 @@
       <div>
         <h3>{tab.title}</h3>
 
+        {#if dualRole}
+          <p class="role-note">
+            <span class="role-pill">Sender</span>
+            <span class="role-pill">Player</span>
+            Works as both — cast out to other devices or receive casts on this machine.
+          </p>
+        {/if}
+
         {#if active === 'desktop'}
           <div class="installer__sub-selector">
             {#each DESKTOP_PLATFORMS as p}
@@ -111,6 +120,17 @@
             <p>
               The Apple TV application is in active development and not yet published on TestFlight.
               Developers and testers can try it by building from source using Xcode.
+            </p>
+          </div>
+        {/if}
+
+        {#if tab.id === 'cli'}
+          <div class="notice-box">
+            <span class="notice-badge">CLI</span>
+            <p>
+              Install from the script below (macOS &amp; Linux) or grab archives from GitHub Releases
+              (search marker <code>7b2c9a</code>). Receiver mode needs
+              <code>mpv</code> on your PATH.
             </p>
           </div>
         {/if}
@@ -149,6 +169,16 @@
                 {:else}
                   <Icon name="download" size={13} stroke={2.0} /> Download
                 {/if}
+              </a>
+            {/if}
+            {#if tab.id === 'cli'}
+              <a
+                href="https://github.com/playbridgeapp/playbridge/blob/main/cli/README.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="btn"
+              >
+                <Icon name="github" size={13} /> CLI docs
               </a>
             {/if}
             <a
@@ -223,6 +253,33 @@
   .step-desc { color: var(--text-dim); }
   .panel-label { font-size: 10px; letter-spacing: 0.16em; color: var(--text-faint); margin-bottom: 8px; }
   .meta-k { color: var(--text-faint); }
+
+  .role-note {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin: 0 0 18px;
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--text-dim);
+  }
+  .role-pill {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 9px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: #4a90e2;
+    background: rgba(74, 144, 226, 0.15);
+    padding: 2px 8px;
+    border-radius: 99px;
+    font-weight: 600;
+  }
+  .notice-box code {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    color: var(--text);
+  }
 
   .installer__group {
     display: flex;

--- a/web/site/src/lib/components/Platforms.svelte
+++ b/web/site/src/lib/components/Platforms.svelte
@@ -8,7 +8,8 @@
     <span class="eyebrow">Platforms</span>
     <h2>Senders and players.</h2>
     <p>
-      Senders push content. Players receive and play it. They find each other on the local network.
+      Senders push content. Players receive and play it. Desktop and the CLI do both — cast out or
+      receive on the same machine. Everything discovers peers on your local network.
     </p>
   </div>
 

--- a/web/site/src/lib/data/site.ts
+++ b/web/site/src/lib/data/site.ts
@@ -13,20 +13,39 @@ export const SITE = {
 };
 
 export type Platform = {
-  icon: 'android' | 'firefox' | 'tv' | 'apple' | 'desktop';
+  icon: 'android' | 'firefox' | 'tv' | 'apple' | 'desktop' | 'terminal';
   name: string;
   desc: string;
 };
 
 export const SENDERS: Platform[] = [
   { icon: 'android', name: 'Android app', desc: 'Browse, search, and send anything to a player.' },
-  { icon: 'firefox', name: 'Browser extension', desc: 'Detect & cast media from Firefox or Chrome tabs.' }
+  { icon: 'firefox', name: 'Browser extension', desc: 'Detect & cast media from Firefox or Chrome tabs.' },
+  {
+    icon: 'desktop',
+    name: 'Desktop app',
+    desc: 'Cast local files and streams to TVs — also runs as a full receiver.'
+  },
+  {
+    icon: 'terminal',
+    name: 'CLI',
+    desc: 'Command-line cast: discover devices, send files/URLs, or host a receiver.'
+  }
 ];
 
 export const PLAYERS: Platform[] = [
   { icon: 'tv', name: 'Android TV', desc: 'Plays anything. Optional GeckoView + uBlock Origin browser plugin.' },
   { icon: 'apple', name: 'Apple TV', desc: 'Native tvOS receiver with AVPlayer.' },
-  { icon: 'desktop', name: 'Desktop', desc: 'macOS, Windows, and Linux receiver.' }
+  {
+    icon: 'desktop',
+    name: 'Desktop app',
+    desc: 'macOS, Windows, and Linux player — also sends to other receivers on your network.'
+  },
+  {
+    icon: 'terminal',
+    name: 'CLI',
+    desc: 'Receive casts via mpv, or run a browser receiver from the terminal.'
+  }
 ];
 
 export type Step = {
@@ -40,13 +59,13 @@ export const STEPS: Step[] = [
   {
     num: '01',
     title: 'Install a player on your TV',
-    desc: 'Put the receiver on the screen you watch on — Android TV, Apple TV, or a Mac / Windows / Linux desktop.',
+    desc: 'Put a receiver on the screen you watch on — Android TV, Apple TV, Desktop, or the CLI with mpv.',
     phase: 'Set up once'
   },
   {
     num: '02',
-    title: 'Install the sender on your phone',
-    desc: 'The Android app is your remote, search bar, and browser, all in one.',
+    title: 'Install a sender',
+    desc: 'Phone app, browser extension, Desktop, or CLI — anything that can push media to a player on your network.',
     phase: 'Set up once'
   },
   {
@@ -115,11 +134,14 @@ export const FEATURES: FeatureItem[] = [
   }
 ];
 
+export type InstallRole = 'sender' | 'player';
+
 export type InstallTab = {
   id: string;
   label: string;
-  role: 'sender' | 'player';
-  icon: 'android' | 'tv' | 'apple' | 'desktop' | 'firefox' | 'windows' | 'linux';
+  /** Products that both send and receive list both roles and appear in each install group. */
+  roles: InstallRole[];
+  icon: 'android' | 'tv' | 'apple' | 'desktop' | 'firefox' | 'windows' | 'linux' | 'terminal';
   title: string;
   steps: Array<[string, string]>;
   cmd: string;
@@ -146,54 +168,57 @@ export const DESKTOP_PLATFORMS: DesktopPlatform[] = [
     id: 'macos',
     label: 'macOS',
     icon: 'apple',
-    title: 'macOS Receiver',
+    title: 'macOS Desktop',
     steps: [
-      ['Download', 'Latest .zip from GitHub Releases.'],
+      ['Download', 'Latest .zip from GitHub Releases (search marker 1a4b6c).'],
       ['Open', 'Extract and right-click → Open (unsigned build).'],
-      ['Approve devices', 'Allow the first sender that connects.']
+      ['Play or send', 'Receive casts from phone/extension, or cast local files and streams to a TV.']
     ],
     cmd: 'github.com/playbridgeapp/PlayBridge/releases?q=1a4b6c&expanded=true',
     downloadUrl: '/download/macos',
     meta: [
       ['sha256', '—'],
       ['size', '86.1 MB'],
-      ['min', 'macOS 12']
+      ['min', 'macOS 12'],
+      ['roles', 'sender + player']
     ]
   },
   {
     id: 'windows',
     label: 'Windows',
     icon: 'windows',
-    title: 'Windows Receiver',
+    title: 'Windows Desktop',
     steps: [
-      ['Download', 'Latest .zip from GitHub Releases.'],
+      ['Download', 'Latest .zip from GitHub Releases (search marker 1a4b6c).'],
       ['Extract & run', 'Run playbridge_desktop.exe — no installer needed.'],
-      ['Approve devices', 'Allow the first sender that connects.']
+      ['Play or send', 'Receive casts from phone/extension, or cast local files and streams to a TV.']
     ],
     cmd: 'github.com/playbridgeapp/PlayBridge/releases?q=1a4b6c&expanded=true',
     downloadUrl: '/download/windows',
     meta: [
       ['sha256', '—'],
       ['size', '86.1 MB'],
-      ['min', 'Windows 10']
+      ['min', 'Windows 10'],
+      ['roles', 'sender + player']
     ]
   },
   {
     id: 'linux',
     label: 'Linux',
     icon: 'linux',
-    title: 'Linux Receiver',
+    title: 'Linux Desktop',
     steps: [
-      ['Download', 'Latest .tar.gz from GitHub Releases.'],
-      ['Extract & run', 'Run bundle/playbridge_desktop from the extracted folder.'],
-      ['Approve devices', 'Allow the first sender that connects.']
+      ['Download', 'Latest .tar.gz from GitHub Releases (search marker 1a4b6c).'],
+      ['Extract & run', 'Run bundle/playbridge_desktop from the extracted folder (needs libmpv2).'],
+      ['Play or send', 'Receive casts from phone/extension, or cast local files and streams to a TV.']
     ],
     cmd: 'github.com/playbridgeapp/PlayBridge/releases?q=1a4b6c&expanded=true',
     downloadUrl: '/download/linux',
     meta: [
       ['sha256', '—'],
       ['size', '86.1 MB'],
-      ['min', 'libmpv2 required']
+      ['min', 'libmpv2 required'],
+      ['roles', 'sender + player']
     ]
   }
 ];
@@ -202,11 +227,11 @@ export const INSTALL_TABS: InstallTab[] = [
   {
     id: 'android',
     label: 'Android',
-    role: 'sender',
+    roles: ['sender'],
     icon: 'android',
     title: 'Android phones',
     steps: [
-      ['Download', 'Latest APK from GitHub Releases.'],
+      ['Download', 'Latest APK from GitHub Releases (search marker 5c9b2f).'],
       ['Allow install', 'Permit installs from unknown sources.'],
       ['Open & connect', 'Send to a player on your network.']
     ],
@@ -221,11 +246,11 @@ export const INSTALL_TABS: InstallTab[] = [
   {
     id: 'androidtv',
     label: 'Android TV',
-    role: 'player',
+    roles: ['player'],
     icon: 'tv',
     title: 'Android TV',
     steps: [
-      ['Download', 'Use Downloader app on TV with code 9557748.'],
+      ['Download', 'Use Downloader app on TV with code 9557748, or GitHub Releases (8d2a1c).'],
       ['Install', 'Sideload via adb install or follow Downloader prompts.'],
       ['Approve devices', 'Allow the first phone that connects.']
     ],
@@ -241,12 +266,12 @@ export const INSTALL_TABS: InstallTab[] = [
     // Not a standalone tab — surfaced as a GeckoView plugin inside the Android TV tab.
     id: 'tvbrowser',
     label: 'GeckoView Browser',
-    role: 'player',
+    roles: ['player'],
     icon: 'tv',
     title: 'GeckoView Browser Plugin',
     hidden: true,
     steps: [
-      ['Download', 'GeckoView browser plugin APK from GitHub Releases.'],
+      ['Download', 'GeckoView browser plugin APK from GitHub Releases (search marker 3e7f9a).'],
       ['Sideload', 'adb install or Downloader app — installs alongside the player.'],
       ['Browse ad-free', 'EasyList + cosmetic filtering on by default.']
     ],
@@ -261,7 +286,7 @@ export const INSTALL_TABS: InstallTab[] = [
   {
     id: 'appletv',
     label: 'Apple TV',
-    role: 'player',
+    roles: ['player'],
     icon: 'apple',
     title: 'Apple TV',
     steps: [
@@ -279,22 +304,54 @@ export const INSTALL_TABS: InstallTab[] = [
   {
     id: 'desktop',
     label: 'Desktop',
-    role: 'player',
+    roles: ['sender', 'player'],
     icon: 'desktop',
-    title: 'Desktop Receiver',
+    title: 'Desktop app',
     steps: [], // Loaded from DESKTOP_PLATFORMS dynamically
     cmd: '',
     meta: []
   },
   {
+    id: 'cli',
+    label: 'CLI',
+    roles: ['sender', 'player'],
+    icon: 'terminal',
+    title: 'PlayBridge CLI',
+    steps: [
+      [
+        'Install',
+        'macOS/Linux: curl -fsSL https://raw.githubusercontent.com/playbridgeapp/playbridge/main/cli/install.sh | sh'
+      ],
+      [
+        'Send',
+        'playbridge discover — then playbridge send video.mp4 (or a stream URL) to a TV, Desktop, or other receiver.'
+      ],
+      [
+        'Receive',
+        'playbridge receiver — plays incoming casts with mpv. Requires mpv on PATH.'
+      ],
+      [
+        'Archives',
+        'Windows and multi-arch packages: GitHub Releases filtered by marker 7b2c9a.'
+      ]
+    ],
+    cmd: 'github.com/playbridgeapp/PlayBridge/releases?q=7b2c9a&expanded=true',
+    meta: [
+      ['binary', 'playbridge'],
+      ['platforms', 'macOS, Linux, Windows'],
+      ['roles', 'sender + player'],
+      ['marker', '7b2c9a']
+    ]
+  },
+  {
     id: 'chrome',
     label: 'Chrome',
-    role: 'sender',
+    roles: ['sender'],
     icon: 'desktop',
     title: 'Chrome Extension',
     steps: [
       ['Open Store', 'Install PlayBridge Video Detector from Chrome Web Store.'],
-      ['Pair Desktop', 'Run PlayBridge desktop receiver to handle casting.'],
+      ['Pair Desktop', 'Run PlayBridge Desktop as a player to handle casting from the browser.'],
       ['Cast Videos', 'Detect and cast streams from web pages with one click.']
     ],
     cmd: 'chromewebstore.google.com/detail/playbridge-video-detector/gofdcnocpnieoonficfnfccolcocoaim',
@@ -308,12 +365,12 @@ export const INSTALL_TABS: InstallTab[] = [
   {
     id: 'firefox',
     label: 'Firefox',
-    role: 'sender',
+    roles: ['sender'],
     icon: 'firefox',
     title: 'Firefox Extension',
     steps: [
       ['Open Store', 'Install PlayBridge Video Detector from Firefox Add-ons.'],
-      ['Pair Desktop', 'Run PlayBridge desktop receiver to handle casting.'],
+      ['Pair Desktop', 'Run PlayBridge Desktop as a player to handle casting from the browser.'],
       ['Cast Videos', 'Detect and cast streams from web pages with one click.']
     ],
     cmd: 'addons.mozilla.org/en-US/firefox/addon/playbridge-video-detector',

--- a/web/site/src/lib/icons/Icon.svelte
+++ b/web/site/src/lib/icons/Icon.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   type IconName =
     | 'phone' | 'tv' | 'cast' | 'desktop' | 'firefox' | 'apple' | 'android'
-    | 'windows' | 'linux'
+    | 'windows' | 'linux' | 'terminal'
     | 'github' | 'link' | 'plus' | 'arrow' | 'download'
     | 'menu' | 'x';
 
@@ -57,6 +57,9 @@
     <rect x="2" y="3" width="20" height="13" rx="2" />
     <path d="M7 9l2 2-2 2M11 13h6" />
     <path d="M8 20h8M12 16v4" />
+  {:else if name === 'terminal'}
+    <rect x="3" y="4" width="18" height="16" rx="2" />
+    <path d="M7 9l3 3-3 3M12 15h5" />
   {:else if name === 'github'}
     <path
       d="M12 2a10 10 0 0 0-3.2 19.5c.5.1.7-.2.7-.5v-2c-2.7.6-3.3-1.2-3.3-1.2-.5-1.1-1.1-1.4-1.1-1.4-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.5 2.3 1.1 2.9.8.1-.7.4-1.1.6-1.4-2.2-.3-4.5-1.1-4.5-4.9 0-1.1.4-2 1-2.7-.1-.3-.5-1.3.1-2.7 0 0 .8-.3 2.7 1 .8-.2 1.6-.3 2.5-.3s1.7.1 2.5.3c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.5 4.9.4.3.7.9.7 1.8v2.7c0 .3.2.6.7.5A10 10 0 0 0 12 2z"


### PR DESCRIPTION
## Summary

The marketing site did **not** mention the CLI. Desktop was only listed as a **player**.

### Changes
- **CLI** install tab: install script, send/receive steps, GitHub Releases `?q=7b2c9a`, link to CLI docs
- **Desktop** + **CLI** use `roles: ['sender', 'player']` so they appear under **both** Install groups
- Platforms section: Desktop/CLI cards on both sender and player sides with dual-role copy
- Sender/player pills + short note on dual-role install panels
- `docs/release.md`: table of GitHub release search markers (including CLI `7b2c9a`)

### Verify
- `pnpm check` / `pnpm build` in `web/site/` (0 errors)

## Test plan
- [ ] Open `/#platforms` — Desktop + CLI in Senders and Players
- [ ] Open `/#install` — CLI tab in both groups; Desktop dual-role note
- [ ] CLI “View on GitHub” → releases filtered by `7b2c9a`