### PR TITLE
chore(agents): add android-adb device control skill

### DIFF
--- a/.agents/skills/android-adb/SKILL.md
+++ b/.agents/skills/android-adb/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: android-adb
+description: Android device control via raw ADB commands. Use for device/emulator discovery, USB or Wi-Fi connection, app launch/force-stop, tap/swipe/keyevent/text input, screenshots, UI hierarchy dump, APK install/uninstall, and ADB troubleshooting on phone or TV hardware.
+---
+
+# Android ADB
+
+Reference for controlling Android devices with raw `adb` commands.
+
+Upstream source: [httprunner/skills `android-adb`](https://github.com/httprunner/skills/blob/main/android-adb/SKILL.md)
+([skills.sh](https://www.skills.sh/httprunner/skills/android-adb)). Adapted for PlayBridge agent workflows.
+
+## PlayBridge context
+
+- Phone package: `com.playbridge.sender`
+- TV package: `com.playbridge.player`
+- Phone Gradle root: `mobile/android/`
+- TV Gradle root: `tv/android/`
+- For phone logcat tag recipes (detection, cast, proxy, downloads), also read
+  `mobile/android/docs/logging.md` after this skill.
+- Prefer debug APKs when verifying detection / proxy / network dumps; many of
+  those paths are gated on `BuildConfig.DEBUG`.
+- On macOS shells, quote logcat filters that contain `*:S` so zsh does not glob.
+
+## Execution Constraints
+
+- Use `adb -s <serial>` whenever more than one device is connected.
+- Confirm screen resolution before coordinate actions: `adb -s SERIAL shell wm size`.
+- Ask for missing required inputs before executing (serial, package/activity, coordinates, APK path).
+- Surface actionable stderr on failure (authorization, cable/network, tcpip state).
+- Prefer ADB Keyboard broadcast for CJK and special character input when ADB Keyboard is installed.
+
+## Device And Server
+
+```bash
+# Start ADB server
+adb start-server
+
+# Stop ADB server
+adb kill-server
+
+# List devices
+adb devices -l
+
+# Target a specific device (use when multiple devices are online)
+adb -s SERIAL <command>
+```
+
+## Wi-Fi Connection
+
+```bash
+# Enable tcpip (USB required first)
+adb -s SERIAL tcpip 5555
+
+# Get device IP
+adb -s SERIAL shell ip route | grep src
+# or
+adb -s SERIAL shell ip addr show wlan0
+
+# Connect over network
+adb connect <ip>:5555
+
+# Disconnect
+adb disconnect <ip>:5555
+```
+
+## Device State
+
+```bash
+# Screen size
+adb -s SERIAL shell wm size
+
+# Current foreground app (package/activity from mCurrentFocus)
+adb -s SERIAL shell dumpsys window | grep -E 'mCurrentFocus|mFocusedApp'
+
+# Get home launcher package (for back-home detection)
+adb -s SERIAL shell cmd package resolve-activity --brief -c android.intent.category.HOME
+
+# Raw shell command
+adb -s SERIAL shell <command>
+```
+
+## App Lifecycle
+
+```bash
+# Verify package installed
+adb -s SERIAL shell pm list packages | grep <package>
+
+# Launch by package (via monkey)
+adb -s SERIAL shell monkey -p <package> -c android.intent.category.LAUNCHER 1
+
+# Launch by activity
+adb -s SERIAL shell am start -W -n <package>/<activity>
+
+# Launch by URI/scheme
+adb -s SERIAL shell am start -W -a android.intent.action.VIEW -d "<scheme://path>"
+
+# Force-stop
+adb -s SERIAL shell am force-stop <package>
+```
+
+## Input Actions
+
+```bash
+# Tap
+adb -s SERIAL shell input tap X Y
+
+# Double tap (two taps with short delay)
+adb -s SERIAL shell input tap X Y && sleep 0.1 && adb -s SERIAL shell input tap X Y
+
+# Long press (swipe to same point with duration)
+adb -s SERIAL shell input swipe X Y X Y 3000
+
+# Swipe
+adb -s SERIAL shell input swipe X1 Y1 X2 Y2 [duration_ms]
+
+# Key event
+adb -s SERIAL shell input keyevent KEYCODE_BACK
+adb -s SERIAL shell input keyevent KEYCODE_HOME
+adb -s SERIAL shell input keyevent KEYCODE_ENTER
+
+# Return to home (press BACK repeatedly, check foreground against home launcher)
+for i in $(seq 1 20); do
+  adb -s SERIAL shell input keyevent KEYCODE_BACK
+  sleep 0.5
+  # Check if home reached by comparing current focus to home package
+  CURRENT=$(adb -s SERIAL shell dumpsys window | grep mCurrentFocus)
+  echo "Round $i: $CURRENT"
+done
+```
+
+## Text Input
+
+```bash
+# Plain text input (ASCII only, spaces escaped as %s)
+adb -s SERIAL shell input text "hello%sworld"
+
+# Input via ADB Keyboard (supports CJK and special characters)
+# First ensure ADB Keyboard is active:
+adb -s SERIAL shell ime set com.android.adbkeyboard/.AdbIME
+# Then send text (base64 encoded):
+adb -s SERIAL shell am broadcast -a ADB_INPUT_B64 --es msg "$(echo -n 'your text' | base64)"
+
+# Clear text via ADB Keyboard
+adb -s SERIAL shell am broadcast -a ADB_CLEAR_TEXT
+```
+
+## Screenshot And UI Tree
+
+```bash
+# Screenshot to local file
+adb -s SERIAL exec-out screencap -p > screenshot.png
+
+# Screenshot to device then pull
+adb -s SERIAL shell screencap -p /sdcard/screen.png
+adb -s SERIAL pull /sdcard/screen.png ./screen.png
+
+# Dump UI hierarchy XML
+adb -s SERIAL shell uiautomator dump /sdcard/window_dump.xml
+adb -s SERIAL pull /sdcard/window_dump.xml ./window_dump.xml
+```
+
+## App Install And Uninstall
+
+```bash
+# Install APK (replace existing)
+adb -s SERIAL install -r /path/to/app.apk
+
+# Uninstall
+adb -s SERIAL uninstall <package>
+```
+
+## PlayBridge install shortcuts
+
+```bash
+# Phone FOSS debug (after assemble from mobile/android)
+adb -s SERIAL install -r app/build/outputs/apk/foss/debug/app-foss-*-debug.apk
+
+# TV FOSS debug (after assemble from tv/android)
+adb -s SERIAL install -r player/app/build/outputs/apk/foss/debug/app-foss-*-debug.apk
+
+# Launch phone / TV
+adb -s SERIAL shell monkey -p com.playbridge.sender -c android.intent.category.LAUNCHER 1
+adb -s SERIAL shell monkey -p com.playbridge.player -c android.intent.category.LAUNCHER 1
+```
+
+## Common Keycodes
+
+| Keycode | Description |
+|---------|-------------|
+| `KEYCODE_BACK` | Back button |
+| `KEYCODE_HOME` | Home button |
+| `KEYCODE_ENTER` | Enter/confirm |
+| `KEYCODE_DEL` | Delete/backspace |
+| `KEYCODE_VOLUME_UP` | Volume up |
+| `KEYCODE_VOLUME_DOWN` | Volume down |
+| `KEYCODE_POWER` | Power button |
+| `KEYCODE_TAB` | Tab key |
+| `KEYCODE_ESCAPE` | Escape key |

--- a/.agents/skills/android-adb/SKILL.md
+++ b/.agents/skills/android-adb/SKILL.md
@@ -1,199 +1,316 @@
 ---
 name: android-adb
-description: Android device control via raw ADB commands. Use for device/emulator discovery, USB or Wi-Fi connection, app launch/force-stop, tap/swipe/keyevent/text input, screenshots, UI hierarchy dump, APK install/uninstall, and ADB troubleshooting on phone or TV hardware.
+description: Android device control via raw ADB for PlayBridge phone/TV work. Use when discovering devices on the LAN, connecting over Wi-Fi ADB, force-stopping apps, rebuilding and installing FOSS debug APKs with ABI splits, launching apps, screenshots, UI dumps, input, logcat, or ADB troubleshooting.
 ---
 
 # Android ADB
 
-Reference for controlling Android devices with raw `adb` commands.
+Reference for controlling Android devices with raw `adb` commands during PlayBridge Android work.
 
 Upstream source: [httprunner/skills `android-adb`](https://github.com/httprunner/skills/blob/main/android-adb/SKILL.md)
-([skills.sh](https://www.skills.sh/httprunner/skills/android-adb)). Adapted for PlayBridge agent workflows.
+([skills.sh](https://www.skills.sh/httprunner/skills/android-adb)). Extended with PlayBridge LAN discovery, Smart TV preference, ABI-split installs, and stop → rebuild → install → launch flow.
 
 ## PlayBridge context
 
-- Phone package: `com.playbridge.sender`
-- TV package: `com.playbridge.player`
-- Phone Gradle root: `mobile/android/`
-- TV Gradle root: `tv/android/`
-- For phone logcat tag recipes (detection, cast, proxy, downloads), also read
-  `mobile/android/docs/logging.md` after this skill.
-- Prefer debug APKs when verifying detection / proxy / network dumps; many of
-  those paths are gated on `BuildConfig.DEBUG`.
-- On macOS shells, quote logcat filters that contain `*:S` so zsh does not glob.
+| Item | Value |
+|---|---|
+| Phone package | `com.playbridge.sender` |
+| TV package | `com.playbridge.player` |
+| Phone Gradle root | `mobile/android/` |
+| TV Gradle root | `tv/android/` |
+| Phone FOSS debug APKs | `mobile/android/app/build/outputs/apk/foss/debug/app-foss-*-debug.apk` |
+| TV FOSS debug APKs | `tv/android/player/app/build/outputs/apk/foss/debug/app-foss-*-debug.apk` |
+| Default ADB port | `5555` |
 
-## Execution Constraints
+- Prefer **debug / FOSS debug** APKs for on-device verification. Many detection, proxy, and network dumps are gated on `BuildConfig.DEBUG`.
+- On macOS, quote logcat filters that contain `*:S` so zsh does not glob.
+- For phone logcat tag recipes, also read `mobile/android/docs/logging.md`.
+- Always run Gradle from the project that owns the change, via:
+  `zsh -c "source ~/.zshrc && ./gradlew …"`.
 
-- Use `adb -s <serial>` whenever more than one device is connected.
-- Confirm screen resolution before coordinate actions: `adb -s SERIAL shell wm size`.
-- Ask for missing required inputs before executing (serial, package/activity, coordinates, APK path).
-- Surface actionable stderr on failure (authorization, cable/network, tcpip state).
-- Prefer ADB Keyboard broadcast for CJK and special character input when ADB Keyboard is installed.
+## Default workflow for Android work
 
-## Device And Server
+When the user is working on Android phone or TV and on-device verification is useful (or they ask to install/run), do this **before** assuming a serial:
+
+1. **Discover** devices already known to ADB and on the LAN (see [LAN discovery](#lan-discovery)).
+2. **Classify** each hit (phone vs TV / Smart TV, authorized vs unauthorized, PlayBridge package present).
+3. **Prefer**:
+   - TV / `tv/android` work → **Smart TV** targets first (`SmartTV`, Hisense/BRAVIA/Android TV leanback, `com.playbridge.player` installed, `_androidtvremote2` / Cast TV names).
+   - Phone / `mobile/android` work → phone / non-TV targets first (`com.playbridge.sender`, handheld product).
+4. **List** candidates to the user (IP/serial, name, model, ADB state, package presence).
+5. **Ask** which device to use when more than one is usable, or when the preferred class is missing / unauthorized.
+6. **Connect** with `adb connect <ip>:5555` and keep using `adb -s SERIAL` for every later command.
+7. For install/run cycles, use [Stop → rebuild → install → launch](#stop--rebuild--install--launch).
+
+Do **not** silently pick a random device when several are online. Do **not** treat `unauthorized` as connected.
+
+## Execution constraints
+
+- Use `adb -s <serial>` whenever more than one device is listed (including leftover unauthorized entries).
+- Confirm screen resolution before coordinate taps: `adb -s SERIAL shell wm size`.
+- Ask for missing required inputs (serial when ambiguous, coordinates, APK path outside the defaults).
+- Surface actionable stderr (authorization dialog, offline, `INSTALL_FAILED_NO_MATCHING_ABIS`, tcpip/Wi-Fi issues).
+- Prefer ADB Keyboard broadcast for CJK / special characters when that IME is installed.
+
+## LAN discovery
+
+### 1. Known ADB devices
 
 ```bash
-# Start ADB server
 adb start-server
-
-# Stop ADB server
-adb kill-server
-
-# List devices
 adb devices -l
-
-# Target a specific device (use when multiple devices are online)
-adb -s SERIAL <command>
 ```
 
-## Wi-Fi Connection
+### 2. Find local IPv4 subnet
 
 ```bash
-# Enable tcpip (USB required first)
-adb -s SERIAL tcpip 5555
-
-# Get device IP
-adb -s SERIAL shell ip route | grep src
-# or
-adb -s SERIAL shell ip addr show wlan0
-
-# Connect over network
-adb connect <ip>:5555
-
-# Disconnect
-adb disconnect <ip>:5555
+ipconfig getifaddr en0   # common Wi-Fi on macOS
+# fallback: other en* / ifconfig inet lines excluding 127.0.0.1 and VPN tunnels if needed
 ```
 
-## Device State
+### 3. Scan the /24 for TCP 5555
 
 ```bash
-# Screen size
+python3 - <<'PY'
+import concurrent.futures, socket, time
+subnet = "192.168.1."  # replace with local /24 prefix
+port, timeout = 5555, 0.35
+
+def probe(ip: str):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+    try:
+        start = time.time()
+        s.connect((ip, port))
+        return ip, (time.time() - start) * 1000
+    except Exception:
+        return ip, None
+    finally:
+        s.close()
+
+open_hosts = []
+with concurrent.futures.ThreadPoolExecutor(max_workers=64) as ex:
+    for ip, ms in ex.map(probe, [f"{subnet}{i}" for i in range(1, 255)]):
+        if ms is not None:
+            open_hosts.append((ip, ms))
+for ip, ms in sorted(open_hosts, key=lambda t: tuple(map(int, t[0].split(".")))):
+    print(f"{ip}:{port} open rtt_ms={ms:.0f}")
+PY
+```
+
+### 4. Optional mDNS labels (names only; still verify via ADB)
+
+```bash
+# brief browse; kill after a few seconds
+dns-sd -B _androidtvremote2._tcp local.
+dns-sd -B _adb._tcp local.
+dns-sd -B _googlecast._tcp local.
+```
+
+Useful instance-name hints: `SmartTV…`, `BRAVIA…`, `Master bedroom TV`, `GoogleTV…`.
+
+### 5. Probe each open host
+
+```bash
+adb connect IP:5555
+adb devices -l
+```
+
+For each `device` (authorized) serial:
+
+```bash
+SERIAL=IP:5555
+adb -s "$SERIAL" shell getprop ro.product.manufacturer
+adb -s "$SERIAL" shell getprop ro.product.model
+adb -s "$SERIAL" shell getprop ro.product.cpu.abi
+adb -s "$SERIAL" shell getprop ro.product.cpu.abilist
+adb -s "$SERIAL" shell settings get global device_name
+adb -s "$SERIAL" shell pm path com.playbridge.player
+adb -s "$SERIAL" shell pm path com.playbridge.sender
+adb -s "$SERIAL" shell pm list packages | grep -E 'leanback|android.tv' | head
+```
+
+Present a table to the user, for example:
+
+| Serial | Name | Model | Kind | ADB | PlayBridge |
+|---|---|---|---|---|---|
+| `192.168.1.34:5555` | Master bedroom TV | Hisense SmartTV 4K FFM | Smart TV | device | `player` |
+| `192.168.1.32:5555` | ? | ? | ? | unauthorized | — |
+
+Then ask which serial to use (default recommendation: Smart TV for TV work).
+
+## Wi-Fi / USB connection
+
+```bash
+# USB first-time wireless enable
+adb -s USB_SERIAL tcpip 5555
+adb -s USB_SERIAL shell ip route | grep src
+
+adb connect IP:5555
+adb disconnect IP:5555
+```
+
+`unauthorized` → user must accept the RSA prompt on the TV/phone. Re-run `adb connect` / `adb devices -l` after they accept.
+
+## Device state
+
+```bash
 adb -s SERIAL shell wm size
-
-# Current foreground app (package/activity from mCurrentFocus)
 adb -s SERIAL shell dumpsys window | grep -E 'mCurrentFocus|mFocusedApp'
-
-# Get home launcher package (for back-home detection)
+adb -s SERIAL shell dumpsys activity activities | grep -E 'mResumedActivity|topResumedActivity'
+adb -s SERIAL shell pidof com.playbridge.player   # or com.playbridge.sender
 adb -s SERIAL shell cmd package resolve-activity --brief -c android.intent.category.HOME
-
-# Raw shell command
-adb -s SERIAL shell <command>
 ```
 
-## App Lifecycle
+## App lifecycle
 
 ```bash
-# Verify package installed
-adb -s SERIAL shell pm list packages | grep <package>
-
-# Launch by package (via monkey)
-adb -s SERIAL shell monkey -p <package> -c android.intent.category.LAUNCHER 1
-
-# Launch by activity
-adb -s SERIAL shell am start -W -n <package>/<activity>
-
-# Launch by URI/scheme
-adb -s SERIAL shell am start -W -a android.intent.action.VIEW -d "<scheme://path>"
-
-# Force-stop
-adb -s SERIAL shell am force-stop <package>
+adb -s SERIAL shell pm list packages | grep playbridge
+adb -s SERIAL shell am force-stop com.playbridge.player
+adb -s SERIAL shell am force-stop com.playbridge.sender
+adb -s SERIAL shell monkey -p com.playbridge.player -c android.intent.category.LAUNCHER 1
+adb -s SERIAL shell monkey -p com.playbridge.sender -c android.intent.category.LAUNCHER 1
+adb -s SERIAL shell am start -W -n com.playbridge.player/.MainActivity
 ```
 
-## Input Actions
+## Stop → rebuild → install → launch
+
+Standard on-device loop after code changes (TV example; swap roots/packages for phone).
+
+### 1. Force-stop
 
 ```bash
-# Tap
+SERIAL=192.168.1.34:5555   # chosen target
+adb -s "$SERIAL" shell am force-stop com.playbridge.player
+adb -s "$SERIAL" shell pidof com.playbridge.player || echo stopped
+```
+
+### 2. Rebuild FOSS debug from the owning root
+
+```bash
+# TV
+cd tv/android
+zsh -c "source ~/.zshrc && ./gradlew :player:app:assembleFossDebug"
+
+# Phone
+cd mobile/android
+zsh -c "source ~/.zshrc && ./gradlew :app:assembleFossDebug"
+```
+
+Outputs (ABI splits + universal):
+
+- TV: `player/app/build/outputs/apk/foss/debug/app-foss-{arm64-v8a,armeabi-v7a,universal}-debug.apk`
+- Phone: `app/build/outputs/apk/foss/debug/app-foss-{arm64-v8a,armeabi-v7a,universal}-debug.apk`
+
+### 3. Pick APK by device ABI
+
+```bash
+ABI=$(adb -s "$SERIAL" shell getprop ro.product.cpu.abi | tr -d '\r')
+# Examples seen in the field:
+#   arm64-v8a  → app-foss-arm64-v8a-debug.apk
+#   armeabi-v7a → app-foss-armeabi-v7a-debug.apk   # some Hisense Smart TVs are 32-bit only
+```
+
+Match split APK to ABI. If install fails with `INSTALL_FAILED_NO_MATCHING_ABIS`, install the other ABI split or the universal APK — **do not** assume every TV is arm64.
+
+```bash
+# TV paths from tv/android
+case "$ABI" in
+  arm64-v8a) APK=player/app/build/outputs/apk/foss/debug/app-foss-arm64-v8a-debug.apk ;;
+  armeabi-v7a|armeabi) APK=player/app/build/outputs/apk/foss/debug/app-foss-armeabi-v7a-debug.apk ;;
+  *) APK=player/app/build/outputs/apk/foss/debug/app-foss-universal-debug.apk ;;
+esac
+
+adb -s "$SERIAL" install -r "$APK"
+```
+
+### 4. Launch and verify foreground
+
+```bash
+adb -s "$SERIAL" shell monkey -p com.playbridge.player -c android.intent.category.LAUNCHER 1
+sleep 2
+adb -s "$SERIAL" shell pidof com.playbridge.player
+adb -s "$SERIAL" shell dumpsys window | grep -E 'mCurrentFocus|mFocusedApp'
+adb -s "$SERIAL" shell dumpsys package com.playbridge.player | grep -E 'versionName|versionCode|lastUpdateTime|primaryCpuAbi'
+```
+
+Success looks like focus/resumed activity on `com.playbridge.player/.MainActivity` (or the phone equivalent) and a non-empty `pidof`.
+
+### Phone variant
+
+Same loop with:
+
+- package `com.playbridge.sender`
+- assemble `:app:assembleFossDebug` from `mobile/android`
+- APKs under `app/build/outputs/apk/foss/debug/`
+
+## Input actions
+
+```bash
 adb -s SERIAL shell input tap X Y
-
-# Double tap (two taps with short delay)
 adb -s SERIAL shell input tap X Y && sleep 0.1 && adb -s SERIAL shell input tap X Y
-
-# Long press (swipe to same point with duration)
 adb -s SERIAL shell input swipe X Y X Y 3000
-
-# Swipe
 adb -s SERIAL shell input swipe X1 Y1 X2 Y2 [duration_ms]
-
-# Key event
 adb -s SERIAL shell input keyevent KEYCODE_BACK
 adb -s SERIAL shell input keyevent KEYCODE_HOME
 adb -s SERIAL shell input keyevent KEYCODE_ENTER
-
-# Return to home (press BACK repeatedly, check foreground against home launcher)
-for i in $(seq 1 20); do
-  adb -s SERIAL shell input keyevent KEYCODE_BACK
-  sleep 0.5
-  # Check if home reached by comparing current focus to home package
-  CURRENT=$(adb -s SERIAL shell dumpsys window | grep mCurrentFocus)
-  echo "Round $i: $CURRENT"
-done
+adb -s SERIAL shell input keyevent KEYCODE_DPAD_CENTER   # TV remote center
+adb -s SERIAL shell input keyevent KEYCODE_DPAD_UP
+adb -s SERIAL shell input keyevent KEYCODE_DPAD_DOWN
+adb -s SERIAL shell input keyevent KEYCODE_DPAD_LEFT
+adb -s SERIAL shell input keyevent KEYCODE_DPAD_RIGHT
 ```
 
-## Text Input
+## Text input
 
 ```bash
-# Plain text input (ASCII only, spaces escaped as %s)
+# ASCII only; spaces as %s
 adb -s SERIAL shell input text "hello%sworld"
 
-# Input via ADB Keyboard (supports CJK and special characters)
-# First ensure ADB Keyboard is active:
+# ADB Keyboard (CJK / special chars) when installed
 adb -s SERIAL shell ime set com.android.adbkeyboard/.AdbIME
-# Then send text (base64 encoded):
 adb -s SERIAL shell am broadcast -a ADB_INPUT_B64 --es msg "$(echo -n 'your text' | base64)"
-
-# Clear text via ADB Keyboard
 adb -s SERIAL shell am broadcast -a ADB_CLEAR_TEXT
 ```
 
-## Screenshot And UI Tree
+## Screenshot and UI tree
 
 ```bash
-# Screenshot to local file
 adb -s SERIAL exec-out screencap -p > screenshot.png
-
-# Screenshot to device then pull
-adb -s SERIAL shell screencap -p /sdcard/screen.png
-adb -s SERIAL pull /sdcard/screen.png ./screen.png
-
-# Dump UI hierarchy XML
 adb -s SERIAL shell uiautomator dump /sdcard/window_dump.xml
 adb -s SERIAL pull /sdcard/window_dump.xml ./window_dump.xml
 ```
 
-## App Install And Uninstall
+## Install / uninstall
 
 ```bash
-# Install APK (replace existing)
 adb -s SERIAL install -r /path/to/app.apk
-
-# Uninstall
-adb -s SERIAL uninstall <package>
+adb -s SERIAL uninstall com.playbridge.player
+adb -s SERIAL uninstall com.playbridge.sender
 ```
 
-## PlayBridge install shortcuts
-
-```bash
-# Phone FOSS debug (after assemble from mobile/android)
-adb -s SERIAL install -r app/build/outputs/apk/foss/debug/app-foss-*-debug.apk
-
-# TV FOSS debug (after assemble from tv/android)
-adb -s SERIAL install -r player/app/build/outputs/apk/foss/debug/app-foss-*-debug.apk
-
-# Launch phone / TV
-adb -s SERIAL shell monkey -p com.playbridge.sender -c android.intent.category.LAUNCHER 1
-adb -s SERIAL shell monkey -p com.playbridge.player -c android.intent.category.LAUNCHER 1
-```
-
-## Common Keycodes
+## Common keycodes
 
 | Keycode | Description |
 |---------|-------------|
-| `KEYCODE_BACK` | Back button |
-| `KEYCODE_HOME` | Home button |
-| `KEYCODE_ENTER` | Enter/confirm |
-| `KEYCODE_DEL` | Delete/backspace |
-| `KEYCODE_VOLUME_UP` | Volume up |
-| `KEYCODE_VOLUME_DOWN` | Volume down |
-| `KEYCODE_POWER` | Power button |
-| `KEYCODE_TAB` | Tab key |
-| `KEYCODE_ESCAPE` | Escape key |
+| `KEYCODE_BACK` | Back |
+| `KEYCODE_HOME` | Home |
+| `KEYCODE_ENTER` | Enter |
+| `KEYCODE_DPAD_CENTER` | TV select / OK |
+| `KEYCODE_DPAD_UP` / `DOWN` / `LEFT` / `RIGHT` | TV d-pad |
+| `KEYCODE_DEL` | Delete |
+| `KEYCODE_VOLUME_UP` / `DOWN` | Volume |
+| `KEYCODE_POWER` | Power |
+| `KEYCODE_TAB` | Tab |
+| `KEYCODE_ESCAPE` | Escape |
+
+## Troubleshooting
+
+| Symptom | What to do |
+|---|---|
+| `unauthorized` | Accept RSA prompt on device; `adb kill-server && adb start-server`; reconnect |
+| No port 5555 open | Enable wireless debugging / ADB over network on the TV; or USB + `tcpip 5555` |
+| `INSTALL_FAILED_NO_MATCHING_ABIS` | Read `ro.product.cpu.abi` and install the matching split (many Smart TVs are `armeabi-v7a` only) |
+| Install succeeds, blank focus | Wait 1–2s and re-check `mCurrentFocus` / `mResumedActivity`; re-launch with `monkey` or `am start` |
+| Glob fails on logcat `*:S` | Quote filters in zsh |
+| Wrong app updated | Confirm package (`player` vs `sender`) and Gradle root before assemble |

--- a/.agents/skills/android-adb/agents/openai.yaml
+++ b/.agents/skills/android-adb/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android ADB"
+  short_description: "Control Android devices and emulators with raw ADB"
+  default_prompt: "Use $android-adb to drive the connected Android device or emulator."

--- a/.agents/skills/playbridge-android/SKILL.md
+++ b/.agents/skills/playbridge-android/SKILL.md
@@ -23,7 +23,7 @@ description: Work across PlayBridge's Android phone, Android TV, and shared Kotl
 5. Never log Debrid tokens, pairing credentials, signing material, or authenticated stream URLs.
 6. Preserve Google Cast's physical local-network binding around VPNs, application-ready handshake, fresh-session behavior after receiver exit, and distinction between stopping media and ending the receiver.
 7. For phone video detection / cast-sheet expectations (SPA soft-nav keeps rows, hard load clears, site patterns), see `docs/android-video-detection.md`.
-8. For device/emulator control (install, launch, input, screenshots, UI dump), load `android-adb`.
+8. For device/emulator control, load `android-adb`. Default on-device loop: LAN-scan for ADB (`:5555`), prefer Smart TV targets for `tv/android` work (phones for `mobile/android`), ask which device when multiple/unauthorized, then force-stop → FOSS debug rebuild → ABI-matched install → launch/verify.
 9. For phone `adb logcat` recipes (detection, cast, proxy, TV, downloads), see `mobile/android/docs/logging.md`.
 
 ## Verify

--- a/.agents/skills/playbridge-android/SKILL.md
+++ b/.agents/skills/playbridge-android/SKILL.md
@@ -23,7 +23,8 @@ description: Work across PlayBridge's Android phone, Android TV, and shared Kotl
 5. Never log Debrid tokens, pairing credentials, signing material, or authenticated stream URLs.
 6. Preserve Google Cast's physical local-network binding around VPNs, application-ready handshake, fresh-session behavior after receiver exit, and distinction between stopping media and ending the receiver.
 7. For phone video detection / cast-sheet expectations (SPA soft-nav keeps rows, hard load clears, site patterns), see `docs/android-video-detection.md`.
-8. For phone `adb logcat` recipes (detection, cast, proxy, TV, downloads), see `mobile/android/docs/logging.md`.
+8. For device/emulator control (install, launch, input, screenshots, UI dump), load `android-adb`.
+9. For phone `adb logcat` recipes (detection, cast, proxy, TV, downloads), see `mobile/android/docs/logging.md`.
 
 ## Verify
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Portable project skills live in `.agents/skills/` and are the canonical speciali
 | `release-and-publish` | The user explicitly requests an uprev or release (see also `docs/release.md`) |
 | `commit-and-open-pr` | Commit, push, or create/update a pull request without an implicit uprev |
 | `code-review-graph-workflow` | Explore, debug, review, or refactor using the repository graph |
+| `android-adb` | Drive a phone/TV device or emulator over ADB (install, launch, input, screenshots, UI dump) |
 
 ### Project specialists
 

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -1,5 +1,19 @@
-import java.util.Properties
-import java.io.FileInputStream
+import com.android.build.api.artifact.ScopedArtifact
+import com.android.build.api.variant.ScopedArtifacts
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
 
 
 plugins {
@@ -7,6 +21,76 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
+}
+
+@CacheableTask
+abstract class StripGeckoViewWebRtcClasses : DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val inputJars: ListProperty<RegularFile>
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val inputDirectories: ListProperty<Directory>
+
+    @get:OutputFile
+    abstract val outputJar: RegularFileProperty
+
+    @TaskAction
+    fun transform() {
+        val writtenEntries = HashSet<String>()
+        val output = outputJar.get().asFile
+        output.parentFile.mkdirs()
+
+        ZipOutputStream(output.outputStream().buffered()).use { jarOutput ->
+            inputDirectories.get().forEach { directory ->
+                val root = directory.asFile
+                root.walkTopDown()
+                    .filter { it.isFile }
+                    .forEach { file ->
+                        val entryName = file.relativeTo(root).invariantSeparatorsPath
+                        writeEntry(entryName, writtenEntries, jarOutput) {
+                            file.inputStream().buffered().use { it.copyTo(jarOutput) }
+                        }
+                    }
+            }
+
+            inputJars.get().forEach { regularFile ->
+                val jar = regularFile.asFile
+                val isGeckoView = jar.name.contains("geckoview", ignoreCase = true)
+                ZipInputStream(jar.inputStream().buffered()).use { jarInput ->
+                    while (true) {
+                        val entry = jarInput.nextEntry ?: break
+                        if (entry.isDirectory ||
+                            (isGeckoView && entry.name.startsWith("org/webrtc/"))
+                        ) {
+                            continue
+                        }
+                        writeEntry(entry.name, writtenEntries, jarOutput) {
+                            jarInput.copyTo(jarOutput)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun writeEntry(
+        name: String,
+        writtenEntries: MutableSet<String>,
+        output: ZipOutputStream,
+        writeContents: () -> Unit,
+    ) {
+        if (!writtenEntries.add(name)) {
+            check(!name.endsWith(".class") || name.startsWith("META-INF/")) {
+                "Duplicate class remained after filtering GeckoView: $name"
+            }
+            return
+        }
+        output.putNextEntry(ZipEntry(name).apply { time = 0L })
+        writeContents()
+        output.closeEntry()
+    }
 }
 
 val googleCastApplicationId = providers.gradleProperty("PLAYBRIDGE_GOOGLE_CAST_APP_ID")
@@ -18,6 +102,10 @@ val googleCastApplicationId = providers.gradleProperty("PLAYBRIDGE_GOOGLE_CAST_A
         }
         applicationId
     }
+
+val buildingAppBundle = gradle.startParameter.taskNames.any { taskName ->
+    taskName.substringAfterLast(':').contains("bundle", ignoreCase = true)
+}
 
 android {
     namespace = "com.playbridge.sender"
@@ -71,7 +159,8 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -109,11 +198,29 @@ android {
 
     splits {
         abi {
-            isEnable = true
+            // AGP cannot combine optimized resource shrinking, APK splits, and bundles.
+            // Keep split APKs for FOSS assembly; Play bundles perform their own ABI splits.
+            isEnable = !buildingAppBundle
             reset()
             include("armeabi-v7a", "arm64-v8a")
             isUniversalApk = true
         }
+    }
+}
+
+androidComponents {
+    onVariants(selector().withBuildType("release")) { variant ->
+        val taskName = "strip${variant.name.replaceFirstChar { it.uppercase() }}GeckoViewWebRtc"
+        val stripTask = tasks.register<StripGeckoViewWebRtcClasses>(taskName)
+        variant.artifacts
+            .forScope(ScopedArtifacts.Scope.ALL)
+            .use(stripTask)
+            .toTransform(
+                ScopedArtifact.CLASSES,
+                StripGeckoViewWebRtcClasses::inputJars,
+                StripGeckoViewWebRtcClasses::inputDirectories,
+                StripGeckoViewWebRtcClasses::outputJar,
+            )
     }
 }
 
@@ -186,7 +293,8 @@ dependencies {
     implementation(libs.moz.ui.widgets)
     implementation(libs.moz.ui.icons)
 
-    // GeckoView
+    // GeckoView also bundles upstream org.webrtc classes. The release scoped-artifact
+    // transform keeps PlayBridge's patched M150 runtime as the single packaged copy.
     implementation(libs.geckoview.omni)
 
     testImplementation(libs.junit)

--- a/mobile/android/app/proguard-rules.pro
+++ b/mobile/android/app/proguard-rules.pro
@@ -12,6 +12,24 @@
 #   public *;
 #}
 
+# TabManager accesses this private field through getDeclaredField().
+-keepclassmembers class mozilla.components.browser.engine.gecko.GeckoEngineSession {
+    org.mozilla.geckoview.GeckoSession geckoSession;
+}
+
+# Mozilla Nimbus can report through the optional Glean telemetry runtime.
+# PlayBridge does not package or initialize Glean.
+-dontwarn mozilla.telemetry.glean.Glean
+-dontwarn mozilla.telemetry.glean.GleanInternalAPI
+-dontwarn mozilla.telemetry.glean.internal.CommonMetricData
+-dontwarn mozilla.telemetry.glean.internal.DynamicLabelType
+-dontwarn mozilla.telemetry.glean.internal.Lifetime
+-dontwarn mozilla.telemetry.glean.internal.TimeUnit
+-dontwarn mozilla.telemetry.glean.private.EventExtras
+-dontwarn mozilla.telemetry.glean.private.EventMetricType
+-dontwarn mozilla.telemetry.glean.private.PingType
+-dontwarn mozilla.telemetry.glean.private.TimingDistributionMetricType
+
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
 #-keepattributes SourceFile,LineNumberTable

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -7,6 +7,10 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
+val buildingAppBundle = gradle.startParameter.taskNames.any { taskName ->
+    taskName.substringAfterLast(':').contains("bundle", ignoreCase = true)
+}
+
 android {
     namespace = "com.playbridge.player"
     compileSdk {
@@ -55,7 +59,8 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -99,7 +104,9 @@ android {
 
     splits {
         abi {
-            isEnable = true
+            // AGP cannot combine optimized resource shrinking, APK splits, and bundles.
+            // Keep split APKs for FOSS assembly; Play bundles perform their own ABI splits.
+            isEnable = !buildingAppBundle
             reset()
             include("armeabi-v7a", "arm64-v8a")
             isUniversalApk = true

--- a/tv/android/player/app/proguard-rules.pro
+++ b/tv/android/player/app/proguard-rules.pro
@@ -5,6 +5,11 @@
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
+# Ktor probes these JVM-only management classes when detecting IntelliJ debug
+# mode. Android does not provide them; the probe falls back to "not attached."
+-dontwarn java.lang.management.ManagementFactory
+-dontwarn java.lang.management.RuntimeMXBean
+
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface
 # class:


### PR DESCRIPTION
## Summary
- add the [httprunner `android-adb`](https://www.skills.sh/httprunner/skills/android-adb) skill under `.agents/skills/android-adb`
- include PlayBridge package IDs, install shortcuts, and a pointer to `mobile/android/docs/logging.md`
- register it in `AGENTS.md` and link it from `playbridge-android`

## Verification
- skill path and frontmatter match existing `.agents/skills/*` layout
- no app code changes