### PR TITLE
ci(android): publish phone Play releases to open testing

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -421,7 +421,7 @@ jobs:
 
       # Play Store publishes are independent: one failing must not block the
       # others (continue-on-error), but any failure is re-surfaced at the end.
-      - name: Publish Phone to Play Store (alpha)
+      - name: Publish Phone to Play Store (open testing)
         id: play_phone
         if: needs.build-phone.outputs.skipped == 'false'
         continue-on-error: true
@@ -430,7 +430,8 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
           packageName: com.playbridge.sender
           releaseFiles: output/phone-release-aab/*.aab
-          tracks: alpha
+          # Play API: beta = Open testing (alpha = Closed testing).
+          tracks: beta
           status: completed
 
       - name: Publish TV Player to Play Store (alpha)


### PR DESCRIPTION
## Summary

Phone release-build currently uploads the Play AAB to the **`alpha`** track, which is **Closed testing**. This app is in **Open testing**, so CI was publishing to the wrong track.

- Phone (`com.playbridge.sender`): `tracks: alpha` → **`beta`** (Open testing)
- TV player: unchanged (`alpha` / Closed testing)

## Notes

Play Developer API track names:

| API track | Console |
| --- | --- |
| `alpha` | Closed testing |
| `beta` | Open testing |

## Test plan

- [ ] Merge after review
- [ ] On next phone version uprev / android release-build, confirm the AAB lands on **Open testing** in Play Console
- [ ] Confirm TV player still targets closed testing if that job runs