### PR TITLE
fix(tv): recover live Exo errors and apply subtitle offset

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/update/UpdateChecker.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/update/UpdateChecker.kt
@@ -91,6 +91,15 @@ class UpdateChecker(
                         )
                         _state.value = UpdateState.Idle
                     }
+                    // "Later" snooze: suppress auto prompts for this exact version until a
+                    // newer release ships (or the user taps Check for updates).
+                    !manual && isSnoozed(info.version) -> {
+                        Log.i(
+                            TAG,
+                            "check: ${info.version} available but snoozed after Later — suppressing"
+                        )
+                        _state.value = UpdateState.Idle
+                    }
                     else -> {
                         Log.i(TAG, "check: update available ${info.version} (${info.source})")
                         _state.value = UpdateState.Available(info)
@@ -202,7 +211,18 @@ class UpdateChecker(
         runCatching { appContext.startActivity(intent) }
     }
 
+    /**
+     * Dismiss the available-update dialog ("Later").
+     *
+     * Persists a per-version snooze so automatic cold-start checks do not re-open the
+     * dialog on every Activity recreate (common in debug) or app relaunch. Manual
+     * "Check for updates" still surfaces the same version.
+     */
     fun dismiss() {
+        val current = _state.value
+        if (current is UpdateState.Available) {
+            snooze(current.info.version)
+        }
         _state.value = UpdateState.Idle
     }
 
@@ -262,12 +282,31 @@ class UpdateChecker(
         return done
     }
 
+    /** Remember that the user chose Later for [version] (auto-check only). */
+    private fun snooze(version: AppVersion) {
+        prefs().edit().putString(KEY_SNOOZED_VERSION, version.toString()).apply()
+        Log.i(TAG, "snooze: will not auto-prompt for $version again")
+    }
+
+    /**
+     * True when [version] was dismissed via Later and is not newer than the snoozed
+     * version. A *newer* release always re-prompts.
+     */
+    private fun isSnoozed(version: AppVersion): Boolean {
+        val raw = prefs().getString(KEY_SNOOZED_VERSION, null) ?: return false
+        val snoozed = AppVersion.parse(raw) ?: return false
+        val matches = version <= snoozed
+        Log.d(TAG, "isSnoozed($version): snoozed=$snoozed -> $matches")
+        return matches
+    }
+
     companion object {
         private const val TAG = "UpdateChecker"
         private const val DOWNLOAD_ENDPOINT = "https://playbridge.app/download/android"
         private const val PLAY_STORE_PACKAGE = "com.android.vending"
         private const val PLAY_WEB_URL =
             "https://play.google.com/store/apps/details?id=com.playbridge.sender"
+        private const val KEY_SNOOZED_VERSION = "snoozed_version"
 
         /**
          * How long after first detecting a new version we wait before nudging a Play Store

--- a/shared/src/androidMain/kotlin/com/playbridge/shared/player/ExoPlayerEngine.kt
+++ b/shared/src/androidMain/kotlin/com/playbridge/shared/player/ExoPlayerEngine.kt
@@ -103,6 +103,13 @@ class ExoPlayerEngine(private val context: Context) : PlaybackEngine {
 
     private var currentPayload: PlayPayload? = null
 
+    /**
+     * Subtitle timing offset in milliseconds. Positive values advance subtitles relative to
+     * video (same convention as TV SubtitleManager / remote UI). Applied by [OffsetTextRenderer].
+     */
+    @Volatile
+    private var subtitleDelayMs: Long = 0L
+
     init {
         // Player is initialized lazily or when first loaded if needed,
         // but for now we initialize it immediately as the original code did.
@@ -450,12 +457,9 @@ class ExoPlayerEngine(private val context: Context) : PlaybackEngine {
                 extensionRendererMode: Int,
                 out: java.util.ArrayList<androidx.media3.exoplayer.Renderer>
             ) {
-                super.buildTextRenderers(context, output, outputLooper, extensionRendererMode, out)
-                out.forEach {
-                    if (it is androidx.media3.exoplayer.text.TextRenderer) {
-                        it.experimentalSetLegacyDecodingEnabled(true)
-                    }
-                }
+                // OffsetTextRenderer wraps final TextRenderer so setSubtitleDelay can shift
+                // cue selection for embedded and sideloaded text tracks.
+                out.add(OffsetTextRenderer(output, outputLooper) { subtitleDelayMs })
             }
         }
 
@@ -522,10 +526,11 @@ class ExoPlayerEngine(private val context: Context) : PlaybackEngine {
             .setMediaSourceFactory(perItem.mediaSourceFactory)
             .setSeekForwardIncrementMs(10_000)
             .setReleaseTimeoutMs(3_000) // Prevent hanging during engine transitions
-            // Many proxy/debrid streams reach the end without signalling EOS, so the player sits
-            // "playing but not ending" and Media3's default 60s STUCK_PLAYING_NOT_ENDING timeout
-            // delays end-of-episode auto-advance. Lower it so the timeout (handled as end-of-stream
-            // in the player Activity) fires quickly. This case only triggers at the end of content.
+            // Proxy/debrid VOD often reaches the end without signalling EOS, so Media3's default
+            // 60s STUCK_PLAYING_NOT_ENDING timeout delays end-of-episode advance. Keep a short
+            // timeout so that case surfaces quickly. Live/mid-stream freezes also raise
+            // ERROR_CODE_TIMEOUT; ExoRendererService recovers those (live edge / re-prepare)
+            // instead of treating them as fatal engine failures.
             .setStuckPlayingNotEndingTimeoutMs(6_000)
             .build()
             .also { exoPlayer ->
@@ -654,6 +659,25 @@ class ExoPlayerEngine(private val context: Context) : PlaybackEngine {
             selector.parameters = params
         } else {
             // Implementation for specific track selection
+        }
+    }
+
+    /**
+     * Apply a subtitle timing offset. Positive advances subtitles (look-ahead in the cue
+     * timeline); negative delays them. Takes effect on the next text render tick; when paused
+     * a no-op seek forces an immediate refresh.
+     */
+    fun setSubtitleDelay(delayMs: Long) {
+        val clamped = delayMs.coerceIn(-120_000L, 120_000L)
+        if (subtitleDelayMs == clamped) return
+        logger.i(TAG, "setSubtitleDelay($clamped)")
+        subtitleDelayMs = clamped
+        val exoPlayer = player ?: return
+        // When paused, render() may not run until the next interaction — nudge position so
+        // OffsetTextRenderer re-evaluates active cues with the new offset immediately.
+        if (!exoPlayer.isPlaying) {
+            val pos = exoPlayer.currentPosition.coerceAtLeast(0L)
+            exoPlayer.seekTo(pos)
         }
     }
 

--- a/shared/src/androidMain/kotlin/com/playbridge/shared/player/OffsetTextRenderer.kt
+++ b/shared/src/androidMain/kotlin/com/playbridge/shared/player/OffsetTextRenderer.kt
@@ -1,0 +1,163 @@
+package com.playbridge.shared.player
+
+import android.os.Looper
+import androidx.media3.common.Format
+import androidx.media3.common.Timeline
+import androidx.media3.common.util.Clock
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlaybackException
+import androidx.media3.exoplayer.MediaClock
+import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.RendererConfiguration
+import androidx.media3.exoplayer.analytics.PlayerId
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.SampleStream
+import androidx.media3.exoplayer.text.TextOutput
+import androidx.media3.exoplayer.text.TextRenderer
+import java.io.IOException
+
+/**
+ * Wraps Media3's final [TextRenderer] so subtitle timing can be offset at render time.
+ *
+ * Sign convention matches TV SubtitleManager / phone remote UI preview:
+ * `effectivePosition = playbackPosition + delayMs` — a positive delay advances subtitles
+ * relative to video (looks ahead in the subtitle timeline).
+ *
+ * Only [render] shifts the query clock; stream attachment stays on the true media timeline.
+ */
+@UnstableApi
+internal class OffsetTextRenderer(
+    output: TextOutput,
+    outputLooper: Looper?,
+    private val delayMsProvider: () -> Long,
+) : Renderer {
+    private val delegate = TextRenderer(output, outputLooper).also {
+        it.experimentalSetLegacyDecodingEnabled(true)
+    }
+
+    override fun getName(): String = "Offset${delegate.name}"
+
+    override fun getTrackType(): Int = delegate.trackType
+
+    override fun getCapabilities() = delegate.capabilities
+
+    override fun init(index: Int, playerId: PlayerId, clock: Clock) {
+        delegate.init(index, playerId, clock)
+    }
+
+    override fun getMediaClock(): MediaClock? = delegate.mediaClock
+
+    override fun getState(): Int = delegate.state
+
+    @Throws(ExoPlaybackException::class)
+    override fun enable(
+        configuration: RendererConfiguration,
+        formats: Array<out Format>,
+        stream: SampleStream,
+        positionUs: Long,
+        joining: Boolean,
+        mayRenderStartOfStream: Boolean,
+        startPositionUs: Long,
+        offsetUs: Long,
+        mediaPeriodId: MediaSource.MediaPeriodId,
+    ) {
+        delegate.enable(
+            configuration,
+            formats,
+            stream,
+            positionUs,
+            joining,
+            mayRenderStartOfStream,
+            startPositionUs,
+            offsetUs,
+            mediaPeriodId,
+        )
+    }
+
+    @Throws(ExoPlaybackException::class)
+    override fun start() {
+        delegate.start()
+    }
+
+    @Throws(ExoPlaybackException::class)
+    override fun replaceStream(
+        formats: Array<out Format>,
+        stream: SampleStream,
+        startPositionUs: Long,
+        offsetUs: Long,
+        mediaPeriodId: MediaSource.MediaPeriodId,
+    ) {
+        delegate.replaceStream(formats, stream, startPositionUs, offsetUs, mediaPeriodId)
+    }
+
+    override fun getStream(): SampleStream? = delegate.stream
+
+    override fun hasReadStreamToEnd(): Boolean = delegate.hasReadStreamToEnd()
+
+    override fun getReadingPositionUs(): Long = delegate.readingPositionUs
+
+    override fun setCurrentStreamFinal() {
+        delegate.setCurrentStreamFinal()
+    }
+
+    override fun isCurrentStreamFinal(): Boolean = delegate.isCurrentStreamFinal
+
+    @Throws(IOException::class)
+    override fun maybeThrowStreamError() {
+        delegate.maybeThrowStreamError()
+    }
+
+    @Throws(ExoPlaybackException::class)
+    override fun resetPosition(positionUs: Long, sampleStreamIsResetToKeyFrame: Boolean) {
+        delegate.resetPosition(positionUs, sampleStreamIsResetToKeyFrame)
+    }
+
+    override fun setTimeline(timeline: Timeline) {
+        delegate.setTimeline(timeline)
+    }
+
+    @Throws(ExoPlaybackException::class)
+    override fun render(positionUs: Long, elapsedRealtimeUs: Long) {
+        val offsetUs = delayMsProvider().coerceIn(MIN_DELAY_MS, MAX_DELAY_MS) * 1_000L
+        delegate.render(positionUs + offsetUs, elapsedRealtimeUs)
+    }
+
+    override fun isReady(): Boolean = delegate.isReady
+
+    override fun isEnded(): Boolean = delegate.isEnded
+
+    override fun stop() {
+        delegate.stop()
+    }
+
+    override fun disable() {
+        delegate.disable()
+    }
+
+    override fun reset() {
+        delegate.reset()
+    }
+
+    override fun release() {
+        delegate.release()
+    }
+
+    @Throws(ExoPlaybackException::class)
+    override fun handleMessage(messageType: Int, message: Any?) {
+        delegate.handleMessage(messageType, message)
+    }
+
+    @Throws(ExoPlaybackException::class)
+    override fun setPlaybackSpeed(currentPlaybackSpeed: Float, targetPlaybackSpeed: Float) {
+        delegate.setPlaybackSpeed(currentPlaybackSpeed, targetPlaybackSpeed)
+    }
+
+    override fun enableMayRenderStartOfStream() {
+        delegate.enableMayRenderStartOfStream()
+    }
+
+    companion object {
+        private const val MIN_DELAY_MS = -120_000L
+        private const val MAX_DELAY_MS = 120_000L
+    }
+}

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlaybackErrorPolicy.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlaybackErrorPolicy.kt
@@ -1,0 +1,311 @@
+package com.playbridge.player.player
+
+/**
+ * Pure classification for ExoPlayer playback failures in the multi-process TV renderer.
+ *
+ * Policy (Nuvio-inspired):
+ * 1. Recover in-engine whenever possible (live edge, re-prepare, seek retry).
+ * 2. Escalate engine failover only for hard capability/format failures **before** first frame.
+ * 3. After first frame, never recommend engine switch for rebuffer / network / live glitches.
+ */
+internal object ExoPlaybackErrorPolicy {
+
+    /** Media3 [androidx.media3.common.PlaybackException] error codes used by classification. */
+    object Codes {
+        const val UNSPECIFIED = 1000
+        const val REMOTE_ERROR = 1001
+        const val BEHIND_LIVE_WINDOW = 1002
+        const val TIMEOUT = 1003
+        const val FAILED_RUNTIME_CHECK = 1004
+
+        const val IO_UNSPECIFIED = 2000
+        const val IO_NETWORK_CONNECTION_FAILED = 2001
+        const val IO_NETWORK_CONNECTION_TIMEOUT = 2002
+        const val IO_INVALID_HTTP_CONTENT_TYPE = 2003
+        const val IO_BAD_HTTP_STATUS = 2004
+        const val IO_FILE_NOT_FOUND = 2005
+        const val IO_NO_PERMISSION = 2006
+        const val IO_CLEARTEXT_NOT_PERMITTED = 2007
+        const val IO_READ_POSITION_OUT_OF_RANGE = 2008
+
+        const val PARSING_CONTAINER_MALFORMED = 3001
+        const val PARSING_MANIFEST_MALFORMED = 3002
+        const val PARSING_CONTAINER_UNSUPPORTED = 3003
+        const val PARSING_MANIFEST_UNSUPPORTED = 3004
+
+        const val DECODER_INIT_FAILED = 4001
+        const val DECODER_QUERY_FAILED = 4002
+        const val DECODING_FAILED = 4003
+        const val DECODING_FORMAT_EXCEEDS_CAPABILITIES = 4004
+        const val DECODING_FORMAT_UNSUPPORTED = 4005
+
+        const val AUDIO_TRACK_INIT_FAILED = 5001
+        const val AUDIO_TRACK_WRITE_FAILED = 5002
+    }
+
+    const val MAX_LIVE_EDGE_RECOVERIES = 5
+    const val MAX_REPREPARE_RECOVERIES = 3
+    const val MAX_AUDIO_DISCONTINUITY_RECOVERIES = 3
+    const val MAX_DECODE_RECOVERIES = 1
+    const val VOD_END_TIMEOUT_WINDOW_MS = 5_000L
+
+    data class AttemptBudget(
+        val liveEdge: Int = 0,
+        val reprepare: Int = 0,
+        val audioDiscontinuity: Int = 0,
+        val decode: Int = 0,
+    )
+
+    enum class RecoveryStrategy {
+        /** Seek to the live edge and re-prepare (live only). */
+        LIVE_EDGE,
+        /** Stop + prepare, optionally seeking back to the last position (VOD). */
+        REPREPARE,
+        /** Seek to current position and re-prepare (audio discontinuity). */
+        SEEK_RETRY,
+    }
+
+    /**
+     * How the host should treat an error that the renderer could not (or should not) recover.
+     *
+     * - [STARTUP_ENGINE_FAILOVER]: hard capability/format failure before first frame → switch engines once.
+     * - [TERMINAL]: give up on this engine for this item; do **not** switch after playback has started.
+     */
+    enum class EscalationSeverity {
+        STARTUP_ENGINE_FAILOVER,
+        TERMINAL,
+    }
+
+    sealed class Disposition {
+        data class Recover(val strategy: RecoveryStrategy) : Disposition()
+        data class TreatAsEnded(val reason: String) : Disposition()
+        data class Escalate(val severity: EscalationSeverity, val reason: String) : Disposition()
+    }
+
+    data class ErrorFacts(
+        val errorCode: Int,
+        val errorCodeName: String,
+        val isLive: Boolean,
+        val hasFirstFrame: Boolean,
+        val positionMs: Long,
+        val durationMs: Long,
+        val causeClassSimpleName: String? = null,
+        val message: String? = null,
+        val httpStatus: Int? = null,
+        val isUnrecognizedFormat: Boolean = false,
+        val budget: AttemptBudget = AttemptBudget(),
+    )
+
+    fun classify(facts: ErrorFacts): Disposition {
+        // Live edge fell outside the available window — rejoin live; never switch engines.
+        if (facts.errorCode == Codes.BEHIND_LIVE_WINDOW) {
+            return if (facts.budget.liveEdge < MAX_LIVE_EDGE_RECOVERIES) {
+                Disposition.Recover(RecoveryStrategy.LIVE_EDGE)
+            } else {
+                Disposition.Escalate(EscalationSeverity.TERMINAL, "behind_live_window_exhausted")
+            }
+        }
+
+        // Stuck-player timeout near VOD end → treat as clean EOS (same as STATE_ENDED).
+        if (facts.errorCode == Codes.TIMEOUT && isNearVodEnd(facts)) {
+            return Disposition.TreatAsEnded("timeout_near_end")
+        }
+
+        // Live / mid-stream stall timeout → rejoin live edge or re-prepare; never engine-hop mid-play.
+        if (facts.errorCode == Codes.TIMEOUT) {
+            return if (facts.isLive) {
+                recoverOrEscalate(
+                    attempts = facts.budget.liveEdge,
+                    max = MAX_LIVE_EDGE_RECOVERIES,
+                    strategy = RecoveryStrategy.LIVE_EDGE,
+                    exhaustedReason = "live_timeout_exhausted",
+                )
+            } else {
+                recoverOrEscalate(
+                    attempts = facts.budget.reprepare,
+                    max = MAX_REPREPARE_RECOVERIES,
+                    strategy = RecoveryStrategy.REPREPARE,
+                    exhaustedReason = "timeout_exhausted",
+                )
+            }
+        }
+
+        if (facts.isUnrecognizedFormat ||
+            facts.errorCode == Codes.PARSING_CONTAINER_UNSUPPORTED ||
+            facts.errorCode == Codes.PARSING_MANIFEST_UNSUPPORTED
+        ) {
+            return Disposition.Escalate(
+                severity = if (facts.hasFirstFrame) {
+                    EscalationSeverity.TERMINAL
+                } else {
+                    EscalationSeverity.STARTUP_ENGINE_FAILOVER
+                },
+                reason = "unsupported_format",
+            )
+        }
+
+        val isAudioDiscontinuity =
+            facts.errorCode == Codes.AUDIO_TRACK_WRITE_FAILED ||
+                facts.causeClassSimpleName == "UnexpectedDiscontinuityException"
+        if (isAudioDiscontinuity) {
+            return recoverOrEscalate(
+                attempts = facts.budget.audioDiscontinuity,
+                max = MAX_AUDIO_DISCONTINUITY_RECOVERIES,
+                strategy = RecoveryStrategy.SEEK_RETRY,
+                exhaustedReason = "audio_discontinuity_exhausted",
+            )
+        }
+
+        if (facts.errorCode == Codes.AUDIO_TRACK_INIT_FAILED) {
+            return recoverOrEscalate(
+                attempts = facts.budget.reprepare,
+                max = MAX_REPREPARE_RECOVERIES,
+                strategy = RecoveryStrategy.REPREPARE,
+                exhaustedReason = "audio_track_init_exhausted",
+            )
+        }
+
+        val isDecoderFailure =
+            facts.errorCode == Codes.DECODER_INIT_FAILED ||
+                facts.errorCode == Codes.DECODING_FAILED ||
+                facts.errorCode == Codes.DECODER_QUERY_FAILED ||
+                facts.errorCode == Codes.DECODING_FORMAT_EXCEEDS_CAPABILITIES ||
+                facts.errorCode == Codes.DECODING_FORMAT_UNSUPPORTED ||
+                facts.causeClassSimpleName == "DecoderInitializationException" ||
+                facts.causeClassSimpleName == "MediaCodecVideoDecoderException"
+
+        if (isDecoderFailure) {
+            // One in-engine re-prepare (and host learns compatibility flags before escalate).
+            if (facts.budget.decode < MAX_DECODE_RECOVERIES) {
+                return Disposition.Recover(RecoveryStrategy.REPREPARE)
+            }
+            return Disposition.Escalate(
+                severity = if (facts.hasFirstFrame) {
+                    EscalationSeverity.TERMINAL
+                } else {
+                    EscalationSeverity.STARTUP_ENGINE_FAILOVER
+                },
+                reason = "decoder_failure",
+            )
+        }
+
+        if (isNetworkOrIoError(facts)) {
+            if (isNonRetryableHttp(facts.httpStatus)) {
+                return Disposition.Escalate(EscalationSeverity.TERMINAL, "http_${facts.httpStatus}")
+            }
+            // Live network blips: rejoin live edge; VOD: re-prepare at position.
+            return if (facts.isLive) {
+                recoverOrEscalate(
+                    attempts = facts.budget.liveEdge,
+                    max = MAX_LIVE_EDGE_RECOVERIES,
+                    strategy = RecoveryStrategy.LIVE_EDGE,
+                    exhaustedReason = "live_network_exhausted",
+                )
+            } else {
+                recoverOrEscalate(
+                    attempts = facts.budget.reprepare,
+                    max = MAX_REPREPARE_RECOVERIES,
+                    strategy = RecoveryStrategy.REPREPARE,
+                    exhaustedReason = "network_exhausted",
+                )
+            }
+        }
+
+        if (facts.errorCode == Codes.PARSING_CONTAINER_MALFORMED ||
+            facts.errorCode == Codes.PARSING_MANIFEST_MALFORMED
+        ) {
+            return if (facts.isLive) {
+                recoverOrEscalate(
+                    attempts = facts.budget.liveEdge,
+                    max = MAX_LIVE_EDGE_RECOVERIES,
+                    strategy = RecoveryStrategy.LIVE_EDGE,
+                    exhaustedReason = "live_malformed_exhausted",
+                )
+            } else {
+                recoverOrEscalate(
+                    attempts = facts.budget.reprepare,
+                    max = MAX_REPREPARE_RECOVERIES,
+                    strategy = RecoveryStrategy.REPREPARE,
+                    exhaustedReason = "malformed_exhausted",
+                )
+            }
+        }
+
+        // Unknown / unspecified: try one re-prepare, then terminal (or startup failover only if
+        // we never painted a frame — last chance for exotic codec paths).
+        if (facts.budget.reprepare < 1) {
+            return Disposition.Recover(RecoveryStrategy.REPREPARE)
+        }
+        return Disposition.Escalate(
+            severity = if (facts.hasFirstFrame) {
+                EscalationSeverity.TERMINAL
+            } else {
+                EscalationSeverity.STARTUP_ENGINE_FAILOVER
+            },
+            reason = "unhandled_${facts.errorCodeName}",
+        )
+    }
+
+    /**
+     * Whether the host may auto-switch engines for this escalated failure.
+     * Engine switches are restricted to startup (no first frame) + [STARTUP_ENGINE_FAILOVER].
+     */
+    fun mayAutoSwitchEngine(
+        severity: EscalationSeverity,
+        hasFirstFrame: Boolean,
+    ): Boolean = !hasFirstFrame && severity == EscalationSeverity.STARTUP_ENGINE_FAILOVER
+
+    fun severityWireValue(severity: EscalationSeverity): String = when (severity) {
+        EscalationSeverity.STARTUP_ENGINE_FAILOVER -> RendererProtocol.ERROR_SEVERITY_STARTUP_FAILOVER
+        EscalationSeverity.TERMINAL -> RendererProtocol.ERROR_SEVERITY_TERMINAL
+    }
+
+    fun parseSeverity(raw: String?): EscalationSeverity? = when (raw) {
+        RendererProtocol.ERROR_SEVERITY_STARTUP_FAILOVER -> EscalationSeverity.STARTUP_ENGINE_FAILOVER
+        RendererProtocol.ERROR_SEVERITY_TERMINAL -> EscalationSeverity.TERMINAL
+        else -> null
+    }
+
+    private fun recoverOrEscalate(
+        attempts: Int,
+        max: Int,
+        strategy: RecoveryStrategy,
+        exhaustedReason: String,
+    ): Disposition {
+        if (attempts < max) return Disposition.Recover(strategy)
+        // Exhausted recoveries are terminal: switching engines does not fix a dead CDN/live edge.
+        // Only decoder/format paths escalate as STARTUP_ENGINE_FAILOVER (handled separately).
+        return Disposition.Escalate(EscalationSeverity.TERMINAL, exhaustedReason)
+    }
+
+    private fun isNearVodEnd(facts: ErrorFacts): Boolean {
+        if (facts.isLive) return false
+        val duration = facts.durationMs
+        if (duration <= 0L) return false
+        return facts.positionMs >= duration - VOD_END_TIMEOUT_WINDOW_MS
+    }
+
+    private fun isNetworkOrIoError(facts: ErrorFacts): Boolean {
+        if (facts.errorCode in Codes.IO_UNSPECIFIED..Codes.IO_READ_POSITION_OUT_OF_RANGE) {
+            // IO_BAD_HTTP_STATUS handled via httpStatus for retryability.
+            return true
+        }
+        val cause = facts.causeClassSimpleName.orEmpty()
+        if (cause == "HttpDataSourceException" ||
+            cause == "InvalidResponseCodeException" ||
+            cause == "UnknownHostException" ||
+            cause == "SocketTimeoutException" ||
+            cause == "PlaylistStuckException"
+        ) {
+            return true
+        }
+        val message = facts.message.orEmpty()
+        return message.contains("timed out", ignoreCase = true) ||
+            message.contains("Unable to connect", ignoreCase = true)
+    }
+
+    private fun isNonRetryableHttp(status: Int?): Boolean = when (status) {
+        400, 401, 403, 404, 410 -> true
+        else -> false
+    }
+}

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
@@ -353,6 +353,7 @@ class ExoPlayerActivity : PlayerActivity() {
                         },
                         onToggleAudioBoost = { controlsViewModel.toggleAudioBoost() },
                         onAdjustSubtitleDelay = { controlsViewModel.adjustSubtitleDelay(it) },
+                        onResetSubtitleDelay = { controlsViewModel.resetSubtitleDelay() },
                         onPreloadSubtitles = { controlsViewModel.preloadSubtitleCues(it) },
                     )
                 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
@@ -415,7 +415,9 @@ class ExoPlayerActivity : PlayerActivity() {
             }
 
             override fun setSubtitleDelay(delayMs: Long) {
-                // Now handled internally by controlsViewModel.subtitleManager
+                // Embedded / native Exo text tracks: shift selection via OffsetTextRenderer.
+                // External overlay cues still go through SubtitleManager.setOffset from the VM.
+                engine?.setSubtitleDelay(delayMs)
             }
 
             override fun setPlaybackSpeed(speed: Float) {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoRendererService.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoRendererService.kt
@@ -10,11 +10,15 @@ import android.os.RemoteException
 import android.media.audiofx.LoudnessEnhancer
 import android.view.Surface
 import android.util.Log
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.C
 import androidx.media3.common.Tracks
 import androidx.media3.common.VideoSize
 import androidx.media3.common.text.CueGroup
+import androidx.media3.datasource.HttpDataSource
+import androidx.media3.exoplayer.ExoPlaybackException
+import androidx.media3.exoplayer.source.UnrecognizedInputFormatException
 import com.playbridge.shared.player.ExoPlayerEngine
 import com.playbridge.shared.protocol.decodePlayPayloadListJson
 import kotlinx.coroutines.CoroutineScope
@@ -66,8 +70,22 @@ class ExoRendererService : Service() {
     private var desiredPlaybackSpeed = 1f
     private var desiredScalingMode = "Fit"
     private var desiredLooping = false
+    private var desiredSubtitleDelayMs = 0L
     private var pendingExternalSubtitle: PendingExternalSubtitle? = null
     private var externalSubtitleTimeout: Runnable? = null
+
+    // In-engine recovery budgets for the current session (reset on prepare / stable play).
+    private var liveEdgeRecoveryCount = 0
+    private var reprepareRecoveryCount = 0
+    private var audioDiscontinuityRecoveryCount = 0
+    private var decodeRecoveryCount = 0
+    private val stableRecoveryResetRunnable = Runnable {
+        val player = engine?.getExoPlayer() ?: return@Runnable
+        if (player.playbackState == Player.STATE_READY && (player.isPlaying || playWhenReady)) {
+            resetRecoveryBudgets()
+            Log.d(TAG, "Recovery budgets reset after stable playback")
+        }
+    }
 
     private val binder = object : IRendererService.Stub() {
         override fun setCallback(callback: IRendererCallback?) = onMain {
@@ -83,6 +101,8 @@ class ExoRendererService : Service() {
             firstFrameSessionId = 0L
             endedSessionId = 0L
             selectedVideoTrackId = null
+            resetRecoveryBudgets()
+            mainHandler.removeCallbacks(stableRecoveryResetRunnable)
             val payload = request.getString(RendererProtocol.KEY_PAYLOAD_JSON)
                 ?.let(::decodePlayPayloadListJson)
                 ?.firstOrNull()
@@ -168,7 +188,11 @@ class ExoRendererService : Service() {
             applyAudioBoost()
         }
 
-        override fun setSubtitleDelay(delayMs: Long, requestedSessionId: Long) = Unit
+        override fun setSubtitleDelay(delayMs: Long, requestedSessionId: Long) = onMain {
+            if (!isCurrent(requestedSessionId)) return@onMain
+            desiredSubtitleDelayMs = delayMs
+            engine?.setSubtitleDelay(delayMs)
+        }
 
         override fun setVideoQuality(maxHeight: Int, requestedSessionId: Long) = onMain {
             if (!isCurrent(requestedSessionId)) return@onMain
@@ -246,7 +270,7 @@ class ExoRendererService : Service() {
                 }
             }
 
-            override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+            override fun onPlayerError(error: PlaybackException) {
                 pendingExternalSubtitle?.let { pending ->
                     completeExternalSubtitleAttachment(
                         pending.uri,
@@ -254,20 +278,28 @@ class ExoRendererService : Service() {
                         success = false,
                     )
                 }
-                sendError(error.errorCodeName)
+                handlePlaybackError(error)
             }
 
             override fun onPlaybackStateChanged(playbackState: Int) {
                 when (playbackState) {
-                    Player.STATE_READY -> sendReadyOnce()
+                    Player.STATE_READY -> {
+                        sendReadyOnce()
+                        scheduleStableRecoveryReset()
+                    }
                     Player.STATE_ENDED -> if (
                         readySessionId == sessionId && endedSessionId != sessionId
                     ) {
                         endedSessionId = sessionId
                         sendEvent(RendererProtocol.EVENT_ENDED)
                     }
+                    Player.STATE_BUFFERING -> mainHandler.removeCallbacks(stableRecoveryResetRunnable)
                     else -> Unit
                 }
+            }
+
+            override fun onIsPlayingChanged(isPlaying: Boolean) {
+                if (isPlaying) scheduleStableRecoveryReset()
             }
 
             override fun onTracksChanged(tracks: Tracks) {
@@ -363,6 +395,7 @@ class ExoRendererService : Service() {
 
     private fun applyDesiredSettings(renderer: ExoPlayerEngine) {
         renderer.setRate(desiredPlaybackSpeed)
+        renderer.setSubtitleDelay(desiredSubtitleDelayMs)
         val player = renderer.getExoPlayer() ?: return
         player.videoScalingMode = when (desiredScalingMode) {
             "Zoom" -> C.VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING
@@ -621,6 +654,8 @@ class ExoRendererService : Service() {
 
     private fun releaseEngine() {
         clearPendingExternalSubtitle()
+        mainHandler.removeCallbacks(stableRecoveryResetRunnable)
+        resetRecoveryBudgets()
         stateJob?.cancel()
         stateJob = null
         engine?.let { renderer ->
@@ -713,9 +748,205 @@ class ExoRendererService : Service() {
         if (Looper.myLooper() == Looper.getMainLooper()) block() else mainHandler.post(block)
     }
 
-    private fun sendError(message: String) {
+    private fun handlePlaybackError(error: PlaybackException) {
+        mainHandler.removeCallbacks(stableRecoveryResetRunnable)
+        val player = engine?.getExoPlayer()
+        if (player == null) {
+            sendError(
+                message = error.errorCodeName,
+                severity = RendererProtocol.ERROR_SEVERITY_TERMINAL,
+                errorCodeName = error.errorCodeName,
+            )
+            return
+        }
+
+        val hasFirstFrame = firstFrameSessionId == sessionId
+        val isLive = player.isCurrentMediaItemLive
+        val httpStatus = findHttpStatus(error)
+        val disposition = ExoPlaybackErrorPolicy.classify(
+            ExoPlaybackErrorPolicy.ErrorFacts(
+                errorCode = error.errorCode,
+                errorCodeName = error.errorCodeName,
+                isLive = isLive,
+                hasFirstFrame = hasFirstFrame,
+                positionMs = player.currentPosition.coerceAtLeast(0L),
+                durationMs = player.duration.takeIf { it > 0L } ?: 0L,
+                causeClassSimpleName = deepestCause(error)?.javaClass?.simpleName,
+                message = error.message,
+                httpStatus = httpStatus,
+                isUnrecognizedFormat = findCause(error, UnrecognizedInputFormatException::class.java) != null,
+                budget = ExoPlaybackErrorPolicy.AttemptBudget(
+                    liveEdge = liveEdgeRecoveryCount,
+                    reprepare = reprepareRecoveryCount,
+                    audioDiscontinuity = audioDiscontinuityRecoveryCount,
+                    decode = decodeRecoveryCount,
+                ),
+            ),
+        )
+
+        when (disposition) {
+            is ExoPlaybackErrorPolicy.Disposition.Recover -> {
+                Log.w(
+                    TAG,
+                    "Recovering from ${error.errorCodeName} via ${disposition.strategy} " +
+                        "(live=$isLive firstFrame=$hasFirstFrame " +
+                        "budget=le:$liveEdgeRecoveryCount/rp:$reprepareRecoveryCount/" +
+                        "ad:$audioDiscontinuityRecoveryCount/dec:$decodeRecoveryCount)",
+                )
+                applyRecovery(player, disposition.strategy, error)
+            }
+            is ExoPlaybackErrorPolicy.Disposition.TreatAsEnded -> {
+                Log.i(TAG, "Treating ${error.errorCodeName} as end-of-stream: ${disposition.reason}")
+                if (endedSessionId != sessionId) {
+                    endedSessionId = sessionId
+                    sendEvent(RendererProtocol.EVENT_ENDED)
+                }
+            }
+            is ExoPlaybackErrorPolicy.Disposition.Escalate -> {
+                if (isDecoderError(error)) {
+                    learnDecoderCompatibilityFlags(error)
+                }
+                Log.e(
+                    TAG,
+                    "Escalating ${error.errorCodeName} as ${disposition.severity} " +
+                        "(${disposition.reason}, firstFrame=$hasFirstFrame)",
+                    error,
+                )
+                sendError(
+                    message = "${error.errorCodeName}: ${disposition.reason}",
+                    severity = ExoPlaybackErrorPolicy.severityWireValue(disposition.severity),
+                    errorCodeName = error.errorCodeName,
+                )
+            }
+        }
+    }
+
+    private fun applyRecovery(
+        player: androidx.media3.exoplayer.ExoPlayer,
+        strategy: ExoPlaybackErrorPolicy.RecoveryStrategy,
+        error: PlaybackException,
+    ) {
+        when (strategy) {
+            ExoPlaybackErrorPolicy.RecoveryStrategy.LIVE_EDGE -> {
+                liveEdgeRecoveryCount++
+                player.seekToDefaultPosition()
+                player.prepare()
+                if (playWhenReady) player.play()
+            }
+            ExoPlaybackErrorPolicy.RecoveryStrategy.REPREPARE -> {
+                if (isDecoderError(error)) {
+                    decodeRecoveryCount++
+                } else {
+                    reprepareRecoveryCount++
+                }
+                val isLive = player.isCurrentMediaItemLive
+                val positionMs = player.currentPosition.coerceAtLeast(0L)
+                // stop() drops the error state so prepare() can restart the same media item.
+                player.stop()
+                player.prepare()
+                if (!isLive && positionMs > 0L) {
+                    player.seekTo(positionMs)
+                } else if (isLive) {
+                    player.seekToDefaultPosition()
+                }
+                player.playWhenReady = playWhenReady
+            }
+            ExoPlaybackErrorPolicy.RecoveryStrategy.SEEK_RETRY -> {
+                audioDiscontinuityRecoveryCount++
+                val positionMs = player.currentPosition.coerceAtLeast(0L)
+                player.seekTo(positionMs)
+                player.prepare()
+                if (playWhenReady) player.play()
+            }
+        }
+    }
+
+    private fun isDecoderError(error: PlaybackException): Boolean =
+        error.errorCode == PlaybackException.ERROR_CODE_DECODER_INIT_FAILED ||
+            error.errorCode == PlaybackException.ERROR_CODE_DECODING_FAILED ||
+            error.errorCode == PlaybackException.ERROR_CODE_DECODER_QUERY_FAILED ||
+            error.errorCode == PlaybackException.ERROR_CODE_DECODING_FORMAT_EXCEEDS_CAPABILITIES ||
+            error.errorCode == PlaybackException.ERROR_CODE_DECODING_FORMAT_UNSUPPORTED ||
+            findCause(error, androidx.media3.exoplayer.mediacodec.MediaCodecRenderer.DecoderInitializationException::class.java) != null ||
+            findCause(error, androidx.media3.exoplayer.video.MediaCodecVideoDecoderException::class.java) != null
+
+    /**
+     * Persist decoder compatibility flags so the *next* ExoPlayer session avoids a broken path
+     * (tunneling / Dolby Vision / async MediaCodec) — same learning as ExoPlayerActivity.
+     */
+    private fun learnDecoderCompatibilityFlags(error: PlaybackException) {
+        val prefs = getSharedPreferences("browser_prefs", MODE_PRIVATE)
+        val wasTunneled = prefs.getBoolean("tunneled_playback", false) &&
+            !prefs.getBoolean("tunneling_auto_blocked", false)
+        val failingDolbyVision =
+            (error as? ExoPlaybackException)?.rendererFormat?.sampleMimeType ==
+                androidx.media3.common.MimeTypes.VIDEO_DOLBY_VISION
+        when {
+            wasTunneled -> {
+                Log.w(TAG, "Decoder failure in tunneled mode — blocking tunneling for future sessions")
+                prefs.edit().putBoolean("tunneling_auto_blocked", true).apply()
+            }
+            failingDolbyVision && !prefs.getBoolean("dv_decoders_blocked", false) -> {
+                Log.w(TAG, "Decoder failure on Dolby Vision — future sessions use HEVC/AVC base layer")
+                prefs.edit().putBoolean("dv_decoders_blocked", true).apply()
+            }
+            !prefs.getBoolean("codec_async_blocked", false) -> {
+                Log.w(TAG, "Decoder failure in async codec mode — future sessions use sync MediaCodec")
+                prefs.edit().putBoolean("codec_async_blocked", true).apply()
+            }
+            else -> Log.w(TAG, "Decoder failure with all compatibility flags already set")
+        }
+    }
+
+    private fun scheduleStableRecoveryReset() {
+        mainHandler.removeCallbacks(stableRecoveryResetRunnable)
+        mainHandler.postDelayed(stableRecoveryResetRunnable, STABLE_RECOVERY_RESET_MS)
+    }
+
+    private fun resetRecoveryBudgets() {
+        liveEdgeRecoveryCount = 0
+        reprepareRecoveryCount = 0
+        audioDiscontinuityRecoveryCount = 0
+        decodeRecoveryCount = 0
+    }
+
+    private fun findHttpStatus(error: PlaybackException): Int? {
+        val invalid = findCause(error, HttpDataSource.InvalidResponseCodeException::class.java)
+        return invalid?.responseCode
+    }
+
+    private fun deepestCause(error: Throwable): Throwable? {
+        var current: Throwable? = error.cause
+        var deepest: Throwable? = error.cause
+        while (current != null) {
+            deepest = current
+            current = current.cause
+        }
+        return deepest
+    }
+
+    private fun <T : Throwable> findCause(error: Throwable, type: Class<T>): T? {
+        var current: Throwable? = error
+        while (current != null) {
+            if (type.isInstance(current)) {
+                @Suppress("UNCHECKED_CAST")
+                return current as T
+            }
+            current = current.cause
+        }
+        return null
+    }
+
+    private fun sendError(
+        message: String,
+        severity: String = RendererProtocol.ERROR_SEVERITY_TERMINAL,
+        errorCodeName: String? = null,
+    ) {
         sendEvent(RendererProtocol.EVENT_ERROR, Bundle().apply {
             putString(RendererProtocol.KEY_ERROR, message)
+            putString(RendererProtocol.KEY_ERROR_SEVERITY, severity)
+            putBoolean(RendererProtocol.KEY_HAD_FIRST_FRAME, firstFrameSessionId == sessionId)
+            errorCodeName?.let { putString(RendererProtocol.KEY_ERROR_CODE, it) }
         })
     }
 
@@ -734,6 +965,8 @@ class ExoRendererService : Service() {
     private companion object {
         const val TAG = "ExoRendererService"
         const val EXTERNAL_SUBTITLE_ATTACH_TIMEOUT_MS = 8_000L
+        /** After this long of healthy READY/playing, recovery attempt counters reset. */
+        const val STABLE_RECOVERY_RESET_MS = 5_000L
     }
 
     private data class PendingExternalSubtitle(

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
@@ -490,6 +490,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
                         },
                         onToggleAudioBoost = { controlsViewModel.toggleAudioBoost() },
                         onAdjustSubtitleDelay = { controlsViewModel.adjustSubtitleDelay(it) },
+                        onResetSubtitleDelay = { controlsViewModel.resetSubtitleDelay() },
                         onPreloadSubtitles = { controlsViewModel.preloadSubtitleCues(it) },
                     )
                 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerHostActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerHostActivity.kt
@@ -469,6 +469,11 @@ class PlayerHostActivity : ComponentActivity(), PlaybackProgressSource {
                         syncPlaybackContext()
                         broadcastPlayerSettings()
                     },
+                    onResetSubtitleDelay = {
+                        controlsViewModel.resetSubtitleDelay()
+                        syncPlaybackContext()
+                        broadcastPlayerSettings()
+                    },
                     onPreloadSubtitles = controlsViewModel::preloadSubtitleCues,
                     onSkipSegment = controlsViewModel::skipCurrentSegment,
                     onSkipButtonFocusChanged = controlsViewModel::setSkipButtonFocused,

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerHostActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerHostActivity.kt
@@ -1635,7 +1635,14 @@ class PlayerHostActivity : ComponentActivity(), PlaybackProgressSource {
                 finish()
             }
             RendererProtocol.EVENT_ERROR -> handleRendererFailure(
-                event.getString(RendererProtocol.KEY_ERROR) ?: "Renderer error",
+                message = event.getString(RendererProtocol.KEY_ERROR) ?: "Renderer error",
+                severity = ExoPlaybackErrorPolicy.parseSeverity(
+                    event.getString(RendererProtocol.KEY_ERROR_SEVERITY),
+                ),
+                hadFirstFrame = event.getBoolean(
+                    RendererProtocol.KEY_HAD_FIRST_FRAME,
+                    sessionCoordinator.current().phase == RendererSessionPhase.PLAYING,
+                ),
             )
         }
         refreshKeepScreenOn()
@@ -1947,10 +1954,40 @@ class PlayerHostActivity : ComponentActivity(), PlaybackProgressSource {
         ServerService.broadcastStatus(this, status)
     }
 
-    private fun handleRendererFailure(message: String) {
+    /**
+     * Handle a renderer failure.
+     *
+     * Auto engine switch is restricted to **startup** hard failures (no first frame yet),
+     * matching Nuvio's model: mid-playback glitches must not flip Exo↔MPV. Watchdog
+     * timeouts while still PREPARING remain eligible for one-shot failover.
+     */
+    private fun handleRendererFailure(
+        message: String,
+        severity: ExoPlaybackErrorPolicy.EscalationSeverity? = null,
+        hadFirstFrame: Boolean = false,
+    ) {
         if (finishingSession || isFinishing || isDestroyed) return
         val failedKind = rendererKind
-        FileLogger.w(TAG, "Renderer $failedKind failed: $message")
+        val firstFrameSeen = hadFirstFrame ||
+            sessionCoordinator.current().phase == RendererSessionPhase.PLAYING
+        val isStartupWatchdog = message.contains("did not become ready", ignoreCase = true)
+        val effectiveSeverity = severity
+            ?: if (isStartupWatchdog || !firstFrameSeen) {
+                // Legacy/MPV errors without severity: allow one startup failover only.
+                ExoPlaybackErrorPolicy.EscalationSeverity.STARTUP_ENGINE_FAILOVER
+            } else {
+                ExoPlaybackErrorPolicy.EscalationSeverity.TERMINAL
+            }
+        val allowEngineFailover = ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
+            severity = effectiveSeverity,
+            hasFirstFrame = firstFrameSeen,
+        )
+
+        FileLogger.w(
+            TAG,
+            "Renderer $failedKind failed: $message " +
+                "(severity=$effectiveSeverity firstFrame=$firstFrameSeen allowFailover=$allowEngineFailover)",
+        )
         val failedSession = session
         requestedStartPositionMs = lastPositionMs.takeIf { it > 0L } ?: requestedStartPositionMs
         pendingSeekTracker.clear()
@@ -1967,7 +2004,7 @@ class PlayerHostActivity : ComponentActivity(), PlaybackProgressSource {
             RendererKind.EXO -> RendererKind.MPV
             else -> null
         }
-        if (fallback == null || fallback in attemptedRenderers) {
+        if (!allowEngineFailover || fallback == null || fallback in attemptedRenderers) {
             showTransition(R.string.player_failed, force = true)
             finishingSession = true
             val finishRunnable = Runnable {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/RendererProtocol.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/RendererProtocol.kt
@@ -10,6 +10,10 @@ internal object RendererProtocol {
     const val KEY_PAYLOAD_JSON = "payload_json"
     const val KEY_EVENT = "event"
     const val KEY_ERROR = "error"
+    /** [ERROR_SEVERITY_STARTUP_FAILOVER] or [ERROR_SEVERITY_TERMINAL]. */
+    const val KEY_ERROR_SEVERITY = "error_severity"
+    const val KEY_ERROR_CODE = "error_code"
+    const val KEY_HAD_FIRST_FRAME = "had_first_frame"
     const val KEY_STATE = "state"
     const val KEY_POSITION_MS = "position_ms"
     const val KEY_DURATION_MS = "duration_ms"
@@ -49,4 +53,12 @@ internal object RendererProtocol {
     const val EVENT_CAPABILITIES = "capabilities"
     const val EVENT_STOPPED = "stopped"
     const val EVENT_ERROR = "error"
+
+    /**
+     * Hard capability/format failure before first frame — host may switch engines once.
+     * Mid-playback recoverable exhaustion must use [ERROR_SEVERITY_TERMINAL] instead.
+     */
+    const val ERROR_SEVERITY_STARTUP_FAILOVER = "startup_failover"
+    /** Give up on this engine/item; do not auto-switch engines after playback has started. */
+    const val ERROR_SEVERITY_TERMINAL = "terminal"
 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsOverlay.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsOverlay.kt
@@ -65,6 +65,7 @@ fun PlayerControlsOverlay(
     onPlayerSwitched: (String) -> Unit = {},
     onToggleAudioBoost: () -> Unit = {},
     onAdjustSubtitleDelay: (Long) -> Unit = {},
+    onResetSubtitleDelay: () -> Unit = {},
     onPreloadSubtitles: (List<String>) -> Unit = {},
     onSkipSegment: () -> Unit = {},
     onSkipButtonFocusChanged: (Boolean) -> Unit = {},
@@ -116,6 +117,7 @@ fun PlayerControlsOverlay(
                         onPreloadLanguage = onPreloadSubtitles,
                         onTrackSelected = onTrackSelected,
                         onAdjustDelay = onAdjustSubtitleDelay,
+                        onResetDelay = onResetSubtitleDelay,
                         onDismiss = onOverlayDismiss,
                         activeMetadata = state.activeMetadata,
                     )

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsViewModel.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/PlayerControlsViewModel.kt
@@ -130,15 +130,24 @@ class PlayerControlsViewModel : ViewModel() {
         _controlsState.update { it.copy(isPlaying = playing) }
     }
 
+    /**
+     * Set absolute subtitle delay (ms). Positive advances cues relative to video.
+     * Always pushes to the engine and external overlay manager — do not only update UI state.
+     */
     fun setSubtitleDelay(delayMs: Long) {
-        _controlsState.update { it.copy(subtitleDelayMs = delayMs) }
+        val clamped = delayMs.coerceIn(-120_000L, 120_000L)
+        engine?.setSubtitleDelay(clamped)
+        subtitleManager?.setOffset(clamped)
+        _controlsState.update { it.copy(subtitleDelayMs = clamped) }
     }
 
     fun adjustSubtitleDelay(deltaMs: Long) {
-        val newDelay = _controlsState.value.subtitleDelayMs + deltaMs
-        engine?.setSubtitleDelay(newDelay)
-        subtitleManager?.setOffset(newDelay)
-        setSubtitleDelay(newDelay)
+        setSubtitleDelay(_controlsState.value.subtitleDelayMs + deltaMs)
+    }
+
+    /** Zero the offset (used by the subtitle Sync "Reset" control). */
+    fun resetSubtitleDelay() {
+        setSubtitleDelay(0L)
     }
 
     fun toggleAudioBoost() {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/SubtitleSelectionOverlay.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/ui/player/SubtitleSelectionOverlay.kt
@@ -210,6 +210,7 @@ fun SubtitleSelectionOverlay(
     onPreloadLanguage: (List<String>) -> Unit,
     onTrackSelected: (UnifiedTrack) -> Unit,
     onAdjustDelay: (Long) -> Unit,
+    onResetDelay: () -> Unit = {},
     onDismiss: () -> Unit,
     activeMetadata: playbridge.VisualMetadata? = null,
 ) {
@@ -348,7 +349,11 @@ fun SubtitleSelectionOverlay(
 
                 // ---- Sync rail ----
                 RailColumn(title = "Sync", width = 250.dp) {
-                    SyncControl(delayMs = subtitleDelayMs, onAdjust = onAdjustDelay)
+                    SyncControl(
+                        delayMs = subtitleDelayMs,
+                        onAdjust = onAdjustDelay,
+                        onReset = onResetDelay,
+                    )
                 }
             }
         }
@@ -485,7 +490,11 @@ private fun EmptyRailCard(text: String) {
 }
 
 @Composable
-private fun SyncControl(delayMs: Long, onAdjust: (Long) -> Unit) {
+private fun SyncControl(
+    delayMs: Long,
+    onAdjust: (Long) -> Unit,
+    onReset: () -> Unit,
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -503,8 +512,10 @@ private fun SyncControl(delayMs: Long, onAdjust: (Long) -> Unit) {
         SyncRow(label = "Fine", minus = "−100ms", plus = "+100ms", step = 100L, onAdjust = onAdjust)
         SyncRow(label = "Coarse", minus = "−1s", plus = "+1s", step = 1000L, onAdjust = onAdjust)
         if (delayMs != 0L) {
+            // Absolute zero — do not use onAdjust(-delayMs): that depends on a captured delay
+            // value and is easy to mis-wire. Reset must always force 0 on engine + UI.
             Button(
-                onClick = { onAdjust(-delayMs) },
+                onClick = onReset,
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.colors(
                     containerColor = Color.White.copy(alpha = 0.1f),

--- a/tv/android/player/app/src/main/java/com/playbridge/player/update/UpdateChecker.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/update/UpdateChecker.kt
@@ -92,6 +92,15 @@ class UpdateChecker private constructor(
                         )
                         _state.value = UpdateState.Idle
                     }
+                    // "Later" snooze: suppress auto prompts for this exact version until a
+                    // newer release ships (or the user taps Check for updates).
+                    !manual && isSnoozed(info.version) -> {
+                        Log.i(
+                            TAG,
+                            "check: ${info.version} available but snoozed after Later — suppressing"
+                        )
+                        _state.value = UpdateState.Idle
+                    }
                     else -> {
                         Log.i(TAG, "check: update available ${info.version} (${info.source})")
                         _state.value = UpdateState.Available(info)
@@ -203,7 +212,18 @@ class UpdateChecker private constructor(
         runCatching { appContext.startActivity(intent) }
     }
 
+    /**
+     * Dismiss the available-update dialog ("Later").
+     *
+     * Persists a per-version snooze so automatic cold-start checks do not re-open the
+     * dialog on every Activity recreate (common in debug) or app relaunch. Manual
+     * "Check for updates" still surfaces the same version.
+     */
     fun dismiss() {
+        val current = _state.value
+        if (current is UpdateState.Available) {
+            snooze(current.info.version)
+        }
         _state.value = UpdateState.Idle
     }
 
@@ -263,12 +283,32 @@ class UpdateChecker private constructor(
         return done
     }
 
+    /** Remember that the user chose Later for [version] (auto-check only). */
+    private fun snooze(version: AppVersion) {
+        prefs().edit().putString(KEY_SNOOZED_VERSION, version.toString()).apply()
+        Log.i(TAG, "snooze: will not auto-prompt for $version again")
+    }
+
+    /**
+     * True when [version] was dismissed via Later and is not newer than the snoozed
+     * version. A *newer* release always clears the snooze path by failing this check.
+     */
+    private fun isSnoozed(version: AppVersion): Boolean {
+        val raw = prefs().getString(KEY_SNOOZED_VERSION, null) ?: return false
+        val snoozed = AppVersion.parse(raw) ?: return false
+        // Snooze covers this version and any older one; a strictly newer release re-prompts.
+        val matches = version <= snoozed
+        Log.d(TAG, "isSnoozed($version): snoozed=$snoozed -> $matches")
+        return matches
+    }
+
     companion object {
         private const val TAG = "UpdateChecker"
         private const val DOWNLOAD_ENDPOINT = "https://playbridge.app/download/tv-player"
         private const val PLAY_STORE_PACKAGE = "com.android.vending"
         private const val PLAY_WEB_URL =
             "https://play.google.com/store/apps/details?id=com.playbridge.player"
+        private const val KEY_SNOOZED_VERSION = "snoozed_version"
 
         /**
          * How long after first detecting a new version we wait before nudging a Play Store

--- a/tv/android/player/app/src/test/java/com/playbridge/player/player/ExoPlaybackErrorPolicyTest.kt
+++ b/tv/android/player/app/src/test/java/com/playbridge/player/player/ExoPlaybackErrorPolicyTest.kt
@@ -1,0 +1,225 @@
+package com.playbridge.player.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExoPlaybackErrorPolicyTest {
+
+    @Test
+    fun `behind live window recovers at live edge`() {
+        val disposition = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.BEHIND_LIVE_WINDOW,
+            isLive = true,
+            hasFirstFrame = true,
+        )
+        assertEquals(
+            ExoPlaybackErrorPolicy.Disposition.Recover(ExoPlaybackErrorPolicy.RecoveryStrategy.LIVE_EDGE),
+            disposition,
+        )
+    }
+
+    @Test
+    fun `behind live window exhausted is terminal not failover`() {
+        val disposition = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.BEHIND_LIVE_WINDOW,
+            isLive = true,
+            hasFirstFrame = true,
+            budget = ExoPlaybackErrorPolicy.AttemptBudget(
+                liveEdge = ExoPlaybackErrorPolicy.MAX_LIVE_EDGE_RECOVERIES,
+            ),
+        )
+        assertEscalate(disposition, ExoPlaybackErrorPolicy.EscalationSeverity.TERMINAL)
+        assertFalse(
+            ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
+                ExoPlaybackErrorPolicy.EscalationSeverity.TERMINAL,
+                hasFirstFrame = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `live timeout recovers at live edge mid playback`() {
+        val disposition = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.TIMEOUT,
+            isLive = true,
+            hasFirstFrame = true,
+            positionMs = 60_000L,
+            durationMs = 0L,
+        )
+        assertEquals(
+            ExoPlaybackErrorPolicy.Disposition.Recover(ExoPlaybackErrorPolicy.RecoveryStrategy.LIVE_EDGE),
+            disposition,
+        )
+    }
+
+    @Test
+    fun `vod timeout near end is treated as ended`() {
+        val disposition = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.TIMEOUT,
+            isLive = false,
+            hasFirstFrame = true,
+            positionMs = 96_000L,
+            durationMs = 100_000L,
+        )
+        assertTrue(disposition is ExoPlaybackErrorPolicy.Disposition.TreatAsEnded)
+    }
+
+    @Test
+    fun `network error on live recovers without engine switch`() {
+        val disposition = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.IO_NETWORK_CONNECTION_TIMEOUT,
+            isLive = true,
+            hasFirstFrame = true,
+        )
+        assertEquals(
+            ExoPlaybackErrorPolicy.Disposition.Recover(ExoPlaybackErrorPolicy.RecoveryStrategy.LIVE_EDGE),
+            disposition,
+        )
+    }
+
+    @Test
+    fun `http 403 is terminal and never engine failover`() {
+        val disposition = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.IO_BAD_HTTP_STATUS,
+            isLive = false,
+            hasFirstFrame = false,
+            httpStatus = 403,
+        )
+        assertEscalate(disposition, ExoPlaybackErrorPolicy.EscalationSeverity.TERMINAL)
+        assertFalse(
+            ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
+                ExoPlaybackErrorPolicy.EscalationSeverity.TERMINAL,
+                hasFirstFrame = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `unsupported format before first frame may failover`() {
+        val disposition = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.PARSING_CONTAINER_UNSUPPORTED,
+            isLive = false,
+            hasFirstFrame = false,
+            isUnrecognizedFormat = true,
+        )
+        assertEscalate(disposition, ExoPlaybackErrorPolicy.EscalationSeverity.STARTUP_ENGINE_FAILOVER)
+        assertTrue(
+            ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
+                ExoPlaybackErrorPolicy.EscalationSeverity.STARTUP_ENGINE_FAILOVER,
+                hasFirstFrame = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `decoder failure after first frame is terminal not failover`() {
+        val disposition = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.DECODING_FAILED,
+            isLive = true,
+            hasFirstFrame = true,
+            budget = ExoPlaybackErrorPolicy.AttemptBudget(decode = 1),
+        )
+        assertEscalate(disposition, ExoPlaybackErrorPolicy.EscalationSeverity.TERMINAL)
+        assertFalse(
+            ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
+                ExoPlaybackErrorPolicy.EscalationSeverity.TERMINAL,
+                hasFirstFrame = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `decoder failure before first frame may failover after one recovery`() {
+        val first = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.DECODER_INIT_FAILED,
+            isLive = false,
+            hasFirstFrame = false,
+        )
+        assertEquals(
+            ExoPlaybackErrorPolicy.Disposition.Recover(ExoPlaybackErrorPolicy.RecoveryStrategy.REPREPARE),
+            first,
+        )
+
+        val second = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.DECODER_INIT_FAILED,
+            isLive = false,
+            hasFirstFrame = false,
+            budget = ExoPlaybackErrorPolicy.AttemptBudget(decode = 1),
+        )
+        assertEscalate(second, ExoPlaybackErrorPolicy.EscalationSeverity.STARTUP_ENGINE_FAILOVER)
+        assertTrue(
+            ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
+                ExoPlaybackErrorPolicy.EscalationSeverity.STARTUP_ENGINE_FAILOVER,
+                hasFirstFrame = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `audio discontinuity seeks and retries`() {
+        val disposition = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.AUDIO_TRACK_WRITE_FAILED,
+            isLive = false,
+            hasFirstFrame = true,
+        )
+        assertEquals(
+            ExoPlaybackErrorPolicy.Disposition.Recover(ExoPlaybackErrorPolicy.RecoveryStrategy.SEEK_RETRY),
+            disposition,
+        )
+    }
+
+    @Test
+    fun `mayAutoSwitchEngine requires startup failover and no first frame`() {
+        assertTrue(
+            ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
+                ExoPlaybackErrorPolicy.EscalationSeverity.STARTUP_ENGINE_FAILOVER,
+                hasFirstFrame = false,
+            ),
+        )
+        assertFalse(
+            ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
+                ExoPlaybackErrorPolicy.EscalationSeverity.STARTUP_ENGINE_FAILOVER,
+                hasFirstFrame = true,
+            ),
+        )
+        assertFalse(
+            ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
+                ExoPlaybackErrorPolicy.EscalationSeverity.TERMINAL,
+                hasFirstFrame = false,
+            ),
+        )
+    }
+
+    private fun classify(
+        errorCode: Int,
+        isLive: Boolean,
+        hasFirstFrame: Boolean,
+        positionMs: Long = 0L,
+        durationMs: Long = 0L,
+        httpStatus: Int? = null,
+        isUnrecognizedFormat: Boolean = false,
+        budget: ExoPlaybackErrorPolicy.AttemptBudget = ExoPlaybackErrorPolicy.AttemptBudget(),
+    ): ExoPlaybackErrorPolicy.Disposition = ExoPlaybackErrorPolicy.classify(
+        ExoPlaybackErrorPolicy.ErrorFacts(
+            errorCode = errorCode,
+            errorCodeName = "ERROR_$errorCode",
+            isLive = isLive,
+            hasFirstFrame = hasFirstFrame,
+            positionMs = positionMs,
+            durationMs = durationMs,
+            httpStatus = httpStatus,
+            isUnrecognizedFormat = isUnrecognizedFormat,
+            budget = budget,
+        ),
+    )
+
+    private fun assertEscalate(
+        disposition: ExoPlaybackErrorPolicy.Disposition,
+        severity: ExoPlaybackErrorPolicy.EscalationSeverity,
+    ) {
+        val escalate = disposition as ExoPlaybackErrorPolicy.Disposition.Escalate
+        assertEquals(severity, escalate.severity)
+    }
+}


### PR DESCRIPTION
## Summary

- **Live playback stability:** Exo renderer no longer treats every Media3 error as fatal engine failover. Transient live/network/timeout/behind-live-window failures recover in-engine (live edge or re-prepare) with budgets; host auto-switch is limited to **startup** hard failures (no first frame), matching Nuvio’s model. Mid-playback stutters should no longer flash “Switching player…”.
- **Subtitle offset (#171):** Exo’s multi-process path had `setSubtitleDelay = Unit`, so phone/TV offset controls did nothing for embedded tracks. Wire delay through `ExoPlayerEngine` + `OffsetTextRenderer` (positive offset advances cues, same as SubtitleManager / UI preview).

## Changes

| Area | What |
|---|---|
| `ExoPlaybackErrorPolicy` | Pure classifier: recover vs escalate vs treat-as-ended |
| `ExoRendererService` | Apply recovery; escalate with severity + `had_first_frame` |
| `PlayerHostActivity` | Auto engine switch only for startup failover |
| `OffsetTextRenderer` / `ExoPlayerEngine` | Subtitle delay for embedded + sideloaded Exo text |
| `ExoRendererService.setSubtitleDelay` | Forward to engine (was no-op) |
| Tests | `ExoPlaybackErrorPolicyTest` |

Fixes #171

## Test plan

- [x] `./gradlew :player:app:testFossDebugUnitTest --tests "com.playbridge.player.player.ExoPlaybackErrorPolicyTest"`
- [x] `./gradlew :player:app:compileFossDebugKotlin`
- [x] Manual: cast a **live** stream to TV on Exo; induce a short rebuffer — should recover without “Switching player…”
- [x] Manual: cast VOD with **embedded** subs; from phone adjust subtitle offset ±250ms — cues should move
- [x] Manual: unsupported/hard decoder fail **before** first frame — still allowed one-shot Exo→MPV switch
- [x] Manual: MPV path still applies `sub-delay` as before