### PR TITLE
fix(web): site UX polish — a11y, CLI copy, honest copy

### DIFF
--- a/web/site/src/app.css
+++ b/web/site/src/app.css
@@ -89,6 +89,56 @@ body::after {
 a { color: inherit; text-decoration: none; }
 button { font-family: inherit; cursor: pointer; }
 
+/* Keyboard focus — visible on dark UI */
+:focus { outline: none; }
+:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--accent) 85%, white);
+  outline-offset: 3px;
+  border-radius: 6px;
+}
+
+.skip-link {
+  position: absolute;
+  left: 12px;
+  top: -48px;
+  z-index: 100;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #06091e;
+  font-weight: 600;
+  font-size: 13px;
+  transition: top 0.15s ease;
+}
+.skip-link:focus {
+  top: 12px;
+  outline: none;
+}
+.skip-link:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.btn--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--text-dim);
+}
+.btn--ghost:hover {
+  color: var(--text);
+  background: rgba(200, 220, 255, 0.04);
+  border-color: transparent;
+  box-shadow: none;
+  transform: none;
+}
+
+.nav__link--active {
+  color: var(--text) !important;
+}
+.nav__link--active::after {
+  opacity: 1 !important;
+}
+
 .wrap {
   max-width: 1080px;
   margin: 0 auto;
@@ -508,11 +558,16 @@ p  { line-height: 1.55; color: var(--text-dim); margin: 0; font-size: 15px; }
 }
 
 @media (max-width: 768px) {
+  /* Horizontal chip scroller — shorter than a tall vertical tab stack */
   .installer__tabs {
-    flex-direction: column;
+    flex-direction: row;
+    flex-wrap: nowrap;
     align-items: stretch;
-    padding: 16px;
-    gap: 16px;
+    padding: 10px 12px;
+    gap: 8px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
   }
   .installer__divider {
     display: none;
@@ -528,14 +583,16 @@ p  { line-height: 1.55; color: var(--text-dim); margin: 0; font-size: 15px; }
     flex: 0 0 100%;
   }
   .installer__tab {
-    border-radius: 6px;
+    border-radius: 999px;
     padding: 8px 14px;
     border: 1px solid var(--line);
     margin-bottom: 0;
     font-size: 12px;
+    border-bottom-color: var(--line);
   }
   .installer__tab--active {
     border-color: var(--accent);
+    border-bottom-color: var(--accent);
   }
   .installer__panel {
     padding: 20px;

--- a/web/site/src/lib/components/Footer.svelte
+++ b/web/site/src/lib/components/Footer.svelte
@@ -43,7 +43,7 @@
     </div>
     <div class="footer__bottom">
       <span>© 2026 PlayBridge contributors • Active Development</span>
-      <span>{SITE.version}</span>
+      <span>{SITE.versionLabel}</span>
     </div>
   </div>
 </footer>

--- a/web/site/src/lib/components/Hero.svelte
+++ b/web/site/src/lib/components/Hero.svelte
@@ -12,12 +12,12 @@
     TV — or Desktop, or the CLI.
   </p>
   <div class="hero__ctas">
-    <a href="/receivers" class="btn btn--primary"
-      ><Icon name="download" size={14} /> Install receivers</a
+    <a href="/#install" class="btn btn--primary"
+      ><Icon name="download" size={14} /> Get started</a
     >
-    <a href="/senders" class="btn"><Icon name="cast" size={14} /> Install senders</a>
-    <a class="btn" href={SITE.github} rel="noopener"
-      ><Icon name="github" size={13} /> View on GitHub</a
+    <a href="/receivers" class="btn">Install receivers</a>
+    <a class="btn btn--ghost" href={SITE.github} rel="noopener noreferrer" target="_blank"
+      ><Icon name="github" size={13} /> GitHub</a
     >
   </div>
   <div class="hero__scene">

--- a/web/site/src/lib/components/HowItWorks.svelte
+++ b/web/site/src/lib/components/HowItWorks.svelte
@@ -33,10 +33,11 @@
   </div>
 
   <div class="cta-row how__cta">
-    <a href="/receivers" class="btn btn--primary"
-      ><Icon name="download" size={14} /> Install a receiver</a
+    <a href="/#install" class="btn btn--primary"
+      ><Icon name="download" size={14} /> Get started</a
     >
-    <a href="/senders" class="btn">Install a sender</a>
+    <a href="/receivers" class="btn">Receivers</a>
+    <a href="/senders" class="btn">Senders</a>
   </div>
 </section>
 

--- a/web/site/src/lib/components/InstallRole.svelte
+++ b/web/site/src/lib/components/InstallRole.svelte
@@ -5,7 +5,9 @@
     type InstallProduct,
     productsForRole,
     detailFor,
-    DESKTOP_PLATFORMS
+    productIdFromHash,
+    DESKTOP_PLATFORMS,
+    EXTENSION_BROWSERS
   } from '$lib/data/site';
   import { onMount } from 'svelte';
 
@@ -18,24 +20,39 @@
   const products = $derived(productsForRole(role));
   let activeId = $state('');
   let activeDesktopOS = $state<'macos' | 'windows' | 'linux'>('macos');
+  let activeBrowser = $state<'chrome' | 'firefox'>('chrome');
+  let copyState = $state<'idle' | 'copied' | 'failed'>('idle');
+  let panelEl = $state<HTMLElement | null>(null);
+
+  function applyHash(scroll = false) {
+    if (typeof window === 'undefined') return;
+    const id = productIdFromHash(window.location.hash, role);
+    const list = productsForRole(role);
+    if (id) {
+      activeId = id;
+      if (window.location.hash === '#chrome') activeBrowser = 'chrome';
+      if (window.location.hash === '#firefox') activeBrowser = 'firefox';
+    } else if (!activeId && list[0]) {
+      activeId = list[0].id;
+    }
+    if (scroll && panelEl) {
+      panelEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }
 
   onMount(() => {
-    if (typeof window === 'undefined') return;
     const ua = window.navigator.userAgent.toLowerCase();
     if (ua.includes('win')) activeDesktopOS = 'windows';
     else if (ua.includes('linux')) activeDesktopOS = 'linux';
     else activeDesktopOS = 'macos';
+    if (ua.includes('firefox')) activeBrowser = 'firefox';
 
-    const fromHash = window.location.hash.replace(/^#/, '');
-    const list = productsForRole(role);
-    if (fromHash && list.some((p) => p.id === fromHash)) {
-      activeId = fromHash;
-    } else if (list[0]) {
-      activeId = list[0].id;
-    }
+    applyHash(true);
+    const onHash = () => applyHash(true);
+    window.addEventListener('hashchange', onHash);
+    return () => window.removeEventListener('hashchange', onHash);
   });
 
-  // SSR + keep selection valid when products change
   $effect(() => {
     const list = products;
     if (!list.length) return;
@@ -54,44 +71,105 @@
     DESKTOP_PLATFORMS.find((p) => p.id === activeDesktopOS) ?? DESKTOP_PLATFORMS[0]
   );
 
+  const browserTab = $derived(
+    EXTENSION_BROWSERS.find((b) => b.id === activeBrowser) ?? EXTENSION_BROWSERS[0]
+  );
+
+  const isExtension = $derived(product?.id === 'extension');
+  const isDesktop = $derived(!!detail?.desktop);
+
   const title = $derived(
-    detail?.desktop ? desktopTab.title : (detail?.title ?? '')
+    isDesktop ? desktopTab.title : isExtension ? browserTab.title : (detail?.title ?? '')
   );
 
   const steps = $derived(
-    detail?.desktop
+    isDesktop
       ? role === 'sender'
         ? desktopTab.senderSteps
         : desktopTab.receiverSteps
-      : (detail?.steps ?? [])
+      : isExtension
+        ? browserTab.steps
+        : (detail?.steps ?? [])
   );
 
-  const cmd = $derived(detail?.desktop ? desktopTab.cmd : (detail?.cmd ?? ''));
+  const cmd = $derived(
+    isDesktop ? desktopTab.cmd : isExtension ? browserTab.cmd : (detail?.cmd ?? '')
+  );
   const downloadUrl = $derived(
-    detail?.desktop ? desktopTab.downloadUrl : detail?.downloadUrl
+    isDesktop ? desktopTab.downloadUrl : isExtension ? browserTab.downloadUrl : detail?.downloadUrl
   );
-  const meta = $derived(detail?.desktop ? desktopTab.meta : (detail?.meta ?? []));
+  const meta = $derived(
+    isDesktop ? desktopTab.meta : isExtension ? browserTab.meta : (detail?.meta ?? [])
+  );
 
-  const otherRole = $derived(role === 'sender' ? 'receiver' : 'sender');
-  const otherHref = $derived(role === 'sender' ? '/receivers' : '/senders');
-  const otherLabel = $derived(role === 'sender' ? 'Receivers' : 'Senders');
   const dual = $derived(!!(product?.sender && product?.receiver));
+  const otherSetupHref = $derived(
+    role === 'sender' ? `/receivers#${product?.id ?? ''}` : `/senders#${product?.id ?? ''}`
+  );
+  const otherSetupLabel = $derived(
+    role === 'sender' ? 'View receiver setup' : 'View sender setup'
+  );
 
   function selectProduct(id: string) {
     activeId = id;
     if (typeof history !== 'undefined') {
       history.replaceState(null, '', `#${id}`);
     }
+    queueMicrotask(() => panelEl?.focus({ preventScroll: true }));
+  }
+
+  function onTabListKeydown(e: KeyboardEvent) {
+    const list = products;
+    if (!list.length) return;
+    const idx = list.findIndex((p) => p.id === activeId);
+    if (idx < 0) return;
+    let next = idx;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      next = (idx + 1) % list.length;
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      next = (idx - 1 + list.length) % list.length;
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      next = 0;
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      next = list.length - 1;
+    } else {
+      return;
+    }
+    selectProduct(list[next].id);
+    const btn = document.getElementById(`tab-${list[next].id}`);
+    btn?.focus();
   }
 
   function hrefForCmd(c: string): string {
     return c.startsWith('http') ? c : `https://${c}`;
   }
+
+  async function copyInstallCommand(text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      copyState = 'copied';
+    } catch {
+      copyState = 'failed';
+    }
+    setTimeout(() => {
+      copyState = 'idle';
+    }, 2000);
+  }
 </script>
 
 {#if product && detail}
   <div class="installer" id="install">
-    <div class="installer__tabs" role="tablist" aria-label={role === 'sender' ? 'Senders' : 'Receivers'}>
+    <div
+      class="installer__tabs"
+      role="tablist"
+      tabindex="-1"
+      aria-label={role === 'sender' ? 'Sender products' : 'Receiver products'}
+      onkeydown={onTabListKeydown}
+    >
       {#each products as t}
         <button
           type="button"
@@ -100,28 +178,39 @@
           onclick={() => selectProduct(t.id)}
           role="tab"
           aria-selected={activeId === t.id}
+          aria-controls="panel-{t.id}"
           id="tab-{t.id}"
+          tabindex={activeId === t.id ? 0 : -1}
         >
           <Icon name={t.icon} size={13} /> {t.label}
         </button>
       {/each}
     </div>
 
-    <div class="installer__panel" role="tabpanel" aria-labelledby="tab-{product.id}">
+    <div
+      class="installer__panel"
+      role="tabpanel"
+      id="panel-{product.id}"
+      aria-labelledby="tab-{product.id}"
+      tabindex="-1"
+      bind:this={panelEl}
+    >
       <div>
         <h3>{title}</h3>
 
         {#if dual}
           <p class="role-note">
             <span class="role-pill">{role === 'sender' ? 'Sender' : 'Receiver'}</span>
-            <span class="role-pill role-pill--muted">Also a {otherRole}</span>
+            <span class="role-pill role-pill--muted"
+              >Also a {role === 'sender' ? 'receiver' : 'sender'}</span
+            >
             Same product, different job on this page.
-            <a href="{otherHref}#{product.id}">View as {otherLabel.slice(0, -1).toLowerCase()}</a>
+            <a href={otherSetupHref}>{otherSetupLabel}</a>
           </p>
         {/if}
 
-        {#if detail.desktop}
-          <div class="installer__sub-selector">
+        {#if isDesktop}
+          <div class="installer__sub-selector" role="group" aria-label="Desktop operating system">
             {#each DESKTOP_PLATFORMS as p}
               <button
                 type="button"
@@ -135,10 +224,52 @@
           </div>
         {/if}
 
+        {#if isExtension}
+          <div class="installer__sub-selector" role="group" aria-label="Browser">
+            {#each EXTENSION_BROWSERS as b}
+              <button
+                type="button"
+                class="sub-tab"
+                class:sub-tab--active={activeBrowser === b.id}
+                onclick={() => {
+                  activeBrowser = b.id;
+                  if (typeof history !== 'undefined') {
+                    history.replaceState(null, '', `#extension`);
+                  }
+                }}
+              >
+                <Icon name={b.icon} size={12} /> {b.label}
+              </button>
+            {/each}
+          </div>
+        {/if}
+
         {#if detail.notice}
           <div class="notice-box">
             <span class="notice-badge">{detail.notice.badge}</span>
             <p>{detail.notice.text}</p>
+          </div>
+        {/if}
+
+        {#if detail.installCommand}
+          <div class="code-block">
+            <div class="code-block__bar">
+              <span class="code-block__label">Install (macOS &amp; Linux)</span>
+              <button
+                type="button"
+                class="code-block__copy"
+                onclick={() => copyInstallCommand(detail.installCommand!)}
+              >
+                {#if copyState === 'copied'}
+                  Copied
+                {:else if copyState === 'failed'}
+                  Copy failed
+                {:else}
+                  Copy
+                {/if}
+              </button>
+            </div>
+            <pre class="code-block__pre"><code>{detail.installCommand}</code></pre>
           </div>
         {/if}
 
@@ -214,9 +345,10 @@
             <span>Universal APK (all CPUs) downloaded by default.</span>
             <span
               >Or download:
-              <a href="{downloadUrl}-v8a" target="_blank" rel="noopener">64-bit (v8a)</a>
+              <a href="{downloadUrl}-v8a" target="_blank" rel="noopener noreferrer">64-bit (v8a)</a>
               ·
-              <a href="{downloadUrl}-v7a" target="_blank" rel="noopener">32-bit (v7a)</a></span
+              <a href="{downloadUrl}-v7a" target="_blank" rel="noopener noreferrer">32-bit (v7a)</a
+              ></span
             >
           </div>
         {/if}
@@ -294,6 +426,53 @@
     background: rgba(200, 220, 255, 0.06);
   }
 
+  .code-block {
+    margin: 0 0 24px;
+    border-radius: 10px;
+    border: 1px solid var(--line-strong);
+    background: rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+  }
+  .code-block__bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--line);
+    background: rgba(200, 220, 255, 0.03);
+  }
+  .code-block__label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+  }
+  .code-block__copy {
+    border: 1px solid var(--line-strong);
+    background: rgba(74, 144, 226, 0.12);
+    color: var(--text);
+    font-size: 12px;
+    font-weight: 500;
+    padding: 4px 10px;
+    border-radius: 6px;
+  }
+  .code-block__copy:hover {
+    border-color: rgba(74, 144, 226, 0.5);
+  }
+  .code-block__pre {
+    margin: 0;
+    padding: 14px 16px;
+    overflow-x: auto;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--text);
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+
   .installer__sub-selector {
     display: flex;
     background: rgba(0, 0, 0, 0.25);
@@ -303,6 +482,7 @@
     margin-bottom: 24px;
     gap: 2px;
     width: fit-content;
+    flex-wrap: wrap;
   }
   .sub-tab {
     background: transparent;
@@ -451,6 +631,13 @@
     margin: 0;
     font-size: 13px;
     color: var(--text-dim);
+  }
+
+  .installer__panel:focus {
+    outline: none;
+  }
+  .installer__panel:focus-visible {
+    box-shadow: inset 0 0 0 1px rgba(74, 144, 226, 0.45);
   }
 
   @media (max-width: 600px) {

--- a/web/site/src/lib/components/Nav.svelte
+++ b/web/site/src/lib/components/Nav.svelte
@@ -2,15 +2,57 @@
   import LogoMark from '$lib/icons/LogoMark.svelte';
   import Icon from '$lib/icons/Icon.svelte';
   import { SITE } from '$lib/data/site';
+  import { page } from '$app/stores';
+  import { onMount } from 'svelte';
 
   let mobileMenuOpen = $state(false);
+  let menuEl = $state<HTMLDivElement | null>(null);
+  let toggleEl = $state<HTMLButtonElement | null>(null);
 
   function closeMenu() {
     mobileMenuOpen = false;
   }
+
+  function toggleMenu() {
+    mobileMenuOpen = !mobileMenuOpen;
+  }
+
+  $effect(() => {
+    if (typeof document === 'undefined') return;
+    document.body.style.overflow = mobileMenuOpen ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  });
+
+  onMount(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && mobileMenuOpen) {
+        closeMenu();
+        toggleEl?.focus();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  });
+
+  $effect(() => {
+    if (mobileMenuOpen) {
+      queueMicrotask(() => {
+        const first = menuEl?.querySelector<HTMLElement>('a, button');
+        first?.focus();
+      });
+    }
+  });
+
+  const path = $derived($page.url.pathname);
+  const onSenders = $derived(path.startsWith('/senders'));
+  const onReceivers = $derived(path.startsWith('/receivers'));
 </script>
 
-<nav class="nav">
+<a class="skip-link" href="#main">Skip to content</a>
+
+<nav class="nav" aria-label="Primary">
   <div class="wrap nav__inner">
     <a class="logo" href="/">
       <LogoMark size={30} />
@@ -19,21 +61,30 @@
     </a>
     <div class="nav__links">
       <a href="/#how">How it works</a>
-      <a href="/#platforms">Platforms</a>
+      <a href="/senders" class:nav__link--active={onSenders} aria-current={onSenders ? 'page' : undefined}
+        >Senders</a
+      >
+      <a
+        href="/receivers"
+        class:nav__link--active={onReceivers}
+        aria-current={onReceivers ? 'page' : undefined}>Receivers</a
+      >
       <a href="/#features">Features</a>
-      <a href="/senders">Senders</a>
-      <a href="/receivers">Receivers</a>
     </div>
     <div class="nav__actions">
-      <a class="btn" href={SITE.github} rel="noopener"><Icon name="github" size={13} /> GitHub</a>
-      <a class="btn btn--primary" href="/receivers">Get started</a>
+      <a class="btn" href={SITE.github} rel="noopener noreferrer" target="_blank"
+        ><Icon name="github" size={13} /> GitHub</a
+      >
+      <a class="btn btn--primary" href="/#install">Get started</a>
     </div>
     <button
       type="button"
       class="nav__toggle"
-      onclick={() => (mobileMenuOpen = !mobileMenuOpen)}
-      aria-label="Toggle menu"
+      bind:this={toggleEl}
+      onclick={toggleMenu}
+      aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
       aria-expanded={mobileMenuOpen}
+      aria-controls="mobile-nav"
     >
       {#if mobileMenuOpen}
         <Icon name="x" size={20} />
@@ -44,21 +95,30 @@
   </div>
 </nav>
 
-<!-- Rendered OUTSIDE <nav> on purpose: the nav's backdrop-filter would otherwise
-     become the containing block for this position:fixed overlay and clip it to the
-     nav bar. As a sibling of <nav>, it resolves against the viewport. -->
 {#if mobileMenuOpen}
-  <div class="nav__mobile-menu">
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div
+    class="nav__mobile-menu"
+    id="mobile-nav"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Menu"
+    tabindex="-1"
+    bind:this={menuEl}
+    onclick={(e) => {
+      if (e.target === e.currentTarget) closeMenu();
+    }}
+  >
     <div class="nav__mobile-links">
       <a href="/#how" onclick={closeMenu}>How it works</a>
-      <a href="/#platforms" onclick={closeMenu}>Platforms</a>
-      <a href="/#features" onclick={closeMenu}>Features</a>
       <a href="/senders" onclick={closeMenu}>Senders</a>
       <a href="/receivers" onclick={closeMenu}>Receivers</a>
+      <a href="/#features" onclick={closeMenu}>Features</a>
+      <a href="/#install" onclick={closeMenu}>Get started</a>
       <a
         class="btn btn--primary nav__mobile-github"
         href={SITE.github}
-        rel="noopener"
+        rel="noopener noreferrer"
         target="_blank"
         onclick={closeMenu}
       >

--- a/web/site/src/lib/data/site.ts
+++ b/web/site/src/lib/data/site.ts
@@ -4,13 +4,17 @@ export const SITE = {
   description:
     'PlayBridge is an open-source casting suite in active development. Browse on your phone, watch on your TV — no accounts, no telemetry, local network only.',
   url: 'https://playbridge.app',
-  ogImage: '/og-image.png',
+  ogImage: '/favicon.svg',
   twitter: '@playbridge',
   email: 'playbridgeapp@gmail.com',
   github: 'https://github.com/playbridgeapp/PlayBridge',
   githubOrg: 'https://github.com/playbridgeapp',
-  version: 'v2.4.1'
+  /** Suite is multi-product; do not invent a single semver for the marketing site. */
+  versionLabel: 'Alpha'
 };
+
+export const CLI_INSTALL_CMD =
+  'curl -fsSL https://raw.githubusercontent.com/playbridgeapp/playbridge/main/cli/install.sh | sh';
 
 /** GitHub release body markers used in ?q= search links (see docs/release.md). */
 export const RELEASE_MARKERS = {
@@ -51,8 +55,8 @@ export const SENDERS: Platform[] = [
   {
     icon: 'firefox',
     name: 'Browser extension',
-    desc: 'Detect and cast media from Firefox or Chrome tabs.',
-    href: '/senders#chrome'
+    desc: 'Detect and cast media from Firefox or Chrome / Edge / Brave tabs.',
+    href: '/senders#extension'
   },
   {
     icon: 'desktop',
@@ -192,10 +196,13 @@ export type InstallDetail = {
   steps: Array<[string, string]>;
   cmd: string;
   downloadUrl?: string;
+  /** Honest metadata only (role, platform, marker, status). No fake sizes/hashes. */
   meta: Array<[string, string]>;
   notice?: { badge: string; text: string };
   /** Use DESKTOP_PLATFORMS for OS-specific download steps. */
   desktop?: boolean;
+  /** Shell one-liner shown in a copyable block (CLI). */
+  installCommand?: string;
   /** Optional plugin callout (Android TV GeckoView). */
   plugin?: {
     title: string;
@@ -203,6 +210,17 @@ export type InstallDetail = {
     downloadUrl?: string;
     cmd?: string;
   };
+};
+
+export type ExtensionBrowser = {
+  id: 'chrome' | 'firefox';
+  label: string;
+  icon: 'desktop' | 'firefox';
+  title: string;
+  steps: Array<[string, string]>;
+  cmd: string;
+  downloadUrl: string;
+  meta: Array<[string, string]>;
 };
 
 export type InstallProduct = {
@@ -315,44 +333,22 @@ export const INSTALL_PRODUCTS: InstallProduct[] = [
     }
   },
   {
-    id: 'chrome',
-    label: 'Chrome',
-    icon: 'desktop',
-    sender: {
-      title: 'Chrome extension (sender)',
-      steps: [
-        ['Open Store', 'Install PlayBridge Video Detector from the Chrome Web Store.'],
-        ['Pair Desktop', 'Run PlayBridge Desktop as a receiver (or another player) to handle casting.'],
-        ['Cast videos', 'Detect streams on web pages and cast with one click.']
-      ],
-      cmd: 'chromewebstore.google.com/detail/playbridge-video-detector/gofdcnocpnieoonficfnfccolcocoaim',
-      downloadUrl:
-        'https://chromewebstore.google.com/detail/playbridge-video-detector/gofdcnocpnieoonficfnfccolcocoaim?hl=en',
-      meta: [
-        ['role', 'sender'],
-        ['store', 'Chrome Web Store'],
-        ['platform', 'Chrome, Brave, Edge']
-      ]
-    }
-  },
-  {
-    id: 'firefox',
-    label: 'Firefox',
+    id: 'extension',
+    label: 'Extension',
     icon: 'firefox',
     sender: {
-      title: 'Firefox extension (sender)',
-      steps: [
-        ['Open Store', 'Install PlayBridge Video Detector from Firefox Add-ons.'],
-        ['Pair Desktop', 'Run PlayBridge Desktop as a receiver (or another player) to handle casting.'],
-        ['Cast videos', 'Detect streams on web pages and cast with one click.']
-      ],
-      cmd: 'addons.mozilla.org/en-US/firefox/addon/playbridge-video-detector',
-      downloadUrl: 'https://addons.mozilla.org/en-US/firefox/addon/playbridge-video-detector/',
+      title: 'Browser extension (sender)',
+      steps: [],
+      cmd: releaseSearchUrl(RELEASE_MARKERS.extension),
       meta: [
         ['role', 'sender'],
-        ['store', 'Firefox Add-ons'],
-        ['platform', 'Firefox Desktop']
-      ]
+        ['browsers', 'Chrome, Edge, Brave, Firefox'],
+        ['marker', RELEASE_MARKERS.extension]
+      ],
+      notice: {
+        badge: 'Needs a receiver',
+        text: 'Pair with PlayBridge Desktop (or another receiver) so casted tabs have somewhere to play.'
+      }
     }
   },
   {
@@ -389,10 +385,7 @@ export const INSTALL_PRODUCTS: InstallProduct[] = [
     sender: {
       title: 'PlayBridge CLI (sender)',
       steps: [
-        [
-          'Install',
-          'macOS/Linux: curl -fsSL https://raw.githubusercontent.com/playbridgeapp/playbridge/main/cli/install.sh | sh'
-        ],
+        ['Install', 'macOS & Linux: run the install script below (adds playbridge to ~/.local/bin).'],
         [
           'Discover',
           'playbridge discover — list TVs, Desktop, and other receivers on your network.'
@@ -402,11 +395,12 @@ export const INSTALL_PRODUCTS: InstallProduct[] = [
           'playbridge send video.mp4 (or a stream URL) to the device you pick.'
         ],
         [
-          'Archives',
-          `Windows and multi-arch packages: GitHub Releases (marker ${RELEASE_MARKERS.cli}).`
+          'Windows / archives',
+          `Download multi-arch packages from GitHub Releases (marker ${RELEASE_MARKERS.cli}).`
         ]
       ],
       cmd: releaseSearchUrl(RELEASE_MARKERS.cli),
+      installCommand: CLI_INSTALL_CMD,
       meta: [
         ['role', 'sender'],
         ['binary', 'playbridge'],
@@ -414,16 +408,13 @@ export const INSTALL_PRODUCTS: InstallProduct[] = [
       ],
       notice: {
         badge: 'Also a receiver',
-        text: 'The same binary can receive casts with mpv. See the Receivers page for receive mode.'
+        text: 'The same binary can receive casts with mpv. Open the Receivers page for receive mode.'
       }
     },
     receiver: {
       title: 'PlayBridge CLI (receiver)',
       steps: [
-        [
-          'Install',
-          'macOS/Linux: curl -fsSL https://raw.githubusercontent.com/playbridgeapp/playbridge/main/cli/install.sh | sh'
-        ],
+        ['Install', 'macOS & Linux: run the install script below (adds playbridge to ~/.local/bin).'],
         [
           'Install mpv',
           'Receiver mode needs mpv on PATH (brew install mpv or your distro package).'
@@ -433,11 +424,12 @@ export const INSTALL_PRODUCTS: InstallProduct[] = [
           'playbridge receiver — approve senders and play incoming casts via mpv.'
         ],
         [
-          'Archives',
-          `Windows and multi-arch packages: GitHub Releases (marker ${RELEASE_MARKERS.cli}).`
+          'Windows / archives',
+          `Download multi-arch packages from GitHub Releases (marker ${RELEASE_MARKERS.cli}).`
         ]
       ],
       cmd: releaseSearchUrl(RELEASE_MARKERS.cli),
+      installCommand: CLI_INSTALL_CMD,
       meta: [
         ['role', 'receiver'],
         ['binary', 'playbridge'],
@@ -445,7 +437,7 @@ export const INSTALL_PRODUCTS: InstallProduct[] = [
       ],
       notice: {
         badge: 'Also a sender',
-        text: 'The same binary can discover devices and send media. See the Senders page for cast-out setup.'
+        text: 'The same binary can discover devices and send media. Open the Senders page for cast-out setup.'
       }
     }
   },
@@ -472,7 +464,7 @@ export const INSTALL_PRODUCTS: InstallProduct[] = [
       ],
       plugin: {
         title: 'GeckoView + uBlock Origin',
-        body: 'Optional plugin: Mozilla GeckoView with uBlock Origin for ad-free browsing on the TV. The player already includes System WebView.',
+        body: 'Optional plugin: Mozilla GeckoView with uBlock Origin for ad-free browsing on the TV. The TV receiver already includes System WebView.',
         downloadUrl: '/download/tv-browser',
         cmd: releaseSearchUrl(RELEASE_MARKERS.tvBrowser)
       }
@@ -503,10 +495,67 @@ export const INSTALL_PRODUCTS: InstallProduct[] = [
   }
 ];
 
+export const EXTENSION_BROWSERS: ExtensionBrowser[] = [
+  {
+    id: 'chrome',
+    label: 'Chrome',
+    icon: 'desktop',
+    title: 'Chrome / Edge / Brave',
+    steps: [
+      ['Open Store', 'Install PlayBridge Video Detector from the Chrome Web Store.'],
+      [
+        'Pair a receiver',
+        'Run PlayBridge Desktop (or another receiver) so the extension has a cast target.'
+      ],
+      ['Cast videos', 'Detect streams on web pages and cast with one click.']
+    ],
+    cmd: 'chromewebstore.google.com/detail/playbridge-video-detector/gofdcnocpnieoonficfnfccolcocoaim',
+    downloadUrl:
+      'https://chromewebstore.google.com/detail/playbridge-video-detector/gofdcnocpnieoonficfnfccolcocoaim?hl=en',
+    meta: [
+      ['role', 'sender'],
+      ['store', 'Chrome Web Store'],
+      ['platform', 'Chrome, Brave, Edge']
+    ]
+  },
+  {
+    id: 'firefox',
+    label: 'Firefox',
+    icon: 'firefox',
+    title: 'Firefox',
+    steps: [
+      ['Open Store', 'Install PlayBridge Video Detector from Firefox Add-ons.'],
+      [
+        'Pair a receiver',
+        'Run PlayBridge Desktop (or another receiver) so the extension has a cast target.'
+      ],
+      ['Cast videos', 'Detect streams on web pages and cast with one click.']
+    ],
+    cmd: 'addons.mozilla.org/en-US/firefox/addon/playbridge-video-detector',
+    downloadUrl: 'https://addons.mozilla.org/en-US/firefox/addon/playbridge-video-detector/',
+    meta: [
+      ['role', 'sender'],
+      ['store', 'Firefox Add-ons'],
+      ['platform', 'Firefox Desktop']
+    ]
+  }
+];
+
 export function productsForRole(role: InstallRole): InstallProduct[] {
   return INSTALL_PRODUCTS.filter((p) => !p.hidden && (role === 'sender' ? p.sender : p.receiver));
 }
 
 export function detailFor(product: InstallProduct, role: InstallRole): InstallDetail | undefined {
   return role === 'sender' ? product.sender : product.receiver;
+}
+
+/** Resolve product id from URL hash (supports legacy #chrome / #firefox → extension). */
+export function productIdFromHash(hash: string, role: InstallRole): string | null {
+  const raw = hash.replace(/^#/, '');
+  if (!raw) return null;
+  if (raw === 'chrome' || raw === 'firefox') {
+    return role === 'sender' ? 'extension' : null;
+  }
+  const list = productsForRole(role);
+  return list.some((p) => p.id === raw) ? raw : null;
 }

--- a/web/site/src/routes/+layout.svelte
+++ b/web/site/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <Nav />
-<main>
+<main id="main">
   {@render children()}
 </main>
 <Footer />

--- a/web/site/src/routes/+page.svelte
+++ b/web/site/src/routes/+page.svelte
@@ -16,7 +16,6 @@
     operatingSystem: 'Android, Android TV, tvOS, macOS, Windows, Linux',
     url: SITE.url,
     downloadUrl: `${SITE.url}/receivers`,
-    softwareVersion: SITE.version,
     license: 'https://www.gnu.org/licenses/gpl-3.0.html',
     offers: {
       '@type': 'Offer',
@@ -31,6 +30,6 @@
 
 <Hero />
 <HowItWorks />
+<InstallCta />
 <Platforms />
 <Features />
-<InstallCta />

--- a/web/site/static/_redirects
+++ b/web/site/static/_redirects
@@ -1,9 +1,14 @@
-# Short links to GitHub releases and assets
+# Short links — role pages and download helpers
 /android       /download/android                                               302
 /androidtv     /download/tv-player                                             302
 /appletv       https://github.com/playbridgeapp/playbridge/tree/main/tv/apple  302
-/desktop       https://github.com/playbridgeapp/playbridge/releases            302
+/desktop       /receivers#desktop                                              302
+/cli           /senders#cli                                                    302
+/send          /senders                                                        302
+/receive       /receivers                                                      302
 /firefox       /download/firefox                                               302
+/chrome        https://chromewebstore.google.com/detail/playbridge-video-detector/gofdcnocpnieoonficfnfccolcocoaim 302
+/extension     /senders#extension                                              302
 /github        https://github.com/playbridgeapp/playbridge                     302
 /docs          https://github.com/playbridgeapp/playbridge#documentation       302
 /contribute    https://github.com/playbridgeapp/playbridge/blob/main/CONTRIBUTING.md 302


### PR DESCRIPTION
## Summary

Implements the high-priority items from the full site UI/UX review.

### Content honesty
- Footer `v2.4.1` → **Alpha** (`versionLabel`)
- Removed fake size/sha metadata from install panels
- Residual “player” wording → **receiver**
- Missing `og-image.png` → use `/favicon.svg`

### Install UX
- **CLI:** copyable install command block + Copy button
- **Extension:** single **Extension** tab with Chrome / Firefox sub-selector (platforms deep-link `#extension`)
- Legacy `#chrome` / `#firefox` hashes still resolve
- Dual-role links use explicit “View sender/receiver setup” (no string slicing)

### A11y / interaction
- Skip link, `:focus-visible` styles
- Install **arrow-key** tabs + `aria-controls` / roving `tabindex`
- Hash change listener + scroll into panel
- Mobile menu: Escape, body scroll lock, dialog semantics, backdrop click
- Nav active state on Senders/Receivers; simpler primary nav
- Hero: Get started → `#install`; lighter GitHub CTA

### Home density
- Install CTA moved **above** Platforms/Features

### Redirects
- `/desktop` → `/receivers#desktop`
- `/cli` → `/senders#cli`
- `/send`, `/receive`, `/extension`, `/chrome`

## Verify
- `pnpm check` / `pnpm build` in `web/site/` (0 errors)

## Test plan
- [ ] `/senders#cli` shows copy block; Copy works
- [ ] `/senders#extension` Chrome/Firefox sub-tabs
- [ ] Keyboard arrows between install tabs
- [ ] Mobile menu Escape closes + restores body scroll
- [ ] Focus ring visible on Tab through CTAs