### PR TITLE
chore(release): uprev Desktop, Phone, and TV Player

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.9.0+30] — 2026-08-11
+
+### Added
+- **Android screen mirroring**: Receive H.264 WebRTC screen mirrors from Android phones with lifecycle-safe signaling and correctly fitted portrait or landscape video.
+- **Native PlayBridge receiver runtime**: Use the secure Rust-backed TLS/WSS receiver with SAS pairing, persisted credentials, typed commands, and integrated pairing UI.
+
+### Changed
+- **Google Cast sessions**: Use persistent Cast sessions and the shared CAF receiver, with resilient receiver refresh, replacement loads, and serialized media operations.
+
+### Fixed
+- **Low-latency HLS casting**: Cast demuxed LL-HLS streams through synthetic master playlists so receivers load the selected audio and video renditions reliably.
+
 ## [0.8.1+29] — 2026-07-19
 
 ### Added

--- a/desktop/lib/update/app_version.dart
+++ b/desktop/lib/update/app_version.dart
@@ -2,7 +2,7 @@
 ///
 /// MUST match `version:` in pubspec.yaml (build-metadata part excluded) —
 /// guarded by `test/update_test.dart` so CI fails if they drift.
-const String kAppVersion = '0.8.1';
+const String kAppVersion = '0.9.0';
 
 /// Dotted numeric version (`0.6.4`, `1.10.2`) with sane comparison semantics.
 ///

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: playbridge_desktop
 description: "PlayBridge desktop receiver — accepts cast commands from the phone and plays via libmpv."
 publish_to: 'none'
-version: 0.8.1+29
+version: 0.9.0+30
 
 environment:
   sdk: ^3.6.0

--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.13.0] — 2026-08-11 (versionCode 223)
+
+### Added
+- **Screen mirroring**: Mirror the phone to compatible PlayBridge TV and Desktop receivers over WebRTC with H.264 video, optional playback audio, orientation-aware sizing, and selectable quality limits.
+
+### Changed
+- **Release optimization**: Enable R8 code and resource optimization for smaller, optimized FOSS and Play release builds.
+
 ## [0.12.0] — 2026-08-03 (versionCode 222)
 
 ### Added

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -130,8 +130,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 222
-        versionName = "0.12.0"
+        versionCode = 223
+        versionName = "0.13.0"
         buildConfigField(
             "String",
             "GOOGLE_CAST_APPLICATION_ID",

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,17 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [0.12.0] — 2026-08-11 (versionCode 227)
+
+### Added
+- **WebRTC screen mirroring**: Receive H.264 phone screen mirrors with lifecycle-safe rendering, orientation-aware video, capability advertisement, and validated signaling.
+
+### Changed
+- **Release optimization**: Enable R8 code and resource optimization for smaller, optimized FOSS and Play release builds.
+
+### Security
+- **Persisted pairing tokens**: Store paired-device credentials as SHA-256 digests, migrate compatible legacy records, and refresh active authentication state after pairing changes.
+
 ## Player [0.11.0] — 2026-07-30 (versionCode 226)
 
 ### Added

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -31,8 +31,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 226
-        versionName = "0.11.0"
+        versionCode = 227
+        versionName = "0.12.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
## Release versions
- Desktop: `0.8.1+29` → `0.9.0+30`
- Android Phone: `0.12.0` (222) → `0.13.0` (223)
- Android TV Player: `0.11.0` (226) → `0.12.0` (227)
- Android TV GeckoView Plugin remains `0.3.4` (212)

## Changelog highlights
- Desktop receives Android WebRTC screen mirrors, uses the native secure receiver runtime, improves persistent Google Cast sessions, and fixes LL-HLS casting
- Phone adds H.264 WebRTC screen mirroring with optional playback audio and enables optimized R8 release builds
- TV Player receives WebRTC screen mirrors, protects persisted pairing tokens with SHA-256 records, and enables optimized R8 release builds

## Verification
- `desktop`: `flutter test test/update_test.dart`
- `mobile/android`: `./gradlew :app:testFossDebugUnitTest :app:assembleFossDebug`
- `tv/android`: `./gradlew :player:app:testFossDebugUnitTest :player:app:assembleFossDebug`
- `git diff --cached --check`

All focused checks passed. After merge, the Android and Desktop release-build workflows should create draft releases for inspection before the manual publish workflows are run.