### PR TITLE
fix(android): resolve remote timeline policy per active context

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -793,6 +793,11 @@ fun AppNavHost(
                         onScreenChange(remoteReturnScreen)
                     }
                     val external = activeExternalDevice
+                    val remoteTimeline = resolveRemoteTimeline(
+                        activeContext = tvActiveContext,
+                        playback = tvPlayback,
+                        playerSettings = tvPlayerSettings,
+                    )
                     if (external != null) {
                         RemoteControlScreen(
                             activeContext = "player",
@@ -839,7 +844,8 @@ fun AppNavHost(
                     } else RemoteControlScreen(
                         activeContext = tvActiveContext,
                         playbackState = tvPlayback?.state,
-                        isLive = tvPlayerSettings.isLive,
+                        isLive = remoteTimeline.isLive,
+                        isSeekable = remoteTimeline.isSeekable,
                         positionMs = tvPlayback?.positionMs ?: 0L,
                         durationMs = tvPlayback?.durationMs ?: 0L,
                         mediaTitle = tvPlayback?.title,

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -147,6 +147,7 @@ fun RemoteControlScreen(
     externalProtocolLabel: String? = null,
     externalCapabilities: Set<Capability>? = null,
     isLive: Boolean = false,
+    isSeekable: Boolean = true,
     positionMs: Long = 0L,
     durationMs: Long = 0L,
     mediaTitle: String? = null,
@@ -180,7 +181,7 @@ fun RemoteControlScreen(
     val capabilities = externalCapabilities.orEmpty()
     val supportsRemote = !externalMode || Capability.REMOTE in capabilities
     val supportsVolume = !externalMode || Capability.VOLUME in capabilities
-    val supportsSeek = !externalMode || Capability.SEEK in capabilities
+    val supportsSeek = if (externalMode) Capability.SEEK in capabilities else isSeekable
     val availableModes = buildList {
         add(RemoteMode.CONTEXT)
         if (supportsRemote) add(RemoteMode.DPAD)
@@ -284,6 +285,7 @@ fun RemoteControlScreen(
                                     positionMs = positionMs,
                                     durationMs = durationMs,
                                     isLive = isLive,
+                                    isSeekable = supportsSeek,
                                     isPlaying = playbackState == null || playbackState == "playing" || playbackState == "buffering",
                                     enableVolume = supportsVolume,
                                     onSeekTo = onSeekTo,
@@ -303,6 +305,7 @@ fun RemoteControlScreen(
                                 positionMs = positionMs,
                                 durationMs = durationMs,
                                 isLive = isLive,
+                                isSeekable = supportsSeek,
                                 dlnaMode = externalMode,
                                 mediaTitle = mediaTitle,
                                 onBrowserControl = onBrowserControl,
@@ -321,7 +324,7 @@ fun RemoteControlScreen(
                                 DpadArea(onRemoteKey = onRemoteKey)
                             }
                             ModeBottomBar(
-                                ctx = ctx, dlnaMode = externalMode, isLive = isLive,
+                                ctx = ctx, dlnaMode = externalMode, isLive = isLive, isSeekable = supportsSeek,
                                 playbackState = playbackState, onRemoteKey = onRemoteKey,
                                 onBrowserControl = onBrowserControl, onPlayerControl = onPlayerControl
                             )
@@ -338,7 +341,7 @@ fun RemoteControlScreen(
                                 )
                             }
                             ModeBottomBar(
-                                ctx = ctx, dlnaMode = externalMode, isLive = isLive,
+                                ctx = ctx, dlnaMode = externalMode, isLive = isLive, isSeekable = supportsSeek,
                                 playbackState = playbackState, onRemoteKey = onRemoteKey,
                                 onBrowserControl = onBrowserControl, onPlayerControl = onPlayerControl
                             )
@@ -540,6 +543,7 @@ private fun ColumnScope.BrowserContextView(
     positionMs: Long,
     durationMs: Long,
     isLive: Boolean,
+    isSeekable: Boolean,
     dlnaMode: Boolean,
     mediaTitle: String?,
     onBrowserControl: (String) -> Unit,
@@ -557,6 +561,7 @@ private fun ColumnScope.BrowserContextView(
             positionMs = positionMs,
             durationMs = durationMs,
             isLive = isLive,
+            isSeekable = isSeekable,
             isPlaying = playbackState == "playing" || playbackState == "buffering",
             enableVolume = !dlnaMode,
             onSeekTo = { ms -> onBrowserControl("seek_to:$ms") },
@@ -576,6 +581,7 @@ private fun ColumnScope.ModeBottomBar(
     ctx: RemoteContext,
     dlnaMode: Boolean,
     isLive: Boolean,
+    isSeekable: Boolean,
     playbackState: String?,
     onRemoteKey: (String) -> Unit,
     onBrowserControl: (String) -> Unit,
@@ -586,7 +592,11 @@ private fun ColumnScope.ModeBottomBar(
             VolumeRow(onVolumeUp = { onRemoteKey("volume_up") }, onVolumeDown = { onRemoteKey("volume_down") })
             BrowserContextRow(onBrowserControl = onBrowserControl, onRemoteKey = onRemoteKey)
         }
-        RemoteContext.PLAYER -> MediaControlRow(onPlayerControl = onPlayerControl, showLoop = !dlnaMode, showSeek = !isLive)
+        RemoteContext.PLAYER -> MediaControlRow(
+            onPlayerControl = onPlayerControl,
+            showLoop = !dlnaMode,
+            showSeek = !isLive && isSeekable,
+        )
         RemoteContext.IDLE -> { /* nothing to control */ }
     }
 }
@@ -691,6 +701,7 @@ private fun SeekVolumeBar(
     positionMs: Long,
     durationMs: Long,
     isLive: Boolean,
+    isSeekable: Boolean,
     isPlaying: Boolean,
     enableVolume: Boolean,
     onSeekTo: (Long) -> Unit,
@@ -698,7 +709,7 @@ private fun SeekVolumeBar(
     onVolumeDown: () -> Unit,
     onPlayPauseToggle: () -> Unit,
 ) {
-    val hasDuration = durationMs > 0L && !isLive
+    val hasDuration = durationMs > 0L && !isLive && isSeekable
     val currentPosition by rememberUpdatedState(positionMs)
 
     var widthPx by remember { mutableFloatStateOf(0f) }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteTimelinePolicy.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteTimelinePolicy.kt
@@ -1,0 +1,32 @@
+package com.playbridge.sender.cast
+
+/**
+ * Timeline capabilities for the active remote surface.
+ *
+ * Player settings belong only to the native player. The TV browser reports its own
+ * position and duration through [TvPlaybackStatus], so it must not inherit live or
+ * seekability flags left behind by native playback.
+ */
+internal data class RemoteTimelineState(
+    val isLive: Boolean,
+    val isSeekable: Boolean,
+)
+
+internal fun resolveRemoteTimeline(
+    activeContext: String,
+    playback: TvPlaybackStatus?,
+    playerSettings: TvPlayerSettings,
+): RemoteTimelineState = when (activeContext) {
+    "player" -> RemoteTimelineState(
+        isLive = playerSettings.isLive,
+        isSeekable = playerSettings.isSeekable && !playerSettings.isLive,
+    )
+    "browser" -> RemoteTimelineState(
+        isLive = false,
+        isSeekable = (playback?.durationMs ?: 0L) > 0L,
+    )
+    else -> RemoteTimelineState(
+        isLive = false,
+        isSeekable = false,
+    )
+}

--- a/mobile/android/app/src/test/java/com/playbridge/sender/cast/RemoteTimelinePolicyTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/cast/RemoteTimelinePolicyTest.kt
@@ -1,0 +1,80 @@
+package com.playbridge.sender.cast
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RemoteTimelinePolicyTest {
+
+    @Test
+    fun browserVodDoesNotInheritStaleLivePlayerSettings() {
+        val state = resolveRemoteTimeline(
+            activeContext = "browser",
+            playback = playback(durationMs = 600_000L),
+            playerSettings = TvPlayerSettings(isLive = true, isSeekable = false),
+        )
+
+        assertFalse(state.isLive)
+        assertTrue(state.isSeekable)
+    }
+
+    @Test
+    fun browserWithUnknownDurationIsNotFalselyLiveOrSeekable() {
+        val state = resolveRemoteTimeline(
+            activeContext = "browser",
+            playback = playback(durationMs = 0L),
+            playerSettings = TvPlayerSettings(isLive = true, isSeekable = true),
+        )
+
+        assertFalse(state.isLive)
+        assertFalse(state.isSeekable)
+    }
+
+    @Test
+    fun nativeLivePlaybackRemainsLiveAndNotSeekable() {
+        val state = resolveRemoteTimeline(
+            activeContext = "player",
+            playback = playback(durationMs = 0L),
+            playerSettings = TvPlayerSettings(isLive = true, isSeekable = true),
+        )
+
+        assertTrue(state.isLive)
+        assertFalse(state.isSeekable)
+    }
+
+    @Test
+    fun nativeVodRespectsPlayerSeekability() {
+        val seekable = resolveRemoteTimeline(
+            activeContext = "player",
+            playback = playback(durationMs = 600_000L),
+            playerSettings = TvPlayerSettings(isLive = false, isSeekable = true),
+        )
+        val notSeekable = resolveRemoteTimeline(
+            activeContext = "player",
+            playback = playback(durationMs = 600_000L),
+            playerSettings = TvPlayerSettings(isLive = false, isSeekable = false),
+        )
+
+        assertTrue(seekable.isSeekable)
+        assertFalse(notSeekable.isSeekable)
+    }
+
+    @Test
+    fun idleContextHasNoTimelineControls() {
+        val state = resolveRemoteTimeline(
+            activeContext = "idle",
+            playback = playback(durationMs = 600_000L),
+            playerSettings = TvPlayerSettings(isLive = true, isSeekable = true),
+        )
+
+        assertFalse(state.isLive)
+        assertFalse(state.isSeekable)
+    }
+
+    private fun playback(durationMs: Long) = TvPlaybackStatus(
+        state = "playing",
+        positionMs = 30_000L,
+        durationMs = durationMs,
+        title = "YouTube",
+    )
+}


### PR DESCRIPTION
## Summary
Decouple native player settings (`isLive`, `isSeekable`) from the TV browser remote control surface in the Android phone sender app.

Previously, TV browser VOD sessions could inherit stale `isLive` or `isSeekable` flags set during earlier native player sessions, causing incorrect timeline rendering and missing seek controls for web media playback.

## Changes
- Introduced `RemoteTimelinePolicy` (`resolveRemoteTimeline`) to evaluate timeline capabilities explicitly per active context (`player`, `browser`, or `idle`).
- Updated `AppNavHost.kt` and `RemoteControlScreen.kt` to compute and respect context-aware `isLive` and `isSeekable` flags.
- Added unit tests in `RemoteTimelinePolicyTest.kt` to cover browser VOD, unknown duration browser playback, native live stream, native VOD, and idle context behavior.