### PR TITLE
bump(cli): 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "playbridge-cast-cli"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "crossterm",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,18 @@
 # PlayBridge CLI Changelog
 
+## 0.2.0 (2026-08-10)
+
+- Make the full-screen dashboard the primary interface for casting, browser
+  receiver hosting, discovery, receiver mode, and remote control.
+- Add dashboard remote and receiver status/control views, including pairing and
+  browser-host approval flows without leaving the dashboard.
+- Add verified dashboard self-updates plus macOS/Linux and Windows installers
+  that resolve releases through `playbridge.app` and verify SHA-256 checksums.
+- Require an explicitly entered, out-of-band SAS pairing code for CLI receiver
+  pairing, preventing automatic approval from the same connection.
+- Improve terminal restoration and background-task reporting so cast and
+  receiver output does not corrupt the dashboard.
+
 ## 0.1.1 (2026-07-25)
 
 - Build self-contained Windows executable (`playbridge.exe`) with static MSVC C runtime linking.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playbridge-cast-cli"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 publish = false
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
## Summary
- bump the PlayBridge CLI from 0.1.1 to 0.2.0
- document the dashboard-first workflow, remote/receiver controls, verified updates and installers, and explicit SAS pairing
- update Cargo.lock to keep the release build reproducible

## Verification
- cargo fmt --all -- --check
- cargo test -p playbridge-cast-cli --locked (50 passed)

## Release note
After merge, CLI Release Build will create a draft cli-v0.2.0 release. Publish it separately when ready.