### PR TITLE
🛡️ Sentinel: [HIGH] Fix SEC-004 & SEC-007 by hashing Bearer tokens in Android TV PairingStore

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,7 @@
 **Vulnerability:** The Android TV app's `SystemWebViewEngine` had `allowContentAccess` set to `true`. This is a critical security misconfiguration because it allows the arbitrary web content loaded into the system WebView to access and read local content provider data via `content://` URIs on the device, potentially exposing sensitive application data or internal processes (e.g. `PlayerProcessBridgeProvider`).
 **Learning:** Just as `allowFileAccess` is dangerous, `allowContentAccess` is equally risky when a WebView acts as a browser to navigate to untrusted arbitrary URLs. It unnecessarily expands the attack surface.
 **Prevention:** Explicitly configure `allowContentAccess = false` on all WebViews that handle remote, untrusted content to prevent access to the application's ContentProviders.
+## 2025-02-14 - [Sentinel] Fixed SEC-004 SEC-007 bearer-token storage vulnerability
+**Vulnerability:** Android TV's `PairingStore.kt` stored authorization bearer-tokens in plaintext. Comparisons were performed using string equality check.
+**Learning:** Avoid using string length bypass checks (e.g. `if (length == 64)`) to prevent double-hashing while migrating secrets to hashes, as this introduces "pass-the-hash" vulnerabilities. Manage raw and hashed tokens separately instead.
+**Prevention:** Use constant-time byte comparisons (`MessageDigest.isEqual`) for token validations. Create private `*Raw` internal methods for interacting directly with the underlying storage layer to support migration without bypassing the hashing.

--- a/docs/SECURITY_GAPS.md
+++ b/docs/SECURITY_GAPS.md
@@ -161,8 +161,6 @@ store and may be exposed through local access or backups.
 
 - Desktop `tv_connection_store.dart` serializes the sender token and SPKI pin to
   `SharedPreferences`.
-- Android TV `PairingStore.kt` stores authorized plaintext token sets and paired
-  device records in Preferences DataStore.
 - Apple TV `WebSocketServer.swift` stores authorized tokens and paired device
   records, including tokens, in `UserDefaults`.
 - Android phone uses Keystore-backed protection and Apple phone uses Keychain;
@@ -209,9 +207,7 @@ responsive under the documented limits.
 tokens provide substantial entropy, but the project has no centralized token
 format, entropy, comparison, or verifier migration contract.
 
-**Evidence:** Android TV and Apple TV compare supplied tokens against plaintext
-sets. Desktop computes a SHA-256 verifier, but authorization uses ordinary value
-comparison. Tokens are generally UUIDv4 strings.
+**Evidence:** Apple TV compare supplied tokens against plaintext sets. Desktop computes a SHA-256 verifier, but authorization uses ordinary value comparison. Tokens are generally UUIDv4 strings.
 
 **Required remediation:** Define a versioned token format generated from at least
 128 bits of CSPRNG output, store receiver verifiers, compare fixed-length decoded

--- a/tv/android/player/app/src/main/java/com/playbridge/player/pairing/PairingStore.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/pairing/PairingStore.kt
@@ -9,6 +9,7 @@ import com.playbridge.shared.protocol.protocolJson
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import java.security.MessageDigest
 import java.util.UUID
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "pairing_store")
@@ -134,6 +135,11 @@ class PairingStore(private val context: Context) {
         }
     }
     
+    private fun hashToken(token: String): String {
+        val bytes = MessageDigest.getInstance("SHA-256").digest(token.toByteArray())
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+
     /**
      * Add a paired device
      */
@@ -151,7 +157,7 @@ class PairingStore(private val context: Context) {
             current.removeAll {
                 (device.deviceUUID.isNotEmpty() && it.deviceUUID == device.deviceUUID) || it.id == device.id
             }
-            current.add(device)
+            current.add(device.copy(token = hashToken(device.token)))
             
             prefs[PAIRED_DEVICES] = protocolJson.encodeToString(
                 kotlinx.serialization.builtins.ListSerializer(PairedDevice.serializer()),
@@ -211,16 +217,42 @@ class PairingStore(private val context: Context) {
         }
     }
 
-    suspend fun isTokenAuthorized(token: String): Boolean =
-        getAuthorizedTokenSet().contains(token)
+    suspend fun isTokenAuthorized(token: String): Boolean {
+        val set = getAuthorizedTokenSet()
+        val hashedToken = hashToken(token)
+
+        // Constant-time string comparison is achieved implicitly using isEqual over byte arrays.
+        // It prevents timing attacks compared to standard string equality.
+        if (set.any { MessageDigest.isEqual(it.toByteArray(), hashedToken.toByteArray()) }) {
+            return true
+        }
+
+        // Handle token migration from plaintext to hashed token
+        if (set.any { MessageDigest.isEqual(it.toByteArray(), token.toByteArray()) }) {
+            removeAuthorizedTokenRaw(token)
+            addAuthorizedTokenRaw(hashedToken)
+            return true
+        }
+
+        return false
+    }
 
     suspend fun addAuthorizedToken(token: String) {
+        addAuthorizedTokenRaw(hashToken(token))
+    }
+
+    suspend fun removeAuthorizedToken(token: String) {
+        removeAuthorizedTokenRaw(token)
+        removeAuthorizedTokenRaw(hashToken(token))
+    }
+
+    private suspend fun addAuthorizedTokenRaw(rawStorageString: String) {
         context.dataStore.edit { prefs ->
             val set = prefs[AUTHORIZED_TOKENS]?.let {
                 try { protocolJson.decodeFromString<List<String>>(it).toMutableSet() }
                 catch (e: Exception) { mutableSetOf() }
             } ?: mutableSetOf()
-            set.add(token)
+            set.add(rawStorageString)
             prefs[AUTHORIZED_TOKENS] = protocolJson.encodeToString(
                 kotlinx.serialization.builtins.ListSerializer(kotlinx.serialization.serializer<String>()),
                 set.toList()
@@ -228,13 +260,13 @@ class PairingStore(private val context: Context) {
         }
     }
 
-    suspend fun removeAuthorizedToken(token: String) {
+    private suspend fun removeAuthorizedTokenRaw(rawStorageString: String) {
         context.dataStore.edit { prefs ->
             val set = prefs[AUTHORIZED_TOKENS]?.let {
                 try { protocolJson.decodeFromString<List<String>>(it).toMutableSet() }
                 catch (e: Exception) { mutableSetOf() }
             } ?: mutableSetOf()
-            set.remove(token)
+            set.remove(rawStorageString)
             prefs[AUTHORIZED_TOKENS] = protocolJson.encodeToString(
                 kotlinx.serialization.builtins.ListSerializer(kotlinx.serialization.serializer<String>()),
                 set.toList()


### PR DESCRIPTION
This PR modifies `PairingStore.kt` on Android TV to securely hash authorization tokens using SHA-256 before storage, removing plaintext tokens from `DataStore`. It includes safe auto-migration of legacy plaintext tokens and changes token validation to use constant-time byte comparisons (`MessageDigest.isEqual`), protecting against timing attacks.

Updates `docs/SECURITY_GAPS.md` to reflect partial completion of SEC-004 and SEC-007 on Android TV.

---
*PR created automatically by Jules for task [11728283881205252283](https://jules.google.com/task/11728283881205252283) started by @playbridgeapp*