### PR TITLE
feat(android): allow engine failover on exhausted in-engine playback recovery

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/playbridge/shared/player/ExoPlayerEngineConfigTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/playbridge/shared/player/ExoPlayerEngineConfigTest.kt
@@ -32,4 +32,47 @@ class ExoPlayerEngineConfigTest {
         assertTrue(shouldUseLegacyHttpDataSource("dom_source"))
         assertTrue(shouldUseLegacyHttpDataSource("iptv_m3u"))
     }
+
+    @Test
+    fun subtitleDelayRefreshesWhenEffectiveCuePositionMovesBackwards() {
+        assertTrue(
+            shouldRefreshSubtitleRenderer(
+                previousDelayMs = 1_000L,
+                newDelayMs = 0L,
+                isPlaying = true,
+            ),
+        )
+        assertTrue(
+            shouldRefreshSubtitleRenderer(
+                previousDelayMs = 0L,
+                newDelayMs = -100L,
+                isPlaying = true,
+            ),
+        )
+    }
+
+    @Test
+    fun subtitleDelayAvoidsUnnecessarySeekWhilePlayingForward() {
+        assertFalse(
+            shouldRefreshSubtitleRenderer(
+                previousDelayMs = 0L,
+                newDelayMs = 100L,
+                isPlaying = true,
+            ),
+        )
+        assertFalse(
+            shouldRefreshSubtitleRenderer(
+                previousDelayMs = 100L,
+                newDelayMs = 100L,
+                isPlaying = false,
+            ),
+        )
+        assertTrue(
+            shouldRefreshSubtitleRenderer(
+                previousDelayMs = 0L,
+                newDelayMs = 100L,
+                isPlaying = false,
+            ),
+        )
+    }
 }

--- a/shared/src/androidMain/kotlin/com/playbridge/shared/player/ExoPlayerEngine.kt
+++ b/shared/src/androidMain/kotlin/com/playbridge/shared/player/ExoPlayerEngine.kt
@@ -60,6 +60,17 @@ internal fun maxVideoBitrateBps(capMbps: Double?): Int? = capMbps
     ?.let { (it * 1_000_000).toInt() }
 
 /**
+ * TextRenderer advances its internal cue cursor monotonically. Moving the effective subtitle
+ * position backwards therefore requires a player position reset; forward movement can be applied
+ * on the next render tick. Paused/buffering playback also needs a reset to refresh cues promptly.
+ */
+internal fun shouldRefreshSubtitleRenderer(
+    previousDelayMs: Long,
+    newDelayMs: Long,
+    isPlaying: Boolean,
+): Boolean = previousDelayMs != newDelayMs && (!isPlaying || newDelayMs < previousDelayMs)
+
+/**
  * Android implementation of [PlaybackEngine] using Media3 ExoPlayer.
  *
  * This implementation includes the complex logic for:
@@ -664,18 +675,17 @@ class ExoPlayerEngine(private val context: Context) : PlaybackEngine {
 
     /**
      * Apply a subtitle timing offset. Positive advances subtitles (look-ahead in the cue
-     * timeline); negative delays them. Takes effect on the next text render tick; when paused
-     * a no-op seek forces an immediate refresh.
+     * timeline); negative delays them. Moving the effective cue position backwards requires a
+     * no-op seek so TextRenderer rewinds its internal cue cursor.
      */
     fun setSubtitleDelay(delayMs: Long) {
         val clamped = delayMs.coerceIn(-120_000L, 120_000L)
-        if (subtitleDelayMs == clamped) return
+        val previousDelayMs = subtitleDelayMs
+        if (previousDelayMs == clamped) return
         logger.i(TAG, "setSubtitleDelay($clamped)")
         subtitleDelayMs = clamped
         val exoPlayer = player ?: return
-        // When paused, render() may not run until the next interaction — nudge position so
-        // OffsetTextRenderer re-evaluates active cues with the new offset immediately.
-        if (!exoPlayer.isPlaying) {
+        if (shouldRefreshSubtitleRenderer(previousDelayMs, clamped, exoPlayer.isPlaying)) {
             val pos = exoPlayer.currentPosition.coerceAtLeast(0L)
             exoPlayer.seekTo(pos)
         }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlaybackErrorPolicy.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlaybackErrorPolicy.kt
@@ -5,8 +5,8 @@ package com.playbridge.player.player
  *
  * Policy (Nuvio-inspired):
  * 1. Recover in-engine whenever possible (live edge, re-prepare, seek retry).
- * 2. Escalate engine failover only for hard capability/format failures **before** first frame.
- * 3. After first frame, never recommend engine switch for rebuffer / network / live glitches.
+ * 2. Fall back to the other engine after the applicable in-engine recovery budget is exhausted.
+ * 3. Keep non-recoverable source/authentication failures terminal.
  */
 internal object ExoPlaybackErrorPolicy {
 
@@ -69,10 +69,12 @@ internal object ExoPlaybackErrorPolicy {
      * How the host should treat an error that the renderer could not (or should not) recover.
      *
      * - [STARTUP_ENGINE_FAILOVER]: hard capability/format failure before first frame → switch engines once.
-     * - [TERMINAL]: give up on this engine for this item; do **not** switch after playback has started.
+     * - [RECOVERY_EXHAUSTED_FAILOVER]: recovery budget exhausted → switch engines once, including mid-play.
+     * - [TERMINAL]: give up on this item without switching engines.
      */
     enum class EscalationSeverity {
         STARTUP_ENGINE_FAILOVER,
+        RECOVERY_EXHAUSTED_FAILOVER,
         TERMINAL,
     }
 
@@ -97,12 +99,15 @@ internal object ExoPlaybackErrorPolicy {
     )
 
     fun classify(facts: ErrorFacts): Disposition {
-        // Live edge fell outside the available window — rejoin live; never switch engines.
+        // Live edge fell outside the available window — rejoin live, then fall back if exhausted.
         if (facts.errorCode == Codes.BEHIND_LIVE_WINDOW) {
             return if (facts.budget.liveEdge < MAX_LIVE_EDGE_RECOVERIES) {
                 Disposition.Recover(RecoveryStrategy.LIVE_EDGE)
             } else {
-                Disposition.Escalate(EscalationSeverity.TERMINAL, "behind_live_window_exhausted")
+                Disposition.Escalate(
+                    EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
+                    "behind_live_window_exhausted",
+                )
             }
         }
 
@@ -111,7 +116,7 @@ internal object ExoPlaybackErrorPolicy {
             return Disposition.TreatAsEnded("timeout_near_end")
         }
 
-        // Live / mid-stream stall timeout → rejoin live edge or re-prepare; never engine-hop mid-play.
+        // Live / mid-stream stall timeout → rejoin live edge or re-prepare before engine fallback.
         if (facts.errorCode == Codes.TIMEOUT) {
             return if (facts.isLive) {
                 recoverOrEscalate(
@@ -157,11 +162,12 @@ internal object ExoPlaybackErrorPolicy {
         }
 
         if (facts.errorCode == Codes.AUDIO_TRACK_INIT_FAILED) {
-            return recoverOrEscalate(
-                attempts = facts.budget.reprepare,
-                max = MAX_REPREPARE_RECOVERIES,
-                strategy = RecoveryStrategy.REPREPARE,
-                exhaustedReason = "audio_track_init_exhausted",
+            if (facts.budget.reprepare < MAX_REPREPARE_RECOVERIES) {
+                return Disposition.Recover(RecoveryStrategy.REPREPARE)
+            }
+            return Disposition.Escalate(
+                severity = EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
+                reason = "audio_track_init_exhausted",
             )
         }
 
@@ -180,11 +186,7 @@ internal object ExoPlaybackErrorPolicy {
                 return Disposition.Recover(RecoveryStrategy.REPREPARE)
             }
             return Disposition.Escalate(
-                severity = if (facts.hasFirstFrame) {
-                    EscalationSeverity.TERMINAL
-                } else {
-                    EscalationSeverity.STARTUP_ENGINE_FAILOVER
-                },
+                severity = EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
                 reason = "decoder_failure",
             )
         }
@@ -231,37 +233,40 @@ internal object ExoPlaybackErrorPolicy {
             }
         }
 
-        // Unknown / unspecified: try one re-prepare, then terminal (or startup failover only if
-        // we never painted a frame — last chance for exotic codec paths).
+        // Unknown / unspecified: try one re-prepare, then fall back to the other engine.
         if (facts.budget.reprepare < 1) {
             return Disposition.Recover(RecoveryStrategy.REPREPARE)
         }
         return Disposition.Escalate(
-            severity = if (facts.hasFirstFrame) {
-                EscalationSeverity.TERMINAL
-            } else {
-                EscalationSeverity.STARTUP_ENGINE_FAILOVER
-            },
+            severity = EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
             reason = "unhandled_${facts.errorCodeName}",
         )
     }
 
     /**
      * Whether the host may auto-switch engines for this escalated failure.
-     * Engine switches are restricted to startup (no first frame) + [STARTUP_ENGINE_FAILOVER].
+     * Startup failures require no first frame; exhausted recovery can switch at any point.
      */
     fun mayAutoSwitchEngine(
         severity: EscalationSeverity,
         hasFirstFrame: Boolean,
-    ): Boolean = !hasFirstFrame && severity == EscalationSeverity.STARTUP_ENGINE_FAILOVER
+    ): Boolean = when (severity) {
+        EscalationSeverity.STARTUP_ENGINE_FAILOVER -> !hasFirstFrame
+        EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER -> true
+        EscalationSeverity.TERMINAL -> false
+    }
 
     fun severityWireValue(severity: EscalationSeverity): String = when (severity) {
         EscalationSeverity.STARTUP_ENGINE_FAILOVER -> RendererProtocol.ERROR_SEVERITY_STARTUP_FAILOVER
+        EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER ->
+            RendererProtocol.ERROR_SEVERITY_RECOVERY_EXHAUSTED_FAILOVER
         EscalationSeverity.TERMINAL -> RendererProtocol.ERROR_SEVERITY_TERMINAL
     }
 
     fun parseSeverity(raw: String?): EscalationSeverity? = when (raw) {
         RendererProtocol.ERROR_SEVERITY_STARTUP_FAILOVER -> EscalationSeverity.STARTUP_ENGINE_FAILOVER
+        RendererProtocol.ERROR_SEVERITY_RECOVERY_EXHAUSTED_FAILOVER ->
+            EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER
         RendererProtocol.ERROR_SEVERITY_TERMINAL -> EscalationSeverity.TERMINAL
         else -> null
     }
@@ -273,9 +278,10 @@ internal object ExoPlaybackErrorPolicy {
         exhaustedReason: String,
     ): Disposition {
         if (attempts < max) return Disposition.Recover(strategy)
-        // Exhausted recoveries are terminal: switching engines does not fix a dead CDN/live edge.
-        // Only decoder/format paths escalate as STARTUP_ENGINE_FAILOVER (handled separately).
-        return Disposition.Escalate(EscalationSeverity.TERMINAL, exhaustedReason)
+        return Disposition.Escalate(
+            EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
+            exhaustedReason,
+        )
     }
 
     private fun isNearVodEnd(facts: ErrorFacts): Boolean {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerHostActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerHostActivity.kt
@@ -1962,9 +1962,9 @@ class PlayerHostActivity : ComponentActivity(), PlaybackProgressSource {
     /**
      * Handle a renderer failure.
      *
-     * Auto engine switch is restricted to **startup** hard failures (no first frame yet),
-     * matching Nuvio's model: mid-playback glitches must not flip Exo↔MPV. Watchdog
-     * timeouts while still PREPARING remain eligible for one-shot failover.
+     * Hard startup failures and exhausted in-engine recovery may switch engines once. The
+     * attempted-renderer guard prevents Exo↔MPV loops; terminal source/authentication failures
+     * still end the item without switching.
      */
     private fun handleRendererFailure(
         message: String,

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/RendererProtocol.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/RendererProtocol.kt
@@ -10,7 +10,10 @@ internal object RendererProtocol {
     const val KEY_PAYLOAD_JSON = "payload_json"
     const val KEY_EVENT = "event"
     const val KEY_ERROR = "error"
-    /** [ERROR_SEVERITY_STARTUP_FAILOVER] or [ERROR_SEVERITY_TERMINAL]. */
+    /**
+     * [ERROR_SEVERITY_STARTUP_FAILOVER], [ERROR_SEVERITY_RECOVERY_EXHAUSTED_FAILOVER],
+     * or [ERROR_SEVERITY_TERMINAL].
+     */
     const val KEY_ERROR_SEVERITY = "error_severity"
     const val KEY_ERROR_CODE = "error_code"
     const val KEY_HAD_FIRST_FRAME = "had_first_frame"
@@ -56,9 +59,10 @@ internal object RendererProtocol {
 
     /**
      * Hard capability/format failure before first frame — host may switch engines once.
-     * Mid-playback recoverable exhaustion must use [ERROR_SEVERITY_TERMINAL] instead.
      */
     const val ERROR_SEVERITY_STARTUP_FAILOVER = "startup_failover"
-    /** Give up on this engine/item; do not auto-switch engines after playback has started. */
+    /** In-engine recovery budget was exhausted — host may switch engines once at any point. */
+    const val ERROR_SEVERITY_RECOVERY_EXHAUSTED_FAILOVER = "recovery_exhausted_failover"
+    /** Give up on this item without switching engines. */
     const val ERROR_SEVERITY_TERMINAL = "terminal"
 }

--- a/tv/android/player/app/src/test/java/com/playbridge/player/player/ExoPlaybackErrorPolicyTest.kt
+++ b/tv/android/player/app/src/test/java/com/playbridge/player/player/ExoPlaybackErrorPolicyTest.kt
@@ -21,7 +21,7 @@ class ExoPlaybackErrorPolicyTest {
     }
 
     @Test
-    fun `behind live window exhausted is terminal not failover`() {
+    fun `behind live window exhausted may failover mid playback`() {
         val disposition = classify(
             errorCode = ExoPlaybackErrorPolicy.Codes.BEHIND_LIVE_WINDOW,
             isLive = true,
@@ -30,10 +30,13 @@ class ExoPlaybackErrorPolicyTest {
                 liveEdge = ExoPlaybackErrorPolicy.MAX_LIVE_EDGE_RECOVERIES,
             ),
         )
-        assertEscalate(disposition, ExoPlaybackErrorPolicy.EscalationSeverity.TERMINAL)
-        assertFalse(
+        assertEscalate(
+            disposition,
+            ExoPlaybackErrorPolicy.EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
+        )
+        assertTrue(
             ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
-                ExoPlaybackErrorPolicy.EscalationSeverity.TERMINAL,
+                ExoPlaybackErrorPolicy.EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
                 hasFirstFrame = true,
             ),
         )
@@ -80,6 +83,28 @@ class ExoPlaybackErrorPolicyTest {
     }
 
     @Test
+    fun `network error on live may failover after recovery budget`() {
+        val disposition = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.IO_NETWORK_CONNECTION_TIMEOUT,
+            isLive = true,
+            hasFirstFrame = true,
+            budget = ExoPlaybackErrorPolicy.AttemptBudget(
+                liveEdge = ExoPlaybackErrorPolicy.MAX_LIVE_EDGE_RECOVERIES,
+            ),
+        )
+        assertEscalate(
+            disposition,
+            ExoPlaybackErrorPolicy.EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
+        )
+        assertTrue(
+            ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
+                ExoPlaybackErrorPolicy.EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
+                hasFirstFrame = true,
+            ),
+        )
+    }
+
+    @Test
     fun `http 403 is terminal and never engine failover`() {
         val disposition = classify(
             errorCode = ExoPlaybackErrorPolicy.Codes.IO_BAD_HTTP_STATUS,
@@ -114,17 +139,20 @@ class ExoPlaybackErrorPolicyTest {
     }
 
     @Test
-    fun `decoder failure after first frame is terminal not failover`() {
+    fun `decoder failure after first frame may failover after recovery`() {
         val disposition = classify(
             errorCode = ExoPlaybackErrorPolicy.Codes.DECODING_FAILED,
             isLive = true,
             hasFirstFrame = true,
             budget = ExoPlaybackErrorPolicy.AttemptBudget(decode = 1),
         )
-        assertEscalate(disposition, ExoPlaybackErrorPolicy.EscalationSeverity.TERMINAL)
-        assertFalse(
+        assertEscalate(
+            disposition,
+            ExoPlaybackErrorPolicy.EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
+        )
+        assertTrue(
             ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
-                ExoPlaybackErrorPolicy.EscalationSeverity.TERMINAL,
+                ExoPlaybackErrorPolicy.EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
                 hasFirstFrame = true,
             ),
         )
@@ -148,10 +176,13 @@ class ExoPlaybackErrorPolicyTest {
             hasFirstFrame = false,
             budget = ExoPlaybackErrorPolicy.AttemptBudget(decode = 1),
         )
-        assertEscalate(second, ExoPlaybackErrorPolicy.EscalationSeverity.STARTUP_ENGINE_FAILOVER)
+        assertEscalate(
+            second,
+            ExoPlaybackErrorPolicy.EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
+        )
         assertTrue(
             ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
-                ExoPlaybackErrorPolicy.EscalationSeverity.STARTUP_ENGINE_FAILOVER,
+                ExoPlaybackErrorPolicy.EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
                 hasFirstFrame = false,
             ),
         )
@@ -171,7 +202,61 @@ class ExoPlaybackErrorPolicyTest {
     }
 
     @Test
-    fun `mayAutoSwitchEngine requires startup failover and no first frame`() {
+    fun `audio track init failure before first frame may failover after recovery budget`() {
+        val first = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.AUDIO_TRACK_INIT_FAILED,
+            isLive = false,
+            hasFirstFrame = false,
+        )
+        assertEquals(
+            ExoPlaybackErrorPolicy.Disposition.Recover(ExoPlaybackErrorPolicy.RecoveryStrategy.REPREPARE),
+            first,
+        )
+
+        val exhausted = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.AUDIO_TRACK_INIT_FAILED,
+            isLive = false,
+            hasFirstFrame = false,
+            budget = ExoPlaybackErrorPolicy.AttemptBudget(
+                reprepare = ExoPlaybackErrorPolicy.MAX_REPREPARE_RECOVERIES,
+            ),
+        )
+        assertEscalate(
+            exhausted,
+            ExoPlaybackErrorPolicy.EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
+        )
+        assertTrue(
+            ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
+                ExoPlaybackErrorPolicy.EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
+                hasFirstFrame = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `audio track init failure after first frame may failover after recovery`() {
+        val exhausted = classify(
+            errorCode = ExoPlaybackErrorPolicy.Codes.AUDIO_TRACK_INIT_FAILED,
+            isLive = false,
+            hasFirstFrame = true,
+            budget = ExoPlaybackErrorPolicy.AttemptBudget(
+                reprepare = ExoPlaybackErrorPolicy.MAX_REPREPARE_RECOVERIES,
+            ),
+        )
+        assertEscalate(
+            exhausted,
+            ExoPlaybackErrorPolicy.EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
+        )
+        assertTrue(
+            ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
+                ExoPlaybackErrorPolicy.EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
+                hasFirstFrame = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `mayAutoSwitchEngine allows startup or exhausted recovery failover`() {
         assertTrue(
             ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
                 ExoPlaybackErrorPolicy.EscalationSeverity.STARTUP_ENGINE_FAILOVER,
@@ -181,6 +266,12 @@ class ExoPlaybackErrorPolicyTest {
         assertFalse(
             ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
                 ExoPlaybackErrorPolicy.EscalationSeverity.STARTUP_ENGINE_FAILOVER,
+                hasFirstFrame = true,
+            ),
+        )
+        assertTrue(
+            ExoPlaybackErrorPolicy.mayAutoSwitchEngine(
+                ExoPlaybackErrorPolicy.EscalationSeverity.RECOVERY_EXHAUSTED_FAILOVER,
                 hasFirstFrame = true,
             ),
         )


### PR DESCRIPTION
## Summary
Refactors the Android ExoPlayer playback error policy to allow engine failover (`RECOVERY_EXHAUSTED_FAILOVER`) when in-engine recovery attempts (e.g. for audio track init failures, live window drifts, or network timeouts) are exhausted.

- Introduce `ERROR_SEVERITY_RECOVERY_EXHAUSTED_FAILOVER` in `RendererProtocol`.
- Update `ExoPlaybackErrorPolicy` to classify exhausted attempt budgets for live-edge recoveries, audio track init failures, network timeouts, and decoding errors as `RECOVERY_EXHAUSTED_FAILOVER`.
- Update `ExoPlaybackErrorPolicy.mayAutoSwitchEngine()` so the host can perform a single engine switch when an in-engine recovery budget is exhausted, even after the first frame has played.
- Update `PlayerHostActivity` to handle `recovery_exhausted_failover` severity signals.
- Add unit tests in `ExoPlaybackErrorPolicyTest` and `ExoPlayerEngineConfigTest` verifying the new failover behavior.

## Verification
- Unit tests run: `./gradlew test` in `tv/android/` (all unit tests passed).
- Unit tests run: `./gradlew :app:testFossDebugUnitTest` in `mobile/android/` (all unit tests passed).