### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SEC-004 bearer-token storage vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The Android TV app's `SystemWebViewEngine` had `allowContentAccess` set to `true`. This is a critical security misconfiguration because it allows the arbitrary web content loaded into the system WebView to access and read local content provider data via `content://` URIs on the device, potentially exposing sensitive application data or internal processes (e.g. `PlayerProcessBridgeProvider`).
 **Learning:** Just as `allowFileAccess` is dangerous, `allowContentAccess` is equally risky when a WebView acts as a browser to navigate to untrusted arbitrary URLs. It unnecessarily expands the attack surface.
 **Prevention:** Explicitly configure `allowContentAccess = false` on all WebViews that handle remote, untrusted content to prevent access to the application's ContentProviders.
+
+## 2026-07-21 - Inconsistent Bearer-Token Storage (SEC-004)
+**Vulnerability:** Sender authorization tokens were stored in plaintext on both Android TV and Apple TV receivers. While the desktop client correctly stored SHA-256 verifiers, the TV platforms persisted the original tokens directly in standard preference files (DataStore / UserDefaults).
+**Learning:** Storing authentication tokens in plaintext on the receiving device expands the attack surface; local backups, debugging tools, or processes with access to preference files can extract the token and impersonate the sender to the TV.
+**Prevention:** Authorization tokens must never be persisted in plaintext. Use secure cryptographic hashing (like SHA-256) on the token immediately, store only the hash, and authenticate clients by generating the hash of the provided token and comparing it against stored records. Ensure legacy plaintext records are transparently migrated upon their next successful use.

--- a/tv/android/player/app/src/main/java/com/playbridge/player/pairing/PairingStore.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/pairing/PairingStore.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import java.util.UUID
+import java.security.MessageDigest
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "pairing_store")
 
@@ -28,6 +29,12 @@ class PairingStore(private val context: Context) {
         private val AUTHORIZED_TOKENS = stringPreferencesKey("authorized_tokens")
 
         const val DEFAULT_PORT = com.playbridge.shared.protocol.Config.DEFAULT_PORT
+
+        private fun tokenDigest(token: String): String {
+            if (token.startsWith("sha256:")) return token
+            val bytes = MessageDigest.getInstance("SHA-256").digest(token.toByteArray(Charsets.UTF_8))
+            return "sha256:" + bytes.joinToString("") { java.lang.String.format("%02x", it) }
+        }
     }
     
     /**
@@ -151,7 +158,9 @@ class PairingStore(private val context: Context) {
             current.removeAll {
                 (device.deviceUUID.isNotEmpty() && it.deviceUUID == device.deviceUUID) || it.id == device.id
             }
-            current.add(device)
+
+            val protectedDevice = device.copy(token = tokenDigest(device.token))
+            current.add(protectedDevice)
             
             prefs[PAIRED_DEVICES] = protocolJson.encodeToString(
                 kotlinx.serialization.builtins.ListSerializer(PairedDevice.serializer()),
@@ -200,6 +209,43 @@ class PairingStore(private val context: Context) {
         }
     }
 
+    suspend fun updateLastConnected(token: String) {
+        val digest = tokenDigest(token)
+        context.dataStore.edit { prefs ->
+            val current = prefs[PAIRED_DEVICES]?.let {
+                try {
+                    protocolJson.decodeFromString<List<PairedDevice>>(it).toMutableList()
+                } catch (e: Exception) {
+                    mutableListOf()
+                }
+            } ?: mutableListOf()
+
+            val index = current.indexOfFirst { it.token == token || it.token == digest }
+            if (index != -1) {
+                val device = current[index]
+                current[index] = device.copy(token = digest, lastConnected = System.currentTimeMillis())
+                prefs[PAIRED_DEVICES] = protocolJson.encodeToString(
+                    kotlinx.serialization.builtins.ListSerializer(PairedDevice.serializer()),
+                    current
+                )
+            }
+
+            // Migrate the token in the authorized tokens set as well
+            val authSet = prefs[AUTHORIZED_TOKENS]?.let {
+                try { protocolJson.decodeFromString<List<String>>(it).toMutableSet() }
+                catch (e: Exception) { mutableSetOf() }
+            } ?: mutableSetOf()
+            if (authSet.contains(token)) {
+                authSet.remove(token)
+                authSet.add(digest)
+                prefs[AUTHORIZED_TOKENS] = protocolJson.encodeToString(
+                    kotlinx.serialization.builtins.ListSerializer(kotlinx.serialization.serializer<String>()),
+                    authSet.toList()
+                )
+            }
+        }
+    }
+
     // ── Per-device token authorization ────────────────────────────────────────
 
     private suspend fun getAuthorizedTokenSet(): MutableSet<String> {
@@ -211,16 +257,20 @@ class PairingStore(private val context: Context) {
         }
     }
 
-    suspend fun isTokenAuthorized(token: String): Boolean =
-        getAuthorizedTokenSet().contains(token)
+    suspend fun isTokenAuthorized(token: String): Boolean {
+        val set = getAuthorizedTokenSet()
+        val digest = tokenDigest(token)
+        return set.contains(token) || set.contains(digest)
+    }
 
     suspend fun addAuthorizedToken(token: String) {
+        val digest = tokenDigest(token)
         context.dataStore.edit { prefs ->
             val set = prefs[AUTHORIZED_TOKENS]?.let {
                 try { protocolJson.decodeFromString<List<String>>(it).toMutableSet() }
                 catch (e: Exception) { mutableSetOf() }
             } ?: mutableSetOf()
-            set.add(token)
+            set.add(digest)
             prefs[AUTHORIZED_TOKENS] = protocolJson.encodeToString(
                 kotlinx.serialization.builtins.ListSerializer(kotlinx.serialization.serializer<String>()),
                 set.toList()
@@ -229,12 +279,14 @@ class PairingStore(private val context: Context) {
     }
 
     suspend fun removeAuthorizedToken(token: String) {
+        val digest = tokenDigest(token)
         context.dataStore.edit { prefs ->
             val set = prefs[AUTHORIZED_TOKENS]?.let {
                 try { protocolJson.decodeFromString<List<String>>(it).toMutableSet() }
                 catch (e: Exception) { mutableSetOf() }
             } ?: mutableSetOf()
             set.remove(token)
+            set.remove(digest)
             prefs[AUTHORIZED_TOKENS] = protocolJson.encodeToString(
                 kotlinx.serialization.builtins.ListSerializer(kotlinx.serialization.serializer<String>()),
                 set.toList()

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
@@ -308,7 +308,13 @@ class ServerService : Service() {
             val tlsDir = java.io.File(filesDir, "tls").also { it.mkdirs() }
             webSocketServer = WebSocketServer(
                 port = port,
-                isTokenAuthorized = { token -> pairingStore.isTokenAuthorized(token) },
+                isTokenAuthorized = { token ->
+                    val authorized = pairingStore.isTokenAuthorized(token)
+                    if (authorized) {
+                        pairingStore.updateLastConnected(token)
+                    }
+                    authorized
+                },
                 onPairingApproved = { deviceName, deviceUUID ->
                     val newToken = java.util.UUID.randomUUID().toString()
                     pairingStore.addAuthorizedToken(newToken)

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
@@ -101,6 +101,14 @@ class WebSocketServer: ObservableObject {
     /// driven by the player UI (next/jump), which never pass through the server.
     private var playlistCancellable: AnyCancellable?
 
+    private func tokenDigest(_ token: String) -> String {
+        if token.hasPrefix("sha256:") { return token }
+        let data = Data(token.utf8)
+        let digest = SHA256.hash(data: data)
+        let hex = digest.compactMap { String(format: "%02x", $0) }.joined()
+        return "sha256:" + hex
+    }
+
     init(historyStore: HistoryStore? = nil, playlistStore: PlaylistStore? = nil) {
         self.historyStore = historyStore
         self.playlistStore = playlistStore
@@ -644,14 +652,15 @@ class WebSocketServer: ObservableObject {
         autoTimeoutWork = nil
 
         let token = UUID().uuidString
+        let digest = tokenDigest(token)
         var tokens = authorizedTokens
-        tokens.insert(token)
+        tokens.insert(digest)
         authorizedTokens = tokens
 
         let device = PairedDevice(
             deviceUUID: handshake.deviceUUID,
             deviceName: handshake.deviceName,
-            token: token,
+            token: digest,
             lastConnected: Date()
         )
         savePairedDevice(device)
@@ -785,7 +794,8 @@ class WebSocketServer: ObservableObject {
             send(json: ["type": "auth_response", "success": false], to: connection)
             return
         }
-        if authorizedTokens.contains(msg.token) {
+        let digest = tokenDigest(msg.token)
+        if authorizedTokens.contains(msg.token) || authorizedTokens.contains(digest) {
             updateLastConnected(token: msg.token)
             completeAuth(from: connection, token: msg.token)
         } else {
@@ -838,6 +848,7 @@ class WebSocketServer: ObservableObject {
         storedPairedDevices = devices
         var tokens = authorizedTokens
         tokens.remove(device.token)
+        tokens.remove(tokenDigest(device.token))
         authorizedTokens = tokens
     }
 
@@ -848,14 +859,21 @@ class WebSocketServer: ObservableObject {
     }
 
     private func updateLastConnected(token: String) {
+        let digest = tokenDigest(token)
         var devices = storedPairedDevices
-        if let idx = devices.firstIndex(where: { $0.token == token }) {
+        if let idx = devices.firstIndex(where: { $0.token == token || $0.token == digest }) {
             let d = devices[idx]
             devices[idx] = PairedDevice(
                 deviceUUID: d.deviceUUID, deviceName: d.deviceName,
-                token: token, lastConnected: Date()
+                token: digest, lastConnected: Date()
             )
             storedPairedDevices = devices
+        }
+        var tokens = authorizedTokens
+        if tokens.contains(token) {
+            tokens.remove(token)
+            tokens.insert(digest)
+            authorizedTokens = tokens
         }
     }
 


### PR DESCRIPTION
This PR addresses **SEC-004: Bearer-token storage is inconsistent**, a critical security vulnerability where authorization bearer-tokens were stored in plaintext inside ordinary preference files (DataStore on Android, UserDefaults on iOS/tvOS). 

The risk is that local access to these files (via backups, debugging tools, or vulnerabilities like path traversal/file access) could expose the tokens, allowing an attacker to impersonate the legitimate sender.

**Changes made:**
- **Android TV (`tv/android/player/...`)**: Modified `PairingStore` to securely hash tokens using SHA-256 before persisting them in the DataStore for both `PAIRED_DEVICES` and `AUTHORIZED_TOKENS`. Implemented transparent migration functionality in `updateLastConnected()` so that a legacy plaintext token is converted to a SHA-256 hash automatically when a client reconnects successfully. 
- **Apple TV (`tv/apple/...`)**: Modified `WebSocketServer.swift` to introduce a `tokenDigest` method utilizing `CryptoKit`. Refactored `approvePairing`, `handleAuth`, `forgetDevice`, and `updateLastConnected` to only store and verify against token digests. Legacy tokens are migrated upon next reconnect.
- **Sentinel Journal**: Added an entry logging this vulnerability and the required prevention strategy going forward.

Tests have been run and passed for the Android TV app. Apple TV changes have been carefully audited for logic and syntax correctness.

---
*PR created automatically by Jules for task [4485869061177864925](https://jules.google.com/task/4485869061177864925) started by @playbridgeapp*