### PR TITLE
ci: standardize staged release publish flows

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -384,9 +384,6 @@ jobs:
 
             📋 [Changelog](https://github.com/playbridgeapp/playbridge/blob/phone-v${{ steps.versions.outputs.phone }}/mobile/android/CHANGELOG.md)
 
-            This is a **draft** candidate. Publish with **Actions → Android Publish**
-            (after any configured Play Store upload succeeds).
-
             > Download the `.apk` for your device's architecture (`arm64-v8a` for most modern devices) and sideload it.
           files: |
             output/phone-release-apk/*.apk
@@ -406,9 +403,6 @@ jobs:
             **TV Player:** v${{ steps.versions.outputs.player }}
 
             📋 [Changelog](https://github.com/playbridgeapp/playbridge/blob/tv-player-v${{ steps.versions.outputs.player }}/tv/android/CHANGELOG.md)
-
-            This is a **draft** candidate. Publish with **Actions → Android Publish**
-            (after any configured Play Store upload succeeds).
 
             > 💡 **Easy Install on TV**: Open the **Downloader** app on your Android TV / Fire TV and enter code **`9557748`** to download and install this release directly.
 
@@ -431,9 +425,6 @@ jobs:
             **TV GeckoView Plugin:** v${{ steps.versions.outputs.browser }}
 
             📋 [Changelog](https://github.com/playbridgeapp/playbridge/blob/tv-geckoview-plugin-v${{ steps.versions.outputs.browser }}/tv/android/CHANGELOG.md)
-
-            This is a **draft** candidate. Publish with **Actions → Android Publish**
-            (after any configured Play Store upload succeeds).
 
             > Download the `.apk` for your device's architecture (`arm64-v8a` for most modern devices) and sideload it.
           files: |

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -1,4 +1,7 @@
-name: Android Build
+name: Android Release Build
+
+# Stage 2: signed packages → draft GitHub Releases.
+# Stage 3: .github/workflows/android_publish.yml
 
 on:
   push:
@@ -324,15 +327,15 @@ jobs:
           s3://${{ secrets.R2_BUCKET }}/tv-geckoview-plugin-release-aab/ \
           --recursive --exclude "*" --include "*.aab"
 
-  release:
+  draft-release:
     needs: [build-phone, build-tv-player, build-tv-geckoview-plugin]
     if: |
       (success() || always()) &&
-      (needs.build-phone.outputs.skipped == 'false' || 
-       needs.build-tv-player.outputs.skipped == 'false' || 
+      (needs.build-phone.outputs.skipped == 'false' ||
+       needs.build-tv-player.outputs.skipped == 'false' ||
        needs.build-tv-geckoview-plugin.outputs.skipped == 'false') &&
-      (needs.build-phone.result != 'failure' && 
-       needs.build-tv-player.result != 'failure' && 
+      (needs.build-phone.result != 'failure' &&
+       needs.build-tv-player.result != 'failure' &&
        needs.build-tv-geckoview-plugin.result != 'failure')
     runs-on: ubuntu-latest
     permissions:
@@ -343,13 +346,19 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Download artifacts from R2
+      - name: Download build artifacts from R2
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
         run: |
-          aws s3 sync s3://${{ secrets.R2_BUCKET }}/ output/
+          mkdir -p output
+          aws s3 sync s3://${{ secrets.R2_BUCKET }}/phone-release-apk/ output/phone-release-apk/
+          aws s3 sync s3://${{ secrets.R2_BUCKET }}/phone-release-aab/ output/phone-release-aab/
+          aws s3 sync s3://${{ secrets.R2_BUCKET }}/tv-player-release-apk/ output/tv-player-release-apk/
+          aws s3 sync s3://${{ secrets.R2_BUCKET }}/tv-player-release-aab/ output/tv-player-release-aab/
+          aws s3 sync s3://${{ secrets.R2_BUCKET }}/tv-geckoview-plugin-release-apk/ output/tv-geckoview-plugin-release-apk/
+          aws s3 sync s3://${{ secrets.R2_BUCKET }}/tv-geckoview-plugin-release-aab/ output/tv-geckoview-plugin-release-aab/
 
       - name: Get versions
         id: versions
@@ -361,12 +370,13 @@ jobs:
           echo "player=$PLAYER" >> $GITHUB_OUTPUT
           echo "browser=$BROWSER" >> $GITHUB_OUTPUT
 
-      - name: Create Phone release
+      - name: Create Phone draft release
         if: needs.build-phone.outputs.skipped == 'false'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: phone-v${{ steps.versions.outputs.phone }}
           name: PlayBridge Phone v${{ steps.versions.outputs.phone }}
+          draft: true
           body: |
             <!-- tag: 5c9b2f -->
             <!-- playbridge-rollout-delay-hours: 24 -->
@@ -374,19 +384,22 @@ jobs:
 
             📋 [Changelog](https://github.com/playbridgeapp/playbridge/blob/phone-v${{ steps.versions.outputs.phone }}/mobile/android/CHANGELOG.md)
 
+            This is a **draft** candidate. Publish with **Actions → Android Publish**
+            (after any configured Play Store upload succeeds).
+
             > Download the `.apk` for your device's architecture (`arm64-v8a` for most modern devices) and sideload it.
           files: |
-            output/phone-release-*/*.apk
+            output/phone-release-apk/*.apk
             output/phone-release-aab/*.aab
           generate_release_notes: false
-          draft: false
 
-      - name: Create TV Player release
+      - name: Create TV Player draft release
         if: needs.build-tv-player.outputs.skipped == 'false'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: tv-player-v${{ steps.versions.outputs.player }}
           name: PlayBridge TV Player v${{ steps.versions.outputs.player }}
+          draft: true
           body: |
             <!-- tag: 8d2a1c -->
             <!-- playbridge-rollout-delay-hours: 24 -->
@@ -394,21 +407,24 @@ jobs:
 
             📋 [Changelog](https://github.com/playbridgeapp/playbridge/blob/tv-player-v${{ steps.versions.outputs.player }}/tv/android/CHANGELOG.md)
 
+            This is a **draft** candidate. Publish with **Actions → Android Publish**
+            (after any configured Play Store upload succeeds).
+
             > 💡 **Easy Install on TV**: Open the **Downloader** app on your Android TV / Fire TV and enter code **`9557748`** to download and install this release directly.
 
             Or download the `.apk` below (universal APK is recommended) and sideload it manually.
           files: |
-            output/tv-player-release-*/*.apk
+            output/tv-player-release-apk/*.apk
             output/tv-player-release-aab/*.aab
           generate_release_notes: false
-          draft: false
 
-      - name: Create TV GeckoView Plugin release
+      - name: Create TV GeckoView Plugin draft release
         if: needs.build-tv-geckoview-plugin.outputs.skipped == 'false'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: tv-geckoview-plugin-v${{ steps.versions.outputs.browser }}
           name: PlayBridge TV GeckoView Plugin v${{ steps.versions.outputs.browser }}
+          draft: true
           body: |
             <!-- tag: 3e7f9a -->
             <!-- playbridge-rollout-delay-hours: 24 -->
@@ -416,58 +432,25 @@ jobs:
 
             📋 [Changelog](https://github.com/playbridgeapp/playbridge/blob/tv-geckoview-plugin-v${{ steps.versions.outputs.browser }}/tv/android/CHANGELOG.md)
 
+            This is a **draft** candidate. Publish with **Actions → Android Publish**
+            (after any configured Play Store upload succeeds).
+
             > Download the `.apk` for your device's architecture (`arm64-v8a` for most modern devices) and sideload it.
           files: |
-            output/tv-geckoview-plugin-release-*/*.apk
+            output/tv-geckoview-plugin-release-apk/*.apk
             output/tv-geckoview-plugin-release-aab/*.aab
           generate_release_notes: false
-          draft: false
 
-      # Play Store publishes are independent: one failing must not block the
-      # others (continue-on-error), but any failure is re-surfaced at the end.
-      - name: Publish Phone to Play Store (open testing)
-        id: play_phone
-        if: needs.build-phone.outputs.skipped == 'false'
-        continue-on-error: true
-        uses: r0adkll/upload-google-play@v1.1.5
-        with:
-          serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
-          packageName: com.playbridge.sender
-          releaseFiles: output/phone-release-aab/*.aab
-          # Play API: beta = Open testing (alpha = Closed testing).
-          tracks: beta
-          status: completed
-
-      - name: Publish TV Player to Play Store (alpha)
-        id: play_tv_player
-        if: needs.build-tv-player.outputs.skipped == 'false'
-        continue-on-error: true
-        uses: r0adkll/upload-google-play@v1.1.5
-        with:
-          serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
-          packageName: com.playbridge.player
-          releaseFiles: output/tv-player-release-aab/*.aab
-          tracks: alpha
-          status: completed
-
-      - name: Check Play Store publish results
-        if: always()
-        run: |
-          failed=""
-          [ "${{ steps.play_phone.outcome }}" = "failure" ]      && failed="$failed phone"
-          [ "${{ steps.play_tv_player.outcome }}" = "failure" ]  && failed="$failed tv-player"
-          if [ -n "$failed" ]; then
-            echo "### ❌ Play Store publish failed for:$failed" >> "$GITHUB_STEP_SUMMARY"
-            echo "GitHub releases were still created; re-publish to Play manually or re-run after fixing." >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-          echo "✅ All attempted Play Store publishes succeeded" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Clean up R2 after release
+      - name: Clean up Android R2 staging
         if: always()
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
         run: |
-          aws s3 rm s3://${{ secrets.R2_BUCKET }}/ --recursive
+          aws s3 rm s3://${{ secrets.R2_BUCKET }}/phone-release-apk/ --recursive
+          aws s3 rm s3://${{ secrets.R2_BUCKET }}/phone-release-aab/ --recursive
+          aws s3 rm s3://${{ secrets.R2_BUCKET }}/tv-player-release-apk/ --recursive
+          aws s3 rm s3://${{ secrets.R2_BUCKET }}/tv-player-release-aab/ --recursive
+          aws s3 rm s3://${{ secrets.R2_BUCKET }}/tv-geckoview-plugin-release-apk/ --recursive
+          aws s3 rm s3://${{ secrets.R2_BUCKET }}/tv-geckoview-plugin-release-aab/ --recursive

--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -117,17 +117,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh release view "$TAG" --repo "$REPOSITORY" --json body >/tmp/android-release.json
-          body=$(jq -r '.body // ""' /tmp/android-release.json)
-          draft_notice=$'This is a **draft** candidate. Publish with **Actions → Android Publish**\n(after any configured Play Store upload succeeds).'
-          published_notice='**Published release.** PlayBridge.app availability follows the configured rollout delay.'
-          if [[ "$body" == *"$draft_notice"* ]]; then
-            body="${body/$draft_notice/$published_notice}"
-            echo "Replaced draft-only release note"
-          else
-            echo "Draft-only release note not present; preserving edited release notes"
-          fi
-
-          gh release edit "$TAG" --repo "$REPOSITORY" --notes "$body" --draft=false
+          gh release edit "$TAG" --repo "$REPOSITORY" --draft=false
           echo "Published $TAG"
           gh release view "$TAG" --repo "$REPOSITORY" --json url,isDraft,tagName

--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -1,0 +1,133 @@
+name: Android Publish
+
+# Stage 3: publish an existing Android draft release; Play Store uploads happen before undrafting.
+# Stage 2: .github/workflows/android_build.yml
+
+on:
+  workflow_dispatch:
+    inputs:
+      product:
+        description: 'Android product to publish'
+        required: true
+        type: choice
+        options:
+          - phone
+          - tv-player
+          - tv-geckoview-plugin
+      version:
+        description: 'Version to publish (e.g. 1.2.3 or phone-v1.2.3)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    name: validate draft release
+    runs-on: ubuntu-latest
+    outputs:
+      is_draft: ${{ steps.release.outputs.is_draft }}
+      tag: ${{ steps.release.outputs.tag }}
+    steps:
+      - name: Find draft GitHub release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRODUCT: ${{ inputs.product }}
+          RAW_VERSION: ${{ inputs.version }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PREFIX="$PRODUCT"
+          VERSION="${RAW_VERSION#${PREFIX}-v}"
+          test -n "$VERSION"
+          TAG="${PREFIX}-v${VERSION}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+          if ! gh release view "$TAG" --repo "$REPOSITORY" --json isDraft,url >/tmp/android-release.json; then
+            echo "No GitHub Release found for $TAG." >&2
+            echo "Run Android Release Build first (uprev or workflow_dispatch)." >&2
+            exit 1
+          fi
+
+          is_draft=$(jq -r '.isDraft' /tmp/android-release.json)
+          url=$(jq -r '.url' /tmp/android-release.json)
+          echo "is_draft=$is_draft" >> "$GITHUB_OUTPUT"
+          if [ "$is_draft" = "false" ]; then
+            echo "⏭️ $TAG is already published: $url"
+          else
+            echo "✅ Found draft $TAG: $url"
+          fi
+
+  publish-play-store:
+    name: publish to Play Store
+    needs: validate
+    if: needs.validate.outputs.is_draft == 'true' && inputs.product != 'tv-geckoview-plugin'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download app bundle from draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir dist
+          gh release download "$TAG" --repo "$REPOSITORY" --pattern '*.aab' --dir dist
+          test "$(find dist -maxdepth 1 -name '*.aab' -type f | wc -l)" -eq 1
+
+      - name: Publish Phone to Play Store (open testing)
+        if: inputs.product == 'phone'
+        uses: r0adkll/upload-google-play@v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+          packageName: com.playbridge.sender
+          releaseFiles: dist/*.aab
+          tracks: beta
+          status: completed
+
+      - name: Publish TV Player to Play Store (alpha)
+        if: inputs.product == 'tv-player'
+        uses: r0adkll/upload-google-play@v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+          packageName: com.playbridge.player
+          releaseFiles: dist/*.aab
+          tracks: alpha
+          status: completed
+
+  publish-github:
+    name: publish GitHub release
+    needs: [validate, publish-play-store]
+    if: |
+      always() &&
+      needs.validate.result == 'success' &&
+      needs.validate.outputs.is_draft == 'true' &&
+      (needs.publish-play-store.result == 'success' || needs.publish-play-store.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release view "$TAG" --repo "$REPOSITORY" --json body >/tmp/android-release.json
+          body=$(jq -r '.body // ""' /tmp/android-release.json)
+          draft_notice=$'This is a **draft** candidate. Publish with **Actions → Android Publish**\n(after any configured Play Store upload succeeds).'
+          published_notice='**Published release.** PlayBridge.app availability follows the configured rollout delay.'
+          if [[ "$body" == *"$draft_notice"* ]]; then
+            body="${body/$draft_notice/$published_notice}"
+            echo "Replaced draft-only release note"
+          else
+            echo "Draft-only release note not present; preserving edited release notes"
+          fi
+
+          gh release edit "$TAG" --repo "$REPOSITORY" --notes "$body" --draft=false
+          echo "Published $TAG"
+          gh release view "$TAG" --repo "$REPOSITORY" --json url,isDraft,tagName

--- a/.github/workflows/cli_build.yml
+++ b/.github/workflows/cli_build.yml
@@ -200,16 +200,13 @@ jobs:
           body: |
             <!-- tag: 7b2c9a -->
             <!-- playbridge-rollout-delay-hours: 24 -->
-            **CLI:** v${{ needs.validate.outputs.version }} (draft)
+            **CLI:** v${{ needs.validate.outputs.version }}
 
             📋 [Changelog](https://github.com/playbridgeapp/playbridge/blob/main/cli/CHANGELOG.md)
 
             Cross-platform PlayBridge sender and receiver CLI.
 
-            This is a **draft** candidate. Publish with **Actions → CLI Publish**
-            (sets `draft=false`). Until then, `install.sh` will not pick it up as latest.
-
-            **Installation after publish and the configured rollout delay:**
+            **Installation after the configured rollout delay:**
 
             macOS & Linux:
             ```sh

--- a/.github/workflows/cli_publish.yml
+++ b/.github/workflows/cli_publish.yml
@@ -32,7 +32,7 @@ jobs:
           test -n "$VERSION"
           TAG="cli-v${VERSION}"
 
-          if ! gh release view "$TAG" --repo "$REPOSITORY" --json isDraft,url,body >/tmp/cli-release.json; then
+          if ! gh release view "$TAG" --repo "$REPOSITORY" --json isDraft,url >/tmp/cli-release.json; then
             echo "No GitHub Release found for $TAG." >&2
             echo "Run CLI Release Build first (uprev or workflow_dispatch)." >&2
             exit 1
@@ -46,16 +46,6 @@ jobs:
             exit 0
           fi
 
-          body=$(jq -r '.body // ""' /tmp/cli-release.json)
-          draft_notice=$'This is a **draft** candidate. Publish with **Actions → CLI Publish**\n(sets `draft=false`). Until then, `install.sh` will not pick it up as latest.'
-          published_notice='**Published release.** PlayBridge.app availability follows the configured rollout delay.'
-          if [[ "$body" == *"$draft_notice"* ]]; then
-            body="${body/$draft_notice/$published_notice}"
-            echo "Replaced draft-only release note"
-          else
-            echo "Draft-only release note not present; preserving edited release notes"
-          fi
-
-          gh release edit "$TAG" --repo "$REPOSITORY" --notes "$body" --draft=false
+          gh release edit "$TAG" --repo "$REPOSITORY" --draft=false
           echo "Published $TAG"
           gh release view "$TAG" --repo "$REPOSITORY" --json url,isDraft,tagName

--- a/.github/workflows/desktop_build.yml
+++ b/.github/workflows/desktop_build.yml
@@ -1,4 +1,7 @@
-name: Desktop Build
+name: Desktop Release Build
+
+# Stage 2: multi-platform packages → draft GitHub Release.
+# Stage 3: .github/workflows/desktop_publish.yml
 
 on:
   push:
@@ -295,7 +298,7 @@ jobs:
         aws s3 cp "playbridge-cli-macos-${{ steps.version.outputs.version }}.zip" \
           s3://${{ secrets.R2_BUCKET }}/desktop-release/
 
-  release:
+  draft-release:
     needs: [build-windows, build-linux, build-macos]
     if: |
       (success() || always()) &&
@@ -330,17 +333,21 @@ jobs:
         mkdir -p output
         aws s3 sync s3://${{ secrets.R2_BUCKET }}/desktop-release/ output/
 
-    - name: Create GitHub release
-      uses: softprops/action-gh-release@v1
+    - name: Create draft GitHub release
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: desktop-v${{ steps.version.outputs.version }}
         name: PlayBridge Desktop v${{ steps.version.outputs.version }}
+        draft: true
         body: |
           <!-- tag: 1a4b6c -->
           <!-- playbridge-rollout-delay-hours: 24 -->
           **Desktop Receiver:** v${{ steps.version.outputs.version }}
 
           📋 [Changelog](https://github.com/playbridgeapp/playbridge/blob/desktop-v${{ steps.version.outputs.version }}/desktop/CHANGELOG.md)
+
+          This is a **draft** candidate. Publish with **Actions → Desktop Publish**
+          (sets `draft=false`; no rebuild).
 
           | Platform | File |
           |----------|------|
@@ -356,7 +363,7 @@ jobs:
         files: output/*
         generate_release_notes: false
 
-    - name: Clean up R2 after release
+    - name: Clean up R2 after draft creation
       if: always()
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/.github/workflows/desktop_build.yml
+++ b/.github/workflows/desktop_build.yml
@@ -346,9 +346,6 @@ jobs:
 
           📋 [Changelog](https://github.com/playbridgeapp/playbridge/blob/desktop-v${{ steps.version.outputs.version }}/desktop/CHANGELOG.md)
 
-          This is a **draft** candidate. Publish with **Actions → Desktop Publish**
-          (sets `draft=false`; no rebuild).
-
           | Platform | File |
           |----------|------|
           | Windows 10+ | `playbridge-desktop-windows-${{ steps.version.outputs.version }}.zip` — extract and run `playbridge_desktop.exe` |

--- a/.github/workflows/desktop_publish.yml
+++ b/.github/workflows/desktop_publish.yml
@@ -1,0 +1,60 @@
+name: Desktop Publish
+
+# Stage 3: promote an existing draft desktop-v* GitHub Release (no rebuild).
+# Stage 2: .github/workflows/desktop_build.yml
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Desktop version to publish (e.g. 1.2.3 or desktop-v1.2.3)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: publish draft release
+    runs-on: ubuntu-latest
+    # Optional: add environment: desktop-release with required reviewers in repo settings.
+    steps:
+      - name: Publish draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RAW_VERSION: ${{ inputs.version }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${RAW_VERSION#desktop-v}"
+          test -n "$VERSION"
+          TAG="desktop-v${VERSION}"
+
+          if ! gh release view "$TAG" --repo "$REPOSITORY" --json isDraft,url,body >/tmp/desktop-release.json; then
+            echo "No GitHub Release found for $TAG." >&2
+            echo "Run Desktop Release Build first (uprev or workflow_dispatch)." >&2
+            exit 1
+          fi
+
+          is_draft=$(jq -r '.isDraft' /tmp/desktop-release.json)
+          url=$(jq -r '.url' /tmp/desktop-release.json)
+          if [ "$is_draft" = "false" ]; then
+            echo "⏭️ $TAG is already published: $url"
+            exit 0
+          fi
+
+          body=$(jq -r '.body // ""' /tmp/desktop-release.json)
+          draft_notice=$'This is a **draft** candidate. Publish with **Actions → Desktop Publish**\n(sets `draft=false`; no rebuild).'
+          published_notice='**Published release.** PlayBridge.app availability follows the configured rollout delay.'
+          if [[ "$body" == *"$draft_notice"* ]]; then
+            body="${body/$draft_notice/$published_notice}"
+            echo "Replaced draft-only release note"
+          else
+            echo "Draft-only release note not present; preserving edited release notes"
+          fi
+
+          gh release edit "$TAG" --repo "$REPOSITORY" --notes "$body" --draft=false
+          echo "Published $TAG"
+          gh release view "$TAG" --repo "$REPOSITORY" --json url,isDraft,tagName

--- a/.github/workflows/desktop_publish.yml
+++ b/.github/workflows/desktop_publish.yml
@@ -45,16 +45,6 @@ jobs:
             exit 0
           fi
 
-          body=$(jq -r '.body // ""' /tmp/desktop-release.json)
-          draft_notice=$'This is a **draft** candidate. Publish with **Actions → Desktop Publish**\n(sets `draft=false`; no rebuild).'
-          published_notice='**Published release.** PlayBridge.app availability follows the configured rollout delay.'
-          if [[ "$body" == *"$draft_notice"* ]]; then
-            body="${body/$draft_notice/$published_notice}"
-            echo "Replaced draft-only release note"
-          else
-            echo "Draft-only release note not present; preserving edited release notes"
-          fi
-
-          gh release edit "$TAG" --repo "$REPOSITORY" --notes "$body" --draft=false
+          gh release edit "$TAG" --repo "$REPOSITORY" --draft=false
           echo "Published $TAG"
           gh release view "$TAG" --repo "$REPOSITORY" --json url,isDraft,tagName

--- a/docs/release.md
+++ b/docs/release.md
@@ -23,8 +23,9 @@ project does not require shipping the others.
 2. **Uprev = intent to ship that project** — bump its version file and changelog.
 3. **No uprev → no release-build** — ordinary merges only run PR-style CI.
 4. **Draft is the handoff** — release-build attaches assets to a draft release;
-   publish promotes that same version (CLI: `draft=false`).
-5. **Stores are separate from GitHub** — undrafting does not submit to Play / AMO / CWS.
+   publish promotes that same version without rebuilding it.
+5. **Stores are separate steps from GitHub** — Android uploads to Play first and
+   only undrafts the GitHub release after the configured store upload succeeds.
 6. **Shared crates** (`cast/`, `protocol/`, `shared/`) rebuild consumer CI; only
    **upreved consumers** get release-build / publish.
 
@@ -39,6 +40,15 @@ stable releases after each release's rollout delay.
 | Project | Version source | Tag prefix | Changelog | PR CI | Release-build | Publish |
 | --- | --- | --- | --- | --- | --- | --- |
 | **CLI** | `cli/Cargo.toml` | `cli-v*` | `cli/CHANGELOG.md` | `rust_pr.yml` | `cli_build.yml` → **draft** | `cli_publish.yml` → undraft |
+| **Extension** | `extension/manifests/*.json` | `extension-v*` | `extension/CHANGELOG.md` | `extension_pr.yml` | `extension_build.yml` → draft | Publish workflow — *target* |
+| **Desktop** | `desktop/pubspec.yaml` | `desktop-v*` | `desktop/CHANGELOG.md` | `desktop_pr.yml` | `desktop_build.yml` → **draft** | `desktop_publish.yml` → undraft |
+| **Android phone** | `versionName` / `versionCode` | `phone-v*` | `mobile/android/CHANGELOG.md` | `android_pr.yml` | `android_build.yml` → **draft** | `android_publish.yml` → Play + undraft |
+| **Android TV player** | TV `versionName` / `versionCode` | `tv-player-v*` | `tv/android/CHANGELOG.md` | `android_pr.yml` | `android_build.yml` → **draft** | `android_publish.yml` → Play + undraft |
+| **Android TV GeckoView plugin** | TV `versionName` / `versionCode` | `tv-geckoview-plugin-v*` | `tv/android/CHANGELOG.md` | `android_pr.yml` | `android_build.yml` → **draft** | `android_publish.yml` → undraft |
+| **Stream proxy** | crate / image version | image tags / optional git tag | project changelog | `stream_proxy_pr.yml` | `stream_proxy_build.yml` | Promote image tags — *target* |
+| **Web** | deploy-on-main | n/a | n/a | `web_pr.yml` | — | `web_deploy.yml` (Pages) |
+| **Protocol / Rust core** | n/a (library) | n/a | n/a | contract / rust PR checks | ships inside consumers | — |
+| **Apple apps** | Xcode marketing version | store / TestFlight | Apple changelogs | local / future CI | archive | App Store Connect |
 
 ### GitHub release search markers
 
@@ -55,16 +65,6 @@ deep-link to that product’s releases (`?q=<marker>&expanded=true`):
 | CLI | `7b2c9a` | [releases?q=7b2c9a](https://github.com/playbridgeapp/PlayBridge/releases?q=7b2c9a&expanded=true) |
 
 Keep the marker in every draft/publish body for that product. Do not reuse markers across products.
-| **Extension** | `extension/manifests/*.json` | `extension-v*` | `extension/CHANGELOG.md` | `extension_pr.yml` | `extension_build.yml` | GH undraft (+ optional store) — *target* |
-| **Desktop** | `desktop/pubspec.yaml` | `desktop-v*` | `desktop/CHANGELOG.md` | `desktop_pr.yml` | `desktop_build.yml` | GH undraft — *target* |
-| **Android phone** | `versionName` / `versionCode` | `phone-v*` | `mobile/android/CHANGELOG.md` | `android_pr.yml` | `android_build.yml` | GH undraft + Play promote — *target* |
-| **Android TV** | TV `versionName` / `versionCode` | `tv-player-v*` | `tv/android/CHANGELOG.md` | `android_pr.yml` | `android_build.yml` | GH undraft (+ Play if used) — *target* |
-| **Stream proxy** | crate / image version | image tags / optional git tag | project changelog | `stream_proxy_pr.yml` | `stream_proxy_build.yml` | promote image tags — *target* |
-| **Web** | deploy-on-main | n/a | n/a | `web_pr.yml` | — | `web_deploy.yml` (Pages) |
-| **Protocol / Rust core** | n/a (library) | n/a | n/a | contract / rust PR checks | ships inside consumers | — |
-| **Apple apps** | Xcode marketing version | store / TestFlight | Apple changelogs | local / future CI | archive | App Store connect |
-
-\* *target* = same three-stage model; some workflows still collapse build+publish today. **CLI is the reference implementation.**
 
 ---
 
@@ -152,6 +152,18 @@ Actions → CLI Release Build → Run workflow
 Actions → CLI Publish → Run workflow
   version: 0.1.1
 ```
+
+## Android and Desktop publish
+
+`Android Release Build` creates separate draft releases for Phone, TV Player,
+and the TV GeckoView plugin. Run `Android Publish` with the product and version
+after inspecting the draft assets. Phone and TV Player upload the attached AAB
+to their configured Play Store track first; the GitHub release is undrafted only
+after that upload succeeds. The GeckoView plugin has no Play Store step.
+
+`Desktop Release Build` creates a draft `desktop-v*` release containing all
+platform archives. Run `Desktop Publish` with the version to undraft the existing
+release without rebuilding its assets.
 
 ---
 


### PR DESCRIPTION
## Summary
- create draft GitHub releases from Android and Desktop release builds
- add manual Android and Desktop publish workflows modeled after CLI Publish
- upload Android AABs to Play before undrafting the corresponding GitHub release
- keep CLI, Android, and Desktop release notes written exactly as they will appear publicly
- make publish workflows preserve release notes and only promote the existing draft
- document the Android and Desktop draft-to-publish process

## Verification
- `actionlint` passed for all modified and new workflows
- modified workflows parsed successfully as YAML
- embedded Bash scripts passed `bash -n`
- `git diff --check` passed

## Risk / manual verification
- GitHub Actions publication was not dispatched because it would mutate release and Play Store state
- repository-wide `actionlint` still reports the unrelated existing `softprops/action-gh-release@v1` use in `extension_build.yml`