### PR TITLE
fix(android-tv): protect persisted pairing tokens

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'mobile/android/**'
       - 'tv/android/**'
+      - 'third_party/webrtc-runtime/**'
       - 'shared/**'
       - 'libs/**'
       - 'gradle/**'

--- a/.github/workflows/android_pr.yml
+++ b/.github/workflows/android_pr.yml
@@ -47,6 +47,7 @@ jobs:
             relevant:
               - 'mobile/android/**'
               - 'tv/android/**'
+              - 'third_party/webrtc-runtime/**'
               - 'shared/**'
               - 'protocol/**'
               - 'gradle/**'

--- a/third_party/webrtc-runtime/build.gradle.kts
+++ b/third_party/webrtc-runtime/build.gradle.kts
@@ -16,6 +16,11 @@ android {
 
     defaultConfig { minSdk = 26 }
 
+    lint {
+        // Keep the pinned upstream snapshot unchanged. Existing upstream findings are
+        // recorded by exact file and line so lint still fails on newly introduced issues.
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 dependencies {

--- a/third_party/webrtc-runtime/lint-baseline.xml
+++ b/third_party/webrtc-runtime/lint-baseline.xml
@@ -1,0 +1,873 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 9.2.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.2.1)" variant="all" version="9.2.1">
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by CameraManager.openCamera: android.permission.CAMERA"
+        errorLine1="      cameraManager.openCamera(cameraId, new CameraStateCallback(), cameraThreadHandler);"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/Camera2Session.java"
+            line="357"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.getActiveNetworkInfo: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="      return getNetworkState(connectivityManager.getActiveNetworkInfo());"
+        errorLine2="                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="260"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.getNetworkInfo: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="      NetworkInfo networkInfo = connectivityManager.getNetworkInfo(network);"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="272"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.getNetworkCapabilities: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="            connectivityManager.getNetworkCapabilities(network);"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="296"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.getActiveNetwork: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="            &amp;&amp; network.equals(connectivityManager.getActiveNetwork())) {"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="321"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.getActiveNetworkInfo: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="          NetworkInfo underlyingActiveNetworkInfo = connectivityManager.getActiveNetworkInfo();"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="325"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.getAllNetworks: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="      return connectivityManager.getAllNetworks();"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="369"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.getActiveNetworkInfo: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="      final NetworkInfo defaultNetworkInfo = connectivityManager.getActiveNetworkInfo();"
+        errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="400"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.getNetworkInfo: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="        final NetworkInfo networkInfo = connectivityManager.getNetworkInfo(network);"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="410"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.getLinkProperties: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="      LinkProperties linkProperties = connectivityManager.getLinkProperties(network);"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="445"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.getNetworkCapabilities: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="      final NetworkCapabilities capabilities = connectivityManager.getNetworkCapabilities(network);"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="486"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.getNetworkCapabilities: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="      final NetworkCapabilities capabilities = connectivityManager.getNetworkCapabilities(network);"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="509"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.registerNetworkCallback: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="      connectivityManager.registerNetworkCallback(createNetworkRequest(), networkCallback);"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="550"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by ConnectivityManager.registerNetworkCallback: android.permission.ACCESS_NETWORK_STATE"
+        errorLine1="      connectivityManager.registerNetworkCallback(request, networkCallback);"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="554"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Call requires permission which may be rejected by user: code should explicitly check to see if permission is available (with `checkPermission`) or explicitly handle a potential `SecurityException`"
+        errorLine1="        manager.requestGroupInfo("
+        errorLine2="        ^">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="646"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Call requires permission which may be rejected by user: code should explicitly check to see if permission is available (with `checkPermission`) or explicitly handle a potential `SecurityException`"
+        errorLine1="    return new AudioRecord.Builder()"
+        errorLine2="           ^">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="441"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by Builder.build: android.permission.RECORD_AUDIO"
+        errorLine1="    return new AudioRecord.Builder()"
+        errorLine2="           ^">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="441"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Call requires permission which may be rejected by user: code should explicitly check to see if permission is available (with `checkPermission`) or explicitly handle a potential `SecurityException`"
+        errorLine1="    return new AudioRecord(audioSource, sampleRate, channelConfig, audioFormat, bufferSizeInBytes);"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="455"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="MissingPermission"
+        message="Missing permissions required by AudioRecord.AudioRecord: android.permission.RECORD_AUDIO"
+        errorLine1="    return new AudioRecord(audioSource, sampleRate, channelConfig, audioFormat, bufferSizeInBytes);"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="455"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 33 (current min is 26): `android.media.MediaFormat#KEY_CROP_RIGHT`"
+        errorLine1="      newWidth = 1 + format.getInteger(MediaFormat.KEY_CROP_RIGHT)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/AndroidVideoDecoder.java"
+            line="566"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 33 (current min is 26): `android.media.MediaFormat#KEY_CROP_LEFT`"
+        errorLine1="          - format.getInteger(MediaFormat.KEY_CROP_LEFT);"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/AndroidVideoDecoder.java"
+            line="567"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 33 (current min is 26): `android.media.MediaFormat#KEY_CROP_BOTTOM`"
+        errorLine1="      newHeight = 1 + format.getInteger(MediaFormat.KEY_CROP_BOTTOM)"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/AndroidVideoDecoder.java"
+            line="568"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 33 (current min is 26): `android.media.MediaFormat#KEY_CROP_TOP`"
+        errorLine1="          - format.getInteger(MediaFormat.KEY_CROP_TOP);"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/AndroidVideoDecoder.java"
+            line="569"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 33 (current min is 26): `android.media.MediaFormat#KEY_VIDEO_ENCODING_STATISTICS_LEVEL`"
+        errorLine1="        format.setInteger(MediaFormat.KEY_VIDEO_ENCODING_STATISTICS_LEVEL,"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/HardwareVideoEncoder.java"
+            line="276"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 33 (current min is 26): `android.media.MediaFormat#VIDEO_ENCODING_STATISTICS_LEVEL_1`"
+        errorLine1="            MediaFormat.VIDEO_ENCODING_STATISTICS_LEVEL_1);"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/HardwareVideoEncoder.java"
+            line="277"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 33 (current min is 26): `android.media.MediaFormat#KEY_VIDEO_QP_AVERAGE`"
+        errorLine1="          qp = format.getInteger(MediaFormat.KEY_VIDEO_QP_AVERAGE);"
+        errorLine2="                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/HardwareVideoEncoder.java"
+            line="622"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 33 (current min is 26): `android.media.MediaCodecInfo.CodecCapabilities#FEATURE_EncodingStatistics`"
+        errorLine1="    return codecCaps.isFeatureSupported(CodecCapabilities.FEATURE_EncodingStatistics);"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/HardwareVideoEncoder.java"
+            line="764"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="Range"
+        message="Value must be ≥ 1 (was 0)"
+        errorLine1="        .setSessionId(AudioManager.AUDIO_SESSION_ID_GENERATE)"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioTrack.java"
+            line="459"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="WrongConstant"
+        message="Must be one or more of: AudioManager.GET_DEVICES_INPUTS, AudioManager.GET_DEVICES_OUTPUTS"
+        errorLine1="    final AudioDeviceInfo[] devices = audioManager.getDevices(AudioManager.GET_DEVICES_ALL);"
+        errorLine2="                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioUtils.java"
+            line="255"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.annotation:annotation than 1.9.1 is available: 1.10.0"
+        errorLine1="    compileOnly(&quot;androidx.annotation:annotation:1.9.1&quot;)"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="27"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(29) instead of `@TargetApi` to propagate the requirement to callers of `isHardwareAcceleratedQOrHigher`"
+        errorLine1="  @TargetApi(29)"
+        errorLine2="  ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/MediaCodecUtils.java"
+            line="104"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(29) instead of `@TargetApi` to propagate the requirement to callers of `isSoftwareOnlyQOrHigher`"
+        errorLine1="  @TargetApi(29)"
+        errorLine2="  ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/MediaCodecUtils.java"
+            line="122"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.M) instead of `@TargetApi` to propagate the requirement to callers of `setPreferredDevice`"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.M)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="379"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.M) instead of `@TargetApi` to propagate the requirement to callers of `createAudioRecordOnMOrHigher`"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.M)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="437"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.M) instead of `@TargetApi` to propagate the requirement to callers of `logMainParametersExtended`"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.M)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="466"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.N) instead of `@TargetApi` to propagate the requirement to callers of `logRecordingConfigurations`"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.N)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="476"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.N) instead of `@TargetApi` to propagate the requirement to callers of `logActiveRecordingConfigs`"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.N)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="636"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.N) instead of `@TargetApi` to propagate the requirement to callers of `verifyAudioConfig`"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.N)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="704"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.N) instead of `@TargetApi` to propagate the requirement to callers of `checkDeviceMatch`"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.N)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="737"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.O) instead of `@TargetApi` to propagate the requirement to callers of `createAudioTrackOnOreoOrHigher`"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.O)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioTrack.java"
+            line="442"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(Build.VERSION_CODES.Q) instead of `@TargetApi` to propagate the requirement to callers of `applyAttributesOnQOrHigher`"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.Q)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioTrack.java"
+            line="463"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="UseRequiresApi"
+        message="Use `@RequiresApi(VERSION_CODES.N) instead of `@TargetApi` to propagate the requirement to callers of `audioEncodingToString`"
+        errorLine1="  @TargetApi(VERSION_CODES.N)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioUtils.java"
+            line="184"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is never &lt; 26"
+        errorLine1="    if (Build.VERSION.SDK_INT &lt; Build.VERSION_CODES.LOLLIPOP_MR1"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/Camera2Enumerator.java"
+            line="137"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="        || (name.startsWith(EXYNOS_PREFIX) &amp;&amp; Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/HardwareVideoEncoderFactory.java"
+            line="211"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="        &amp;&amp; Build.VERSION.SDK_INT >= Build.VERSION_CODES.N;"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/HardwareVideoEncoderFactory.java"
+            line="220"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is never &lt; 26"
+        errorLine1="      if (Build.VERSION.SDK_INT &lt; Build.VERSION_CODES.M) {"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/HardwareVideoEncoderFactory.java"
+            line="242"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is never &lt; 26"
+        errorLine1="      if (Build.VERSION.SDK_INT == Build.VERSION_CODES.M) {"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/HardwareVideoEncoderFactory.java"
+            line="245"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="    return enableH264HighProfile &amp;&amp; Build.VERSION.SDK_INT > Build.VERSION_CODES.M"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/HardwareVideoEncoderFactory.java"
+            line="269"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="      if (useLowLatency &amp;&amp; Build.VERSION.SDK_INT >= MIN_LOW_LATENCY_SDK_VERSION) {"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/JavaAudioDeviceModule.java"
+            line="267"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 23"
+        errorLine1="  @RequiresApi(Build.VERSION_CODES.M)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/JavaAudioDeviceModule.java"
+            line="453"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="    if (Build.VERSION.SDK_INT >= 26) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/LowLatencyAudioBufferManager.java"
+            line="42"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &amp;&amp; name.startsWith(EXYNOS_PREFIX)) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/MediaCodecVideoDecoderFactory.java"
+            line="129"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="320"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/NetworkMonitorAutoDetect.java"
+            line="996"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="      if (Build.VERSION.SDK_INT >= 24) {"
+        errorLine2="          ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="137"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="            if (Build.VERSION.SDK_INT >= 24) {"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="152"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="      } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="331"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 23"
+        errorLine1="  @RequiresApi(Build.VERSION_CODES.M)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="378"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 23"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.M)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="379"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 23"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.M)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="437"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 23"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.M)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="466"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="468"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 24"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.N)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="476"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `Build.VERSION.SDK_INT &lt; Build.VERSION_CODES.N` is never true here"
+        errorLine1="    if (Build.VERSION.SDK_INT &lt; Build.VERSION_CODES.N) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="480"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is never &lt; 26"
+        errorLine1="    if (Build.VERSION.SDK_INT &lt; Build.VERSION_CODES.N) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="616"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 24"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.N)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="636"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 24"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.N)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="704"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 24"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.N)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioRecord.java"
+            line="737"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="      if (useLowLatency &amp;&amp; Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioTrack.java"
+            line="230"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioTrack.java"
+            line="257"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="    if (Build.VERSION.SDK_INT >= 24) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioTrack.java"
+            line="365"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="  @TargetApi(Build.VERSION_CODES.O)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioTrack.java"
+            line="442"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioTrack.java"
+            line="470"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioTrack.java"
+            line="480"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioTrack.java"
+            line="492"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioTrack.java"
+            line="512"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 24"
+        errorLine1="  @TargetApi(VERSION_CODES.N)"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioUtils.java"
+            line="184"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 26"
+        errorLine1="        if (Build.VERSION.SDK_INT >= VERSION_CODES.M) {"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioUtils.java"
+            line="243"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is never &lt; 26"
+        errorLine1="    if (Build.VERSION.SDK_INT &lt; VERSION_CODES.M) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/webrtc/audio/WebRtcAudioUtils.java"
+            line="252"
+            column="9"/>
+    </issue>
+
+</issues>

--- a/tv/android/player/app/src/main/java/com/playbridge/player/model/PairedDevice.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/model/PairedDevice.kt
@@ -11,5 +11,6 @@ data class PairedDevice(
     val name: String,
     val deviceUUID: String = "",
     val token: String = "",
+    val tokenVerifier: String = "",
     val lastConnected: Long = System.currentTimeMillis()
 )

--- a/tv/android/player/app/src/main/java/com/playbridge/player/pairing/PairingStore.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/pairing/PairingStore.kt
@@ -1,14 +1,23 @@
 package com.playbridge.player.pairing
 
 import android.content.Context
+import android.os.Build
 import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.*
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.playbridge.player.model.PairedDevice
 import com.playbridge.shared.protocol.protocolJson
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import java.security.MessageDigest
 import java.util.UUID
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "pairing_store")
@@ -16,7 +25,14 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 /**
  * DataStore-backed storage for pairing information
  */
-class PairingStore(private val context: Context) {
+class PairingStore private constructor(
+    private val dataStore: DataStore<Preferences>,
+    private val defaultDeviceName: String,
+) {
+
+    constructor(context: Context) : this(context.dataStore, Build.MODEL)
+
+    internal constructor(dataStore: DataStore<Preferences>) : this(dataStore, "PlayBridge TV")
     
     companion object {
         private val AUTH_TOKEN = stringPreferencesKey("auth_token")
@@ -26,6 +42,7 @@ class PairingStore(private val context: Context) {
         private val DEVICE_ID = stringPreferencesKey("device_id")
         private val ONBOARDING_DONE = booleanPreferencesKey("onboarding_done")
         private val AUTHORIZED_TOKENS = stringPreferencesKey("authorized_tokens")
+        private val AUTHORIZED_TOKEN_VERIFIERS = stringPreferencesKey("authorized_token_verifiers")
 
         const val DEFAULT_PORT = com.playbridge.shared.protocol.Config.DEFAULT_PORT
     }
@@ -33,12 +50,12 @@ class PairingStore(private val context: Context) {
     /**
      * Track if the user has seen the pairing screen.
      */
-    val isOnboardingDone: Flow<Boolean> = context.dataStore.data.map { prefs ->
+    val isOnboardingDone: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[ONBOARDING_DONE] ?: false
     }
 
     suspend fun setOnboardingDone(done: Boolean) {
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             prefs[ONBOARDING_DONE] = done
         }
     }
@@ -47,11 +64,11 @@ class PairingStore(private val context: Context) {
      * Get the current device ID (UUID), or create a new one if none exists
      */
     suspend fun getOrCreateDeviceId(): String {
-        val current = context.dataStore.data.first()[DEVICE_ID]
+        val current = dataStore.data.first()[DEVICE_ID]
         if (current != null) return current
 
         val newId = UUID.randomUUID().toString()
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             prefs[DEVICE_ID] = newId
         }
         return newId
@@ -60,7 +77,7 @@ class PairingStore(private val context: Context) {
     /**
      * Device ID flow
      */
-    val deviceId: Flow<String> = context.dataStore.data.map { prefs ->
+    val deviceId: Flow<String> = dataStore.data.map { prefs ->
         prefs[DEVICE_ID] ?: getOrCreateDeviceId()
     }
 
@@ -68,11 +85,11 @@ class PairingStore(private val context: Context) {
      * Get the current auth token, or create a new one if none exists
      */
     suspend fun getOrCreateToken(): String {
-        val current = context.dataStore.data.first()[AUTH_TOKEN]
+        val current = dataStore.data.first()[AUTH_TOKEN]
         if (current != null) return current
         
         val newToken = UUID.randomUUID().toString()
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             prefs[AUTH_TOKEN] = newToken
         }
         return newToken
@@ -83,7 +100,7 @@ class PairingStore(private val context: Context) {
      */
     suspend fun regenerateToken(): String {
         val newToken = UUID.randomUUID().toString()
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             prefs[AUTH_TOKEN] = newToken
         }
         return newToken
@@ -92,7 +109,7 @@ class PairingStore(private val context: Context) {
     /**
      * Server port flow
      */
-    val serverPort: Flow<Int> = context.dataStore.data.map { prefs ->
+    val serverPort: Flow<Int> = dataStore.data.map { prefs ->
         prefs[SERVER_PORT]?.takeIf { it in 1..65535 } ?: DEFAULT_PORT
     }
     
@@ -101,7 +118,7 @@ class PairingStore(private val context: Context) {
      */
     suspend fun setServerPort(port: Int) {
         require(port in 1..65535) { "Server port must be between 1 and 65535" }
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             prefs[SERVER_PORT] = port
         }
     }
@@ -109,15 +126,15 @@ class PairingStore(private val context: Context) {
     /**
      * Device name flow
      */
-    val deviceName: Flow<String> = context.dataStore.data.map { prefs ->
-        prefs[DEVICE_NAME] ?: android.os.Build.MODEL
+    val deviceName: Flow<String> = dataStore.data.map { prefs ->
+        prefs[DEVICE_NAME] ?: defaultDeviceName
     }
     
     /**
      * Set device name
      */
     suspend fun setDeviceName(name: String) {
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             prefs[DEVICE_NAME] = name
         }
     }
@@ -125,7 +142,7 @@ class PairingStore(private val context: Context) {
     /**
      * Get list of paired devices
      */
-    val pairedDevices: Flow<List<PairedDevice>> = context.dataStore.data.map { prefs ->
+    val pairedDevices: Flow<List<PairedDevice>> = dataStore.data.map { prefs ->
         val json = prefs[PAIRED_DEVICES] ?: "[]"
         try {
             protocolJson.decodeFromString<List<PairedDevice>>(json)
@@ -135,75 +152,91 @@ class PairingStore(private val context: Context) {
     }
     
     /**
-     * Add a paired device
+     * Authorize and record a paired device without ever persisting the raw token.
      */
-    suspend fun addPairedDevice(device: PairedDevice) {
-        context.dataStore.edit { prefs ->
-            val current = prefs[PAIRED_DEVICES]?.let {
-                try {
-                    protocolJson.decodeFromString<List<PairedDevice>>(it).toMutableList()
-                } catch (e: Exception) {
-                    mutableListOf()
-                }
-            } ?: mutableListOf()
-            
-            // Deduplicate by deviceUUID (phone's stable identifier); fall back to id.
-            current.removeAll {
-                (device.deviceUUID.isNotEmpty() && it.deviceUUID == device.deviceUUID) || it.id == device.id
-            }
-            current.add(device)
-            
-            prefs[PAIRED_DEVICES] = protocolJson.encodeToString(
-                kotlinx.serialization.builtins.ListSerializer(PairedDevice.serializer()),
-                current
-            )
+    suspend fun addAuthorizedPairedDevice(device: PairedDevice, token: String) {
+        val verifier = hashToken(token)
+        dataStore.edit { prefs ->
+            val verifiers = prefs.decodeStringSet(AUTHORIZED_TOKEN_VERIFIERS)
+            verifiers.add(verifier)
+            prefs.writeStringSet(AUTHORIZED_TOKEN_VERIFIERS, verifiers)
+            prefs.upsertPairedDevice(device.copy(token = "", tokenVerifier = verifier))
         }
     }
     
     /**
-     * Remove a paired device by id
-     */
-    suspend fun removePairedDevice(deviceId: String) {
-        context.dataStore.edit { prefs ->
-            val current = prefs[PAIRED_DEVICES]?.let {
-                try {
-                    protocolJson.decodeFromString<List<PairedDevice>>(it).toMutableList()
-                } catch (e: Exception) {
-                    mutableListOf()
-                }
-            } ?: mutableListOf()
-
-            current.removeAll { it.id == deviceId }
-
-            prefs[PAIRED_DEVICES] = protocolJson.encodeToString(
-                kotlinx.serialization.builtins.ListSerializer(PairedDevice.serializer()),
-                current
-            )
-        }
-    }
-
-    /**
      * Forget a paired device: remove from the list and revoke its token so it cannot reconnect.
      */
     suspend fun forgetDevice(device: PairedDevice) {
-        removePairedDevice(device.id)
-        if (device.token.isNotEmpty()) removeAuthorizedToken(device.token)
+        dataStore.edit { prefs ->
+            val devices = prefs.decodePairedDevices()
+            devices.removeAll { it.id == device.id }
+            prefs.writePairedDevices(devices)
+
+            val legacyTokens = prefs.decodeStringSet(AUTHORIZED_TOKENS)
+            if (device.token.isNotEmpty()) {
+                legacyTokens.remove(device.token)
+            }
+            prefs.writeStringSet(AUTHORIZED_TOKENS, legacyTokens)
+
+            val verifiers = prefs.decodeStringSet(AUTHORIZED_TOKEN_VERIFIERS)
+            if (device.tokenVerifier.isNotEmpty()) {
+                verifiers.remove(device.tokenVerifier)
+            }
+            if (device.token.isNotEmpty()) {
+                verifiers.remove(hashToken(device.token))
+            }
+            prefs.writeStringSet(AUTHORIZED_TOKEN_VERIFIERS, verifiers)
+        }
     }
 
     /**
      * Forget all paired devices and clear all authorized tokens.
      */
     suspend fun forgetAllDevices() {
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             prefs[PAIRED_DEVICES] = "[]"
             prefs[AUTHORIZED_TOKENS] = "[]"
+            prefs[AUTHORIZED_TOKEN_VERIFIERS] = "[]"
         }
     }
 
     // ── Per-device token authorization ────────────────────────────────────────
 
-    private suspend fun getAuthorizedTokenSet(): MutableSet<String> {
-        val json = context.dataStore.data.first()[AUTHORIZED_TOKENS] ?: "[]"
+    fun hashToken(token: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hashBytes = digest.digest(token.toByteArray(Charsets.UTF_8))
+        return hashBytes.joinToString("") { "%02x".format(it) }
+    }
+
+    private fun Preferences.decodePairedDevices(): MutableList<PairedDevice> {
+        val json = this[PAIRED_DEVICES] ?: "[]"
+        return try {
+            protocolJson.decodeFromString<List<PairedDevice>>(json).toMutableList()
+        } catch (e: Exception) {
+            mutableListOf()
+        }
+    }
+
+    private fun MutablePreferences.writePairedDevices(devices: List<PairedDevice>) {
+        this[PAIRED_DEVICES] = protocolJson.encodeToString(
+            ListSerializer(PairedDevice.serializer()),
+            devices,
+        )
+    }
+
+    private fun MutablePreferences.upsertPairedDevice(device: PairedDevice) {
+        val devices = decodePairedDevices()
+        devices.removeAll {
+            (device.deviceUUID.isNotEmpty() && it.deviceUUID == device.deviceUUID) ||
+                it.id == device.id
+        }
+        devices.add(device)
+        writePairedDevices(devices)
+    }
+
+    private fun Preferences.decodeStringSet(key: Preferences.Key<String>): MutableSet<String> {
+        val json = this[key] ?: "[]"
         return try {
             protocolJson.decodeFromString<List<String>>(json).toMutableSet()
         } catch (e: Exception) {
@@ -211,34 +244,55 @@ class PairingStore(private val context: Context) {
         }
     }
 
-    suspend fun isTokenAuthorized(token: String): Boolean =
-        getAuthorizedTokenSet().contains(token)
+    private fun MutablePreferences.writeStringSet(
+        key: Preferences.Key<String>,
+        values: Set<String>,
+    ) {
+        this[key] = protocolJson.encodeToString(
+            ListSerializer(String.serializer()),
+            values.toList(),
+        )
+    }
 
-    suspend fun addAuthorizedToken(token: String) {
-        context.dataStore.edit { prefs ->
-            val set = prefs[AUTHORIZED_TOKENS]?.let {
-                try { protocolJson.decodeFromString<List<String>>(it).toMutableSet() }
-                catch (e: Exception) { mutableSetOf() }
-            } ?: mutableSetOf()
-            set.add(token)
-            prefs[AUTHORIZED_TOKENS] = protocolJson.encodeToString(
-                kotlinx.serialization.builtins.ListSerializer(kotlinx.serialization.serializer<String>()),
-                set.toList()
-            )
+    private fun MutablePreferences.migratePairedDeviceToken(token: String, verifier: String) {
+        val devices = decodePairedDevices()
+        var changed = false
+        val migrated = devices.map { device ->
+            if (device.token == token) {
+                changed = true
+                device.copy(token = "", tokenVerifier = verifier)
+            } else {
+                device
+            }
+        }
+        if (changed) {
+            writePairedDevices(migrated)
         }
     }
 
-    suspend fun removeAuthorizedToken(token: String) {
-        context.dataStore.edit { prefs ->
-            val set = prefs[AUTHORIZED_TOKENS]?.let {
-                try { protocolJson.decodeFromString<List<String>>(it).toMutableSet() }
-                catch (e: Exception) { mutableSetOf() }
-            } ?: mutableSetOf()
-            set.remove(token)
-            prefs[AUTHORIZED_TOKENS] = protocolJson.encodeToString(
-                kotlinx.serialization.builtins.ListSerializer(kotlinx.serialization.serializer<String>()),
-                set.toList()
-            )
+    suspend fun isTokenAuthorized(token: String): Boolean {
+        val verifier = hashToken(token)
+        var authorized = false
+        dataStore.edit { prefs ->
+            val verifiers = prefs.decodeStringSet(AUTHORIZED_TOKEN_VERIFIERS)
+            val legacyTokens = prefs.decodeStringSet(AUTHORIZED_TOKENS)
+            if (verifier in verifiers) {
+                if (legacyTokens.remove(token)) {
+                    prefs.writeStringSet(AUTHORIZED_TOKENS, legacyTokens)
+                }
+                prefs.migratePairedDeviceToken(token, verifier)
+                authorized = true
+                return@edit
+            }
+
+            if (legacyTokens.remove(token)) {
+                verifiers.add(verifier)
+                prefs.writeStringSet(AUTHORIZED_TOKENS, legacyTokens)
+                prefs.writeStringSet(AUTHORIZED_TOKEN_VERIFIERS, verifiers)
+                prefs.migratePairedDeviceToken(token, verifier)
+                authorized = true
+            }
         }
+        return authorized
     }
 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
@@ -320,14 +320,13 @@ class ServerService : Service() {
                 isTokenAuthorized = { token -> pairingStore.isTokenAuthorized(token) },
                 onPairingApproved = { deviceName, deviceUUID ->
                     val newToken = java.util.UUID.randomUUID().toString()
-                    pairingStore.addAuthorizedToken(newToken)
-                    pairingStore.addPairedDevice(
+                    pairingStore.addAuthorizedPairedDevice(
                         com.playbridge.player.model.PairedDevice(
                             id = java.util.UUID.randomUUID().toString(),
                             name = deviceName,
                             deviceUUID = deviceUUID,
-                            token = newToken
-                        )
+                        ),
+                        newToken,
                     )
                     newToken
                 },

--- a/tv/android/player/app/src/test/java/com/playbridge/player/pairing/PairingStoreTest.kt
+++ b/tv/android/player/app/src/test/java/com/playbridge/player/pairing/PairingStoreTest.kt
@@ -1,0 +1,145 @@
+package com.playbridge.player.pairing
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.playbridge.player.model.PairedDevice
+import com.playbridge.shared.protocol.protocolJson
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class PairingStoreTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val dataStoreScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var store: PairingStore
+
+    @Before
+    fun setUp() {
+        dataStore = PreferenceDataStoreFactory.create(scope = dataStoreScope) {
+            File(temporaryFolder.root, "pairing_store.preferences_pb")
+        }
+        store = PairingStore(dataStore)
+    }
+
+    @After
+    fun tearDown() {
+        dataStoreScope.cancel()
+    }
+
+    @Test
+    fun `new pairing stores only a verifier and revokes it when forgotten`() = runTest {
+        val token = "new-pairing-token"
+        val device = PairedDevice(id = "device-1", name = "Phone", deviceUUID = "phone-1")
+
+        store.addAuthorizedPairedDevice(device, token)
+
+        val storedDevice = store.pairedDevices.first().single()
+        val verifier = store.hashToken(token)
+        assertEquals("", storedDevice.token)
+        assertEquals(verifier, storedDevice.tokenVerifier)
+        assertTrue(store.isTokenAuthorized(token))
+        assertFalse(store.isTokenAuthorized(verifier))
+        assertEquals(setOf(verifier), storedStringSet(AUTHORIZED_TOKEN_VERIFIERS))
+        assertTrue(storedStringSet(AUTHORIZED_TOKENS).isEmpty())
+
+        store.forgetDevice(storedDevice)
+
+        assertTrue(store.pairedDevices.first().isEmpty())
+        assertFalse(store.isTokenAuthorized(token))
+        assertTrue(storedStringSet(AUTHORIZED_TOKEN_VERIFIERS).isEmpty())
+    }
+
+    @Test
+    fun `legacy authorization migrates token and paired device atomically`() = runTest {
+        val token = "legacy-token"
+        val device = PairedDevice(
+            id = "device-2",
+            name = "Legacy Phone",
+            deviceUUID = "phone-2",
+            token = token,
+        )
+        seedState(device = device, legacyTokens = setOf(token))
+
+        assertTrue(store.isTokenAuthorized(token))
+
+        val verifier = store.hashToken(token)
+        val migratedDevice = store.pairedDevices.first().single()
+        assertEquals("", migratedDevice.token)
+        assertEquals(verifier, migratedDevice.tokenVerifier)
+        assertTrue(storedStringSet(AUTHORIZED_TOKENS).isEmpty())
+        assertEquals(setOf(verifier), storedStringSet(AUTHORIZED_TOKEN_VERIFIERS))
+        assertTrue(store.isTokenAuthorized(token))
+        assertFalse(store.isTokenAuthorized(verifier))
+    }
+
+    @Test
+    fun `existing verifier migrates a leftover plaintext paired device`() = runTest {
+        val token = "partially-migrated-token"
+        val verifier = store.hashToken(token)
+        val device = PairedDevice(
+            id = "device-3",
+            name = "Partially Migrated Phone",
+            deviceUUID = "phone-3",
+            token = token,
+        )
+        seedState(device = device, verifiers = setOf(verifier))
+
+        assertTrue(store.isTokenAuthorized(token))
+
+        val migratedDevice = store.pairedDevices.first().single()
+        assertEquals("", migratedDevice.token)
+        assertEquals(verifier, migratedDevice.tokenVerifier)
+    }
+
+    private suspend fun seedState(
+        device: PairedDevice,
+        legacyTokens: Set<String> = emptySet(),
+        verifiers: Set<String> = emptySet(),
+    ) {
+        dataStore.edit { prefs ->
+            prefs[PAIRED_DEVICES] = protocolJson.encodeToString(
+                ListSerializer(PairedDevice.serializer()),
+                listOf(device),
+            )
+            prefs[AUTHORIZED_TOKENS] = protocolJson.encodeToString(
+                ListSerializer(String.serializer()),
+                legacyTokens.toList(),
+            )
+            prefs[AUTHORIZED_TOKEN_VERIFIERS] = protocolJson.encodeToString(
+                ListSerializer(String.serializer()),
+                verifiers.toList(),
+            )
+        }
+    }
+
+    private suspend fun storedStringSet(key: Preferences.Key<String>): Set<String> {
+        val json = dataStore.data.first()[key] ?: "[]"
+        return protocolJson.decodeFromString<List<String>>(json).toSet()
+    }
+
+    companion object {
+        private val PAIRED_DEVICES = stringPreferencesKey("paired_devices")
+        private val AUTHORIZED_TOKENS = stringPreferencesKey("authorized_tokens")
+        private val AUTHORIZED_TOKEN_VERIFIERS = stringPreferencesKey("authorized_token_verifiers")
+    }
+}


### PR DESCRIPTION
## Summary

- Persist SHA-256 verifiers instead of raw Android TV pairing tokens.
- Store newly authorized devices and verifiers in one DataStore transaction.
- Atomically migrate legacy and partially migrated plaintext device records after successful authentication.
- Revoke device records and every compatible credential representation atomically.
- Reject attempts to replay persisted verifiers as bearer tokens.
- Record the pinned upstream WebRTC lint findings in a location-specific module baseline without modifying vendored source.
- Run Android workflows whenever the shared vendored WebRTC runtime changes.

## Verification

```bash
# Focused Android TV security tests
zsh -c "source ~/.zshrc && ./gradlew :player:app:testFossDebugUnitTest --tests 'com.playbridge.player.pairing.PairingStoreTest'"

# Exact Android PR workflow commands
cd mobile/android
zsh -c "source ~/.zshrc && ./gradlew assembleDebug check --stacktrace"

cd ../../tv/android
zsh -c "source ~/.zshrc && ./gradlew assembleDebug check --stacktrace"
```

Both Gradle roots report no new WebRTC lint issues; the baseline records 21 upstream errors and 58 upstream warnings by exact source location so newly introduced findings still fail CI.

Replaces #193.
