### PR TITLE
feat(android): redesign Devices screen and cast destination sheet

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -315,12 +315,22 @@ fun AppNavHost(
     // Device picker opened from the idle cast bar (rendered once at the host level so
     // it survives screen transitions in the AnimatedContent below).
     var showDevicePicker by remember { mutableStateOf(false) }
+    // "Find more devices" from host-level pickers must expand Other devices even when
+    // the parent left connectionInitialTab at 0 (BrowserActivity only sets tab=1 on some paths).
+    var expandOtherDevices by remember { mutableStateOf(false) }
+    LaunchedEffect(currentScreen) {
+        if (currentScreen != Screen.Connection) expandOtherDevices = false
+    }
+    fun openAllDevicesExpanded() {
+        expandOtherDevices = true
+        onScreenChange(Screen.Connection)
+    }
     if (showDevicePicker) {
         DeviceConnectionSheet(
             onDismiss = { showDevicePicker = false },
             onOpenAllDevices = {
                 showDevicePicker = false
-                onScreenChange(Screen.Connection)
+                openAllDevicesExpanded()
             },
             showThisDevice = true,
         )
@@ -734,7 +744,7 @@ fun AppNavHost(
                                 onScreenChange(Screen.Remote)
                             }
                         } else null,
-                        initialTab = connectionInitialTab
+                        initialTab = if (expandOtherDevices) 1 else connectionInitialTab,
                     )
                 }
                 Screen.Downloads -> {
@@ -1461,7 +1471,7 @@ fun AppNavHost(
                         viewModel = connectionViewModel,
                         uiState = phoneFilesUiState,
                         onBack = { onScreenChange(Screen.Dashboard) },
-                        onOpenAllDevices = { onScreenChange(Screen.Connection) },
+                        onOpenAllDevices = { openAllDevicesExpanded() },
                         onAddToCollection = { media ->
                             onAddToCollection(
                                 com.playbridge.sender.data.collection.CollectionItemDraft(

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/DevicePicker.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/DevicePicker.kt
@@ -259,8 +259,11 @@ fun DeviceConnectionSheet(
     }
 
     val playBridgeList = ConnectionMerge.playBridgeHistory(history).map { saved ->
+        // Prefer the live discovered endpoint (DHCP/control URL can change) while
+        // keeping the history entry for credentials and last-connected metadata.
+        val live = ConnectionMerge.withDiscoveredEndpoint(saved, discoveredDevices)
         UnifiedDevice(
-            connectDevice = saved,
+            connectDevice = live,
             historyEntry = saved,
             isOnline = pings[saved.endpointKey.toString()] == true ||
                 discoveredDevices.any { ConnectionMerge.isSameDevice(it, saved) },
@@ -273,8 +276,9 @@ fun DeviceConnectionSheet(
         )
 
     val recentExternal = ConnectionMerge.recentExternalHistory(history).map { saved ->
+        val live = ConnectionMerge.withDiscoveredEndpoint(saved, discoveredDevices)
         UnifiedDevice(
-            connectDevice = saved,
+            connectDevice = live,
             historyEntry = saved,
             isOnline = pings[saved.endpointKey.toString()] == true ||
                 discoveredDevices.any { ConnectionMerge.isSameDevice(it, saved) },
@@ -285,30 +289,33 @@ fun DeviceConnectionSheet(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     fun pick(device: TvDevice) {
-        val ready = when (device.resolvedProtocol) {
-            CastProtocol.DLNA -> viewModel.selectDlnaTarget(device)
-            CastProtocol.ROKU -> true.also { viewModel.selectRokuTarget(device) }
-            CastProtocol.GOOGLE_CAST -> true.also { viewModel.selectGoogleCastTarget(device) }
+        // Heal stale saved IPs / DLNA control URLs against the current discovery set
+        // before selecting — shortcuts stay "online" by UUID but may still hold old endpoints.
+        val target = ConnectionMerge.withDiscoveredEndpoint(device, discoveredDevices)
+        val ready = when (target.resolvedProtocol) {
+            CastProtocol.DLNA -> viewModel.selectDlnaTarget(target)
+            CastProtocol.ROKU -> true.also { viewModel.selectRokuTarget(target) }
+            CastProtocol.GOOGLE_CAST -> true.also { viewModel.selectGoogleCastTarget(target) }
             CastProtocol.PLAYBRIDGE -> {
                 viewModel.selectNativeRoute()
                 val alreadyLinked = isConnected && tvDevice?.let {
-                    ConnectionMerge.isSameDevice(it, device)
+                    ConnectionMerge.isSameDevice(it, target)
                 } == true
                 if (!alreadyLinked) {
                     connectKnownOrPair(
                         viewModel,
                         history,
-                        device.ip,
-                        device.port,
-                        device.name,
-                        device.uuid,
+                        target.ip,
+                        target.port,
+                        target.name,
+                        target.uuid,
                     )
                 }
                 true
             }
         }
         if (ready) {
-            onPickedDevice?.invoke(device)
+            onPickedDevice?.invoke(target)
             onDismiss()
         }
     }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/DevicePicker.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/DevicePicker.kt
@@ -1,6 +1,8 @@
 package com.playbridge.sender.cast
+
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,23 +10,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Cast
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Smartphone
 import androidx.compose.material.icons.filled.Tv
-import androidx.compose.runtime.LaunchedEffect
-import com.playbridge.sender.ui.UnifiedDevice
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -33,10 +27,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -46,18 +40,23 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.playbridge.sender.connection.ConnectionViewModel
 import com.playbridge.sender.connection.ConnectionMerge
+import com.playbridge.sender.connection.ConnectionViewModel
 import com.playbridge.sender.connection.WebSocketClient
 import com.playbridge.sender.data.settings.SettingsRepository
-import com.playbridge.sender.model.TvDevice
 import com.playbridge.sender.model.CastProtocol
+import com.playbridge.sender.model.TvDevice
+import com.playbridge.sender.ui.FindMoreDevicesRow
+import com.playbridge.sender.ui.LocalNetworkBanners
+import com.playbridge.sender.ui.NowDestinationCard
+import com.playbridge.sender.ui.SectionLabel
+import com.playbridge.sender.ui.ThisDeviceDestinationRow
 import com.playbridge.sender.ui.TvDeviceRow
+import com.playbridge.sender.ui.UnifiedDevice
 import com.playbridge.sender.ui.connectKnownOrPair
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
@@ -78,7 +77,7 @@ private val ConnectingOrange = Color(0xFFFF9800)
  * @param showThisDevice include a "This Device" (play on phone) entry — false in the Cast sheet.
  * @param castStatusLabel use cast-target status wording ("<device name>" when connected,
  *   "Not connected" otherwise) instead of the default "Watching on: …" framing. True in the Cast sheet.
- * @param onOpenAllDevices open the full TV Connection screen (manual connect, DLNA, auto-connect).
+ * @param onOpenAllDevices open the full Devices screen (discovery, manual IP, auto-connect).
  */
 @Composable
 fun DeviceChip(
@@ -205,12 +204,10 @@ fun DeviceChip(
 }
 
 /**
- * Bottom-sheet device picker: a minimal version of the full TV Connection screen. Shows the active
- * cast target (with Disconnect), an optional "This Device" entry, the saved "Your TVs" list,
- * and an "All devices" link to the full discovery screen.
+ * Fast destination picker: current cast target, optional "This phone", paired PlayBridge
+ * TVs, a short "Recent other" list, and a link into the full Devices screen for discovery.
  *
- * Self-sources the activity [ConnectionViewModel] and drives connect/disconnect/DLNA directly;
- * [onPickedThisDevice] / [onPickedDevice] are optional host hooks after routing changes.
+ * Self-sources the activity [ConnectionViewModel]; host hooks run after routing changes.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -219,15 +216,17 @@ fun DeviceConnectionSheet(
     onOpenAllDevices: () -> Unit,
     showThisDevice: Boolean = true,
     onPickedThisDevice: (() -> Unit)? = null,
-    onPickedDevice: ((TvDevice) -> Unit)? = null
+    onPickedDevice: ((TvDevice) -> Unit)? = null,
 ) {
     val viewModel: ConnectionViewModel = koinViewModel()
     val history by viewModel.deviceHistory.collectAsState(initial = emptyList())
+    val discoveredDevices by viewModel.discoveredDevices.collectAsState()
     val pings by viewModel.savedDevicesOnlineStatus.collectAsState()
     val connectionState by viewModel.connectionState.collectAsState()
     val tvDevice by viewModel.tvDevice.collectAsState(initial = null)
     val activeExternalDevice by viewModel.activeExternalDevice.collectAsState()
     val route by viewModel.route.collectAsState()
+    val networkStatus by viewModel.networkStatus.collectAsState()
 
     val isConnected = connectionState is WebSocketClient.ConnectionState.Connected
     val nativeSelected = route is CastSessionManager.Route.NativeTv
@@ -236,31 +235,83 @@ fun DeviceConnectionSheet(
             connectionState is WebSocketClient.ConnectionState.WaitingForApproval ||
             connectionState is WebSocketClient.ConnectionState.Retrying
         )
-    val onPhone = route is CastSessionManager.Route.ThisDevice
+    val onPhone = route is CastSessionManager.Route.ThisDevice && activeExternalDevice == null
 
-    // Ping saved devices when history changes or sheet is opened
+    DisposableEffect(Unit) {
+        viewModel.retainDiscovery()
+        onDispose { viewModel.releaseDiscovery() }
+    }
+
     LaunchedEffect(history) {
         viewModel.pingSavedDevices(history)
     }
 
-    val unified = history.map { saved ->
-        val isOnline = pings[saved.endpointKey.toString()] == true
+    fun isActive(device: TvDevice): Boolean {
+        val external = activeExternalDevice
+        if (external != null && ConnectionMerge.isSameDevice(device, external)) {
+            return true
+        }
+        val linked = tvDevice
+        if (isConnected && linked != null && ConnectionMerge.isSameDevice(device, linked)) {
+            return true
+        }
+        return false
+    }
+
+    val playBridgeList = ConnectionMerge.playBridgeHistory(history).map { saved ->
         UnifiedDevice(
             connectDevice = saved,
             historyEntry = saved,
-            isOnline = isOnline,
-            lastConnected = saved.lastConnected
+            isOnline = pings[saved.endpointKey.toString()] == true ||
+                discoveredDevices.any { ConnectionMerge.isSameDevice(it, saved) },
+            lastConnected = saved.lastConnected,
         )
-    }.filterNot { u ->
-        activeExternalDevice?.let { ConnectionMerge.isSameDevice(u.connectDevice, it) } == true ||
-            (nativeSelected && isConnected && tvDevice?.let { c ->
-                ConnectionMerge.isSameDevice(u.connectDevice, c)
-            } == true)
-    }.sortedWith(
-        compareByDescending<UnifiedDevice> { it.isOnline }
-            .thenByDescending { it.lastConnected ?: Long.MAX_VALUE }
-    )
+    }.filterNot { isActive(it.connectDevice) }
+        .sortedWith(
+            compareByDescending<UnifiedDevice> { it.isOnline }
+                .thenByDescending { it.lastConnected ?: 0L },
+        )
+
+    val recentExternal = ConnectionMerge.recentExternalHistory(history).map { saved ->
+        UnifiedDevice(
+            connectDevice = saved,
+            historyEntry = saved,
+            isOnline = pings[saved.endpointKey.toString()] == true ||
+                discoveredDevices.any { ConnectionMerge.isSameDevice(it, saved) },
+            lastConnected = saved.lastConnected,
+        )
+    }.filterNot { isActive(it.connectDevice) }
+
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    fun pick(device: TvDevice) {
+        val ready = when (device.resolvedProtocol) {
+            CastProtocol.DLNA -> viewModel.selectDlnaTarget(device)
+            CastProtocol.ROKU -> true.also { viewModel.selectRokuTarget(device) }
+            CastProtocol.GOOGLE_CAST -> true.also { viewModel.selectGoogleCastTarget(device) }
+            CastProtocol.PLAYBRIDGE -> {
+                viewModel.selectNativeRoute()
+                val alreadyLinked = isConnected && tvDevice?.let {
+                    ConnectionMerge.isSameDevice(it, device)
+                } == true
+                if (!alreadyLinked) {
+                    connectKnownOrPair(
+                        viewModel,
+                        history,
+                        device.ip,
+                        device.port,
+                        device.name,
+                        device.uuid,
+                    )
+                }
+                true
+            }
+        }
+        if (ready) {
+            onPickedDevice?.invoke(device)
+            onDismiss()
+        }
+    }
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(
@@ -269,53 +320,36 @@ fun DeviceConnectionSheet(
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 20.dp)
                 .padding(bottom = 24.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
                 text = "Cast to",
                 style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold
+                fontWeight = FontWeight.Bold,
             )
 
-            // Active target card (DLNA / connected TV) or a connecting indicator.
-            val external = activeExternalDevice
-            when {
-                external != null -> ActiveDeviceCard(
-                    name = external.name,
-                    subtitle = "${external.ip} · cast a video to play here",
-                    icon = Icons.Default.Cast,
-                    badge = external.resolvedProtocol.displayName,
-                    onDisconnect = {
-                        viewModel.disconnectExternalTarget()
-                        onDismiss()
-                    }
-                )
-                nativeSelected && isConnected -> {
-                    val connected = connectionState as WebSocketClient.ConnectionState.Connected
-                    ActiveDeviceCard(
-                        name = connected.serverName,
-                        subtitle = tvDevice?.let { "${it.ip}:${it.port}" },
-                        icon = Icons.Default.Tv,
-                        badge = CastProtocol.PLAYBRIDGE.displayName,
-                        onDisconnect = {
-                            // A manual disconnect is a deliberate "stop watching on TV":
-                            // route back to this phone so nothing tries to reconnect.
-                            viewModel.selectThisDevice()
-                            viewModel.disconnect()
-                            onDismiss()
-                        }
-                    )
-                }
-                // While connecting/reconnecting, the global connection popup (in
-                // BrowserActivity) is the single source of truth — don't also show an
-                // inline card here, which produced two overlays saying the same thing.
-                isConnecting -> Unit
-            }
+            LocalNetworkBanners(status = networkStatus)
 
-            // Player-engine picker, shown with the connected TV it configures (native
-            // sessions only — DLNA renderers pick their own player). Options reflect
-            // what this TV reported at auth; the choice persists via SettingsRepository.
-            if (nativeSelected && isConnected && external == null) {
+            NowDestinationCard(
+                connectionState = connectionState,
+                route = route,
+                tvDevice = tvDevice,
+                activeExternalDevice = activeExternalDevice,
+                onCastHere = { viewModel.selectNativeRoute() },
+                onDisconnectNative = {
+                    viewModel.selectThisDevice()
+                    viewModel.disconnect()
+                    onDismiss()
+                },
+                onDisconnectExternal = {
+                    viewModel.disconnectExternalTarget()
+                    onDismiss()
+                },
+                isConnecting = isConnecting,
+            )
+
+            // Player-engine picker for a linked PlayBridge session (native route only).
+            if (nativeSelected && isConnected && activeExternalDevice == null) {
                 val settingsRepository: SettingsRepository = koinInject()
                 val playerMode by settingsRepository.tvPlayerMode.collectAsState(initial = "tv")
                 val scope = rememberCoroutineScope()
@@ -326,243 +360,92 @@ fun DeviceConnectionSheet(
                         .fillMaxWidth()
                         .horizontalScroll(rememberScrollState()),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
                         text = "Player",
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     playerOptions.forEach { (id, label) ->
                         FilterChip(
                             selected = id == selectedPlayer,
                             onClick = { scope.launch { settingsRepository.setTvPlayerMode(id) } },
-                            label = { Text(label) }
+                            label = { Text(label) },
                         )
                     }
                 }
             }
 
             if (showThisDevice) {
-                ThisDeviceRow(
-                    selected = onPhone,
+                ThisDeviceDestinationRow(
+                    selected = onPhone && !isConnecting,
                     onClick = {
-                        // Authoritative routing intent.
                         viewModel.selectThisDevice()
                         onPickedThisDevice?.invoke()
                         onDismiss()
-                    }
+                    },
                 )
             }
 
             Row(
-                modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 4.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    text = "Your TVs",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    fontWeight = FontWeight.Bold
-                )
-                IconButton(onClick = { viewModel.pingSavedDevices(history) }) {
+                SectionLabel("PlayBridge")
+                IconButton(onClick = {
+                    viewModel.pingSavedDevices(history)
+                    viewModel.rescan()
+                }) {
                     Icon(
                         imageVector = Icons.Default.Refresh,
-                        contentDescription = "Refresh TV status",
-                        tint = MaterialTheme.colorScheme.primary
+                        contentDescription = "Refresh",
+                        tint = MaterialTheme.colorScheme.primary,
                     )
                 }
             }
 
-            if (unified.isEmpty()) {
+            if (playBridgeList.isEmpty()) {
                 Text(
-                    text = "No saved TVs. Tap 'Set up new TV' to scan.",
+                    text = "No PlayBridge TVs yet. Tap Find more devices to scan and pair.",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(vertical = 8.dp)
+                    modifier = Modifier.padding(vertical = 4.dp),
                 )
             } else {
-                var selectedProtocolFilter by remember { mutableStateOf("All") }
-
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .horizontalScroll(rememberScrollState()),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    listOf("All", "PlayBridge", "DLNA", "Roku", "Google Cast").forEach { proto ->
-                        FilterChip(
-                            selected = selectedProtocolFilter == proto,
-                            onClick = { selectedProtocolFilter = proto },
-                            label = { Text(proto) }
-                        )
-                    }
-                }
-
-                val filtered = unified.filter { u ->
-                    when (selectedProtocolFilter) {
-                        "PlayBridge" -> u.connectDevice.resolvedProtocol == CastProtocol.PLAYBRIDGE
-                        "DLNA" -> u.connectDevice.resolvedProtocol == CastProtocol.DLNA
-                        "Roku" -> u.connectDevice.resolvedProtocol == CastProtocol.ROKU
-                        "Google Cast" -> u.connectDevice.resolvedProtocol == CastProtocol.GOOGLE_CAST
-                        else -> true
-                    }
-                }
-
-                filtered.forEach { device ->
+                playBridgeList.forEach { device ->
                     TvDeviceRow(
                         device = device,
-                        onClick = {
-                            val ready = when (device.connectDevice.resolvedProtocol) {
-                                CastProtocol.DLNA -> viewModel.selectDlnaTarget(device.connectDevice)
-                                CastProtocol.ROKU -> true.also {
-                                    viewModel.selectRokuTarget(device.connectDevice)
-                                }
-                                CastProtocol.GOOGLE_CAST -> true.also {
-                                    viewModel.selectGoogleCastTarget(device.connectDevice)
-                                }
-                                CastProtocol.PLAYBRIDGE -> {
-                                    viewModel.selectNativeRoute()
-                                    val alreadyLinked = isConnected && tvDevice?.let {
-                                        ConnectionMerge.isSameDevice(it, device.connectDevice)
-                                    } == true
-                                    if (!alreadyLinked) {
-                                        connectKnownOrPair(
-                                            viewModel,
-                                            history,
-                                            device.connectDevice.ip,
-                                            device.connectDevice.port,
-                                            device.connectDevice.name,
-                                            device.connectDevice.uuid
-                                        )
-                                    }
-                                    true
-                                }
-                            }
-                            if (ready) {
-                                onPickedDevice?.invoke(device.connectDevice)
-                                onDismiss()
-                            }
-                        },
+                        showProtocolBadge = false,
+                        onClick = { pick(device.connectDevice) },
                         onRemove = device.historyEntry?.let { entry ->
                             { viewModel.removeDeviceFromHistory(entry) }
-                        }
+                        },
                     )
                 }
             }
 
-            AllDevicesRow(onClick = onOpenAllDevices)
-        }
-    }
-}
-
-@Composable
-private fun ActiveDeviceCard(
-    name: String,
-    subtitle: String?,
-    icon: ImageVector,
-    badge: String?,
-    onDisconnect: () -> Unit
-) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Icon(icon, contentDescription = null, modifier = Modifier.size(32.dp), tint = MaterialTheme.colorScheme.onPrimaryContainer)
-            Column(modifier = Modifier.weight(1f)) {
-                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(
-                        text = name,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f, fill = false)
-                    )
-                    if (badge != null) ProtocolBadge(badge)
-                }
-                if (subtitle != null) {
-                    Text(
-                        text = subtitle,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+            if (recentExternal.isNotEmpty()) {
+                SectionLabel("Recent other")
+                recentExternal.forEach { device ->
+                    TvDeviceRow(
+                        device = device,
+                        showProtocolBadge = true,
+                        onClick = { pick(device.connectDevice) },
+                        onRemove = device.historyEntry?.let { entry ->
+                            { viewModel.removeDeviceFromHistory(entry) }
+                        },
                     )
                 }
             }
-            TextButton(onClick = onDisconnect) {
-                Text("Disconnect", color = MaterialTheme.colorScheme.error)
-            }
-        }
-    }
-}
 
-@Composable
-private fun ThisDeviceRow(selected: Boolean, onClick: () -> Unit) {
-    Card(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Icon(Icons.Default.Smartphone, contentDescription = null, modifier = Modifier.size(32.dp), tint = MaterialTheme.colorScheme.primary)
-            Text("This Device", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
-            if (selected) {
-                Icon(Icons.Default.Check, contentDescription = "Selected", tint = ConnectedGreen)
-            }
+            FindMoreDevicesRow(onClick = {
+                onDismiss()
+                onOpenAllDevices()
+            })
         }
-    }
-}
-
-@Composable
-private fun AllDevicesRow(onClick: () -> Unit) {
-    Surface(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
-        color = Color.Transparent
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Icon(
-                Icons.Default.Add,
-                contentDescription = null,
-                modifier = Modifier.size(20.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
-            Text(
-                text = "Set up new TV",
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.weight(1f)
-            )
-        }
-    }
-}
-
-@Composable
-private fun ProtocolBadge(text: String) {
-    Surface(
-        color = MaterialTheme.colorScheme.tertiaryContainer,
-        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
-        shape = RoundedCornerShape(4.dp)
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.labelSmall,
-            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
-        )
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionMerge.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionMerge.kt
@@ -1,9 +1,18 @@
 package com.playbridge.sender.connection
 
+import com.playbridge.sender.model.CastProtocol
 import com.playbridge.sender.model.TvDevice
 
 /** Pure connection-bookkeeping helpers, extracted for testability. */
 object ConnectionMerge {
+    /** Paired / saved PlayBridge receivers shown as first-class "Your TVs". */
+    const val MAX_PLAYBRIDGE_HISTORY = 10
+
+    /**
+     * Recent non-PlayBridge cast targets kept as optional shortcuts (DLNA / Roku / Cast).
+     * These have no pairing token — persistence is convenience only.
+     */
+    const val MAX_EXTERNAL_HISTORY = 3
     /**
      * Returns [device] with its complete endpoint taken from the live [discovered] list
      * when a match is found (by uuid, then ip/port). Receiver ports and DHCP addresses
@@ -33,21 +42,47 @@ object ConnectionMerge {
             ((a.uuid.isNotEmpty() && a.uuid == b.uuid) || (a.ip == b.ip && a.port == b.port))
 
     /**
-     * Put [device] at the front of connection history while replacing every older
-     * endpoint for the same receiver. UUID is the stable identity; ip/port remains
-     * the fallback for manual and legacy entries that do not have one.
+     * Put [device] at the front of its protocol class while replacing older endpoints
+     * for the same receiver. PlayBridge entries are first-class (pairing credentials);
+     * external protocols are capped to [MAX_EXTERNAL_HISTORY] recent shortcuts.
      */
-    fun upsertHistory(current: List<TvDevice>, device: TvDevice, limit: Int = 10): List<TvDevice> =
-        (listOf(device) + current.filterNot { isSameDevice(it, device) }).take(limit)
+    fun upsertHistory(
+        current: List<TvDevice>,
+        device: TvDevice,
+        playBridgeLimit: Int = MAX_PLAYBRIDGE_HISTORY,
+        externalLimit: Int = MAX_EXTERNAL_HISTORY,
+    ): List<TvDevice> {
+        val without = current.filterNot { isSameDevice(it, device) }
+        val playBridge = without.filter { it.resolvedProtocol == CastProtocol.PLAYBRIDGE }
+        val external = without.filter { it.resolvedProtocol != CastProtocol.PLAYBRIDGE }
+        return if (device.resolvedProtocol == CastProtocol.PLAYBRIDGE) {
+            (listOf(device) + playBridge).take(playBridgeLimit) + external.take(externalLimit)
+        } else {
+            playBridge.take(playBridgeLimit) + (listOf(device) + external).take(externalLimit)
+        }
+    }
 
     /**
      * Collapse duplicates already written by older builds. History is newest-first,
      * so the first entry retains the current endpoint and pairing credentials.
+     * Also re-applies PlayBridge / external caps for legacy oversized lists.
      */
-    fun normalizeHistory(history: List<TvDevice>): List<TvDevice> =
-        history.fold(emptyList()) { unique, device ->
-            if (unique.any { isSameDevice(it, device) }) unique else unique + device
+    fun normalizeHistory(history: List<TvDevice>): List<TvDevice> {
+        val unique = history.fold(emptyList<TvDevice>()) { acc, device ->
+            if (acc.any { isSameDevice(it, device) }) acc else acc + device
         }
+        val playBridge = unique.filter { it.resolvedProtocol == CastProtocol.PLAYBRIDGE }
+            .take(MAX_PLAYBRIDGE_HISTORY)
+        val external = unique.filter { it.resolvedProtocol != CastProtocol.PLAYBRIDGE }
+            .take(MAX_EXTERNAL_HISTORY)
+        return playBridge + external
+    }
+
+    fun playBridgeHistory(history: List<TvDevice>): List<TvDevice> =
+        history.filter { it.resolvedProtocol == CastProtocol.PLAYBRIDGE }
+
+    fun recentExternalHistory(history: List<TvDevice>): List<TvDevice> =
+        history.filter { it.resolvedProtocol != CastProtocol.PLAYBRIDGE }
 
     /** Remove every stale endpoint that belongs to [device]. */
     fun removeHistoryDevice(history: List<TvDevice>, device: TvDevice): List<TvDevice> =

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
@@ -38,6 +38,7 @@ class ConnectionViewModel(
     private val commandHistoryDb: com.playbridge.sender.data.history.HistoryDatabase = DatabaseProvider.getDatabase(application),
     val castSessionManager: CastSessionManager,
     private val discoveryRepository: ReceiverDiscoveryRepository,
+    private val networkStatusRepository: NetworkStatusRepository = NetworkStatusRepository(application),
 ) : AndroidViewModel(application) {
 
     private val TAG = "ConnectionViewModel"
@@ -47,20 +48,12 @@ class ConnectionViewModel(
     val connectionState: StateFlow<WebSocketClient.ConnectionState> = webSocketClient.connectionState
     val tvDevice: Flow<TvDevice?> = connectionStore.tvDevice
 
-    private val _selectedDiscoveryProtocols = MutableStateFlow(CastProtocol.entries.toSet())
-    val selectedDiscoveryProtocols: StateFlow<Set<CastProtocol>> =
-        _selectedDiscoveryProtocols.asStateFlow()
+    /** Live discovery results (sticky across rescans; all protocols). */
+    val discoveredDevices: StateFlow<List<TvDevice>> = discoveryRepository.devices
+    val discoveredEndpoints = discoveryRepository.endpoints
 
-    val discoveredDevices: StateFlow<List<TvDevice>> = combine(
-        discoveryRepository.devices,
-        _selectedDiscoveryProtocols,
-    ) { devices, protocols -> devices.filter { it.resolvedProtocol in protocols } }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
-    val discoveredEndpoints = combine(
-        discoveryRepository.endpoints,
-        _selectedDiscoveryProtocols,
-    ) { endpoints, protocols -> endpoints.filter { it.protocol in protocols } }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+    /** Wi‑Fi/Ethernet availability and VPN posture for cast banners. */
+    val networkStatus: StateFlow<NetworkStatusRepository.Status> = networkStatusRepository.status
 
     val deviceHistory: Flow<List<TvDevice>> = connectionStore.deviceHistory
 
@@ -124,12 +117,14 @@ class ConnectionViewModel(
     val externalMediaTitle: StateFlow<String?> = castSessionManager.externalMediaTitle
     val castSessionState = castSessionManager.sessionState
 
-    // Foreground scan session. Discovery is time-boxed (SCAN_WINDOW_MS) so the SSDP
-    // M-SEARCH loop and mDNS listener don't run forever; the UI binds [isScanning] for
-    // the spinner and shows a Rescan affordance once a window elapses. rescan() re-arms it.
+    // Foreground discovery session (ref-counted so Connection screen + cast sheet can share).
+    // Each window is time-boxed (SCAN_WINDOW_MS); while any UI holds the session we quietly
+    // rescan every BACKGROUND_RESCAN_MS so the sticky list stays fresh without flashing empty.
     private val _isScanning = MutableStateFlow(false)
     val isScanning: StateFlow<Boolean> = _isScanning.asStateFlow()
     private var scanTimeoutJob: Job? = null
+    private var backgroundRescanJob: Job? = null
+    private var discoveryRetainCount = 0
 
     // Stable identity sent to receivers during pairing so the TV can display a friendly name.
     private val phoneDeviceName: String = Build.MODEL
@@ -514,16 +509,58 @@ class ConnectionViewModel(
         webSocketClient.send(commandJson)
     }
     /**
-     * Start a time-boxed scan: run mDNS + DLNA SSDP discovery for [SCAN_WINDOW_MS], then
-     * stop automatically. Idempotent for the engines (their start() is a no-op when already
-     * running); calling again re-arms the timeout, so this doubles as rescan().
+     * Hold a discovery session open while a UI surface is visible (Connection screen or
+     * cast sheet). First retain starts a scan + background refresh loop; last release stops.
      */
-    fun startDiscovery(protocols: Set<CastProtocol> = _selectedDiscoveryProtocols.value) {
-        _selectedDiscoveryProtocols.value = protocols.ifEmpty { CastProtocol.entries.toSet() }
+    fun retainDiscovery() {
+        discoveryRetainCount++
+        if (discoveryRetainCount == 1) {
+            runScanWindow()
+            backgroundRescanJob?.cancel()
+            backgroundRescanJob = viewModelScope.launch {
+                while (true) {
+                    delay(BACKGROUND_RESCAN_MS)
+                    if (discoveryRetainCount > 0) runScanWindow()
+                }
+            }
+        } else if (!_isScanning.value) {
+            runScanWindow()
+        }
+    }
+
+    /** Drop one discovery session hold. */
+    fun releaseDiscovery() {
+        discoveryRetainCount = (discoveryRetainCount - 1).coerceAtLeast(0)
+        if (discoveryRetainCount == 0) {
+            backgroundRescanJob?.cancel()
+            backgroundRescanJob = null
+            endScanWindow()
+        }
+    }
+
+    /**
+     * Start a time-boxed scan: run mDNS + DLNA SSDP discovery for [SCAN_WINDOW_MS], then
+     * mark scanning finished. Sticky results remain published. Prefer [retainDiscovery] from UI.
+     */
+    fun startDiscovery() = runScanWindow()
+
+    /** User-triggered re-scan; restarts the scan window without dropping sticky results. */
+    fun rescan() = runScanWindow()
+
+    fun stopDiscovery() {
+        if (discoveryRetainCount > 0) {
+            // Session still held by UI — only end the current window; background loop continues.
+            endScanWindow()
+        } else {
+            endScanWindow()
+        }
+    }
+
+    private fun runScanWindow() {
         scanTimeoutJob?.cancel()
         discoveryRepository.start(
             owner = ReceiverDiscoveryRepository.OWNER_UI,
-            protocols = _selectedDiscoveryProtocols.value,
+            protocols = CastProtocol.entries.toSet(),
             timeoutMs = SCAN_WINDOW_MS,
         ) { summary ->
             Log.i(
@@ -534,16 +571,15 @@ class ConnectionViewModel(
         _isScanning.value = true
         scanTimeoutJob = viewModelScope.launch {
             delay(SCAN_WINDOW_MS)
-            stopDiscovery()
+            // Keep sticky results; only clear the scanning flag and release the native scanner
+            // if no other owner needs it. UI retain still schedules the next window.
+            discoveryRepository.stop(ReceiverDiscoveryRepository.OWNER_UI)
+            _isScanning.value = false
+            scanTimeoutJob = null
         }
     }
 
-    /** User-triggered re-scan (e.g. the Rescan button); restarts the scan window. */
-    fun rescan() = startDiscovery()
-
-    fun setDiscoveryProtocols(protocols: Set<CastProtocol>) = startDiscovery(protocols)
-
-    fun stopDiscovery() {
+    private fun endScanWindow() {
         scanTimeoutJob?.cancel()
         scanTimeoutJob = null
         discoveryRepository.stop(ReceiverDiscoveryRepository.OWNER_UI)
@@ -552,7 +588,10 @@ class ConnectionViewModel(
 
     override fun onCleared() {
         super.onCleared()
-        discoveryRepository.stop(ReceiverDiscoveryRepository.OWNER_UI)
+        discoveryRetainCount = 0
+        backgroundRescanJob?.cancel()
+        backgroundRescanJob = null
+        endScanWindow()
         // While a cast session is active, CastSessionManager + CastSessionService own the
         // socket's lifetime — episode queueing must survive this ViewModel (screen-off /
         // activity death). Otherwise close the socket as before. Never destroy(): the
@@ -565,5 +604,7 @@ class ConnectionViewModel(
     companion object {
         // Two-plus DLNA SSDP refresh cycles (6s each) plus headroom for mDNS resolves.
         private const val SCAN_WINDOW_MS = 15_000L
+        /** Quiet rescan interval while Connection UI / cast sheet holds discovery. */
+        private const val BACKGROUND_RESCAN_MS = 45_000L
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/NetworkStatusRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/NetworkStatusRepository.kt
@@ -1,0 +1,101 @@
+package com.playbridge.sender.connection
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.util.Log
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Live phone network posture for cast / discovery UI.
+ *
+ * - [onLocalNetwork]: Wi‑Fi or Ethernet is available (cellular-only / offline is false).
+ * - [vpnActive]: a VPN interface is up (may hide LAN even when Wi‑Fi is connected).
+ */
+class NetworkStatusRepository(context: Context) {
+
+    data class Status(
+        val onLocalNetwork: Boolean = true,
+        val vpnActive: Boolean = false,
+    )
+
+    private val appContext = context.applicationContext
+    private val connectivity = appContext.getSystemService(ConnectivityManager::class.java)
+
+    private val _status = MutableStateFlow(readStatus())
+    val status: StateFlow<Status> = _status.asStateFlow()
+
+    private val callback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) = publish()
+        override fun onLost(network: Network) = publish()
+        override fun onCapabilitiesChanged(network: Network, caps: NetworkCapabilities) = publish()
+        override fun onUnavailable() = publish()
+    }
+
+    init {
+        val cm = connectivity
+        if (cm == null) {
+            Log.w(TAG, "ConnectivityManager unavailable")
+        } else {
+            // Default-network callback covers transport + capability flips (VPN up/down, Wi‑Fi).
+            runCatching {
+                cm.registerDefaultNetworkCallback(callback)
+            }.onFailure {
+                Log.w(TAG, "registerDefaultNetworkCallback failed: ${it.message}")
+                // Fallback: listen for any Wi‑Fi / Ethernet / VPN network events.
+                runCatching {
+                    val request = NetworkRequest.Builder()
+                        .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                        .addTransportType(NetworkCapabilities.TRANSPORT_ETHERNET)
+                        .addTransportType(NetworkCapabilities.TRANSPORT_VPN)
+                        .build()
+                    cm.registerNetworkCallback(request, callback)
+                }.onFailure { err ->
+                    Log.w(TAG, "registerNetworkCallback failed: ${err.message}")
+                }
+            }
+            publish()
+        }
+    }
+
+    private fun publish() {
+        _status.value = readStatus()
+    }
+
+    private fun readStatus(): Status {
+        val cm = connectivity ?: return Status(onLocalNetwork = true, vpnActive = false)
+        val networks = cm.allNetworks
+        var onLocal = false
+        var vpn = false
+        for (network in networks) {
+            val caps = cm.getNetworkCapabilities(network) ?: continue
+            if (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+                caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+            ) {
+                onLocal = true
+            }
+            if (caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
+                vpn = true
+            }
+            // Active VPN path often lacks NOT_VPN even when TRANSPORT_VPN is missing on some OEMs.
+            if (!caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN) &&
+                network == cm.activeNetwork
+            ) {
+                vpn = true
+            }
+        }
+        // No networks at all → not on local LAN.
+        if (networks.isEmpty()) {
+            onLocal = false
+        }
+        return Status(onLocalNetwork = onLocal, vpnActive = vpn)
+    }
+
+    companion object {
+        private const val TAG = "NetworkStatus"
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/RustReceiverDiscovery.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/RustReceiverDiscovery.kt
@@ -48,6 +48,9 @@ data class RustDiscoverySummary(
 /**
  * Runs Rust discovery (mDNS + DLNA SSDP + Roku ECP + Google Cast mDNS) using native Rust cast-core engine.
  * Emits protocol-qualified receivers via [discoveredEndpoints].
+ *
+ * Results are sticky across rescans: starting a new window seeds from the last known map and never
+ * flashes an empty list. Entries age out after [STICKY_TTL_MS] without a fresh sighting.
  */
 internal class RustReceiverDiscovery(context: Context) {
     private val wifiManager = context.applicationContext.getSystemService(WifiManager::class.java)
@@ -57,6 +60,9 @@ internal class RustReceiverDiscovery(context: Context) {
     private val descriptionParser = DeviceDescription(DlnaProxyHolder.httpClient)
     private val descriptionCache = ConcurrentHashMap<String, DeviceDescription.Renderer>()
     private val descriptionsInFlight = ConcurrentHashMap.newKeySet<String>()
+
+    /** Process-lifetime discovery cache keyed by [EndpointKey] string. */
+    private val stickyEndpoints = ConcurrentHashMap<String, StickyEndpoint>()
 
     private val _discoveredEndpoints = MutableStateFlow<List<ReceiverEndpoint>>(emptyList())
     val discoveredEndpoints: StateFlow<List<ReceiverEndpoint>> = _discoveredEndpoints.asStateFlow()
@@ -68,7 +74,8 @@ internal class RustReceiverDiscovery(context: Context) {
         onFinished: ((RustDiscoverySummary) -> Unit)? = null,
     ) {
         stop()
-        _discoveredEndpoints.value = emptyList()
+        // Keep prior results visible while the new scan fills in — Web Video Caster style.
+        publishSticky()
         val multicastLock = acquireMulticastLock()
         val handle = try {
             RustDiscoveryNative.start(
@@ -94,6 +101,7 @@ internal class RustReceiverDiscovery(context: Context) {
             // Keep the authoritative map concurrent so a later mDNS/SSDP event cannot replace an
             // enriched DLNA endpoint with the earlier description-only snapshot.
             val deviceMap = ConcurrentHashMap<String, ReceiverEndpoint>()
+            stickyEndpoints.forEach { (key, sticky) -> deviceMap[key] = sticky.endpoint }
             val receivers = mutableMapOf<String, MutableSet<String>>()
             var errors = 0
             val deadline = SystemClock.elapsedRealtime() + timeoutMs + FINISH_GRACE_MS
@@ -110,8 +118,10 @@ internal class RustReceiverDiscovery(context: Context) {
 
                             val parsed = parseDiscoveredDevice(receiver)
                             if (parsed != null) {
-                                deviceMap[parsed.key.toString()] = parsed
-                                _discoveredEndpoints.value = deviceMap.values.toList()
+                                val key = parsed.key.toString()
+                                deviceMap[key] = parsed
+                                rememberSticky(key, parsed)
+                                publishMap(deviceMap)
                                 if (parsed.protocol == CastProtocol.DLNA &&
                                     parsed.descriptionUrl != null && parsed.controlUrl == null &&
                                     descriptionsInFlight.add(parsed.descriptionUrl)
@@ -122,7 +132,6 @@ internal class RustReceiverDiscovery(context: Context) {
                                             val description = descriptionParser.fetch(location)
                                             if (description != null) {
                                                 descriptionCache[location] = description
-                                                val key = parsed.key.toString()
                                                 deviceMap.computeIfPresent(key) { _, endpoint ->
                                                     if (endpoint.descriptionUrl == location) {
                                                         endpoint.copy(
@@ -134,7 +143,8 @@ internal class RustReceiverDiscovery(context: Context) {
                                                         endpoint
                                                     }
                                                 }
-                                                _discoveredEndpoints.value = deviceMap.values.toList()
+                                                deviceMap[key]?.let { rememberSticky(key, it) }
+                                                publishMap(deviceMap)
                                             }
                                         } finally {
                                             descriptionsInFlight.remove(location)
@@ -149,6 +159,8 @@ internal class RustReceiverDiscovery(context: Context) {
             } catch (error: LinkageError) {
                 Log.w(TAG, "Rust discovery stopped: ${error.javaClass.simpleName}")
             } finally {
+                pruneSticky()
+                publishSticky()
                 onFinished?.invoke(
                     RustDiscoverySummary(
                         playBridgeDevices = receivers["PlayBridge"]?.size ?: receivers["playbridge"]?.size ?: 0,
@@ -187,6 +199,31 @@ internal class RustReceiverDiscovery(context: Context) {
                 Log.w(TAG, "Rust discovery cleanup failed: ${error.javaClass.simpleName}")
             }
         }
+        // Leave sticky results published so the UI does not collapse when a scan window ends.
+        pruneSticky()
+        publishSticky()
+    }
+
+    private data class StickyEndpoint(
+        val endpoint: ReceiverEndpoint,
+        val lastSeenElapsedMs: Long,
+    )
+
+    private fun rememberSticky(key: String, endpoint: ReceiverEndpoint) {
+        stickyEndpoints[key] = StickyEndpoint(endpoint, SystemClock.elapsedRealtime())
+    }
+
+    private fun pruneSticky() {
+        val now = SystemClock.elapsedRealtime()
+        stickyEndpoints.entries.removeIf { now - it.value.lastSeenElapsedMs > STICKY_TTL_MS }
+    }
+
+    private fun publishSticky() {
+        _discoveredEndpoints.value = stickyEndpoints.values.map { it.endpoint }
+    }
+
+    private fun publishMap(deviceMap: ConcurrentHashMap<String, ReceiverEndpoint>) {
+        _discoveredEndpoints.value = deviceMap.values.toList()
     }
 
     private fun parseDiscoveredDevice(receiver: JSONObject): ReceiverEndpoint? {
@@ -263,6 +300,8 @@ internal class RustReceiverDiscovery(context: Context) {
         const val PROTOCOL_GOOGLE_CAST = 16
         const val EVENT_WAIT_MS = 250L
         const val FINISH_GRACE_MS = 1_000L
+        /** Keep last-seen devices across rescans so the list never flashes empty. */
+        const val STICKY_TTL_MS = 180_000L
         const val MULTICAST_LOCK_TAG = "playbridge:rust-discovery"
     }
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
@@ -115,6 +115,7 @@ val appModule = module {
             scope = CoroutineScope(SupervisorJob() + Dispatchers.IO.limitedParallelism(1)),
         )
     }
+    single { com.playbridge.sender.connection.NetworkStatusRepository(androidContext()) }
 
     // 5. ConnectionCoordinator Singleton
     single {
@@ -215,6 +216,7 @@ val appModule = module {
             commandHistoryDb = get(),
             castSessionManager = get(),
             discoveryRepository = get(),
+            networkStatusRepository = get(),
         )
     }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/ui/ConnectionScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/ui/ConnectionScreen.kt
@@ -1,54 +1,103 @@
 package com.playbridge.sender.ui
 
+import android.content.Intent
+import android.provider.Settings
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Cast
-import androidx.compose.material.icons.filled.Computer
-import androidx.compose.material.icons.filled.Tv
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Gamepad
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.LockOpen
-import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.ui.graphics.Color
-import androidx.compose.material3.*
-import androidx.compose.ui.res.painterResource
-import com.playbridge.sender.R
-import androidx.compose.foundation.Image
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Smartphone
+import androidx.compose.material.icons.filled.Tv
+import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
-import kotlinx.coroutines.launch
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import kotlinx.coroutines.delay
-import com.playbridge.sender.connection.ConnectionViewModel
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.playbridge.sender.cast.CastSessionManager
 import com.playbridge.sender.connection.ConnectionMerge
+import com.playbridge.sender.connection.ConnectionViewModel
+import com.playbridge.sender.connection.NetworkStatusRepository
 import com.playbridge.sender.connection.WebSocketClient
 import com.playbridge.sender.model.CastProtocol
 import com.playbridge.sender.model.TvDevice
+import kotlinx.coroutines.launch
 
+private val OnlineGreen = Color(0xFF4CAF50)
+private val WarningAmber = Color(0xFFFFA000)
+
+/**
+ * Full-screen device manager: current destination, paired PlayBridge TVs, and live network
+ * discovery (sticky, quiet background rescans while open). No tabs / protocol filter chips.
+ *
+ * @param initialTab legacy: non-zero opens with the "Other devices" section expanded
+ *   (used when the cast sheet routes here via "Find more devices").
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ConnectionScreen(
@@ -56,79 +105,86 @@ fun ConnectionScreen(
     onMenuClick: () -> Unit,
     modifier: Modifier = Modifier,
     onRemoteClick: (() -> Unit)? = null,
-    initialTab: Int = 0
+    initialTab: Int = 0,
 ) {
     val discoveredDevices by viewModel.discoveredDevices.collectAsState()
     val history by viewModel.deviceHistory.collectAsState(initial = emptyList())
     val pings by viewModel.savedDevicesOnlineStatus.collectAsState()
-
     val connectionState by viewModel.connectionState.collectAsState()
     val autoConnectEnabled by viewModel.autoConnectEnabled.collectAsState()
     val tvDevice by viewModel.tvDevice.collectAsState(initial = null)
     val activeExternalDevice by viewModel.activeExternalDevice.collectAsState()
     val route by viewModel.route.collectAsState()
+    val isScanning by viewModel.isScanning.collectAsState()
+    val networkStatus by viewModel.networkStatus.collectAsState()
 
     val isConnected = connectionState is WebSocketClient.ConnectionState.Connected
-    val isScanning by viewModel.isScanning.collectAsState()
-    val discoveryProtocols by viewModel.selectedDiscoveryProtocols.collectAsState()
+    val nativeSelected = route is CastSessionManager.Route.NativeTv
+    val isConnecting = nativeSelected && (
+        connectionState is WebSocketClient.ConnectionState.Connecting ||
+            connectionState is WebSocketClient.ConnectionState.WaitingForApproval ||
+            connectionState is WebSocketClient.ConnectionState.Retrying
+        )
 
-    var selectedTab by remember { mutableStateOf(initialTab) }
-
-    // Start discovery ONLY when the Discover tab is active
-    DisposableEffect(selectedTab) {
-        if (selectedTab == 1) {
-            viewModel.startDiscovery()
-        }
-        onDispose {
-            viewModel.stopDiscovery()
-        }
+    DisposableEffect(Unit) {
+        viewModel.retainDiscovery()
+        onDispose { viewModel.releaseDiscovery() }
     }
 
-    // Ping saved devices when history changes or Your Devices tab is active
-    LaunchedEffect(history, selectedTab) {
-        if (selectedTab == 0) {
-            viewModel.pingSavedDevices(history)
-        }
+    LaunchedEffect(history) {
+        viewModel.pingSavedDevices(history)
     }
 
-    val savedUnified = history.map { saved ->
-        val isOnline = pings[saved.endpointKey.toString()] == true
-        UnifiedDevice(
-            connectDevice = saved,
-            historyEntry = saved,
-            isOnline = isOnline,
-            lastConnected = saved.lastConnected
-        )
-    }.filterNot { u ->
-        activeExternalDevice?.let { ConnectionMerge.isSameDevice(u.connectDevice, it) } == true ||
-            (isConnected && tvDevice?.let { c ->
-                ConnectionMerge.isSameDevice(u.connectDevice, c)
-            } == true)
-    }.sortedWith(
-        compareByDescending<UnifiedDevice> { it.isOnline }
-            .thenByDescending { it.lastConnected ?: Long.MAX_VALUE }
-    )
+    val playBridgeSaved = remember(history, pings, activeExternalDevice, isConnected, tvDevice) {
+        ConnectionMerge.playBridgeHistory(history).map { saved ->
+            UnifiedDevice(
+                connectDevice = saved,
+                historyEntry = saved,
+                isOnline = pings[saved.endpointKey.toString()] == true ||
+                    discoveredDevices.any { ConnectionMerge.isSameDevice(it, saved) },
+                lastConnected = saved.lastConnected,
+            )
+        }.filterNot { u -> isActiveTarget(u.connectDevice, activeExternalDevice, isConnected, tvDevice) }
+            .sortedWith(
+                compareByDescending<UnifiedDevice> { it.isOnline }
+                    .thenByDescending { it.lastConnected ?: 0L },
+            )
+    }
 
-    val discoveredUnified = discoveredDevices.map { discovered ->
-        val historyEntry = history.find { ConnectionMerge.isSameDevice(it, discovered) }
-        UnifiedDevice(
-            connectDevice = discovered,
-            historyEntry = historyEntry,
-            isOnline = true,
-            lastConnected = historyEntry?.lastConnected
-        )
-    }.filterNot { u ->
-        activeExternalDevice?.let { ConnectionMerge.isSameDevice(u.connectDevice, it) } == true ||
-            (isConnected && tvDevice?.let { c ->
-                ConnectionMerge.isSameDevice(u.connectDevice, c)
-            } == true)
+    val recentExternal = remember(history, pings, activeExternalDevice, isConnected, tvDevice) {
+        ConnectionMerge.recentExternalHistory(history).map { saved ->
+            UnifiedDevice(
+                connectDevice = saved,
+                historyEntry = saved,
+                isOnline = pings[saved.endpointKey.toString()] == true ||
+                    discoveredDevices.any { ConnectionMerge.isSameDevice(it, saved) },
+                lastConnected = saved.lastConnected,
+            )
+        }.filterNot { u -> isActiveTarget(u.connectDevice, activeExternalDevice, isConnected, tvDevice) }
+    }
+
+    val discoveredByProtocol = remember(discoveredDevices, history, activeExternalDevice, isConnected, tvDevice) {
+        discoveredDevices
+            .filterNot { d -> isActiveTarget(d, activeExternalDevice, isConnected, tvDevice) }
+            .map { discovered ->
+                val historyEntry = history.find { ConnectionMerge.isSameDevice(it, discovered) }
+                UnifiedDevice(
+                    connectDevice = discovered,
+                    historyEntry = historyEntry,
+                    isOnline = true,
+                    lastConnected = historyEntry?.lastConnected,
+                )
+            }
+            .groupBy { it.connectDevice.resolvedProtocol }
     }
 
     var showManualDialog by remember { mutableStateOf(false) }
+    var otherExpanded by remember { mutableStateOf(initialTab != 0) }
+    var overflowOpen by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+    val listState = rememberLazyListState()
 
-    // Show a snackbar when pairing is denied or a stale token is rejected.
     LaunchedEffect(connectionState) {
         when (val state = connectionState) {
             is WebSocketClient.ConnectionState.PairingDenied ->
@@ -142,14 +198,13 @@ fun ConnectionScreen(
             is WebSocketClient.ConnectionState.PinMismatch ->
                 coroutineScope.launch {
                     snackbarHostState.showSnackbar(
-                        "Security warning: ${state.serverName}'s certificate changed. Forget the device and re-pair."
+                        "Security warning: ${state.serverName}'s certificate changed. Forget the device and re-pair.",
                     )
                 }
             else -> Unit
         }
     }
 
-    // When a device is selected, check history for a saved token (shared with the device-picker sheet).
     fun onDeviceSelected(ip: String, port: Int, name: String, uuid: String = "") =
         connectKnownOrPair(viewModel, history, ip, port, name, uuid)
 
@@ -179,452 +234,761 @@ fun ConnectionScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("TV Connection") },
+                title = { Text("Devices") },
                 navigationIcon = {
                     IconButton(
                         onClick = onMenuClick,
                         modifier = Modifier.semantics {
                             contentDescription = "Dashboard"
                             role = androidx.compose.ui.semantics.Role.Button
-                        }
+                        },
                     ) {
-                        DashboardBlocksIcon(
-                            modifier = Modifier.size(22.dp)
-                        )
+                        DashboardBlocksIcon(modifier = Modifier.size(22.dp))
                     }
                 },
                 actions = {
-                    if (onRemoteClick != null) {
-                        IconButton(onClick = onRemoteClick) {
-                            Icon(Icons.Default.Gamepad, contentDescription = "Remote Control", tint = MaterialTheme.colorScheme.primary)
+                    if (isScanning) {
+                        CircularProgressIndicator(
+                            modifier = Modifier
+                                .padding(end = 4.dp)
+                                .size(18.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        IconButton(onClick = { viewModel.rescan() }) {
+                            Icon(
+                                Icons.Default.Refresh,
+                                contentDescription = "Rescan network",
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
                         }
                     }
-                }
+                    if (onRemoteClick != null) {
+                        IconButton(onClick = onRemoteClick) {
+                            Icon(
+                                Icons.Default.Gamepad,
+                                contentDescription = "Remote Control",
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                    Box {
+                        IconButton(onClick = { overflowOpen = true }) {
+                            Icon(Icons.Default.MoreVert, contentDescription = "More")
+                        }
+                        DropdownMenu(expanded = overflowOpen, onDismissRequest = { overflowOpen = false }) {
+                            DropdownMenuItem(
+                                text = { Text("Connect by IP…") },
+                                onClick = {
+                                    overflowOpen = false
+                                    showManualDialog = true
+                                },
+                                leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) },
+                            )
+                        }
+                    }
+                },
             )
         },
-        floatingActionButton = {
-            ExtendedFloatingActionButton(
-                onClick = { showManualDialog = true },
-                icon = { Icon(Icons.Default.Add, "Manual Connect") },
-                text = { Text("Manual Connect") }
-            )
-        },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { paddingValues ->
-        Column(
+        LazyColumn(
+            state = listState,
             modifier = modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .padding(horizontal = 16.dp),
+            contentPadding = PaddingValues(top = 12.dp, bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            TabRow(selectedTabIndex = selectedTab) {
-                Tab(
-                    selected = selectedTab == 0,
-                    onClick = { selectedTab = 0 },
-                    text = { Text("Your Devices") }
-                )
-                Tab(
-                    selected = selectedTab == 1,
-                    onClick = { selectedTab = 1 },
-                    text = { Text("Discover") }
+            // ── NOW ──────────────────────────────────────────────────────────
+            item(key = "now-header") {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    LocalNetworkBanners(status = networkStatus)
+                    SectionLabel("Now")
+                }
+            }
+            item(key = "now-card") {
+                NowDestinationCard(
+                    connectionState = connectionState,
+                    route = route,
+                    tvDevice = tvDevice,
+                    activeExternalDevice = activeExternalDevice,
+                    autoConnectEnabled = autoConnectEnabled,
+                    showAutoConnect = true,
+                    onAutoConnectChange = { viewModel.setAutoConnectEnabled(it) },
+                    onCastHere = { viewModel.selectNativeRoute() },
+                    onDisconnectNative = {
+                        viewModel.selectThisDevice()
+                        viewModel.disconnect()
+                    },
+                    onDisconnectExternal = { viewModel.disconnectExternalTarget() },
+                    isConnecting = isConnecting,
                 )
             }
 
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp),
-                contentPadding = PaddingValues(top = 16.dp, bottom = 96.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+            item(key = "this-phone") {
+                ThisDeviceDestinationRow(
+                    selected = route is CastSessionManager.Route.ThisDevice &&
+                        activeExternalDevice == null &&
+                        !isConnecting,
+                    onClick = { viewModel.selectThisDevice() },
+                )
+            }
+
+            // ── PlayBridge ───────────────────────────────────────────────────
+            item(key = "pb-header") {
+                SectionLabel("PlayBridge")
+            }
+
+            if (playBridgeSaved.isEmpty() &&
+                (discoveredByProtocol[CastProtocol.PLAYBRIDGE].orEmpty().isEmpty())
             ) {
-                if (selectedTab == 0) {
-                    // TAB 0: YOUR DEVICES
-                    // Exactly one external protocol session can own playback at a time.
-                    val externalDevice = activeExternalDevice
-                    if (externalDevice != null) {
-                        item {
+                item(key = "pb-empty") {
+                    EmptyHintCard(
+                        if (isScanning) {
+                            "Looking for PlayBridge TVs on your network…"
+                        } else {
+                            "No PlayBridge TVs yet. Open the PlayBridge app on your TV (same Wi‑Fi), then pull to refresh."
+                        },
+                    )
+                }
+            } else {
+                items(
+                    items = playBridgeSaved,
+                    key = { "pb-saved-${it.connectDevice.endpointKey}" },
+                ) { device ->
+                    TvDeviceRow(
+                        device = device,
+                        showProtocolBadge = false,
+                        onClick = { selectEndpoint(device.connectDevice) },
+                        onRemove = device.historyEntry?.let { entry ->
+                            { viewModel.removeDeviceFromHistory(entry) }
+                        },
+                    )
+                }
+                val unpairedDiscovered = discoveredByProtocol[CastProtocol.PLAYBRIDGE]
+                    .orEmpty()
+                    .filter { d ->
+                        playBridgeSaved.none { ConnectionMerge.isSameDevice(it.connectDevice, d.connectDevice) }
+                    }
+                items(
+                    items = unpairedDiscovered,
+                    key = { "pb-new-${it.connectDevice.endpointKey}" },
+                ) { device ->
+                    TvDeviceRow(
+                        device = device,
+                        showProtocolBadge = false,
+                        onClick = { selectEndpoint(device.connectDevice) },
+                        onRemove = null,
+                    )
+                }
+            }
+
+            // ── Recent other (saved external shortcuts) ──────────────────────
+            if (recentExternal.isNotEmpty()) {
+                item(key = "recent-header") {
+                    SectionLabel("Recent other")
+                }
+                items(
+                    items = recentExternal,
+                    key = { "ext-${it.connectDevice.endpointKey}" },
+                ) { device ->
+                    TvDeviceRow(
+                        device = device,
+                        showProtocolBadge = true,
+                        onClick = { selectEndpoint(device.connectDevice) },
+                        onRemove = device.historyEntry?.let { entry ->
+                            { viewModel.removeDeviceFromHistory(entry) }
+                        },
+                    )
+                }
+            }
+
+            // ── Other devices on this network ────────────────────────────────
+            item(key = "other-header") {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { otherExpanded = !otherExpanded }
+                        .padding(vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        SectionLabel("Other devices on this network")
+                        Text(
+                            text = if (isScanning) "Scanning quietly…" else "DLNA, Roku, Google Cast",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Icon(
+                        imageVector = if (otherExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                        contentDescription = if (otherExpanded) "Collapse" else "Expand",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            if (otherExpanded) {
+                val otherProtocols = listOf(
+                    CastProtocol.DLNA,
+                    CastProtocol.ROKU,
+                    CastProtocol.GOOGLE_CAST,
+                )
+                var anyOther = false
+                otherProtocols.forEach { protocol ->
+                    val devices = discoveredByProtocol[protocol].orEmpty()
+                    if (devices.isNotEmpty()) {
+                        anyOther = true
+                        item(key = "proto-label-${protocol.name}") {
                             Text(
-                                text = "Casting via ${externalDevice.resolvedProtocol.displayName}",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.primary,
-                                fontWeight = FontWeight.Bold
+                                text = protocol.displayName,
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(top = 4.dp),
                             )
                         }
-                        item {
-                            Card(
-                                modifier = Modifier.fillMaxWidth(),
-                                colors = CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.primaryContainer
-                                )
-                            ) {
-                                Column(
-                                    modifier = Modifier.fillMaxWidth().padding(16.dp),
-                                    verticalArrangement = Arrangement.spacedBy(12.dp)
-                                ) {
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(16.dp),
-                                        modifier = Modifier.fillMaxWidth()
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Default.Cast,
-                                            contentDescription = null,
-                                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                                            modifier = Modifier.size(32.dp)
-                                        )
-                                        Column(modifier = Modifier.weight(1f)) {
-                                            Text(
-                                                text = externalDevice.name,
-                                                style = MaterialTheme.typography.titleMedium,
-                                                fontWeight = FontWeight.SemiBold,
-                                                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                                maxLines = 1,
-                                                overflow = TextOverflow.Ellipsis
-                                            )
-                                            Text(
-                                                text = "${externalDevice.ip} · ${externalDevice.resolvedProtocol.displayName}",
-                                                style = MaterialTheme.typography.bodySmall,
-                                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
-                                            )
-                                        }
-                                    }
-                                    Row(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.End
-                                    ) {
-                                        Button(
-                                            onClick = {
-                                                viewModel.disconnectExternalTarget()
-                                            },
-                                            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
-                                        ) {
-                                            Text("Disconnect")
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        item { Spacer(modifier = Modifier.height(8.dp)) }
-                    }
-
-                    // Connected TV Section
-                    if (connectionState is WebSocketClient.ConnectionState.Connected) {
-                        val connected = connectionState as WebSocketClient.ConnectionState.Connected
-                        val serverName = connected.serverName
-                        item {
-                            Text(
-                                text = if (route is com.playbridge.sender.cast.CastSessionManager.Route.NativeTv) {
-                                    "Casting via ${CastProtocol.PLAYBRIDGE.displayName}"
-                                } else {
-                                    "Connected via ${CastProtocol.PLAYBRIDGE.displayName}"
-                                },
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.primary,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
-
-                        item {
-                            Card(
-                                modifier = Modifier.fillMaxWidth(),
-                                colors = CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.primaryContainer
-                                )
-                            ) {
-                                Column(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(16.dp),
-                                    verticalArrangement = Arrangement.spacedBy(12.dp)
-                                ) {
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(16.dp),
-                                        modifier = Modifier.fillMaxWidth()
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Default.Tv,
-                                            contentDescription = null,
-                                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                                            modifier = Modifier.size(32.dp)
-                                        )
-                                        Column(modifier = Modifier.weight(1f)) {
-                                            Text(
-                                                text = serverName,
-                                                style = MaterialTheme.typography.titleMedium,
-                                                fontWeight = FontWeight.SemiBold,
-                                                color = MaterialTheme.colorScheme.onPrimaryContainer
-                                            )
-                                            if (tvDevice != null) {
-                                                Text(
-                                                    text = "${tvDevice?.ip}:${if (connected.secure) (tvDevice?.wssPort ?: tvDevice?.port) else tvDevice?.port}",
-                                                    style = MaterialTheme.typography.bodySmall,
-                                                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
-                                                )
-                                            }
-                                            Row(
-                                                verticalAlignment = Alignment.CenterVertically,
-                                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                                modifier = Modifier.padding(top = 2.dp)
-                                            ) {
-                                                Icon(
-                                                    imageVector = if (connected.secure) Icons.Default.Lock else Icons.Default.LockOpen,
-                                                    contentDescription = null,
-                                                    modifier = Modifier.size(14.dp),
-                                                    tint = if (connected.secure) Color(0xFF4CAF50) else Color(0xFFFFA000)
-                                                )
-                                                Text(
-                                                    text = if (connected.secure) "Secure (wss)" else "Not secure (ws)",
-                                                    style = MaterialTheme.typography.bodySmall,
-                                                    color = if (connected.secure) Color(0xFF4CAF50) else Color(0xFFFFA000)
-                                                )
-                                            }
-                                        }
-                                    }
-
-                                    Row(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        verticalAlignment = Alignment.CenterVertically
-                                    ) {
-                                        Checkbox(
-                                            checked = autoConnectEnabled,
-                                            onCheckedChange = { viewModel.setAutoConnectEnabled(it) }
-                                        )
-                                        Text("Auto-connect to this TV", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onPrimaryContainer)
-                                    }
-                                    Row(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
-                                    ) {
-                                        if (route !is com.playbridge.sender.cast.CastSessionManager.Route.NativeTv) {
-                                            TextButton(onClick = { viewModel.selectNativeRoute() }) {
-                                                Text("Cast here")
-                                            }
-                                        }
-                                        Button(
-                                            onClick = { viewModel.disconnect() },
-                                            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
-                                        ) {
-                                            Text("Disconnect")
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        item {
-                            Spacer(modifier = Modifier.height(8.dp))
-                        }
-                    }
-
-                    // Your TVs list (Saved Devices only, online status checked via direct socket pings)
-                    item {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = "Your TVs",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.primary,
-                                fontWeight = FontWeight.Bold
-                            )
-                            IconButton(onClick = { viewModel.pingSavedDevices(history) }) {
-                                Icon(
-                                    imageVector = Icons.Default.Refresh,
-                                    contentDescription = "Refresh TV status",
-                                    tint = MaterialTheme.colorScheme.primary
-                                )
-                            }
-                        }
-                    }
-
-                    if (savedUnified.isEmpty()) {
-                        item {
-                            Card(
-                                modifier = Modifier.fillMaxWidth(),
-                                colors = CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-                                )
-                            ) {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(24.dp),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    Text(
-                                        "No saved TVs. Tap 'Discover' to scan for new TVs.",
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
-                            }
-                        }
-                    } else {
-                        items(savedUnified) { device ->
+                        items(
+                            items = devices,
+                            key = { "live-${it.connectDevice.endpointKey}" },
+                        ) { device ->
                             TvDeviceRow(
                                 device = device,
+                                showProtocolBadge = false,
                                 onClick = { selectEndpoint(device.connectDevice) },
                                 onRemove = device.historyEntry?.let { entry ->
                                     { viewModel.removeDeviceFromHistory(entry) }
-                                }
-                            )
-                        }
-                    }
-                } else {
-                    // TAB 1: DISCOVER
-                    item {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = "Discover Devices",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.primary,
-                                fontWeight = FontWeight.Bold
-                            )
-                            if (isScanning) {
-                                Row(
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                                ) {
-                                    CircularProgressIndicator(modifier = Modifier.size(14.dp), strokeWidth = 2.dp)
-                                    Text(
-                                        "Scanning…",
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
-                            } else {
-                                IconButton(onClick = { viewModel.rescan() }) {
-                                    Icon(
-                                        imageVector = Icons.Default.Refresh,
-                                        contentDescription = "Rescan for TVs",
-                                        tint = MaterialTheme.colorScheme.primary
-                                    )
-                                }
-                            }
-                        }
-                    }
-
-                    item {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .horizontalScroll(rememberScrollState()),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            FilterChip(
-                                selected = discoveryProtocols.size == CastProtocol.entries.size,
-                                onClick = {
-                                    viewModel.setDiscoveryProtocols(CastProtocol.entries.toSet())
                                 },
-                                label = { Text("All") },
                             )
-                            CastProtocol.entries.forEach { protocol ->
-                                FilterChip(
-                                    selected = protocol in discoveryProtocols,
-                                    onClick = {
-                                        val next = if (discoveryProtocols.size == CastProtocol.entries.size) {
-                                            setOf(protocol)
-                                        } else if (protocol in discoveryProtocols && discoveryProtocols.size > 1) {
-                                            discoveryProtocols - protocol
-                                        } else {
-                                            discoveryProtocols + protocol
-                                        }
-                                        viewModel.setDiscoveryProtocols(next)
-                                    },
-                                    label = { Text(protocol.displayName) },
-                                )
-                            }
                         }
                     }
-
-                    if (discoveredUnified.isEmpty()) {
-                        item {
-                            Card(
-                                modifier = Modifier.fillMaxWidth(),
-                                colors = CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-                                )
-                            ) {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(24.dp),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    Text(
-                                        if (isScanning) "Looking for TVs on your network…"
-                                        else "No TVs found. Tap the refresh icon to scan again.",
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
-                            }
-                        }
-                    } else {
-                        CastProtocol.entries.forEach { protocol ->
-                            val protocolDevices = discoveredUnified.filter {
-                                it.connectDevice.resolvedProtocol == protocol
-                            }
-                            if (protocolDevices.isNotEmpty()) {
-                                item(key = "protocol-${protocol.name}") {
-                                    Text(
-                                        text = protocol.displayName,
-                                        style = MaterialTheme.typography.labelLarge,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        modifier = Modifier.padding(top = 4.dp),
-                                    )
-                                }
-                                items(
-                                    items = protocolDevices,
-                                    key = { it.connectDevice.endpointKey.toString() },
-                                ) { device ->
-                                    TvDeviceRow(
-                                        device = device,
-                                        onClick = { selectEndpoint(device.connectDevice) },
-                                        onRemove = device.historyEntry?.let { entry ->
-                                            { viewModel.removeDeviceFromHistory(entry) }
-                                        },
-                                    )
-                                }
-                            }
-                        }
+                }
+                if (!anyOther) {
+                    item(key = "other-empty") {
+                        EmptyHintCard(
+                            if (isScanning) "Looking for cast devices…"
+                            else "No other devices found. Tap refresh to scan again.",
+                        )
                     }
                 }
             }
         }
     }
-    
-    // Manual Dialog
+
     if (showManualDialog) {
         ManualConnectionDialog(
             onDismiss = { showManualDialog = false },
             onConnect = { ip, port ->
                 showManualDialog = false
-                // Check history first
                 onDeviceSelected(ip, port, "Manual TV")
-            }
+            },
         )
     }
+}
 
+private fun isActiveTarget(
+    device: TvDevice,
+    activeExternal: TvDevice?,
+    isConnected: Boolean,
+    tvDevice: TvDevice?,
+): Boolean {
+    if (activeExternal != null && ConnectionMerge.isSameDevice(device, activeExternal)) return true
+    if (isConnected && tvDevice != null && ConnectionMerge.isSameDevice(device, tvDevice)) return true
+    return false
+}
 
+@Composable
+internal fun SectionLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.primary,
+        fontWeight = FontWeight.Bold,
+    )
 }
 
 /**
- * A device in the unified "Your TVs" list: the device to connect with, whether it's
- * currently reachable on the network, and (if saved) its history entry + last-connected
- * time so the row can show "Online" vs. "Last seen …".
+ * Sticky cast/discovery banners for missing Wi‑Fi/Ethernet and active VPN.
+ * Used on the Devices screen and the cast sheet.
+ */
+@Composable
+fun LocalNetworkBanners(
+    status: NetworkStatusRepository.Status,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    var vpnDismissed by remember { mutableStateOf(false) }
+
+    // Re-show the VPN tip if the VPN toggles off then on again this session.
+    LaunchedEffect(status.vpnActive) {
+        if (!status.vpnActive) vpnDismissed = false
+    }
+
+    val showWifi = !status.onLocalNetwork
+    val showVpn = status.onLocalNetwork && status.vpnActive && !vpnDismissed
+    if (!showWifi && !showVpn) return
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        if (showWifi) {
+            NetworkBanner(
+                icon = Icons.Default.WifiOff,
+                title = "Not on Wi‑Fi",
+                body = "Connect this phone to the same Wi‑Fi as your TV to cast and discover devices.",
+                containerColor = MaterialTheme.colorScheme.errorContainer,
+                contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                actionLabel = "Wi‑Fi settings",
+                onAction = {
+                    runCatching {
+                        context.startActivity(
+                            Intent(Settings.ACTION_WIFI_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                        )
+                    }
+                },
+            )
+        } else if (showVpn) {
+            NetworkBanner(
+                icon = Icons.Default.Shield,
+                title = "VPN may block casting",
+                body = "Some VPNs hide your local network. If devices don’t appear, pause the VPN and try again.",
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                actionLabel = null,
+                onAction = null,
+                onDismiss = { vpnDismissed = true },
+            )
+        }
+    }
+}
+
+@Composable
+private fun NetworkBanner(
+    icon: ImageVector,
+    title: String,
+    body: String,
+    containerColor: Color,
+    contentColor: Color,
+    actionLabel: String?,
+    onAction: (() -> Unit)?,
+    onDismiss: (() -> Unit)? = null,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.Top,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = contentColor,
+                    modifier = Modifier
+                        .padding(top = 2.dp)
+                        .size(22.dp),
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = contentColor,
+                    )
+                    Text(
+                        text = body,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = contentColor.copy(alpha = 0.9f),
+                    )
+                }
+                if (onDismiss != null) {
+                    IconButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.size(32.dp),
+                    ) {
+                        Icon(
+                            Icons.Default.Close,
+                            contentDescription = "Dismiss",
+                            tint = contentColor,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                }
+            }
+            if (actionLabel != null && onAction != null) {
+                TextButton(
+                    onClick = onAction,
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                ) {
+                    Text(actionLabel, color = contentColor, fontWeight = FontWeight.SemiBold)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyHintCard(message: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+        ),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/**
+ * Active cast destination card shared by the Devices screen and the cast sheet.
+ */
+@Composable
+fun NowDestinationCard(
+    connectionState: WebSocketClient.ConnectionState,
+    route: CastSessionManager.Route,
+    tvDevice: TvDevice?,
+    activeExternalDevice: TvDevice?,
+    autoConnectEnabled: Boolean = false,
+    showAutoConnect: Boolean = false,
+    onAutoConnectChange: (Boolean) -> Unit = {},
+    onCastHere: () -> Unit = {},
+    onDisconnectNative: () -> Unit,
+    onDisconnectExternal: () -> Unit,
+    isConnecting: Boolean = false,
+) {
+    val external = activeExternalDevice
+    when {
+        external != null -> {
+            ActiveDestinationCard(
+                name = external.name,
+                subtitle = "${external.ip} · cast a video to play here",
+                icon = Icons.Default.Cast,
+                badge = external.resolvedProtocol.displayName,
+                statusPill = "Casting",
+                statusFilled = true,
+                onDisconnect = onDisconnectExternal,
+            )
+        }
+        connectionState is WebSocketClient.ConnectionState.Connected -> {
+            val connected = connectionState
+            val castingHere = route is CastSessionManager.Route.NativeTv
+            ActiveDestinationCard(
+                name = connected.serverName,
+                subtitle = tvDevice?.let {
+                    "${it.ip}:${if (connected.secure) (it.wssPort ?: it.port) else it.port}"
+                },
+                icon = Icons.Default.Tv,
+                badge = null,
+                statusPill = when {
+                    castingHere -> if (connected.secure) "Casting" else "Casting"
+                    connected.secure -> "Linked"
+                    else -> "Connected"
+                },
+                statusFilled = castingHere,
+                trailing = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Icon(
+                            imageVector = if (connected.secure) Icons.Default.Lock else Icons.Default.LockOpen,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp),
+                            tint = if (connected.secure) OnlineGreen else WarningAmber,
+                        )
+                        Text(
+                            text = if (connected.secure) "wss" else "ws",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (connected.secure) OnlineGreen else WarningAmber,
+                        )
+                    }
+                },
+                footer = {
+                    if (showAutoConnect) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Checkbox(
+                                checked = autoConnectEnabled,
+                                onCheckedChange = onAutoConnectChange,
+                            )
+                            Text(
+                                "Auto-connect to this TV",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            )
+                        }
+                    }
+                },
+                onDisconnect = onDisconnectNative,
+                secondaryAction = if (!castingHere) "Cast here" to onCastHere else null,
+            )
+        }
+        isConnecting -> {
+            ActiveDestinationCard(
+                name = tvDevice?.name ?: "TV",
+                subtitle = "Connecting…",
+                icon = Icons.Default.Tv,
+                badge = null,
+                statusPill = "Connecting",
+                statusFilled = false,
+                onDisconnect = onDisconnectNative,
+            )
+        }
+        else -> {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
+                ),
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Icon(
+                        Icons.Default.Smartphone,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Column {
+                        Text(
+                            "Nothing selected",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            "Pick a TV below, or play on this phone.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ActiveDestinationCard(
+    name: String,
+    subtitle: String?,
+    icon: ImageVector,
+    badge: String?,
+    statusPill: String? = null,
+    statusFilled: Boolean = false,
+    trailing: (@Composable () -> Unit)? = null,
+    footer: (@Composable () -> Unit)? = null,
+    secondaryAction: Pair<String, () -> Unit>? = null,
+    onDisconnect: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(32.dp),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    // Name alone on the first line so protocol/status chips never truncate it.
+                    Text(
+                        text = name,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    if (badge != null || statusPill != null) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            if (badge != null) ProtocolBadge(badge)
+                            if (statusPill != null) {
+                                StatusPill(statusPill, filled = statusFilled)
+                            }
+                        }
+                    }
+                    if (subtitle != null) {
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f),
+                        )
+                    }
+                    trailing?.invoke()
+                }
+            }
+            footer?.invoke()
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+            ) {
+                if (secondaryAction != null) {
+                    TextButton(onClick = secondaryAction.second) {
+                        Text(secondaryAction.first)
+                    }
+                }
+                Button(
+                    onClick = onDisconnect,
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+                ) {
+                    Text("Disconnect")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ThisDeviceDestinationRow(selected: Boolean, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Icon(
+                Icons.Default.Smartphone,
+                contentDescription = null,
+                modifier = Modifier.size(28.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                "This phone",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.weight(1f),
+            )
+            if (selected) {
+                Icon(Icons.Default.Check, contentDescription = "Selected", tint = OnlineGreen)
+            }
+        }
+    }
+}
+
+@Composable
+fun FindMoreDevicesRow(onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        color = Color.Transparent,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                Icons.Default.Add,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                text = "Find more devices…",
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+fun ProtocolBadge(text: String) {
+    Surface(
+        color = MaterialTheme.colorScheme.tertiaryContainer,
+        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        shape = RoundedCornerShape(4.dp),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+        )
+    }
+}
+
+@Composable
+fun StatusPill(text: String, filled: Boolean) {
+    val bg = if (filled) OnlineGreen.copy(alpha = 0.18f) else MaterialTheme.colorScheme.surfaceVariant
+    val fg = if (filled) OnlineGreen else MaterialTheme.colorScheme.onSurfaceVariant
+    Surface(color = bg, contentColor = fg, shape = RoundedCornerShape(50)) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}
+
+/**
+ * A device in a destination list: the device to connect with, whether it's reachable,
+ * and (if saved) its history entry + last-connected time.
  */
 data class UnifiedDevice(
     val connectDevice: TvDevice,
     val historyEntry: TvDevice?,
     val isOnline: Boolean,
-    val lastConnected: Long?
+    val lastConnected: Long?,
 ) {
     val isKnown: Boolean get() = historyEntry != null
 }
@@ -640,22 +1004,29 @@ fun connectKnownOrPair(
     ip: String,
     port: Int,
     name: String,
-    uuid: String = ""
+    uuid: String = "",
 ) {
-    val nativeHistory = history.filter { it.resolvedProtocol == CastProtocol.PLAYBRIDGE }
+    val nativeHistory = ConnectionMerge.playBridgeHistory(history)
     val existing = if (uuid.isNotEmpty()) {
         nativeHistory.find { it.uuid == uuid } ?: nativeHistory.find { it.ip == ip && it.port == port }
     } else {
         nativeHistory.find { it.ip == ip && it.port == port }
     }
     if (existing != null && existing.token.isNotEmpty()) {
-        viewModel.connect(existing.copy(name = name, ip = ip, port = port, uuid = if (uuid.isNotEmpty()) uuid else existing.uuid))
+        viewModel.connect(
+            existing.copy(
+                name = name,
+                ip = ip,
+                port = port,
+                uuid = if (uuid.isNotEmpty()) uuid else existing.uuid,
+            ),
+        )
     } else {
         viewModel.connect(TvDevice(ip = ip, port = port, token = "", name = name, uuid = uuid))
     }
 }
 
-private fun formatLastSeen(millis: Long): String {
+fun formatLastSeen(millis: Long): String {
     val diff = System.currentTimeMillis() - millis
     return when {
         diff < 60_000L -> "Last seen just now"
@@ -670,64 +1041,53 @@ private fun formatLastSeen(millis: Long): String {
 fun TvDeviceRow(
     device: UnifiedDevice,
     onClick: () -> Unit,
-    onRemove: (() -> Unit)? = null
+    onRemove: (() -> Unit)? = null,
+    showProtocolBadge: Boolean = true,
 ) {
-    val onlineColor = Color(0xFF4CAF50)
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer
-        )
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        ),
     ) {
         Row(
             modifier = Modifier
                 .padding(16.dp)
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
+            horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f),
             ) {
                 Icon(
-                    imageVector = if (
-                        device.connectDevice.resolvedProtocol == CastProtocol.DLNA ||
-                        device.connectDevice.resolvedProtocol == CastProtocol.GOOGLE_CAST
-                    ) Icons.Default.Cast else Icons.Default.Tv,
+                    imageVector = when (device.connectDevice.resolvedProtocol) {
+                        CastProtocol.DLNA, CastProtocol.GOOGLE_CAST -> Icons.Default.Cast
+                        else -> Icons.Default.Tv
+                    },
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(32.dp)
+                    modifier = Modifier.size(28.dp),
                 )
 
-                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        Text(
-                            text = device.connectDevice.name,
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.SemiBold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f, fill = false)
-                        )
-                        Surface(
-                            color = MaterialTheme.colorScheme.tertiaryContainer,
-                            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
-                            shape = RoundedCornerShape(4.dp)
-                        ) {
-                            Text(
-                                text = device.connectDevice.resolvedProtocol.displayName,
-                                style = MaterialTheme.typography.labelSmall,
-                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
-                            )
-                        }
-                    }
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    // Full-width title: protocol badge lives on the meta row so long
+                    // TV names (e.g. "Samsung QN90B Living Room") are not clipped.
+                    Text(
+                        text = device.connectDevice.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
                     Text(
                         text = if (device.connectDevice.port > 0) {
                             "${device.connectDevice.ip}:${device.connectDevice.port}"
@@ -735,20 +1095,20 @@ fun TvDeviceRow(
                             device.connectDevice.ip
                         },
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        modifier = Modifier.padding(top = 2.dp)
+                        modifier = Modifier.padding(top = 2.dp),
                     ) {
-                        val dotColor = if (device.isOnline) onlineColor
-                            else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                        val dotColor = if (device.isOnline) OnlineGreen
+                        else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
                         Box(
                             modifier = Modifier
                                 .size(8.dp)
                                 .clip(CircleShape)
-                                .background(dotColor)
+                                .background(dotColor),
                         )
                         val statusText = when {
                             device.isOnline && !device.isKnown -> "Online · New"
@@ -759,9 +1119,12 @@ fun TvDeviceRow(
                         Text(
                             text = statusText,
                             style = MaterialTheme.typography.bodySmall,
-                            color = if (device.isOnline) onlineColor
-                                else MaterialTheme.colorScheme.onSurfaceVariant
+                            color = if (device.isOnline) OnlineGreen
+                            else MaterialTheme.colorScheme.onSurfaceVariant,
                         )
+                        if (showProtocolBadge) {
+                            ProtocolBadge(device.connectDevice.resolvedProtocol.displayName)
+                        }
                     }
                 }
             }
@@ -772,12 +1135,12 @@ fun TvDeviceRow(
                     modifier = Modifier.semantics {
                         contentDescription = "Remove"
                         role = androidx.compose.ui.semantics.Role.Button
-                    }
+                    },
                 ) {
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = null,
-                        tint = MaterialTheme.colorScheme.error
+                        tint = MaterialTheme.colorScheme.error,
                     )
                 }
             }
@@ -788,14 +1151,16 @@ fun TvDeviceRow(
 @Composable
 fun ManualConnectionDialog(
     onDismiss: () -> Unit,
-    onConnect: (String, Int) -> Unit
+    onConnect: (String, Int) -> Unit,
 ) {
     var ip by remember { mutableStateOf("") }
-    var port by remember { mutableStateOf(com.playbridge.shared.protocol.Config.DEFAULT_PORT.toString()) }
+    var port by remember {
+        mutableStateOf(com.playbridge.shared.protocol.Config.DEFAULT_PORT.toString())
+    }
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Manual Connection") },
+        title = { Text("Connect by IP") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                 OutlinedTextField(
@@ -803,7 +1168,7 @@ fun ManualConnectionDialog(
                     onValueChange = { ip = it },
                     label = { Text("IP Address") },
                     singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 )
                 OutlinedTextField(
                     value = port,
@@ -811,7 +1176,7 @@ fun ManualConnectionDialog(
                     label = { Text("Port") },
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         },
@@ -823,7 +1188,7 @@ fun ManualConnectionDialog(
                         onConnect(ip, portInt)
                     }
                 },
-                enabled = ip.isNotEmpty() && port.isNotEmpty()
+                enabled = ip.isNotEmpty() && port.isNotEmpty(),
             ) {
                 Text("Connect")
             }
@@ -832,6 +1197,6 @@ fun ManualConnectionDialog(
             TextButton(onClick = onDismiss) {
                 Text("Cancel")
             }
-        }
+        },
     )
 }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/ui/ConnectionScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/ui/ConnectionScreen.kt
@@ -135,10 +135,20 @@ fun ConnectionScreen(
         viewModel.pingSavedDevices(history)
     }
 
-    val playBridgeSaved = remember(history, pings, activeExternalDevice, isConnected, tvDevice) {
+    val playBridgeSaved = remember(
+        history,
+        pings,
+        discoveredDevices,
+        activeExternalDevice,
+        isConnected,
+        tvDevice,
+    ) {
         ConnectionMerge.playBridgeHistory(history).map { saved ->
+            // Prefer the live discovered endpoint (DHCP / ports can change) while keeping
+            // the history entry for credentials and last-connected metadata.
+            val live = ConnectionMerge.withDiscoveredEndpoint(saved, discoveredDevices)
             UnifiedDevice(
-                connectDevice = saved,
+                connectDevice = live,
                 historyEntry = saved,
                 isOnline = pings[saved.endpointKey.toString()] == true ||
                     discoveredDevices.any { ConnectionMerge.isSameDevice(it, saved) },
@@ -151,10 +161,18 @@ fun ConnectionScreen(
             )
     }
 
-    val recentExternal = remember(history, pings, activeExternalDevice, isConnected, tvDevice) {
+    val recentExternal = remember(
+        history,
+        pings,
+        discoveredDevices,
+        activeExternalDevice,
+        isConnected,
+        tvDevice,
+    ) {
         ConnectionMerge.recentExternalHistory(history).map { saved ->
+            val live = ConnectionMerge.withDiscoveredEndpoint(saved, discoveredDevices)
             UnifiedDevice(
-                connectDevice = saved,
+                connectDevice = live,
                 historyEntry = saved,
                 isOnline = pings[saved.endpointKey.toString()] == true ||
                     discoveredDevices.any { ConnectionMerge.isSameDevice(it, saved) },
@@ -209,23 +227,26 @@ fun ConnectionScreen(
         connectKnownOrPair(viewModel, history, ip, port, name, uuid)
 
     fun selectEndpoint(device: TvDevice) {
-        val ready = when (device.resolvedProtocol) {
-            CastProtocol.DLNA -> viewModel.selectDlnaTarget(device)
-            CastProtocol.ROKU -> true.also { viewModel.selectRokuTarget(device) }
-            CastProtocol.GOOGLE_CAST -> true.also { viewModel.selectGoogleCastTarget(device) }
+        // Heal stale saved IPs / control URLs against the current discovery set before
+        // selecting (same path as DeviceConnectionSheet).
+        val target = ConnectionMerge.withDiscoveredEndpoint(device, discoveredDevices)
+        val ready = when (target.resolvedProtocol) {
+            CastProtocol.DLNA -> viewModel.selectDlnaTarget(target)
+            CastProtocol.ROKU -> true.also { viewModel.selectRokuTarget(target) }
+            CastProtocol.GOOGLE_CAST -> true.also { viewModel.selectGoogleCastTarget(target) }
             CastProtocol.PLAYBRIDGE -> true.also {
                 val alreadyLinked = isConnected && tvDevice?.let {
-                    ConnectionMerge.isSameDevice(it, device)
+                    ConnectionMerge.isSameDevice(it, target)
                 } == true
                 if (alreadyLinked) viewModel.selectNativeRoute()
-                else onDeviceSelected(device.ip, device.port, device.name, device.uuid)
+                else onDeviceSelected(target.ip, target.port, target.name, target.uuid)
             }
         }
-        if (device.resolvedProtocol != CastProtocol.PLAYBRIDGE) {
+        if (target.resolvedProtocol != CastProtocol.PLAYBRIDGE) {
             coroutineScope.launch {
                 snackbarHostState.showSnackbar(
-                    if (ready) "Selected ${device.name} — cast a video to play here"
-                    else "${device.name} is still preparing. Try again in a moment.",
+                    if (ready) "Selected ${target.name} — cast a video to play here"
+                    else "${target.name} is still preparing. Try again in a moment.",
                 )
             }
         }

--- a/mobile/android/app/src/test/java/com/playbridge/sender/connection/ConnectionMergeTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/connection/ConnectionMergeTest.kt
@@ -19,8 +19,27 @@ class ConnectionMergeTest {
         val history = ConnectionMerge.upsertHistory(listOf(native), dlna)
 
         assertEquals(2, history.size)
-        assertEquals(CastProtocol.DLNA, history[0].resolvedProtocol)
-        assertEquals(CastProtocol.PLAYBRIDGE, history[1].resolvedProtocol)
+        // PlayBridge stays first-class; external shortcuts follow.
+        assertEquals(CastProtocol.PLAYBRIDGE, history[0].resolvedProtocol)
+        assertEquals(CastProtocol.DLNA, history[1].resolvedProtocol)
+    }
+
+    @Test
+    fun externalHistoryIsCappedAndDoesNotEvictPlayBridge() {
+        val pb = dev("1.1.1.1", 8765, uuid = "pb1", token = "t")
+            .copy(protocol = CastProtocol.PLAYBRIDGE)
+        val externals = (1..5).map { i ->
+            dev("2.2.2.$i", 1400 + i, uuid = "dlna$i").copy(
+                protocol = CastProtocol.DLNA,
+                isDlna = true,
+            )
+        }
+        var history = listOf(pb)
+        externals.forEach { history = ConnectionMerge.upsertHistory(history, it) }
+
+        assertEquals(1, ConnectionMerge.playBridgeHistory(history).size)
+        assertEquals(ConnectionMerge.MAX_EXTERNAL_HISTORY, ConnectionMerge.recentExternalHistory(history).size)
+        assertEquals(pb.uuid, ConnectionMerge.playBridgeHistory(history).first().uuid)
     }
 
     private fun dev(


### PR DESCRIPTION
## Summary
- Redesign the phone **Devices** screen (was tabbed “TV Connection”) into a single destination-first scroll: Now → This phone → PlayBridge → recent other → expandable network discovery.
- Redesign the **cast sheet** the same way: no protocol chips, PlayBridge-first list, optional recent external shortcuts, **Find more devices…**.
- **Sticky discovery cache** so rescans never flash empty; quiet auto-rescan every 45s while Devices or the cast sheet is open.
- Cap history: PlayBridge first-class (10); external DLNA/Roku/Cast as max 3 recent shortcuts.
- Device names get full width (protocol badge on the meta row so long TV names are not clipped).
- **Wi‑Fi / VPN banners** on Devices + cast sheet when the phone is not on local network or a VPN may hide LAN casting.

## Test plan
- [x] Open Devices: no tabs; Now / PlayBridge / Other devices sections render cleanly
- [x] Open cast sheet from Library / cast chip: PlayBridge list, Find more devices → Devices with Other expanded
- [x] Rescan: list does not wipe to empty; spinner only
- [x] Leave Devices open ~45s: quiet rescan refreshes without flicker
- [x] Pair a PlayBridge TV; cast sheet shows it under PlayBridge
- [x] Select a DLNA/Roku/Cast target: appears under Recent other (max 3), not mixed as equal peers forever
- [x] Long TV name with protocol badge: name wraps, badge does not clip the title
- [x] Toggle Wi‑Fi off: red “Not on Wi‑Fi” banner + Wi‑Fi settings action
- [x] Enable VPN on Wi‑Fi: amber VPN banner; dismiss works; reappears after VPN off→on
- [x] Unit: `ConnectionMergeTest` (history caps / protocol separation)