### PR TITLE
release(tv): Android TV Player 0.11.0

### DIFF
--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,22 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [0.11.0] — 2026-07-30 (versionCode 226)
+
+### Added
+- **Live/Network Exo Recovery**: Classifies Media3 errors in `ExoRendererService` and recovers in-engine (live edge / re-prepare) before escalating; host engine auto-switch is limited to startup hard failures, with failover allowed only after in-engine recovery is exhausted.
+- **Embedded Subtitle Offset**: Wires ExoPlayer embedded subtitle delay through `OffsetTextRenderer` so phone/TV offset controls apply to in-band tracks (fixes #171).
+- **Debug Network Diagnostics**: Optional debug-only network logging for stream fetches, ContentSniffer, skip/subtitle downloads, and browser traffic (not retained in release diagnostics).
+
+### Fixed
+- **Subtitle Sync Reset**: Forces absolute zero offset on Sync Reset instead of applying a captured delta that could leave engine/UI state uncleared.
+- **Update Dialog Snooze**: Persists "Later" per version so Activity recreation does not re-show the update prompt until a newer release; manual Check for updates still prompts.
+
+### Security
+- **WebView Mixed Content**: Switched `mixedContentMode` from `ALWAYS_ALLOW` to `COMPATIBILITY_MODE` to reduce MITM/XSS exposure from active HTTP content on HTTPS pages.
+- **WebView Content Access**: Disabled `allowContentAccess` to block local content-provider access from the TV browser WebView.
+- **Auth Response Disclosure**: Stopped echoing authentication tokens in `auth_response` payloads (shared protocol hardening, SEC-005).
+
 ## Player [0.10.1] — 2026-07-22 (versionCode 225)
 
 ### Fixed

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 225
-        versionName = "0.10.1"
+        versionCode = 226
+        versionName = "0.11.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
Bumps Android TV Player to **0.11.0** (versionCode **226**) and updates the changelog. GeckoView plugin remains at 0.3.4.

## What's New in 0.11.0

### Added
- **Live/Network Exo Recovery**: Classifies Media3 errors and recovers in-engine (live edge / re-prepare) before escalating; host engine auto-switch is limited to startup hard failures, with failover after recovery is exhausted.
- **Embedded Subtitle Offset**: Wires ExoPlayer embedded subtitle delay through `OffsetTextRenderer` so phone/TV offset controls apply to in-band tracks (fixes #171).
- **Debug Network Diagnostics**: Optional debug-only network logging for stream fetches, ContentSniffer, skip/subtitle downloads, and browser traffic (not retained in release diagnostics).

### Fixed
- **Subtitle Sync Reset**: Forces absolute zero offset on Sync Reset instead of a captured delta that could leave engine/UI state uncleared.
- **Update Dialog Snooze**: Persists "Later" per version so Activity recreation does not re-show the update prompt until a newer release; manual Check for updates still prompts.

### Security
- **WebView Mixed Content**: `mixedContentMode` set to `COMPATIBILITY_MODE` instead of `ALWAYS_ALLOW`.
- **WebView Content Access**: Disabled `allowContentAccess` to block local content-provider access from the TV browser WebView.
- **Auth Response Disclosure**: Stopped echoing authentication tokens in `auth_response` (shared protocol hardening, SEC-005).

## Version
| Field | Before | After |
| --- | --- | --- |
| `versionName` | 0.10.1 | 0.11.0 |
| `versionCode` | 225 | 226 |

## Verification
- `./gradlew test` under `tv/android/`: **Passed**
- `./gradlew :player:app:assembleDebug` under `tv/android/`: **Passed**