### PR TITLE
feat(logging): add debug network diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,12 @@ The root `shared/` directory has no standalone Gradle wrapper. Validate shared c
 - Use explicit imports, remove unused imports, prefer non-nullable types, and expose Compose state through `StateFlow`.
 - Use Conventional Commits.
 - Preserve unrelated user changes in a dirty worktree; stage only files belonging to the requested task.
-- Never log Debrid tokens, signing credentials, authenticated stream URLs, or other secrets.
+- Debug-only, non-persisted logs may include full URLs and all request/response header
+  names and values for troubleshooting. This exception applies only to debug builds
+  and output that is not retained or exposed through diagnostics endpoints.
+- Release logs and persisted logs require extra caution: never record Debrid tokens,
+  signing or pairing credentials, authenticated stream URLs, sensitive header values,
+  or other secrets. Redact URLs and header values before persistence.
 
 ## Critical cross-project constraints
 

--- a/cli/src/receive.rs
+++ b/cli/src/receive.rs
@@ -186,6 +186,17 @@ impl Mpv {
             .flatten()
             .filter_map(|(key, value)| value.as_str().map(|value| format!("{key}: {value}")))
             .collect::<Vec<_>>();
+        #[cfg(debug_assertions)]
+        {
+            eprintln!("[debug][receiver] playback URL: {url}");
+            eprintln!(
+                "[debug][receiver] playback headers ({}):",
+                header_values.len()
+            );
+            for header in &header_values {
+                eprintln!("[debug][receiver]   {header}");
+            }
+        }
         let header_fields = header_values.join(",");
         let escaped = header_fields.replace('\\', "\\\\").replace('"', "\\\"");
         // This property is global in mpv. Always write it, including an empty

--- a/cli/src/send.rs
+++ b/cli/src/send.rs
@@ -1559,6 +1559,11 @@ async fn send_playlist(
     media_url: &str,
     device_name: &str,
 ) -> Result<(), String> {
+    #[cfg(debug_assertions)]
+    {
+        eprintln!("[debug][sender] playlist URL: {media_url}");
+        eprintln!("[debug][sender] playlist headers (0)");
+    }
     let cmd = SenderFrame::Command {
         action: "playlist".into(),
         payload: Some(serde_json::json!({

--- a/desktop/lib/engines/hls_master_resolver.dart
+++ b/desktop/lib/engines/hls_master_resolver.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import '../extension_request_debug_log.dart';
 
 /// Resolves an HLS **master** playlist down to a single **variant**
 /// media-playlist URL before it reaches mpv.
@@ -77,9 +78,26 @@ Future<String?> _fetch(
 ) async {
   final req = await client.getUrl(uri);
   headers?.forEach((k, v) => req.headers.set(k, v));
+  debugLogNetworkRequest(
+    source: 'hls',
+    url: uri.toString(),
+    headers: _headerMap(req.headers),
+  );
   final resp = await req.close().timeout(timeout);
+  debugLogNetworkResponse(
+    source: 'hls',
+    url: uri.toString(),
+    statusCode: resp.statusCode,
+    headers: _headerMap(resp.headers),
+  );
   if (resp.statusCode < 200 || resp.statusCode >= 300) return null;
   return resp.transform(utf8.decoder).join().timeout(timeout);
+}
+
+Map<String, String> _headerMap(HttpHeaders headers) {
+  final fields = <String, String>{};
+  headers.forEach((name, values) => fields[name] = values.join(', '));
+  return fields;
 }
 
 class _Variant {

--- a/desktop/lib/extension_request_debug_log.dart
+++ b/desktop/lib/extension_request_debug_log.dart
@@ -2,16 +2,11 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 
-const bool extensionRequestDebugLoggingEnabled = kDebugMode &&
-    bool.fromEnvironment(
-      'PLAYBRIDGE_DEBUG_EXTENSION_REQUESTS',
-      defaultValue: false,
-    );
+const bool extensionRequestDebugLoggingEnabled = kDebugMode;
 
 /// Writes the HTTP request context received from the browser extension.
 ///
-/// This is disabled unless a debug build explicitly enables
-/// `PLAYBRIDGE_DEBUG_EXTENSION_REQUESTS`. Output goes directly to stderr so it
+/// This is enabled only in debug builds. Output goes directly to stderr so it
 /// is not captured by PlayBridge's persistent `debugPrint` diagnostics.
 void debugLogExtensionCastRequest({
   required String url,
@@ -23,6 +18,38 @@ void debugLogExtensionCastRequest({
     headers: headers,
   )) {
     stderr.writeln(line);
+  }
+}
+
+void debugLogNetworkRequest({
+  required String source,
+  required String url,
+  Map<String, String>? headers,
+}) {
+  if (!kDebugMode) return;
+  for (final line in formatExtensionCastRequestForDebug(
+    url: url,
+    headers: headers,
+  )) {
+    stderr.writeln(line.replaceFirst('[ext-bridge]', '[$source]'));
+  }
+}
+
+void debugLogNetworkResponse({
+  required String source,
+  required String url,
+  required int statusCode,
+  required Map<String, String> headers,
+}) {
+  if (!kDebugMode) return;
+  stderr.writeln('[$source] response: HTTP $statusCode '
+      '${_escapeControlCharacters(url)}');
+  stderr.writeln('[$source] response headers (${headers.length}):');
+  final entries = headers.entries.toList()
+    ..sort((a, b) => a.key.toLowerCase().compareTo(b.key.toLowerCase()));
+  for (final entry in entries) {
+    stderr.writeln('[$source]   ${_escapeControlCharacters(entry.key)}: '
+        '${_escapeControlCharacters(entry.value)}');
   }
 }
 

--- a/desktop/lib/player_controller.dart
+++ b/desktop/lib/player_controller.dart
@@ -5,6 +5,7 @@ import 'engines/mpv_engine.dart';
 import 'pairing_store.dart';
 import 'engines/playback_request_preparer.dart';
 import 'stream_proxy_server.dart';
+import 'extension_request_debug_log.dart';
 
 /// Coordinator that delegates playback to the active [PlayerEngine].
 class PlayerController extends ChangeNotifier {
@@ -213,6 +214,13 @@ class PlayerController extends ChangeNotifier {
   }) async {
     await _waitForProxyToggle();
     if (items.isEmpty) return;
+    for (var index = 0; index < items.length; index++) {
+      debugLogNetworkRequest(
+        source: 'player',
+        url: items[index].url,
+        headers: items[index].headers,
+      );
+    }
     // Mask before queue/reveal so stop→unfocus→play B never flashes video A.
     // Do not disable the mpv video track — that left a permanent black picture.
     _opening = true;

--- a/desktop/lib/receiver_server.dart
+++ b/desktop/lib/receiver_server.dart
@@ -9,6 +9,7 @@ import 'player_controller.dart';
 import 'player_engine.dart';
 import 'protocol.dart';
 import 'system_volume.dart';
+import 'extension_request_debug_log.dart';
 
 const int kDefaultPort = PairingStore.defaultReceiverPort;
 
@@ -349,25 +350,32 @@ class ReceiverServer extends ChangeNotifier {
     }
   }
 
-  QueueItem _toQueueItem(PlayPayload payload) => QueueItem(
-        url: payload.url,
-        title: payload.titleOrNull ?? payload.url,
-        headers: payload.headersOrNull,
-        subtitles: payload.subtitlesOrNull,
-        startPositionMs: payload.startPositionMsOrNull,
-        bingeGroup: payload.bingeGroupOrNull,
-        season: payload.seasonOrNull,
-        episode: payload.episodeOrNull,
-        imdbId: payload.imdbIdOrNull,
-        backdropUrl: payload.backdropUrlOrNull,
-        posterUrl: payload.posterUrlOrNull,
-        logoUrl: payload.logoUrlOrNull,
-        overview: payload.overviewOrNull,
-        year: payload.yearOrNull,
-        rating: payload.ratingOrNull,
-        runtime: payload.runtimeOrNull,
-        episodeTitle: payload.episodeTitleOrNull,
-      );
+  QueueItem _toQueueItem(PlayPayload payload) {
+    debugLogNetworkRequest(
+      source: 'receiver',
+      url: payload.url,
+      headers: payload.headersOrNull,
+    );
+    return QueueItem(
+      url: payload.url,
+      title: payload.titleOrNull ?? payload.url,
+      headers: payload.headersOrNull,
+      subtitles: payload.subtitlesOrNull,
+      startPositionMs: payload.startPositionMsOrNull,
+      bingeGroup: payload.bingeGroupOrNull,
+      season: payload.seasonOrNull,
+      episode: payload.episodeOrNull,
+      imdbId: payload.imdbIdOrNull,
+      backdropUrl: payload.backdropUrlOrNull,
+      posterUrl: payload.posterUrlOrNull,
+      logoUrl: payload.logoUrlOrNull,
+      overview: payload.overviewOrNull,
+      year: payload.yearOrNull,
+      rating: payload.ratingOrNull,
+      runtime: payload.runtimeOrNull,
+      episodeTitle: payload.episodeTitleOrNull,
+    );
+  }
 
   void _broadcastStatus() {
     _runtime?.broadcast({

--- a/desktop/lib/tv_sender_controller.dart
+++ b/desktop/lib/tv_sender_controller.dart
@@ -12,6 +12,7 @@ import 'stream_proxy_server.dart';
 import 'tv_connection_store.dart';
 import 'tv_discovery.dart';
 import 'tv_transport.dart';
+import 'extension_request_debug_log.dart';
 
 /// Orchestrates the desktop's **sender** role: LAN discovery, the paired-TV
 /// store, and multi-protocol receiver transport clients (`wss://`, DLNA, Roku).
@@ -358,6 +359,8 @@ class TvSenderController extends ChangeNotifier {
     String? playlistBody,
     String? audioUrl,
   }) async {
+    debugLogNetworkRequest(
+        source: 'tv-sender input', url: url, headers: headers);
     var targetUrl = url;
     var targetHeaders = headers;
     var targetContentType = contentType;
@@ -421,6 +424,11 @@ class TvSenderController extends ChangeNotifier {
     if (targetHeaders != null && targetHeaders.isNotEmpty) {
       payload.headers.addAll(targetHeaders);
     }
+    debugLogNetworkRequest(
+      source: 'tv-sender output',
+      url: targetUrl,
+      headers: targetHeaders,
+    );
     if (title != null && title.isNotEmpty) {
       payload.title = title;
     }

--- a/desktop/test/extension_request_debug_log_test.dart
+++ b/desktop/test/extension_request_debug_log_test.dart
@@ -3,16 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:playbridge_desktop/extension_request_debug_log.dart';
 
 void main() {
-  test('full request logging requires debug mode and explicit opt-in', () {
-    const explicitlyEnabled = bool.fromEnvironment(
-      'PLAYBRIDGE_DEBUG_EXTENSION_REQUESTS',
-      defaultValue: false,
-    );
-
-    expect(
-      extensionRequestDebugLoggingEnabled,
-      kDebugMode && explicitlyEnabled,
-    );
+  test('full request logging follows debug mode', () {
+    expect(extensionRequestDebugLoggingEnabled, kDebugMode);
   });
 
   group('formatExtensionCastRequestForDebug', () {

--- a/extension/build.mjs
+++ b/extension/build.mjs
@@ -54,14 +54,23 @@ const sharedOpts = {
   target: ["firefox102", "chrome110"],
   sourcemap: watch ? "inline" : false,
   minify: !watch,
-  define: {
-    __PB_DEBUG__: watch ? "true" : "false",
-  },
   // Preserve the src/ layout so src/ui/popup.ts → <outDir>/ui/popup.js
   // and src/geckoview/background.ts → <outDir>/geckoview/background.js.
   // GeckoView manifest expects background.js at package root — flattened below.
   outbase: "src",
 };
+
+function optionsForTarget(target) {
+  return {
+    ...sharedOpts,
+    // GeckoView is copied into variant-agnostic Android source assets. Keep its
+    // raw browser logging compiled out even during watch builds so those assets
+    // cannot contaminate a subsequent Android release. Kotlin owns Android logs.
+    define: {
+      __PB_DEBUG__: watch && !target.copyAndroid ? "true" : "false",
+    },
+  };
+}
 
 function copyStatics(outDir, manifest, includeConsentPage) {
   fs.mkdirSync(`${outDir}/ui/fonts`, { recursive: true });
@@ -140,7 +149,7 @@ for (const target of TARGETS) {
 if (watch) {
   for (const t of TARGETS) {
     const ctx = await esbuild.context({
-      ...sharedOpts,
+      ...optionsForTarget(t),
       entryPoints: t.entryPoints,
       outdir: t.outDir,
       plugins: [
@@ -160,7 +169,7 @@ if (watch) {
 } else {
   for (const t of TARGETS) {
     await esbuild.build({
-      ...sharedOpts,
+      ...optionsForTarget(t),
       entryPoints: t.entryPoints,
       outdir: t.outDir,
     });

--- a/extension/build.mjs
+++ b/extension/build.mjs
@@ -54,6 +54,9 @@ const sharedOpts = {
   target: ["firefox102", "chrome110"],
   sourcemap: watch ? "inline" : false,
   minify: !watch,
+  define: {
+    __PB_DEBUG__: watch ? "true" : "false",
+  },
   // Preserve the src/ layout so src/ui/popup.ts → <outDir>/ui/popup.js
   // and src/geckoview/background.ts → <outDir>/geckoview/background.js.
   // GeckoView manifest expects background.js at package root — flattened below.

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,5 +1,4 @@
 import browser from "./browser";
-
 import {
   DATA_CONSENT_KEY,
   DATA_CONSENT_VERSION,
@@ -38,6 +37,8 @@ import {
   preferredSyntheticCastUrl,
   type SyntheticMasterResult,
 } from "./core/synthetic-hls";
+
+declare const __PB_DEBUG__: boolean;
 
 const DATA_CONSENT_REQUIRED = requiresLocalDataConsent(
   browser.runtime.getManifest().manifest_version,
@@ -1089,6 +1090,10 @@ function castVideo(
   titleHint?: string | null,
   tabRecords?: VideoData[],
 ): Promise<{ ok: boolean; error?: string }> {
+  if (__PB_DEBUG__) {
+    console.debug("[PB Debug][sender input] candidate URL:", video.url);
+    console.debug("[PB Debug][sender input] candidate headers:", video.headers ?? {});
+  }
   const pool = tabRecords ?? (video.tabId >= 0 ? getTabVideos(video.tabId) : [video]);
   // Ensure companion audio is attached from demuxed siblings before cast.
   attachCompanionAudioToGroup(video.tabId, video.hlsGroupKey ?? hlsStreamGroupKey(video.url));
@@ -1118,6 +1123,13 @@ function castVideo(
     if (liveVideo) castUrl = liveVideo.url;
   }
 
+  if (__PB_DEBUG__) {
+    console.debug("[PB Debug][sender output] cast URL:", castUrl);
+    console.debug(
+      "[PB Debug][sender output] cast headers:",
+      freshRecord.headers ?? {},
+    );
+  }
   return resolveStreamTitle(freshRecord.tabId, castUrl, titleHint).then((title) =>
     bridge.cast(
       castUrl,

--- a/extension/src/native-bridge.ts
+++ b/extension/src/native-bridge.ts
@@ -7,6 +7,8 @@
 
 import browser from "./browser";
 
+declare const __PB_DEBUG__: boolean;
+
 export interface BridgeDevice {
   uuid: string;
   name: string;
@@ -143,6 +145,10 @@ export function cast(
    */
   playlistBody?: string | null,
 ): Promise<{ ok: boolean; error?: string }> {
+  if (__PB_DEBUG__) {
+    console.debug("[PB Debug][native bridge] cast URL:", url);
+    console.debug("[PB Debug][native bridge] cast headers:", headers ?? {});
+  }
   return request({
     cmd: "cast",
     url,

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -11,6 +11,9 @@ plugins {
 
 android {
     namespace = "com.playbridge.sender"
+    buildFeatures {
+        buildConfig = true
+    }
     compileSdk {
         version = release(37)
     }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
@@ -14,6 +14,7 @@ import com.playbridge.sender.cast.roku.RokuCastTarget
 import com.playbridge.sender.connection.ConnectionCoordinator
 import com.playbridge.sender.connection.ReceiverDiscoveryRepository
 import com.playbridge.sender.connection.WebSocketClient
+import com.playbridge.sender.logging.DebugNetworkLogger
 import com.playbridge.sender.data.settings.SettingsRepository
 import com.playbridge.sender.model.TvDevice
 import com.playbridge.sender.model.CastProtocol
@@ -974,6 +975,12 @@ class CastSessionManager(
 
     fun load(media: MediaItem, userInitiated: Boolean = true): Boolean {
         val target = _externalTarget.value ?: return false
+        DebugNetworkLogger.urlAndHeaders(
+            TAG,
+            "External ${target.kind} cast input",
+            media.url,
+            media.headers,
+        )
         if (userInitiated) _externalInterrupts.tryEmit(Unit)
         _externalMediaTitle.value = media.title ?: "Casting media"
         _externalMediaLoaded.value = true

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
@@ -2,6 +2,7 @@ package com.playbridge.sender.connection
 import androidx.core.content.edit
 
 import android.app.Application
+import com.playbridge.sender.BuildConfig
 import android.content.Context
 import android.os.Build
 import androidx.core.net.toUri
@@ -440,6 +441,12 @@ class ConnectionViewModel(
         title: String? = null,
         mime: String? = null,
     ): Boolean {
+        com.playbridge.sender.logging.DebugNetworkLogger.urlAndHeaders(
+            TAG,
+            "Cast input",
+            url,
+            headers,
+        )
         val media = MediaItem(url = url, headers = headers, mimeType = mime, title = title)
         if (castSessionManager.load(media)) return true
         if (route.value is CastSessionManager.Route.NativeTv &&
@@ -468,6 +475,12 @@ class ConnectionViewModel(
                             headers = packaged.headers ?: emptyMap(),
                             content_type = packaged.contentType ?: mime,
                         ),
+                    )
+                    com.playbridge.sender.logging.DebugNetworkLogger.urlAndHeaders(
+                        TAG,
+                        "Cast packaged output",
+                        packaged.url,
+                        packaged.headers,
                     )
                     sendCommandAndRecord(cmd, "play", packaged.url, title)
                     castSessionManager.notifyNativePlaybackStarted()
@@ -526,7 +539,7 @@ class ConnectionViewModel(
                 )
             )
         }
-        Log.d(TAG, "Sending command payload: $commandJson")
+        if (BuildConfig.DEBUG) Log.d(TAG, "Sending command payload: $commandJson")
         webSocketClient.send(commandJson)
     }
     /**

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
@@ -2,7 +2,6 @@ package com.playbridge.sender.connection
 import androidx.core.content.edit
 
 import android.app.Application
-import com.playbridge.sender.BuildConfig
 import android.content.Context
 import android.os.Build
 import androidx.core.net.toUri
@@ -539,7 +538,6 @@ class ConnectionViewModel(
                 )
             )
         }
-        if (BuildConfig.DEBUG) Log.d(TAG, "Sending command payload: $commandJson")
         webSocketClient.send(commandJson)
     }
     /**

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
@@ -1,6 +1,7 @@
 package com.playbridge.sender.connection
 
 import android.util.Log
+import com.playbridge.sender.logging.DebugNetworkLogger
 import com.playbridge.shared.protocol.createAuthJson
 import com.playbridge.shared.protocol.createContextQueryJson
 import com.playbridge.shared.protocol.createPairingCommitJson
@@ -584,6 +585,7 @@ class WebSocketClient {
             Log.w(TAG, "Cannot send, webSocket is null. State: ${_connectionState.value}")
             return false
         }
+        DebugNetworkLogger.command(TAG, message)
         return ws.send(message)
     }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/diagnostics/LogcatReader.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/diagnostics/LogcatReader.kt
@@ -1,6 +1,7 @@
 package com.playbridge.sender.diagnostics
 
 import android.os.Process
+import com.playbridge.sender.logging.DebugNetworkLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.BufferedReader
@@ -117,7 +118,14 @@ object LogcatReader {
         } finally {
             process?.destroy()
         }
-        val filtered = if (includeNoise) out else out.filterNot { isNoise(it) }
+        // Full URLs and header values remain available to developers in debug logcat, but must
+        // never flow into the in-app viewer or its persisted share attachment.
+        val diagnosticsSafe = out.filter(::isSafeForDiagnostics)
+        val filtered = if (includeNoise) {
+            diagnosticsSafe
+        } else {
+            diagnosticsSafe.filterNot { isNoise(it) }
+        }
         val userFiltered = if (excludeFilters.isEmpty()) filtered else filtered.filterNot { line ->
             excludeFilters.any { filter ->
                 line.tag.contains(filter, ignoreCase = true) || line.message.contains(filter, ignoreCase = true)
@@ -126,6 +134,9 @@ object LogcatReader {
         if (userFiltered.size > maxLines) userFiltered.subList(userFiltered.size - maxLines, userFiltered.size).toList()
         else userFiltered
     }
+
+    internal fun isSafeForDiagnostics(line: LogLine): Boolean =
+        line.tag != DebugNetworkLogger.LOGCAT_TAG
 
     /** Clears the log buffer. Returns true on success. */
     suspend fun clear(): Boolean = withContext(Dispatchers.IO) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/logging/DebugNetworkLogger.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/logging/DebugNetworkLogger.kt
@@ -15,6 +15,13 @@ import kotlinx.serialization.json.jsonPrimitive
  * command URLs and their replay headers are emitted.
  */
 object DebugNetworkLogger {
+    /**
+     * Raw network diagnostics must remain available only through developer logcat access.
+     * [com.playbridge.sender.diagnostics.LogcatReader] excludes this tag from the in-app
+     * diagnostics viewer and its persisted share attachments.
+     */
+    const val LOGCAT_TAG = "PBDebugNetworkRaw"
+
     fun urlAndHeaders(
         tag: String,
         label: String,
@@ -22,10 +29,12 @@ object DebugNetworkLogger {
         headers: Map<String, String>?,
     ) {
         if (!BuildConfig.DEBUG) return
-        Log.d(tag, "$label URL: $url")
+        Log.d(LOGCAT_TAG, "[$tag] $label URL: $url")
         val fields = headers.orEmpty()
-        Log.d(tag, "$label headers (${fields.size}):")
-        fields.forEach { (name, value) -> Log.d(tag, "$label $name: $value") }
+        Log.d(LOGCAT_TAG, "[$tag] $label headers (${fields.size}):")
+        fields.forEach { (name, value) ->
+            Log.d(LOGCAT_TAG, "[$tag] $label $name: $value")
+        }
     }
 
     fun command(tag: String, message: String) {
@@ -49,7 +58,10 @@ object DebugNetworkLogger {
                 }
             }
         }.onFailure {
-            Log.d(tag, "Unable to decode outbound media command for debug logging: ${it.message}")
+            Log.d(
+                LOGCAT_TAG,
+                "[$tag] Unable to decode outbound media command for debug logging: ${it.message}",
+            )
         }
     }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/logging/DebugNetworkLogger.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/logging/DebugNetworkLogger.kt
@@ -1,0 +1,63 @@
+package com.playbridge.sender.logging
+
+import android.util.Log
+import com.playbridge.sender.BuildConfig
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Full sender payload diagnostics for debug logcat only.
+ *
+ * This deliberately ignores authentication and pairing envelopes. Only media/browser
+ * command URLs and their replay headers are emitted.
+ */
+object DebugNetworkLogger {
+    fun urlAndHeaders(
+        tag: String,
+        label: String,
+        url: String,
+        headers: Map<String, String>?,
+    ) {
+        if (!BuildConfig.DEBUG) return
+        Log.d(tag, "$label URL: $url")
+        val fields = headers.orEmpty()
+        Log.d(tag, "$label headers (${fields.size}):")
+        fields.forEach { (name, value) -> Log.d(tag, "$label $name: $value") }
+    }
+
+    fun command(tag: String, message: String) {
+        if (!BuildConfig.DEBUG) return
+        runCatching {
+            val envelope = Json.parseToJsonElement(message) as? JsonObject ?: return
+            val action = envelope["action"]?.jsonPrimitive?.contentOrNull ?: return
+            val payload = envelope["payload"] as? JsonObject ?: return
+            when (action) {
+                "playlist" -> (payload["items"] as? JsonArray).orEmpty()
+                    .forEachIndexed { index, item ->
+                        logItem(tag, "Outbound playlist item $index", item as? JsonObject)
+                    }
+                "queue_add" -> logItem(
+                    tag,
+                    "Outbound queue item",
+                    payload["item"] as? JsonObject,
+                )
+                "browser" -> payload["url"]?.jsonPrimitive?.contentOrNull?.let { url ->
+                    urlAndHeaders(tag, "Outbound browser command", url, null)
+                }
+            }
+        }.onFailure {
+            Log.d(tag, "Unable to decode outbound media command for debug logging: ${it.message}")
+        }
+    }
+
+    private fun logItem(tag: String, label: String, item: JsonObject?) {
+        val value = item ?: return
+        val url = value["url"]?.jsonPrimitive?.contentOrNull ?: return
+        val headers = (value["headers"] as? JsonObject)
+            ?.mapValues { (_, field) -> field.jsonPrimitive.contentOrNull.orEmpty() }
+        urlAndHeaders(tag, label, url, headers)
+    }
+}

--- a/mobile/android/app/src/test/java/com/playbridge/sender/diagnostics/LogcatReaderTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/diagnostics/LogcatReaderTest.kt
@@ -1,0 +1,30 @@
+package com.playbridge.sender.diagnostics
+
+import com.playbridge.sender.logging.DebugNetworkLogger
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LogcatReaderTest {
+    @Test
+    fun `raw network diagnostics are excluded from in-app diagnostics`() {
+        val line = logLine(tag = DebugNetworkLogger.LOGCAT_TAG)
+
+        assertFalse(LogcatReader.isSafeForDiagnostics(line))
+    }
+
+    @Test
+    fun `ordinary application logs remain visible in diagnostics`() {
+        val line = logLine(tag = "ConnectionViewModel")
+
+        assertTrue(LogcatReader.isSafeForDiagnostics(line))
+    }
+
+    private fun logLine(tag: String) = LogcatReader.LogLine(
+        timestamp = "07-29 14:30:00.000",
+        level = LogcatReader.Level.DEBUG,
+        tag = tag,
+        message = "message",
+        raw = "raw",
+    )
+}

--- a/mobile/apple/PlayBridge Phone/PlayBridge Phone/Browser/StreamHTTP.swift
+++ b/mobile/apple/PlayBridge Phone/PlayBridge Phone/Browser/StreamHTTP.swift
@@ -1,5 +1,36 @@
 import Foundation
 
+enum SenderDebugNetwork {
+    static func request(
+        _ source: String,
+        url: String,
+        method: String = "GET",
+        headers: [String: String] = [:]
+    ) {
+#if DEBUG
+        print("[DebugNetwork][\(source)] request: \(method) \(url)")
+        print("[DebugNetwork][\(source)] request headers (\(headers.count)):")
+        for (name, value) in headers.sorted(by: { $0.key.lowercased() < $1.key.lowercased() }) {
+            print("[DebugNetwork][\(source)]   \(name): \(value)")
+        }
+#endif
+    }
+
+    static func response(_ source: String, response: URLResponse) {
+#if DEBUG
+        guard let http = response as? HTTPURLResponse else { return }
+        print("[DebugNetwork][\(source)] response: HTTP \(http.statusCode) \(http.url?.absoluteString ?? "?")")
+        print("[DebugNetwork][\(source)] response headers (\(http.allHeaderFields.count)):")
+        let fields = http.allHeaderFields
+            .map { (String(describing: $0.key), String(describing: $0.value)) }
+            .sorted { $0.0.lowercased() < $1.0.lowercased() }
+        for (name, value) in fields {
+            print("[DebugNetwork][\(source)]   \(name): \(value)")
+        }
+#endif
+    }
+}
+
 /// Shared HTTP helpers for fetching playlists/manifests with the stream's captured headers.
 enum StreamHTTP {
     static let fallbackUA =
@@ -14,8 +45,14 @@ enum StreamHTTP {
         if !headers.keys.contains(where: { $0.caseInsensitiveCompare("User-Agent") == .orderedSame }) {
             req.setValue(fallbackUA, forHTTPHeaderField: "User-Agent")
         }
+        SenderDebugNetwork.request(
+            "StreamHTTP",
+            url: url.absoluteString,
+            headers: req.allHTTPHeaderFields ?? [:]
+        )
         do {
-            let (data, _) = try await URLSession.shared.data(for: req)
+            let (data, response) = try await URLSession.shared.data(for: req)
+            SenderDebugNetwork.response("StreamHTTP", response: response)
             return String(data: data, encoding: .utf8)
         } catch {
             return nil

--- a/mobile/apple/PlayBridge Phone/PlayBridge Phone/Network/ConnectionViewModel.swift
+++ b/mobile/apple/PlayBridge Phone/PlayBridge Phone/Network/ConnectionViewModel.swift
@@ -274,6 +274,7 @@ final class ConnectionViewModel: ObservableObject {
     func cast(urlString: String, title: String? = nil) {
         let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        SenderDebugNetwork.request("Cast output", url: trimmed)
         ws.send(WireProtocol.singleVideoCommand(url: trimmed, title: title))
     }
 
@@ -282,6 +283,7 @@ final class ConnectionViewModel: ObservableObject {
     func castMedia(url: String, title: String? = nil, headers: [String: String] = [:], contentType: String? = nil) {
         let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        SenderDebugNetwork.request("Cast output", url: trimmed, headers: headers)
         ws.send(WireProtocol.singleVideoCommand(
             url: trimmed,
             title: title,
@@ -296,12 +298,14 @@ final class ConnectionViewModel: ObservableObject {
     /// attached subtitles. Mirrors the Android `CastSheet` → `createSingleVideoCommandJson` path.
     func castStream(_ video: DetectedVideo, quality: VideoQuality? = nil, subtitles: [String] = [], playerMode: String? = nil) {
         let url = quality?.url ?? video.url
+        let headers = VideoDetector.mediaHeaders(for: video)
+        SenderDebugNetwork.request("Browser cast output", url: url, headers: headers)
         ws.send(WireProtocol.singleVideoCommand(
             url: url,
             title: video.displayTitle,
             contentType: video.contentType,
             subtitles: subtitles,
-            headers: VideoDetector.mediaHeaders(for: video),
+            headers: headers,
             detectedBy: video.detectedBy,
             playerMode: playerMode
         ))
@@ -310,12 +314,14 @@ final class ConnectionViewModel: ObservableObject {
     /// Queue a browser-detected stream.
     func queueStream(_ video: DetectedVideo, quality: VideoQuality? = nil, subtitles: [String] = [], playerMode: String? = nil) {
         let url = quality?.url ?? video.url
+        let headers = VideoDetector.mediaHeaders(for: video)
+        SenderDebugNetwork.request("Browser queue output", url: url, headers: headers)
         ws.send(WireProtocol.queueVideoCommand(
             url: url,
             title: video.displayTitle,
             contentType: video.contentType,
             subtitles: subtitles,
-            headers: VideoDetector.mediaHeaders(for: video),
+            headers: headers,
             detectedBy: video.detectedBy,
             playerMode: playerMode
         ))
@@ -325,6 +331,7 @@ final class ConnectionViewModel: ObservableObject {
     func browseTo(url: String, browserMode: String? = nil, desktopMode: Bool = false) {
         let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        SenderDebugNetwork.request("Browser command output", url: trimmed)
         ws.send(WireProtocol.browserCommand(
             url: trimmed,
             browserMode: browserMode,

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/SystemWebViewEngine.kt
@@ -16,6 +16,7 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
+import com.playbridge.player.logging.DebugNetworkLogger
 import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
@@ -936,6 +937,12 @@ class SystemWebViewEngine(
 
         override fun shouldInterceptRequest(view: WebView?, request: WebResourceRequest?): WebResourceResponse? {
             val url = request?.url?.toString() ?: return null
+            DebugNetworkLogger.urlAndHeaders(
+                TAG,
+                "WebView ${request.method} request",
+                url,
+                request.requestHeaders,
+            )
 
             val resourceType = getResourceType(request)
 
@@ -944,6 +951,23 @@ class SystemWebViewEngine(
             }
 
             return null
+        }
+
+        override fun onReceivedHttpError(
+            view: WebView?,
+            request: WebResourceRequest?,
+            errorResponse: WebResourceResponse?,
+        ) {
+            super.onReceivedHttpError(view, request, errorResponse)
+            val url = request?.url?.toString() ?: return
+            val response = errorResponse ?: return
+            DebugNetworkLogger.response(
+                TAG,
+                "WebView",
+                url,
+                response.statusCode,
+                response.responseHeaders.orEmpty(),
+            )
         }
 
         private fun getResourceType(request: WebResourceRequest): Int {

--- a/tv/android/player/app/src/main/java/com/playbridge/player/logging/DebugNetworkLogger.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/logging/DebugNetworkLogger.kt
@@ -1,0 +1,60 @@
+package com.playbridge.player.logging
+
+import android.util.Log
+import com.playbridge.player.BuildConfig
+import okhttp3.Headers
+import okhttp3.Request
+import okhttp3.Response
+
+/**
+ * Full-fidelity network diagnostics for debug logcat only.
+ *
+ * Do not route these messages through [FileLogger]: its output is persisted and can be
+ * downloaded over the LAN. Release builds compile the calls but never emit their values.
+ */
+object DebugNetworkLogger {
+    fun urlAndHeaders(
+        tag: String,
+        label: String,
+        url: String,
+        headers: Map<String, String>?,
+    ) {
+        if (!BuildConfig.DEBUG) return
+        Log.d(tag, "$label URL: $url")
+        logHeaders(tag, "$label headers", headers.orEmpty())
+    }
+
+    fun request(tag: String, label: String, request: Request) {
+        if (!BuildConfig.DEBUG) return
+        Log.d(tag, "$label request: ${request.method} ${request.url}")
+        logHeaders(tag, "$label request headers", request.headers)
+    }
+
+    fun response(tag: String, label: String, response: Response) {
+        if (!BuildConfig.DEBUG) return
+        Log.d(tag, "$label response: HTTP ${response.code} ${response.request.url}")
+        logHeaders(tag, "$label response headers", response.headers)
+    }
+
+    fun response(
+        tag: String,
+        label: String,
+        url: String,
+        statusCode: Int,
+        headers: Map<String, String>,
+    ) {
+        if (!BuildConfig.DEBUG) return
+        Log.d(tag, "$label response: HTTP $statusCode $url")
+        logHeaders(tag, "$label response headers", headers)
+    }
+
+    private fun logHeaders(tag: String, label: String, headers: Map<String, String>) {
+        Log.d(tag, "$label (${headers.size}):")
+        headers.forEach { (name, value) -> Log.d(tag, "$label $name: $value") }
+    }
+
+    private fun logHeaders(tag: String, label: String, headers: Headers) {
+        Log.d(tag, "$label (${headers.size}):")
+        headers.forEach { (name, value) -> Log.d(tag, "$label $name: $value") }
+    }
+}

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ContentSniffer.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ContentSniffer.kt
@@ -2,6 +2,7 @@ package com.playbridge.player.player
 
 import android.net.Uri
 import android.util.Log
+import com.playbridge.player.logging.DebugNetworkLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.net.InetAddress
@@ -98,19 +99,18 @@ class ContentSniffer {
                        .hostnameVerifier(LocalHostnameVerifier(::isLocalHost))
             }
 
-            if (headers != null && headers.isNotEmpty()) {
-                builder.addInterceptor { chain ->
-                    val requestBuilder = chain.request().newBuilder()
-                    val url = chain.request().url.toString()
-                    headers.forEach { (key, value) ->
+            builder.addInterceptor { chain ->
+                val requestBuilder = chain.request().newBuilder()
+                headers.orEmpty().forEach { (key, value) ->
                         // Use .header() instead of .addHeader() to overwrite any existing
                         // duplicate headers that ExoPlayer might have set (like double User-Agent)
-                        requestBuilder.header(key, value)
-                    }
-                    val finalRequest = requestBuilder.build()
-                    Log.d("OkHttpInterceptor", "Prepared request with ${finalRequest.headers.size} header(s)")
-                    chain.proceed(finalRequest)
+                    requestBuilder.header(key, value)
                 }
+                val finalRequest = requestBuilder.build()
+                DebugNetworkLogger.request("OkHttpInterceptor", "Playback", finalRequest)
+                val response = chain.proceed(finalRequest)
+                DebugNetworkLogger.response("OkHttpInterceptor", "Playback", response)
+                response
             }
 
             return builder.build()

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ExoPlayerActivity.kt
@@ -14,6 +14,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import com.playbridge.player.logging.FileLogger
+import com.playbridge.player.logging.DebugNetworkLogger
 import com.playbridge.shared.logging.redactUrlForLog
 import android.view.KeyEvent
 import android.view.WindowManager
@@ -610,6 +611,7 @@ class ExoPlayerActivity : PlayerActivity() {
         FileLogger.i(TAG, "Request headers: ${intentHeaders?.size ?: 0} field(s)")
         FileLogger.i(TAG, "Content Type: $contentType")
         FileLogger.i(TAG, "===========================================")
+        DebugNetworkLogger.urlAndHeaders(TAG, "Play command", url, intentHeaders)
 
         // Do NOT releasePlayer() here: engine.load() swaps the media source on the
         // live player (see ExoPlayerEngine.reloadOnLivePlayer), which kills the

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/MpvPlayerActivity.kt
@@ -22,6 +22,7 @@ import com.playbridge.player.util.getStringMapExtra
 import `is`.xyz.mpv.MPVLib
 import `is`.xyz.mpv.MPVNode
 import com.playbridge.player.logging.FileLogger
+import com.playbridge.player.logging.DebugNetworkLogger
 import com.playbridge.shared.logging.redactUrlForLog
 import androidx.annotation.OptIn
 import androidx.lifecycle.setViewTreeLifecycleOwner
@@ -1129,6 +1130,7 @@ class MpvPlayerActivity : PlayerActivity(), MPVLib.EventObserver {
         FileLogger.i(TAG, "Request headers: ${headers?.size ?: 0} field(s)")
         FileLogger.i(TAG, "Start Paused: $startPaused")
         FileLogger.i(TAG, "===========================================")
+        DebugNetworkLogger.urlAndHeaders(TAG, "Play command", url, headers)
 
 
         // seekTo() will intercept this call while durationMs == 0 (file not yet loaded)

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/SkipSegmentFetcher.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/SkipSegmentFetcher.kt
@@ -2,6 +2,7 @@ package com.playbridge.player.player
 
 import android.content.Context
 import android.util.Log
+import com.playbridge.player.logging.DebugNetworkLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -95,8 +96,11 @@ object SkipSegmentFetcher {
             }
         }
 
+        val request = requestBuilder.build()
+        DebugNetworkLogger.request(TAG, "IntroDB", request)
         return try {
-            client.newCall(requestBuilder.build()).execute().use { response ->
+            client.newCall(request).execute().use { response ->
+                DebugNetworkLogger.response(TAG, "IntroDB", response)
                 if (!response.isSuccessful) {
                     Log.w(TAG, "IntroDB fetch failed: HTTP ${response.code}")
                     return emptyList()
@@ -155,9 +159,11 @@ object SkipSegmentFetcher {
             .url(url)
             .header("User-Agent", "PlayBridgeTV/1.0")
             .build()
+        DebugNetworkLogger.request(TAG, "TheIntroDB", request)
 
         return try {
             client.newCall(request).execute().use { response ->
+                DebugNetworkLogger.response(TAG, "TheIntroDB", response)
                 if (!response.isSuccessful) {
                     Log.w(TAG, "TheIntroDB fetch failed: HTTP ${response.code}")
                     return emptyList()

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/SubtitleFetcher.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/SubtitleFetcher.kt
@@ -1,6 +1,7 @@
 package com.playbridge.player.player
 
 import android.util.Log
+import com.playbridge.player.logging.DebugNetworkLogger
 import com.playbridge.shared.logging.redactUrlForLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -39,9 +40,11 @@ object SubtitleFetcher {
             .url(url)
             .header("User-Agent", "Mozilla/5.0")
             .build()
+        DebugNetworkLogger.request(TAG, "Subtitle lookup", request)
 
         try {
             client.newCall(request).execute().use { response ->
+                DebugNetworkLogger.response(TAG, "Subtitle lookup", response)
                 if (!response.isSuccessful) {
                     Log.w(TAG, "Failed to fetch subtitles: HTTP ${response.code}")
                     return@withContext emptyList()

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import com.playbridge.player.logging.FileLogger
+import com.playbridge.player.logging.DebugNetworkLogger
 import com.playbridge.player.player.MpvProcess
 import com.playbridge.player.player.RendererProcessSupervisor
 import androidx.core.app.NotificationCompat
@@ -471,6 +472,7 @@ class ServerService : Service() {
                     .getString(KEY_ACTIVE_UA_VALUE, "") ?: ""
 
                 FileLogger.i(TAG, "Browser command: ${redactUrlForLog(url)} (mode: $browserMode)")
+                DebugNetworkLogger.urlAndHeaders(TAG, "Browser command", url, null)
 
                 val useGecko = browserMode == "gecko"
 
@@ -622,6 +624,14 @@ class ServerService : Service() {
             is IncomingMessage.Playlist -> {
                 val payload = msg.payload
                 FileLogger.i(TAG, "=== PLAYLIST COMMAND === (${payload.items.size} items, startIndex: ${payload.start_index})")
+                payload.items.forEachIndexed { index, item ->
+                    DebugNetworkLogger.urlAndHeaders(
+                        TAG,
+                        "Playlist item $index",
+                        item.url,
+                        item.headers,
+                    )
+                }
 
                 val prefs = getSharedPreferences("browser_prefs", Context.MODE_PRIVATE)
                 val tvPref = prefs.getString("player_mode", "phone") ?: "phone"
@@ -658,6 +668,7 @@ class ServerService : Service() {
                 val item = msg.payload.item
                 FileLogger.i(TAG, "=== QUEUE_ADD === title: ${item?.title}")
                 if (item != null) {
+                    DebugNetworkLogger.urlAndHeaders(TAG, "Queue item", item.url, item.headers)
                     // Buffer the item so the player can drain it even if its receiver isn't registered yet.
                     // The broadcast acts only as a wake signal — the player always reads from pendingQueueItems.
                     pendingQueueItems.add(item)

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/ProtocolMapper.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/ProtocolMapper.swift
@@ -1,5 +1,38 @@
 import Foundation
 
+func debugLogNetworkRequest(
+    _ source: String,
+    url: URL,
+    method: String = "GET",
+    headers: [String: String]? = nil
+) {
+#if DEBUG
+    print("[DebugNetwork][\(source)] request: \(method) \(url.absoluteString)")
+    let fields = headers ?? [:]
+    print("[DebugNetwork][\(source)] request headers (\(fields.count)):")
+    for (name, value) in fields.sorted(by: { $0.key.lowercased() < $1.key.lowercased() }) {
+        print("[DebugNetwork][\(source)]   \(name): \(value)")
+    }
+#endif
+}
+
+func debugLogNetworkResponse(
+    _ source: String,
+    url: URL?,
+    statusCode: Int,
+    headers: [AnyHashable: Any]
+) {
+#if DEBUG
+    print("[DebugNetwork][\(source)] response: HTTP \(statusCode) \(url?.absoluteString ?? "?")")
+    print("[DebugNetwork][\(source)] response headers (\(headers.count)):")
+    let fields = headers.map { (String(describing: $0.key), String(describing: $0.value)) }
+        .sorted { $0.0.lowercased() < $1.0.lowercased() }
+    for (name, value) in fields {
+        print("[DebugNetwork][\(source)]   \(name): \(value)")
+    }
+#endif
+}
+
 /// Convenience accessors over the Wire-generated proto types so the rest of the app
 /// doesn't have to parse strings or unwrap optionals at every consumer.
 extension Playbridge_PlayPayload {

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/VLCProxyServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/VLCProxyServer.swift
@@ -512,7 +512,9 @@ class VLCProxyServer {
             let lines = req.components(separatedBy: "\r\n")
             guard let requestLine = lines.first else { connection.cancel(); return }
 
+#if DEBUG
             print("[Proxy] VLC request: \(requestLine)")
+#endif
 
             let parts = requestLine.split(separator: " ")
             let method = parts.count > 0 ? String(parts[0]) : "GET"
@@ -532,16 +534,18 @@ class VLCProxyServer {
             if decodedRequestPath == Self.extPath {
                 // HLS sub-resource on an arbitrary host — full URL is encoded in the query
                 guard let q = requestQuery, let decoded = Self.decodeExtURL(fromQuery: q) else {
+#if DEBUG
                     print("[Proxy] Failed to decode ext URL: \(requestURI)")
+#endif
                     connection.cancel()
                     return
                 }
                 upstreamURL = decoded
-                print("[Proxy] Resolved as ext-encoded sub-request -> \(upstreamURL.absoluteString)")
+                debugLogNetworkRequest("VLC proxy ext sub-request", url: upstreamURL, headers: self.headers)
             } else if decodedRequestPath == targetPath || requestPath == "/" {
                 // Initial request — use the original target URL exactly
                 upstreamURL = self.targetURL
-                print("[Proxy] Resolved as initial request -> \(upstreamURL.absoluteString)")
+                debugLogNetworkRequest("VLC proxy initial request", url: upstreamURL, headers: self.headers)
             } else {
                 // Same-host sub-request (path-relative resolution)
                 var c = URLComponents()
@@ -551,7 +555,7 @@ class VLCProxyServer {
                 c.path = decodedRequestPath
                 c.percentEncodedQuery = requestQuery
                 upstreamURL = c.url ?? self.targetURL
-                print("[Proxy] Resolved as same-host sub-request -> \(upstreamURL.absoluteString)")
+                debugLogNetworkRequest("VLC proxy same-host sub-request", url: upstreamURL, headers: self.headers)
             }
 
             var urlRequest = URLRequest(url: upstreamURL)

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/VLCProxyServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/VLCProxyServer.swift
@@ -64,9 +64,13 @@ class ProxySessionManager: NSObject, URLSessionDataDelegate {
         states[task.taskIdentifier] = state
         lock.unlock()
 
-        print("[Proxy] T\(task.taskIdentifier) upstream request: \(request.httpMethod ?? "GET") \(request.url?.absoluteString ?? "?")")
-        if let headers = request.allHTTPHeaderFields, !headers.isEmpty {
-            print("[Proxy] T\(task.taskIdentifier) request headers: \(headers.count) field(s)")
+        if let url = request.url {
+            debugLogNetworkRequest(
+                "Proxy T\(task.taskIdentifier)",
+                url: url,
+                method: request.httpMethod ?? "GET",
+                headers: request.allHTTPHeaderFields
+            )
         }
 
         // Watch for VLC closing its end of the connection. Capture only the
@@ -187,6 +191,12 @@ class ProxySessionManager: NSObject, URLSessionDataDelegate {
         }
 
         print("[Proxy] T\(dataTask.taskIdentifier) upstream response: \(http.statusCode) content-length=\(http.value(forHTTPHeaderField: "Content-Length") ?? "unknown") type=\(http.value(forHTTPHeaderField: "Content-Type") ?? "unknown")")
+        debugLogNetworkResponse(
+            "Proxy T\(dataTask.taskIdentifier)",
+            url: http.url,
+            statusCode: http.statusCode,
+            headers: http.allHeaderFields
+        )
 
         // HLS playlists: buffer the body so we can rewrite every URI inside to
         // route back through this proxy. Headers + rewritten body are flushed

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
@@ -426,12 +426,14 @@ class WebSocketServer: ObservableObject {
     // Use SwiftProtobuf JSON for all typed sub-messages.
 
     private func handleMessage(_ jsonString: String, data: Data, from connection: NWConnection) {
-        print("WebSocket Received: \(jsonString)")
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let msgType = json["type"] as? String else {
             print("WebSocket Error: Failed to parse message")
             return
         }
+#if DEBUG
+        print("WebSocket Received: \(msgType)")
+#endif
 
         switch msgType {
         case "ping":

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
@@ -949,7 +949,8 @@ class WebSocketServer: ObservableObject {
 
     private func handlePlay(_ payload: Playbridge_PlayPayload) {
         let url = payload.validURL!  // pre-validated by caller
-        print("WebSocket Play: \(payload.titleOrNil ?? "No Title") - \(url)")
+        print("WebSocket Play: \(payload.titleOrNil ?? "No Title")")
+        debugLogNetworkRequest("WebSocket play", url: url, headers: payload.headersOrNil)
         historyStore?.addToHistory(url: url, title: payload.titleOrNil, headers: payload.headersOrNil)
         DispatchQueue.main.async {
             TrackPreferences.shared.reset() // new cast session — drop carried track picks
@@ -962,6 +963,15 @@ class WebSocketServer: ObservableObject {
     private func handlePlaylist(_ payload: Playbridge_PlaylistPayload) {
         let valid = payload.items.filter { $0.validURL != nil }
         print("WebSocket Playlist: \(valid.count)/\(payload.items.count) items, startIndex: \(payload.startIndex)")
+        for (index, item) in valid.enumerated() {
+            if let url = item.validURL {
+                debugLogNetworkRequest(
+                    "WebSocket playlist item \(index)",
+                    url: url,
+                    headers: item.headersOrNil
+                )
+            }
+        }
         guard !valid.isEmpty else { return }
         DispatchQueue.main.async {
             TrackPreferences.shared.reset() // new cast session — drop carried track picks

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/MPVPlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/MPVPlayerView.swift
@@ -296,6 +296,7 @@ class MPVViewController: UIViewController {
     /// state is reset; the handle, render context, and demuxer caches survive.
     func loadNewItem(url: URL, headers: [String: String]?, subtitles: [String]?,
                      initialTime: Double, title: String?) {
+        debugLogNetworkRequest("MPV playback", url: url, headers: headers)
         self.url = url
         self.headers = headers
         self.subtitles = subtitles

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/NativePlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/NativePlayerView.swift
@@ -26,6 +26,7 @@ struct NativePlayerView: UIViewControllerRepresentable {
     let onBroadcast: ([String: Any]) -> Void
 
     func makeUIViewController(context: Context) -> AVPlayerViewController {
+        debugLogNetworkRequest("AVPlayer playback", url: url, headers: headers)
         let controller = ActivityAVPlayerViewController()
         controller.delegate = context.coordinator
 

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/PlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/PlayerView.swift
@@ -128,7 +128,6 @@ struct PlayerView: View {
 
             let currentRequest = playlistStore.currentItem ?? payload
             if let currentURL = currentRequest.validURL {
-                let _ = print("PlayerView: Rendering with URL: \(currentURL)")
                 if effectiveEngine(for: currentRequest) == "vlc" {
                     VLCPlayerView(
                         url: currentURL,

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/VLCPlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/VLCPlayerView.swift
@@ -260,6 +260,7 @@ struct VLCPlayerView: UIViewControllerRepresentable {
             print("[VLC] setupPlayer: drawable=videoView bounds=\(videoView.bounds) view.bounds=\(view.bounds)")
 
             guard let url = url else { return }
+            debugLogNetworkRequest("VLC playback", url: url, headers: headers)
             originalURL = url
             let scheme = url.scheme?.lowercased()
             guard scheme == "http" || scheme == "https" else {
@@ -349,6 +350,12 @@ struct VLCPlayerView: UIViewControllerRepresentable {
             if let headers = headers {
                 for (k, v) in headers { req.setValue(v, forHTTPHeaderField: k) }
             }
+            debugLogNetworkRequest(
+                "VLC redirect resolver",
+                url: url,
+                method: req.httpMethod ?? "GET",
+                headers: req.allHTTPHeaderFields
+            )
             redirectResolver = RedirectResolver(request: req) { [weak self] finalURL in
                 self?.redirectResolver = nil
                 completion(finalURL)   // nil on failure → caller relays through the proxy
@@ -981,6 +988,14 @@ private final class RedirectResolver: NSObject, URLSessionDataDelegate {
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
                     didReceive response: URLResponse,
                     completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        if let http = response as? HTTPURLResponse {
+            debugLogNetworkResponse(
+                "VLC redirect resolver",
+                url: http.url,
+                statusCode: http.statusCode,
+                headers: http.allHeaderFields
+            )
+        }
         finish(response.url)               // response.url is the final URL after any redirects
         completionHandler(.cancel)
     }

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Player/VLCPlayerView.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Player/VLCPlayerView.swift
@@ -301,7 +301,8 @@ struct VLCPlayerView: UIViewControllerRepresentable {
             let proxy = VLCProxyServer(targetURL: url, headers: proxyHeaders)
             proxy.start()
             self.proxyServer = proxy
-            print("VLC Proxy: \(url.absoluteString) -> \(proxy.localURL.absoluteString)")
+            debugLogNetworkRequest("VLC proxy upstream", url: url, headers: proxyHeaders)
+            print("VLC Proxy: forwarding through local relay")
             startMedia(playURL: proxy.localURL, useNativeHeaders: false, viaProxy: true)
         }
 
@@ -313,7 +314,8 @@ struct VLCPlayerView: UIViewControllerRepresentable {
             resolvedUseNativeHeaders = useNativeHeaders
             isPlayingViaProxy = viaProxy
             guard let media = VLCMedia(url: playURL) else {   // VLCKit 4.0: VLCMedia(url:) is failable
-                print("VLC: failed to create media for \(playURL)")
+                debugLogNetworkRequest("VLC media creation failure", url: playURL)
+                print("VLC: failed to create media")
                 return
             }
             // network-caching kept modest: a 15s pre-roll caused a long black/buffering stall before
@@ -447,7 +449,8 @@ struct VLCPlayerView: UIViewControllerRepresentable {
             // preference); the media's own embedded tracks remain available in the menu.
             guard let first = subtitles?.first, let url = URL(string: first) else { return }
             let rc = mediaPlayer.addPlaybackSlave(url, type: .subtitle, enforce: false)
-            print("VLC: addPlaybackSlave subtitle=\(url.absoluteString) rc=\(rc)")
+            debugLogNetworkRequest("VLC subtitle", url: url)
+            print("VLC: addPlaybackSlave rc=\(rc)")
             // The slave arrives after the initial parse — refresh the track list so the new
             // entry appears in the Subtitles menu.
             updateSubtitleTracks()


### PR DESCRIPTION
## Summary
- permit full URL and request/response header diagnostics only in debug, non-persisted output
- add receiver-side diagnostics for Android TV, Apple TV, Desktop, and CLI
- add sender-side diagnostics for Android phone, Apple phone, Desktop, CLI, and browser-extension development builds
- keep release and persisted diagnostic paths redacted, and exclude pairing/authentication envelopes
- isolate Android raw network logcat under a dedicated tag excluded from the in-app viewer and Share export
- remove the duplicate Android command-payload log that bypassed the dedicated raw tag
- compile raw extension logging out of GeckoView assets even during watch builds
- move tvOS VLC full-URL output behind debug-only helpers and replace raw WebSocket envelopes with debug-only message types

## Verification
- Android TV: player app Foss debug Kotlin compilation
- Android phone: focused LogcatReader tests; Foss debug tests; Foss Debug and Release Kotlin compilation
- Desktop: focused logging tests and Flutter analysis
- CLI: locked playbridge-cast-cli tests (18 tests)
- Apple TV: Debug and Release tvOS builds with code signing disabled
- Apple phone: Debug iOS Simulator build
- Extension: typecheck, 45 tests, and production build
- Git whitespace validation

## Risk
Debug output may contain credentials by design. Android raw network output remains available through developer logcat but is excluded from in-app diagnostics and persisted Share attachments. Extension store and GeckoView bundles compile raw browser diagnostics out. tvOS release output no longer prints complete VLC stream URLs or WebSocket envelopes, and authentication/pairing payloads are never logged by the new diagnostics.