### PR TITLE
feat(android): add external screen mirroring

### DIFF
--- a/desktop/lib/tv_transport.dart
+++ b/desktop/lib/tv_transport.dart
@@ -716,18 +716,15 @@ class RustCastTransport extends TvTransport {
 }
 
 class DlnaTransport extends RustCastTransport {
-  DlnaTransport({rust.CastCoreLibrary? core})
-      : super(TvProtocol.dlna, core: core);
+  DlnaTransport({super.core}) : super(TvProtocol.dlna);
 }
 
 class RokuTransport extends RustCastTransport {
-  RokuTransport({rust.CastCoreLibrary? core})
-      : super(TvProtocol.roku, core: core);
+  RokuTransport({super.core}) : super(TvProtocol.roku);
 }
 
 class GoogleCastTransport extends RustCastTransport {
-  GoogleCastTransport({rust.CastCoreLibrary? core})
-      : super(TvProtocol.googleCast, core: core);
+  GoogleCastTransport({super.core}) : super(TvProtocol.googleCast);
 }
 
 /// Transport for a browser page connected to Desktop's on-demand Rust host.

--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -6,10 +6,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.13.0] — 2026-08-11 (versionCode 223)
 
 ### Added
-- **Screen mirroring**: Mirror the phone to compatible PlayBridge TV and Desktop receivers over WebRTC with H.264 video, optional playback audio, orientation-aware sizing, and selectable quality limits.
+- **Screen mirroring**: Mirror the phone to compatible PlayBridge TV and Desktop receivers over WebRTC with H.264 video, optional playback audio, orientation-aware sizing, and selectable quality limits. Google Cast and DLNA receivers can receive the same capture as a video-only H.264/MPEG-TS live stream.
 
 ### Changed
 - **Release optimization**: Enable R8 code and resource optimization for smaller, optimized FOSS and Play release builds.
+- **External screen mirroring**: Keep Google Cast playback active across phone orientation changes by using a stable encoded canvas and resizing only the captured display source.
 
 ## [0.12.0] — 2026-08-03 (versionCode 222)
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
@@ -60,6 +60,24 @@ internal fun externalSessionPhase(
         if (mediaTitle == null) SessionPhase.SELECTED else SessionPhase.CONNECTED
 }
 
+internal fun externalScreenMirrorMedia(
+    targetKind: TargetKind,
+    urls: com.playbridge.sender.cast.mirror.ExternalScreenMirrorCoordinator.Urls,
+): MediaItem {
+    val googleCast = targetKind == TargetKind.GOOGLE_CAST
+    return MediaItem(
+        url = if (googleCast) urls.hls else urls.continuousTs,
+        mimeType = if (googleCast) "application/x-mpegURL" else "video/mp2t",
+        title = "Screen mirror",
+        durationMs = 0L,
+        effectiveRoute = StreamRouteMode.VIA_PHONE,
+        routeReason = "screen_mirror",
+        streamType = "LIVE",
+        hlsVideoSegmentFormat = if (googleCast) "mpeg2_ts" else null,
+        isScreenMirror = true,
+    )
+}
+
 /**
  * Process-wide owner of the active cast session — the single seam every screen sends
  * playback through, regardless of transport.
@@ -87,9 +105,24 @@ class CastSessionManager(
     private val discoveryRepository: ReceiverDiscoveryRepository,
     private val settingsRepository: SettingsRepository,
     private val screenMirrorCoordinator: com.playbridge.sender.cast.mirror.ScreenMirrorCoordinator,
+    private val externalScreenMirrorCoordinator:
+        com.playbridge.sender.cast.mirror.ExternalScreenMirrorCoordinator,
 ) {
     private val TAG = "CastSessionManager"
-    val screenMirrorState = screenMirrorCoordinator.state
+    val screenMirrorState = combine(
+        screenMirrorCoordinator.state,
+        externalScreenMirrorCoordinator.state,
+    ) { native, external ->
+        if (external.phase != com.playbridge.sender.cast.mirror.ScreenMirrorCoordinator.Phase.IDLE) {
+            external
+        } else {
+            native
+        }
+    }.stateIn(
+        scope,
+        SharingStarted.Eagerly,
+        com.playbridge.sender.cast.mirror.ScreenMirrorCoordinator.State(),
+    )
 
     // ------------------------------------------------------------------
     // Routing intent (authoritative)
@@ -137,6 +170,7 @@ class CastSessionManager(
 
     /** Route phone-local. Keeps an idle native link, but stops any external receiver session. */
     fun selectThisDevice() {
+        screenMirrorCoordinator.stop("target_changed")
         stopAndClearExternalTarget()
         _route.value = Route.ThisDevice
         persistBaseRoute("this")
@@ -161,6 +195,7 @@ class CastSessionManager(
 
     /** User picked the native TV receiver. Connecting is a separate concern (caller/Stage B). */
     fun selectNativeRoute() {
+        screenMirrorCoordinator.stop("target_changed")
         stopAndClearExternalTarget()
         _route.value = Route.NativeTv
         persistBaseRoute("native")
@@ -414,7 +449,7 @@ class CastSessionManager(
         ) { externalPhonePath, state, ctx, route, reconnecting ->
             arrayOf(externalPhonePath, state, ctx, route, reconnecting)
         },
-        screenMirrorCoordinator.state,
+        screenMirrorState,
     ) { inputs, mirror ->
         val externalPhonePath = inputs[0] as Boolean
         val state = inputs[1] as WebSocketClient.ConnectionState
@@ -459,7 +494,7 @@ class CastSessionManager(
     val isActivelyPlaying: StateFlow<Boolean> = combine(
         _externalMediaLoaded,
         connectionCoordinator.tvActiveContext,
-        screenMirrorCoordinator.state,
+        screenMirrorState,
     ) { externalMediaLoaded, ctx, mirror ->
         externalMediaLoaded || ctx == "player" || mirror.isActive
     }.stateIn(scope, SharingStarted.Eagerly, false)
@@ -471,7 +506,7 @@ class CastSessionManager(
     val needsCastWakeLock: StateFlow<Boolean> = combine(
         _phonePathActive,
         connectionCoordinator.tvActiveContext,
-        screenMirrorCoordinator.state,
+        screenMirrorState,
     ) { phonePath, ctx, mirror ->
         phonePath || ctx == "player" || mirror.isActive
     }.stateIn(scope, SharingStarted.Eagerly, false)
@@ -489,7 +524,7 @@ class CastSessionManager(
         ) { external, state, playback, externalTitle, ctx ->
             arrayOf(external, state, playback, externalTitle, ctx)
         },
-        screenMirrorCoordinator.state,
+        screenMirrorState,
     ) { inputs, mirror ->
         val external = inputs[0] as TvDevice?
         val state = inputs[1] as WebSocketClient.ConnectionState
@@ -939,6 +974,7 @@ class CastSessionManager(
     // ------------------------------------------------------------------
 
     private fun selectExternalTarget(device: TvDevice, target: CastTarget) {
+        screenMirrorCoordinator.stop("target_changed")
         if (_externalTarget.value != null) _externalInterrupts.tryEmit(Unit)
         detachExternalTarget(stopFirst = true)
         externalTargetSlot.replace(target)
@@ -971,6 +1007,16 @@ class CastSessionManager(
                     return@collect
                 }
                 _externalStatus.value = status
+                if (externalScreenMirrorCoordinator.state.value.isActive) {
+                    when (status.state) {
+                        PlaybackState.PLAYING -> externalScreenMirrorCoordinator.markMirroring()
+                        PlaybackState.ERROR ->
+                            externalScreenMirrorCoordinator.fail("Receiver could not play the screen stream")
+                        PlaybackState.STOPPED ->
+                            externalScreenMirrorCoordinator.stop("receiver_stopped")
+                        else -> Unit
+                    }
+                }
                 maybeClearTerminalExternalMedia(status)
             }
         }
@@ -983,6 +1029,7 @@ class CastSessionManager(
     fun stopAndClearExternalTarget() = detachExternalTarget(stopFirst = true)
 
     private fun detachExternalTarget(stopFirst: Boolean) {
+        externalScreenMirrorCoordinator.stop("target_changed")
         externalLoadGeneration++
         externalLoadJob?.cancel()
         externalLoadJob = null
@@ -1114,6 +1161,11 @@ class CastSessionManager(
                     Log.w(TAG, "${loadTarget.kind} load failed: ${error.message}")
                     if (loadTarget is BrowserCastTarget) {
                         _castNotices.tryEmit("TV browser couldn’t play this stream")
+                    }
+                    if (epochMedia.isScreenMirror) {
+                        externalScreenMirrorCoordinator.fail(
+                            error.message ?: "Receiver could not load the screen stream",
+                        )
                     }
                 }
             }
@@ -1309,8 +1361,8 @@ class CastSessionManager(
      * restorable linked-idle session.
      */
     fun endCastSession() {
-        if (screenMirrorCoordinator.state.value.isActive) {
-            screenMirrorCoordinator.stop("stopped_by_phone")
+        if (screenMirrorState.value.isActive) {
+            stopScreenMirror("stopped_by_phone")
             connectionCoordinator.markIdle()
             return
         }
@@ -1342,6 +1394,7 @@ class CastSessionManager(
     fun disconnectSession() {
         stopEpisodeQueues()
         screenMirrorCoordinator.stop("disconnect")
+        externalScreenMirrorCoordinator.stop("disconnect")
         connectionCoordinator.markIdle()
         val external = _externalTarget.value
         if (external != null) {
@@ -1365,6 +1418,7 @@ class CastSessionManager(
         backgroundStandDownJob = null
         stopEpisodeQueues()
         screenMirrorCoordinator.stop("app_exit")
+        externalScreenMirrorCoordinator.stop("app_exit")
         connectionCoordinator.markIdle()
         val external = _externalTarget.value
         if (external != null) {
@@ -1382,14 +1436,58 @@ class CastSessionManager(
         projectionPermission: android.content.Intent,
         options: com.playbridge.sender.cast.mirror.ScreenMirrorCoordinator.Options,
     ): Boolean {
+        val route = _route.value
+        if (route is Route.External) {
+            val target = _externalTarget.value ?: return false
+            val device = _activeExternalDevice.value ?: return false
+            if (Capability.SCREEN_MIRROR !in target.capabilities) return false
+            externalScreenMirrorCoordinator.start(
+                projectionPermission = projectionPermission,
+                options = options.copy(deviceAudio = false),
+                receiverHost = device.ip,
+                waitForHlsSegment = target.kind == TargetKind.GOOGLE_CAST,
+            ) { urls ->
+                val media = externalScreenMirrorMedia(target.kind, urls)
+                if (!load(media, userInitiated = false)) {
+                    externalScreenMirrorCoordinator.fail("Receiver is no longer connected")
+                }
+            }
+            return true
+        }
         if (webSocketClient.connectionState.value !is WebSocketClient.ConnectionState.Connected) {
             return false
         }
-        if (_route.value is Route.External) return false
         _route.value = Route.NativeTv
         persistBaseRoute("native")
         screenMirrorCoordinator.start(projectionPermission, options)
         return true
+    }
+
+    fun stopScreenMirror(reason: String = "stopped_by_phone") {
+        screenMirrorCoordinator.stop(reason)
+        val externalPhase = externalScreenMirrorCoordinator.state.value.phase
+        externalScreenMirrorCoordinator.stop(reason)
+        if (externalPhase !=
+            com.playbridge.sender.cast.mirror.ScreenMirrorCoordinator.Phase.IDLE
+        ) {
+            externalLoadGeneration++
+            externalLoadJob?.cancel()
+            externalLoadJob = null
+            _externalTarget.value?.let { target ->
+                scope.launch {
+                    runCatching { target.stop() }
+                        .onFailure { Log.w(TAG, "${target.kind} mirror stop failed: ${it.message}") }
+                }
+            }
+            _externalMediaLoaded.value = false
+            _phonePathActive.value = false
+            _externalMediaTitle.value = null
+            _externalNowPlayingMeta.value = null
+            _externalStatus.value = PlaybackStatus(
+                PlaybackState.STOPPED,
+                loadEpoch = externalLoadGeneration,
+            )
+        }
     }
 
     /** Best-effort stop of phone-side series queues (native + external). Lazy Koin to avoid cycles. */

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionManager.kt
@@ -73,6 +73,7 @@ internal fun externalScreenMirrorMedia(
         effectiveRoute = StreamRouteMode.VIA_PHONE,
         routeReason = "screen_mirror",
         streamType = "LIVE",
+        hlsSegmentFormat = if (googleCast && urls.hasAudio) "ts_aac" else null,
         hlsVideoSegmentFormat = if (googleCast) "mpeg2_ts" else null,
         isScreenMirror = true,
     )
@@ -1443,7 +1444,7 @@ class CastSessionManager(
             if (Capability.SCREEN_MIRROR !in target.capabilities) return false
             externalScreenMirrorCoordinator.start(
                 projectionPermission = projectionPermission,
-                options = options.copy(deviceAudio = false),
+                options = options,
                 receiverHost = device.ip,
                 waitForHlsSegment = target.kind == TargetKind.GOOGLE_CAST,
             ) { urls ->

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastTarget.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastTarget.kt
@@ -78,6 +78,9 @@ enum class Capability {
     QUEUE,
 
     SUBTITLES,
+
+    /** Capture and stream the phone screen to this receiver. */
+    SCREEN_MIRROR,
 }
 
 /**
@@ -108,6 +111,13 @@ data class MediaItem(
     val routeReason: String? = null,
     /** Manager-assigned identity for one external load; never serialized or sent to receivers. */
     val loadEpoch: Long? = null,
+    /** Receiver-specific live-stream hint. Never serialized into the PlayBridge wire protocol. */
+    val streamType: String? = null,
+    /** Google Cast HLS container hints; null for non-HLS media and DLNA. */
+    val hlsSegmentFormat: String? = null,
+    val hlsVideoSegmentFormat: String? = null,
+    /** Marks a manager-owned external screen-mirror load for lifecycle cleanup. */
+    val isScreenMirror: Boolean = false,
 )
 
 data class SubtitleRef(

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/dlna/DlnaCastTarget.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/dlna/DlnaCastTarget.kt
@@ -45,6 +45,7 @@ class DlnaCastTarget(
         Capability.SEEK,
         Capability.STOP,
         Capability.NOW_PLAYING,
+        Capability.SCREEN_MIRROR,
         ))
         if (renderingControl != null) add(Capability.VOLUME)
     }
@@ -56,11 +57,13 @@ class DlnaCastTarget(
     private val _status = MutableStateFlow(PlaybackStatus(PlaybackState.IDLE))
     private var pollJob: Job? = null
     @Volatile private var activeLoadEpoch: Long? = null
+    @Volatile private var activeIsLive = false
 
     override suspend fun load(media: MediaItem) {
         stopPolling()
         activeLoadEpoch = media.loadEpoch
         _status.value = PlaybackStatus(PlaybackState.BUFFERING, loadEpoch = media.loadEpoch)
+        activeIsLive = media.streamType.equals("LIVE", ignoreCase = true)
         cachedDurationMs = media.durationMs.coerceAtLeast(0L) // e.g. MediaStore for local files
         durationTries = 0
         val loadUrl = resolveLoadUrl(media)
@@ -69,7 +72,14 @@ class DlnaCastTarget(
         // SOAP/connection failures are control errors. Generic STOPPED is not enough to
         // distinguish an incompatible stream from normal renderer behavior.
         try {
-            avTransport.setAvTransportUri(loadUrl)
+            avTransport.setAvTransportUri(
+                loadUrl,
+                metadata = if (media.isScreenMirror) {
+                    screenMirrorDidl(loadUrl, media.title ?: "Screen mirror")
+                } else {
+                    ""
+                },
+            )
             avTransport.play()
         } catch (error: java.io.IOException) {
             _status.value = PlaybackStatus(
@@ -86,7 +96,7 @@ class DlnaCastTarget(
         // ignored by most renderers while still TRANSITIONING). Poll the transport state
         // instead of a blind delay — a fixed 2.5s missed slow renderers entirely and
         // over-waited on fast ones.
-        if (media.startPositionMs > 0 && !proxy.isLiveStream) {
+        if (media.startPositionMs > 0 && !activeIsLive && !proxy.isLiveStream) {
             scope.launch {
                 val deadline = System.currentTimeMillis() + RESUME_SEEK_TIMEOUT_MS
                 while (System.currentTimeMillis() < deadline) {
@@ -170,7 +180,7 @@ class DlnaCastTarget(
                 runCatching {
                     val pos = avTransport.getPositionInfo()
                     val state = mapState(avTransport.getTransportState())
-                    val live = proxy.isLiveStream
+                    val live = activeIsLive || proxy.isLiveStream
                     // Duration, renderer-first: TrackDuration, else GetMediaInfo (a few tries),
                     // else the proxy's HLS duration, then the probed/seeded duration.
                     var durationMs = if (live) 0L else parseTime(pos?.trackDuration)
@@ -225,6 +235,15 @@ class DlnaCastTarget(
                 runCatching { mmr.release() }
             }
         } ?: 0L
+    }
+
+    private fun screenMirrorDidl(url: String, title: String): String {
+        fun xml(value: String): String = value
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+        return """<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="screen-mirror" parentID="0" restricted="1"><dc:title>${xml(title)}</dc:title><upnp:class>object.item.videoItem</upnp:class><res protocolInfo="http-get:*:video/mp2t:*">${xml(url)}</res></item></DIDL-Lite>"""
     }
 
     private fun mapState(s: String?): PlaybackState = when (s?.uppercase()) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/googlecast/GoogleCastTarget.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/googlecast/GoogleCastTarget.kt
@@ -59,6 +59,7 @@ class GoogleCastTarget(
         Capability.STOP,
         Capability.VOLUME,
         Capability.NOW_PLAYING,
+        Capability.SCREEN_MIRROR,
     )
 
     private val connectionMutex = Mutex()
@@ -285,9 +286,14 @@ class GoogleCastTarget(
         // LOAD metadata so receivers accept MPEG-TS bytes behind misleading
         // segment suffixes (e.g. .jpg on some anime CDNs). Mirrors Desktop.
         val hlsContainer = HlsSegmentHints.formatFromUrl(proxyUrl)
-        val streamType = HlsSegmentHints.streamTypeFromUrl(proxyUrl)
-        val audioFormat = HlsSegmentHints.googleCastAudioFormat(hlsContainer)
-        val videoFormat = HlsSegmentHints.googleCastVideoFormat(hlsContainer)
+        val streamType = googleCastStreamType(
+            explicit = media.streamType,
+            inferred = HlsSegmentHints.streamTypeFromUrl(proxyUrl),
+        )
+        val audioFormat = media.hlsSegmentFormat
+            ?: HlsSegmentHints.googleCastAudioFormat(hlsContainer)
+        val videoFormat = media.hlsVideoSegmentFormat
+            ?: HlsSegmentHints.googleCastVideoFormat(hlsContainer)
         if (BuildConfig.DEBUG) {
             val source = if (media.effectiveRoute?.prefsValue == "direct") "direct" else "phone_proxy"
             Log.d(
@@ -664,3 +670,7 @@ internal fun googleCastNeedsExplicitNetworkBinding(
     activeNetworkHandle: Long?,
     selectedNetworkHandle: Long,
 ): Boolean = selectedNetworkHandle != 0L && activeNetworkHandle != selectedNetworkHandle
+
+
+internal fun googleCastStreamType(explicit: String?, inferred: String?): String? =
+    explicit?.uppercase() ?: inferred

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/ExternalScreenMirrorCoordinator.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/ExternalScreenMirrorCoordinator.kt
@@ -1,0 +1,631 @@
+package com.playbridge.sender.cast.mirror
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.hardware.display.DisplayManager
+import android.media.projection.MediaProjection
+import android.media.projection.MediaProjectionManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Handler
+import android.os.Looper
+import android.os.ParcelFileDescriptor
+import android.util.Log
+import androidx.core.content.getSystemService
+import java.io.BufferedInputStream
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.UUID
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.ceil
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the phone-side capture used by third-party receivers. One H.264/MPEG-TS
+ * producer feeds both a live HLS view for Google Cast and a continuous TS view
+ * for DLNA; capture is never duplicated.
+ */
+class ExternalScreenMirrorCoordinator(
+    private val context: Context,
+    private val appScope: CoroutineScope,
+) {
+    data class Urls(
+        val hls: String,
+        val continuousTs: String,
+    )
+
+    private val _state = MutableStateFlow(ScreenMirrorCoordinator.State())
+    val state = _state.asStateFlow()
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var executor: ExecutorService? = null
+    private var listener: ServerSocket? = null
+    private var pipeRead: ParcelFileDescriptor? = null
+    private var pipeWrite: ParcelFileDescriptor? = null
+    private var encoder: MediaCodecMpegTsEncoder? = null
+    private var projection: MediaProjection? = null
+    private var display: android.hardware.display.VirtualDisplay? = null
+    private var framePacer: MirrorFramePacer? = null
+    private var streamHub: LiveMpegTsHub? = null
+    private var startupTimeoutJob: Job? = null
+    private var generation = 0L
+    private var projectionCallback: MediaProjection.Callback? = null
+    private var sourceSize: Pair<Int, Int>? = null
+
+    /** Called only after CastSessionService entered the mediaProjection FGS type. */
+    fun start(
+        projectionPermission: Intent,
+        options: ScreenMirrorCoordinator.Options,
+        receiverHost: String,
+        waitForHlsSegment: Boolean,
+        onReady: (Urls) -> Unit,
+    ) {
+        if (_state.value.isActive) return
+        val currentGeneration = ++generation
+        _state.value = ScreenMirrorCoordinator.State(
+            phase = ScreenMirrorCoordinator.Phase.STARTING,
+            sessionId = UUID.randomUUID().toString(),
+            message = "Preparing screen capture…",
+            deviceAudioRequested = false,
+            audioStatus = ScreenMirrorCoordinator.AudioStatus.DISABLED,
+            audioMessage = if (options.deviceAudio) {
+                "Device audio is not yet available for Google Cast or DLNA mirroring."
+            } else {
+                null
+            },
+        )
+        startupTimeoutJob?.cancel()
+        startupTimeoutJob = appScope.launch {
+            delay(STARTUP_TIMEOUT_MS)
+            if (currentGeneration == generation &&
+                _state.value.phase == ScreenMirrorCoordinator.Phase.STARTING
+            ) {
+                fail("Screen encoder did not produce a playable stream")
+            }
+        }
+        appScope.launch(Dispatchers.IO) {
+            try {
+                startCapture(
+                    currentGeneration,
+                    projectionPermission,
+                    options,
+                    receiverHost,
+                    waitForHlsSegment,
+                    onReady,
+                )
+            } catch (error: Throwable) {
+                Log.e(TAG, "Unable to start external screen mirror", error)
+                if (currentGeneration == generation) {
+                    fail(error.message ?: "Unable to start screen mirroring")
+                }
+            }
+        }
+    }
+
+    fun markMirroring() {
+        if (_state.value.isActive) {
+            _state.value = _state.value.copy(
+                phase = ScreenMirrorCoordinator.Phase.MIRRORING,
+                message = null,
+            )
+        }
+    }
+
+    fun stop(reason: String = "stopped_by_phone") {
+        Log.i(TAG, "Stopping external screen mirror reason=$reason")
+        stopInternal(preserveFailure = false)
+    }
+
+    fun fail(message: String) {
+        if (!_state.value.isActive) return
+        _state.value = ScreenMirrorCoordinator.State(
+            phase = ScreenMirrorCoordinator.Phase.FAILED,
+            message = message,
+        )
+        stopInternal(preserveFailure = true)
+    }
+
+    @Synchronized
+    private fun startCapture(
+        captureGeneration: Long,
+        permission: Intent,
+        options: ScreenMirrorCoordinator.Options,
+        receiverHost: String,
+        waitForHlsSegment: Boolean,
+        onReady: (Urls) -> Unit,
+    ) {
+        val host = localIpv4ForReceiver(context, receiverHost)
+            ?: throw IOException("No Wi-Fi or Ethernet address can reach this receiver")
+        val worker = Executors.newCachedThreadPool()
+        executor = worker
+        val server = ServerSocket(0)
+        listener = server
+        val token = UUID.randomUUID().toString()
+        val basePath = "/screen/$token"
+        val baseUrl = "http://$host:${server.localPort}$basePath"
+
+        val pipes = ParcelFileDescriptor.createPipe()
+        pipeRead = pipes[0]
+        pipeWrite = pipes[1]
+        val hub = LiveMpegTsHub(
+            input = BufferedInputStream(ParcelFileDescriptor.AutoCloseInputStream(pipes[0])),
+            executor = worker,
+            waitForHlsSegment = waitForHlsSegment,
+            onReady = {
+                if (captureGeneration == generation && _state.value.isActive) {
+                    startupTimeoutJob?.cancel()
+                    startupTimeoutJob = null
+                    _state.value = _state.value.copy(
+                        phase = ScreenMirrorCoordinator.Phase.CONNECTING,
+                        message = "Waiting for receiver…",
+                    )
+                    onReady(
+                        Urls(
+                            hls = "$baseUrl/index.m3u8",
+                            continuousTs = "$baseUrl/stream.ts",
+                        ),
+                    )
+                }
+            },
+        )
+        streamHub = hub
+        hub.start()
+        worker.execute { acceptLoop(server, hub, basePath) }
+
+        val projectionManager = context.getSystemService(MediaProjectionManager::class.java)
+        val activeProjection = checkNotNull(
+            projectionManager.getMediaProjection(Activity.RESULT_OK, permission),
+        ) { "MediaProjection permission was rejected" }
+        projection = activeProjection
+
+        val metrics = context.resources.displayMetrics
+        val (sourceWidth, sourceHeight) = screenMirrorCaptureSize(
+            metrics.widthPixels,
+            metrics.heightPixels,
+            options.quality,
+        )
+        val (outputWidth, outputHeight) = externalMirrorEncoderSize(sourceWidth, sourceHeight)
+        sourceSize = sourceWidth to sourceHeight
+        val callback = object : MediaProjection.Callback() {
+            override fun onStop() {
+                mainHandler.post {
+                    if (captureGeneration == generation && _state.value.isActive) {
+                        fail("Screen capture permission was revoked")
+                    }
+                }
+            }
+
+            override fun onCapturedContentResize(width: Int, height: Int) {
+                resizeCapture(
+                    captureGeneration = captureGeneration,
+                    width = width,
+                    height = height,
+                    densityDpi = metrics.densityDpi,
+                    quality = options.quality,
+                )
+            }
+        }
+        projectionCallback = callback
+        activeProjection.registerCallback(callback, mainHandler)
+        val localEncoder = MediaCodecMpegTsEncoder(
+            width = outputWidth,
+            height = outputHeight,
+            bitrateBps = options.quality.maxBitrateBps,
+            framesPerSecond = FRAME_RATE,
+            output = ParcelFileDescriptor.AutoCloseOutputStream(pipes[1]),
+            onError = { error ->
+                Log.e(TAG, "Screen encoder stopped unexpectedly", error)
+                mainHandler.post { fail("Screen encoder stopped unexpectedly") }
+            },
+        )
+        encoder = localEncoder
+        val pacer = MirrorFramePacer(
+            outputWidth = outputWidth,
+            outputHeight = outputHeight,
+            inputWidth = sourceWidth,
+            inputHeight = sourceHeight,
+            framesPerSecond = FRAME_RATE,
+            outputSurface = localEncoder.inputSurface,
+            onError = { error ->
+                Log.e(TAG, "Mirror frame renderer failed", error)
+                mainHandler.post { fail("Screen renderer stopped unexpectedly") }
+            },
+        )
+        framePacer = pacer
+        display = activeProjection.createVirtualDisplay(
+            "PlayBridgeExternalScreenMirror",
+            sourceWidth,
+            sourceHeight,
+            metrics.densityDpi,
+            DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
+            pacer.inputSurface,
+            null,
+            null,
+        )
+        localEncoder.start()
+        pacer.start()
+        Log.i(
+            TAG,
+            "External mirror capture started source=${sourceWidth}x$sourceHeight " +
+                "output=${outputWidth}x$outputHeight host=$host",
+        )
+    }
+
+    @Synchronized
+    private fun resizeCapture(
+        captureGeneration: Long,
+        width: Int,
+        height: Int,
+        densityDpi: Int,
+        quality: ScreenMirrorCoordinator.Quality,
+    ) {
+        if (captureGeneration != generation || !_state.value.isActive) return
+        val (captureWidth, captureHeight) = screenMirrorCaptureSize(width, height, quality)
+        if (sourceSize == (captureWidth to captureHeight)) return
+        sourceSize = captureWidth to captureHeight
+        framePacer?.resizeInput(captureWidth, captureHeight)
+        runCatching {
+            display?.resize(captureWidth, captureHeight, densityDpi)
+        }.onFailure {
+            Log.w(TAG, "Unable to resize external mirror capture", it)
+        }
+        Log.i(TAG, "External mirror source resized to ${captureWidth}x$captureHeight")
+    }
+
+    @Synchronized
+    private fun stopInternal(preserveFailure: Boolean) {
+        generation++
+        startupTimeoutJob?.cancel()
+        startupTimeoutJob = null
+        val encoderToRelease = encoder
+        encoder = null
+        display?.release()
+        display = null
+        framePacer?.close()
+        framePacer = null
+        sourceSize = null
+        projectionCallback?.let { callback ->
+            projection?.unregisterCallback(callback)
+        }
+        projectionCallback = null
+        projection?.stop()
+        projection = null
+        runCatching { listener?.close() }
+        listener = null
+        streamHub?.close()
+        streamHub = null
+        runCatching { pipeRead?.close() }
+        pipeRead = null
+        runCatching { pipeWrite?.close() }
+        pipeWrite = null
+        executor?.shutdownNow()
+        executor = null
+        if (!preserveFailure) _state.value = ScreenMirrorCoordinator.State()
+        encoderToRelease?.let { releaseEncoderOffMainThread(it) }
+    }
+
+    private fun releaseEncoderOffMainThread(encoder: MediaCodecMpegTsEncoder) {
+        Thread(
+            { runCatching { encoder.close() }.onFailure { Log.w(TAG, "Encoder release failed", it) } },
+            "PlayBridgeExternalMirrorStop",
+        ).apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    private fun acceptLoop(server: ServerSocket, hub: LiveMpegTsHub, basePath: String) {
+        try {
+            while (!server.isClosed) {
+                val socket = server.accept()
+                executor?.execute { serveRequest(socket, hub, basePath) } ?: socket.close()
+            }
+        } catch (_: IOException) {
+            // Expected during teardown.
+        }
+    }
+
+    private fun serveRequest(socket: Socket, hub: LiveMpegTsHub, basePath: String) {
+        try {
+            socket.soTimeout = REQUEST_TIMEOUT_MS
+            val reader = BufferedReader(InputStreamReader(socket.getInputStream(), Charsets.US_ASCII))
+            val requestLine = reader.readLine().orEmpty()
+            var header: String?
+            do {
+                header = reader.readLine()
+            } while (!header.isNullOrEmpty())
+            val request = requestLine.split(' ')
+            val method = request.getOrNull(0)
+            val path = request.getOrNull(1)?.substringBefore('?')
+            when {
+                method == "OPTIONS" && path?.startsWith(basePath) == true ->
+                    respond(socket, MirrorHttpResponse.options())
+                method !in setOf("GET", "HEAD") ->
+                    respond(socket, MirrorHttpResponse.empty(405, "Method Not Allowed", allow = true))
+                path == "$basePath/index.m3u8" -> {
+                    val manifest = hub.manifest()
+                    if (manifest == null) {
+                        respond(socket, MirrorHttpResponse.empty(503, "Stream Not Ready"))
+                    } else {
+                        respond(socket, MirrorHttpResponse.bytes("application/x-mpegURL", manifest, method == "HEAD"))
+                    }
+                }
+                path == "$basePath/stream.ts" -> {
+                    if (method == "HEAD") {
+                        respond(socket, MirrorHttpResponse.streamingTs())
+                    } else {
+                        val output = socket.getOutputStream()
+                        output.write(MirrorHttpResponse.streamingTs())
+                        output.flush()
+                        socket.soTimeout = 0
+                        hub.addContinuousClient(socket)
+                    }
+                }
+                path?.startsWith("$basePath/segment-") == true && path.endsWith(".ts") -> {
+                    val id = path.substringAfterLast("segment-").substringBefore(".ts").toLongOrNull()
+                    val bytes = id?.let(hub::segment)
+                    if (bytes == null) {
+                        respond(socket, MirrorHttpResponse.empty(404, "Not Found"))
+                    } else {
+                        respond(socket, MirrorHttpResponse.bytes("video/mp2t", bytes, method == "HEAD"))
+                    }
+                }
+                else -> respond(socket, MirrorHttpResponse.empty(404, "Not Found"))
+            }
+        } catch (_: IOException) {
+            runCatching { socket.close() }
+        }
+    }
+
+    private fun respond(socket: Socket, response: ByteArray) {
+        socket.use { it.getOutputStream().write(response) }
+    }
+
+    private companion object {
+        private const val TAG = "ExternalScreenMirror"
+        private const val STARTUP_TIMEOUT_MS = 15_000L
+        private const val FRAME_RATE = 24
+        private const val REQUEST_TIMEOUT_MS = 5_000
+    }
+}
+
+internal data class MirrorHlsSegment(
+    val id: Long,
+    val durationSeconds: Double,
+    val bytes: ByteArray = ByteArray(0),
+)
+
+internal fun buildMirrorHlsManifest(segments: List<MirrorHlsSegment>): ByteArray? {
+    if (segments.isEmpty()) return null
+    val targetDuration = ceil(segments.maxOf { it.durationSeconds }).toInt().coerceAtLeast(1)
+    return buildString {
+        appendLine("#EXTM3U")
+        appendLine("#EXT-X-VERSION:3")
+        appendLine("#EXT-X-TARGETDURATION:$targetDuration")
+        appendLine("#EXT-X-MEDIA-SEQUENCE:${segments.first().id}")
+        appendLine("#EXT-X-INDEPENDENT-SEGMENTS")
+        segments.forEach { segment ->
+            appendLine("#EXTINF:${"%.3f".format(java.util.Locale.US, segment.durationSeconds)},")
+            appendLine("segment-${segment.id}.ts")
+        }
+    }.toByteArray(Charsets.UTF_8)
+}
+
+/** Reads the recorder pipe once and exposes bounded HLS and continuous-TS views. */
+private class LiveMpegTsHub(
+    private val input: BufferedInputStream,
+    private val executor: ExecutorService,
+    private val waitForHlsSegment: Boolean,
+    private val onReady: () -> Unit,
+) {
+    private val clients = linkedMapOf<Socket, MirrorClientBuffer>()
+    private val joinBuffer = MpegTsJoinBuffer(MAX_GROUP_BYTES)
+    private val segments = ArrayDeque<MirrorHlsSegment>()
+    private var nextSegmentId = 0L
+    private var readySent = false
+    @Volatile private var closed = false
+
+    fun start() {
+        executor.execute {
+            val buffer = ByteArray(32 * 1024)
+            try {
+                while (!closed) {
+                    val count = input.read(buffer)
+                    if (count < 0) break
+                    var becameReady = false
+                    synchronized(this) {
+                        val chunk = joinBuffer.consume(buffer, count)
+                        if (chunk.isNotEmpty()) {
+                            val failed = clients.filter { (_, queue) -> !queue.offer(chunk) }
+                            failed.keys.forEach(::removeClient)
+                        }
+                        joinBuffer.drainCompletedSegments().forEach { completed ->
+                            segments += MirrorHlsSegment(
+                                id = nextSegmentId++,
+                                durationSeconds = completed.durationSeconds,
+                                bytes = completed.bytes,
+                            )
+                            while (segments.size > RETAINED_SEGMENTS) segments.removeFirst()
+                        }
+                        val transportReady = if (waitForHlsSegment) {
+                            segments.isNotEmpty()
+                        } else {
+                            joinBuffer.isReadyForJoin()
+                        }
+                        if (!readySent && transportReady) {
+                            readySent = true
+                            becameReady = true
+                        }
+                    }
+                    if (becameReady) onReady()
+                }
+            } catch (_: IOException) {
+                // Expected during teardown.
+            } finally {
+                close()
+            }
+        }
+    }
+
+    @Synchronized
+    fun manifest(): ByteArray? =
+        buildMirrorHlsManifest(segments.takeLast(PLAYLIST_SEGMENTS))
+
+    @Synchronized
+    fun segment(id: Long): ByteArray? = segments.firstOrNull { it.id == id }?.bytes
+
+    @Synchronized
+    fun addContinuousClient(socket: Socket) {
+        if (closed) {
+            socket.close()
+            return
+        }
+        val initial = joinBuffer.snapshot()
+        val queue = MirrorClientBuffer(CLIENT_QUEUE_BYTES)
+        clients[socket] = queue
+        executor.execute {
+            try {
+                val output = socket.getOutputStream()
+                output.write(initial)
+                output.flush()
+                while (!closed && !socket.isClosed) {
+                    val chunk = queue.poll(1, TimeUnit.SECONDS) ?: continue
+                    output.write(chunk)
+                    output.flush()
+                }
+            } catch (_: IOException) {
+                // Receiver disconnected.
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+            } finally {
+                synchronized(this) { removeClient(socket) }
+            }
+        }
+    }
+
+    @Synchronized
+    fun close() {
+        if (closed) return
+        closed = true
+        runCatching { input.close() }
+        clients.keys.toList().forEach(::removeClient)
+        segments.clear()
+    }
+
+    private fun removeClient(socket: Socket) {
+        clients.remove(socket)?.close()
+        runCatching { socket.close() }
+    }
+
+    private companion object {
+        private const val TS_PACKET_BYTES = 188
+        private const val MAX_GROUP_BYTES = TS_PACKET_BYTES * 48_000
+        private const val CLIENT_QUEUE_BYTES = 512 * 1024
+        private const val RETAINED_SEGMENTS = 8
+        private const val PLAYLIST_SEGMENTS = 6
+    }
+}
+
+internal class MirrorClientBuffer(private val capacityBytes: Int) {
+    private val queue = LinkedBlockingQueue<ByteArray>()
+    private val queuedBytes = AtomicInteger()
+    @Volatile private var closed = false
+
+    fun offer(chunk: ByteArray): Boolean {
+        if (closed || chunk.size > capacityBytes) return false
+        while (true) {
+            val current = queuedBytes.get()
+            if (current + chunk.size > capacityBytes) return false
+            if (queuedBytes.compareAndSet(current, current + chunk.size)) break
+        }
+        if (closed) {
+            queuedBytes.addAndGet(-chunk.size)
+            return false
+        }
+        queue.offer(chunk)
+        return true
+    }
+
+    fun poll(timeout: Long, unit: TimeUnit): ByteArray? =
+        queue.poll(timeout, unit)?.also { queuedBytes.addAndGet(-it.size) }
+
+    fun close() {
+        closed = true
+        queue.clear()
+        queuedBytes.set(0)
+    }
+}
+
+internal object MirrorHttpResponse {
+    private const val CORS =
+        "Access-Control-Allow-Origin: *\r\n" +
+            "Access-Control-Allow-Methods: GET, HEAD, OPTIONS\r\n" +
+            "Access-Control-Allow-Headers: Range, Content-Type\r\n" +
+            "Access-Control-Expose-Headers: Content-Type, Content-Length\r\n"
+
+    fun streamingTs(): ByteArray = headers("video/mp2t", contentLength = null)
+
+    fun bytes(contentType: String, body: ByteArray, headOnly: Boolean): ByteArray =
+        headers(contentType, body.size) + if (headOnly) ByteArray(0) else body
+
+    fun options(): ByteArray = (
+        "HTTP/1.1 204 No Content\r\n" + CORS +
+            "Access-Control-Max-Age: 86400\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        ).toByteArray(Charsets.US_ASCII)
+
+    fun empty(status: Int, reason: String, allow: Boolean = false): ByteArray = buildString {
+        append("HTTP/1.1 $status $reason\r\n")
+        append(CORS)
+        if (allow) append("Allow: GET, HEAD, OPTIONS\r\n")
+        append("Content-Length: 0\r\nConnection: close\r\n\r\n")
+    }.toByteArray(Charsets.US_ASCII)
+
+    private fun headers(contentType: String, contentLength: Int?): ByteArray = buildString {
+        append("HTTP/1.1 200 OK\r\n")
+        append("Content-Type: $contentType\r\n")
+        append("Cache-Control: no-cache, no-store\r\n")
+        append(CORS)
+        if (contentLength != null) append("Content-Length: $contentLength\r\n")
+        append("Connection: close\r\n\r\n")
+    }.toByteArray(Charsets.US_ASCII)
+}
+
+internal fun localIpv4ForReceiver(context: Context, receiverHost: String): String? {
+    val connectivity = context.getSystemService<ConnectivityManager>() ?: return null
+    val receiver = runCatching { InetAddress.getByName(receiverHost) }.getOrNull()
+    val candidates = connectivity.allNetworks.mapNotNull { network ->
+        val capabilities = connectivity.getNetworkCapabilities(network) ?: return@mapNotNull null
+        val physical = capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+        if (!physical || capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) return@mapNotNull null
+        val properties = connectivity.getLinkProperties(network) ?: return@mapNotNull null
+        network to properties
+    }
+    val selected = candidates.firstOrNull { (_, properties) ->
+        receiver != null && properties.routes.any { it.matches(receiver) }
+    } ?: candidates.firstOrNull()
+    return selected?.second?.linkAddresses
+        ?.asSequence()
+        ?.map { it.address }
+        ?.filterIsInstance<Inet4Address>()
+        ?.filterNot { it.isLoopbackAddress || it.isLinkLocalAddress }
+        ?.sortedByDescending { it.isSiteLocalAddress }
+        ?.firstOrNull()
+        ?.hostAddress
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/ExternalScreenMirrorCoordinator.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/ExternalScreenMirrorCoordinator.kt
@@ -237,7 +237,16 @@ class ExternalScreenMirrorCoordinator(
             output = ParcelFileDescriptor.AutoCloseOutputStream(pipes[1]),
             onError = { error ->
                 Log.e(TAG, "Screen encoder stopped unexpectedly", error)
-                mainHandler.post { fail("Screen encoder stopped unexpectedly") }
+                mainHandler.post {
+                    if (shouldHandleExternalMirrorCallback(
+                            captureGeneration,
+                            generation,
+                            _state.value.isActive,
+                        )
+                    ) {
+                        fail("Screen encoder stopped unexpectedly")
+                    }
+                }
             },
             onAudioActive = {
                 mainHandler.post {
@@ -278,7 +287,16 @@ class ExternalScreenMirrorCoordinator(
             outputSurface = localEncoder.inputSurface,
             onError = { error ->
                 Log.e(TAG, "Mirror frame renderer failed", error)
-                mainHandler.post { fail("Screen renderer stopped unexpectedly") }
+                mainHandler.post {
+                    if (shouldHandleExternalMirrorCallback(
+                            captureGeneration,
+                            generation,
+                            _state.value.isActive,
+                        )
+                    ) {
+                        fail("Screen renderer stopped unexpectedly")
+                    }
+                }
             },
         )
         framePacer = pacer
@@ -439,6 +457,12 @@ class ExternalScreenMirrorCoordinator(
         private const val REQUEST_TIMEOUT_MS = 5_000
     }
 }
+
+internal fun shouldHandleExternalMirrorCallback(
+    callbackGeneration: Long,
+    currentGeneration: Long,
+    isActive: Boolean,
+): Boolean = isActive && callbackGeneration == currentGeneration
 
 internal data class MirrorHlsSegment(
     val id: Long,

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/ExternalScreenMirrorCoordinator.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/ExternalScreenMirrorCoordinator.kt
@@ -48,6 +48,7 @@ class ExternalScreenMirrorCoordinator(
     data class Urls(
         val hls: String,
         val continuousTs: String,
+        val hasAudio: Boolean = false,
     )
 
     private val _state = MutableStateFlow(ScreenMirrorCoordinator.State())
@@ -67,6 +68,8 @@ class ExternalScreenMirrorCoordinator(
     private var generation = 0L
     private var projectionCallback: MediaProjection.Callback? = null
     private var sourceSize: Pair<Int, Int>? = null
+    @Volatile
+    private var transportHasAudio = false
 
     /** Called only after CastSessionService entered the mediaProjection FGS type. */
     fun start(
@@ -77,17 +80,17 @@ class ExternalScreenMirrorCoordinator(
         onReady: (Urls) -> Unit,
     ) {
         if (_state.value.isActive) return
+        transportHasAudio = false
         val currentGeneration = ++generation
         _state.value = ScreenMirrorCoordinator.State(
             phase = ScreenMirrorCoordinator.Phase.STARTING,
             sessionId = UUID.randomUUID().toString(),
             message = "Preparing screen capture…",
-            deviceAudioRequested = false,
-            audioStatus = ScreenMirrorCoordinator.AudioStatus.DISABLED,
-            audioMessage = if (options.deviceAudio) {
-                "Device audio is not yet available for Google Cast or DLNA mirroring."
+            deviceAudioRequested = options.deviceAudio,
+            audioStatus = if (options.deviceAudio) {
+                ScreenMirrorCoordinator.AudioStatus.STARTING
             } else {
-                null
+                ScreenMirrorCoordinator.AudioStatus.DISABLED
             },
         )
         startupTimeoutJob?.cancel()
@@ -179,6 +182,7 @@ class ExternalScreenMirrorCoordinator(
                         Urls(
                             hls = "$baseUrl/index.m3u8",
                             continuousTs = "$baseUrl/stream.ts",
+                            hasAudio = transportHasAudio,
                         ),
                     )
                 }
@@ -228,13 +232,43 @@ class ExternalScreenMirrorCoordinator(
             height = outputHeight,
             bitrateBps = options.quality.maxBitrateBps,
             framesPerSecond = FRAME_RATE,
+            projection = activeProjection,
+            deviceAudio = options.deviceAudio,
             output = ParcelFileDescriptor.AutoCloseOutputStream(pipes[1]),
             onError = { error ->
                 Log.e(TAG, "Screen encoder stopped unexpectedly", error)
                 mainHandler.post { fail("Screen encoder stopped unexpectedly") }
             },
+            onAudioActive = {
+                mainHandler.post {
+                    if (captureGeneration == generation && _state.value.isActive) {
+                        _state.value = _state.value.copy(
+                            audioStatus = ScreenMirrorCoordinator.AudioStatus.ACTIVE,
+                            audioMessage = null,
+                        )
+                    }
+                }
+            },
+            onAudioError = { error ->
+                Log.w(TAG, "Device audio capture unavailable; continuing video-only", error)
+                mainHandler.post {
+                    if (captureGeneration == generation && _state.value.isActive) {
+                        _state.value = _state.value.copy(
+                            audioStatus = ScreenMirrorCoordinator.AudioStatus.UNAVAILABLE,
+                            audioMessage = "Device audio is unavailable. Mirroring video only.",
+                        )
+                    }
+                }
+            },
         )
         encoder = localEncoder
+        transportHasAudio = localEncoder.hasAudio
+        if (options.deviceAudio && !localEncoder.hasAudio) {
+            _state.value = _state.value.copy(
+                audioStatus = ScreenMirrorCoordinator.AudioStatus.UNAVAILABLE,
+                audioMessage = "Device audio is unavailable. Mirroring video only.",
+            )
+        }
         val pacer = MirrorFramePacer(
             outputWidth = outputWidth,
             outputHeight = outputHeight,
@@ -300,6 +334,7 @@ class ExternalScreenMirrorCoordinator(
         framePacer?.close()
         framePacer = null
         sourceSize = null
+        transportHasAudio = false
         projectionCallback?.let { callback ->
             projection?.unregisterCallback(callback)
         }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MediaCodecMpegTsEncoder.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MediaCodecMpegTsEncoder.kt
@@ -18,20 +18,40 @@ internal class MediaCodecMpegTsEncoder(
     height: Int,
     bitrateBps: Int,
     framesPerSecond: Int,
+    projection: android.media.projection.MediaProjection,
+    deviceAudio: Boolean,
     private val output: OutputStream,
     private val onError: (Throwable) -> Unit,
+    onAudioActive: () -> Unit,
+    onAudioError: (Throwable) -> Unit,
 ) : Closeable {
     private val codec = MediaCodec.createEncoderByType(MIME_AVC)
     private val running = AtomicBoolean(false)
     private val closed = AtomicBoolean(false)
-    private val muxer = H264MpegTsMuxer(output)
+    private lateinit var muxer: H264MpegTsMuxer
+    private val audioEncoder: PlaybackAudioMpegTsEncoder?
     private val drainThread = Thread(::drain, "PlayBridgeMirrorEncoder").apply { isDaemon = true }
     private var codecConfig = ByteArray(0)
     private var lastSyncRequestNs = 0L
 
     val inputSurface: Surface
+    val hasAudio: Boolean get() = audioEncoder != null
 
     init {
+        val audio = if (deviceAudio) {
+            PlaybackAudioMpegTsEncoder.create(
+                projection = projection,
+                onFrame = { accessUnit, presentationTimeUs ->
+                    muxer.writeAudioAccessUnit(accessUnit, presentationTimeUs)
+                },
+                onActive = onAudioActive,
+                onError = onAudioError,
+            )
+        } else {
+            null
+        }
+        muxer = H264MpegTsMuxer(output, includeAudio = audio != null)
+        audioEncoder = audio
         require(width > 0 && height > 0)
         require(bitrateBps > 0 && framesPerSecond > 0)
         val format = MediaFormat.createVideoFormat(MIME_AVC, width, height).apply {
@@ -54,10 +74,12 @@ internal class MediaCodecMpegTsEncoder(
         codec.start()
         lastSyncRequestNs = System.nanoTime()
         drainThread.start()
+        audioEncoder?.start()
     }
 
     override fun close() {
         if (!closed.compareAndSet(false, true)) return
+        audioEncoder?.close()
         running.set(false)
         if (drainThread.isAlive && Thread.currentThread() !== drainThread) {
             drainThread.interrupt()
@@ -189,8 +211,11 @@ private fun ByteArray.hasParameterSets(): Boolean {
     return false
 }
 
-/** Minimal single-program MPEG-TS muxer: PAT + PMT + one H.264 PES stream. */
-internal class H264MpegTsMuxer(private val output: OutputStream) {
+/** Minimal single-program MPEG-TS muxer for H.264 video and optional AAC audio. */
+internal class H264MpegTsMuxer(
+    private val output: OutputStream,
+    private val includeAudio: Boolean = false,
+) {
     private val continuity = IntArray(MAX_PID + 1)
     private var wroteTables = false
 
@@ -204,7 +229,21 @@ internal class H264MpegTsMuxer(private val output: OutputStream) {
         }
         val pts90Khz = presentationTimeUs.coerceAtLeast(0L) * 90L / 1_000L
         val pes = pesHeader(pts90Khz) + accessUnit
-        writePes(pes, pts90Khz, keyFrame)
+        writePes(VIDEO_PID, pes, pts90Khz, keyFrame, writePcr = true)
+        output.flush()
+    }
+
+    @Synchronized
+    fun writeAudioAccessUnit(accessUnit: ByteArray, presentationTimeUs: Long) {
+        if (!includeAudio || accessUnit.isEmpty()) return
+        if (!wroteTables) {
+            writePsi(PAT_PID, patSection())
+            writePsi(PMT_PID, pmtSection())
+            wroteTables = true
+        }
+        val pts90Khz = presentationTimeUs.coerceAtLeast(0L) * 90L / 1_000L
+        val pes = pesHeader(pts90Khz, AUDIO_STREAM_ID, accessUnit.size) + accessUnit
+        writePes(AUDIO_PID, pes, pts90Khz, keyFrame = false, writePcr = false)
         output.flush()
     }
 
@@ -216,23 +255,29 @@ internal class H264MpegTsMuxer(private val output: OutputStream) {
         output.write(packet)
     }
 
-    private fun writePes(pes: ByteArray, pts90Khz: Long, keyFrame: Boolean) {
+    private fun writePes(
+        pid: Int,
+        pes: ByteArray,
+        pts90Khz: Long,
+        keyFrame: Boolean,
+        writePcr: Boolean,
+    ) {
         var offset = 0
         var first = true
         while (offset < pes.size) {
-            val packet = ByteArray(TS_PACKET_BYTES) { 0xff.toByte() }
-            val minimumAdaptationBytes = if (first) 8 else 0
+            val minimumAdaptationBytes = if (first && writePcr) 8 else 0
             val maximumPayload = TS_PAYLOAD_BYTES - minimumAdaptationBytes
-            val payloadBytes = minOf(pes.size - offset, maximumPayload)
-            val needsAdaptation = first || payloadBytes < TS_PAYLOAD_BYTES
-            writeHeader(packet, VIDEO_PID, payloadStart = first, adaptationControl = if (needsAdaptation) 3 else 1)
+            val payloadBytes = minOf(maximumPayload, pes.size - offset)
+            val packet = ByteArray(TS_PACKET_BYTES) { 0xff.toByte() }
+            val needsAdaptation = (first && writePcr) || payloadBytes < TS_PAYLOAD_BYTES
+            writeHeader(packet, pid, payloadStart = first, adaptationControl = if (needsAdaptation) 3 else 1)
             var payloadOffset = 4
             if (needsAdaptation) {
                 val adaptationLength = TS_PAYLOAD_BYTES - payloadBytes - 1
                 packet[4] = adaptationLength.toByte()
                 if (adaptationLength > 0) {
-                    packet[5] = if (first && keyFrame) 0x50 else if (first) 0x10 else 0
-                    if (first) writePcr(packet, 6, pts90Khz)
+                    packet[5] = if (first && keyFrame) 0x50 else if (first && writePcr) 0x10 else 0
+                    if (first && writePcr) writePcr(packet, 6, pts90Khz)
                 }
                 payloadOffset = 5 + adaptationLength
             }
@@ -261,15 +306,23 @@ internal class H264MpegTsMuxer(private val output: OutputStream) {
         packet[offset + 5] = 0
     }
 
-    private fun pesHeader(pts90Khz: Long): ByteArray = byteArrayOf(
-        0x00, 0x00, 0x01, 0xe0.toByte(), 0x00, 0x00,
-        0x80.toByte(), 0x80.toByte(), 0x05,
-        (0x21L or (((pts90Khz ushr 30) and 0x07) shl 1)).toByte(),
-        (pts90Khz ushr 22).toByte(),
-        (((pts90Khz ushr 14) and 0xfe) or 0x01).toByte(),
-        (pts90Khz ushr 7).toByte(),
-        (((pts90Khz shl 1) and 0xfe) or 0x01).toByte(),
-    )
+    private fun pesHeader(
+        pts90Khz: Long,
+        streamId: Int = VIDEO_STREAM_ID,
+        payloadSize: Int? = null,
+    ): ByteArray {
+        val packetLength = payloadSize?.plus(PES_OPTIONAL_HEADER_BYTES)?.coerceAtMost(0xffff) ?: 0
+        return byteArrayOf(
+            0x00, 0x00, 0x01, streamId.toByte(),
+            (packetLength ushr 8).toByte(), packetLength.toByte(),
+            0x80.toByte(), 0x80.toByte(), 0x05,
+            (0x21L or (((pts90Khz ushr 30) and 0x07) shl 1)).toByte(),
+            (pts90Khz ushr 22).toByte(),
+            (((pts90Khz ushr 14) and 0xfe) or 0x01).toByte(),
+            (pts90Khz ushr 7).toByte(),
+            (((pts90Khz shl 1) and 0xfe) or 0x01).toByte(),
+        )
+    }
 
     private fun patSection(): ByteArray = psiWithCrc(
         byteArrayOf(
@@ -279,15 +332,26 @@ internal class H264MpegTsMuxer(private val output: OutputStream) {
         ),
     )
 
-    private fun pmtSection(): ByteArray = psiWithCrc(
-        byteArrayOf(
-            0x02, 0xb0.toByte(), 0x12,
-            0x00, 0x01, 0xc1.toByte(), 0x00, 0x00,
-            (0xe0 or (VIDEO_PID ushr 8)).toByte(), VIDEO_PID.toByte(),
-            0xf0.toByte(), 0x00,
+    private fun pmtSection(): ByteArray {
+        val streams = byteArrayOf(
             0x1b, (0xe0 or (VIDEO_PID ushr 8)).toByte(), VIDEO_PID.toByte(), 0xf0.toByte(), 0x00,
-        ),
-    )
+        ) + if (includeAudio) {
+            byteArrayOf(
+                0x0f, (0xe0 or (AUDIO_PID ushr 8)).toByte(), AUDIO_PID.toByte(), 0xf0.toByte(), 0x00,
+            )
+        } else {
+            ByteArray(0)
+        }
+        val sectionLength = PMT_BASE_SECTION_LENGTH + streams.size
+        return psiWithCrc(
+            byteArrayOf(
+                0x02, (0xb0 or (sectionLength ushr 8)).toByte(), sectionLength.toByte(),
+                0x00, 0x01, 0xc1.toByte(), 0x00, 0x00,
+                (0xe0 or (VIDEO_PID ushr 8)).toByte(), VIDEO_PID.toByte(),
+                0xf0.toByte(), 0x00,
+            ) + streams,
+        )
+    }
 
     private fun psiWithCrc(section: ByteArray): ByteArray {
         val crc = mpegCrc32(section)
@@ -305,6 +369,11 @@ internal class H264MpegTsMuxer(private val output: OutputStream) {
         private const val PAT_PID = 0x0000
         private const val PMT_PID = 0x0100
         private const val VIDEO_PID = 0x0101
+        private const val AUDIO_PID = 0x0102
+        private const val VIDEO_STREAM_ID = 0xe0
+        private const val AUDIO_STREAM_ID = 0xc0
+        private const val PES_OPTIONAL_HEADER_BYTES = 8
+        private const val PMT_BASE_SECTION_LENGTH = 13
         private const val MAX_PID = 0x1fff
         private const val PTS_MASK = (1L shl 33) - 1
     }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MediaCodecMpegTsEncoder.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MediaCodecMpegTsEncoder.kt
@@ -28,7 +28,7 @@ internal class MediaCodecMpegTsEncoder(
     private val codec = MediaCodec.createEncoderByType(MIME_AVC)
     private val running = AtomicBoolean(false)
     private val closed = AtomicBoolean(false)
-    private lateinit var muxer: H264MpegTsMuxer
+    private val muxer: H264MpegTsMuxer
     private val audioEncoder: PlaybackAudioMpegTsEncoder?
     private val drainThread = Thread(::drain, "PlayBridgeMirrorEncoder").apply { isDaemon = true }
     private var codecConfig = ByteArray(0)
@@ -38,20 +38,6 @@ internal class MediaCodecMpegTsEncoder(
     val hasAudio: Boolean get() = audioEncoder != null
 
     init {
-        val audio = if (deviceAudio) {
-            PlaybackAudioMpegTsEncoder.create(
-                projection = projection,
-                onFrame = { accessUnit, presentationTimeUs ->
-                    muxer.writeAudioAccessUnit(accessUnit, presentationTimeUs)
-                },
-                onActive = onAudioActive,
-                onError = onAudioError,
-            )
-        } else {
-            null
-        }
-        muxer = H264MpegTsMuxer(output, includeAudio = audio != null)
-        audioEncoder = audio
         require(width > 0 && height > 0)
         require(bitrateBps > 0 && framesPerSecond > 0)
         val format = MediaFormat.createVideoFormat(MIME_AVC, width, height).apply {
@@ -67,6 +53,22 @@ internal class MediaCodecMpegTsEncoder(
         }
         codec.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
         inputSurface = codec.createInputSurface()
+        val audioCandidate = if (deviceAudio) {
+            PlaybackAudioMpegTsEncoder.create(
+                projection = projection,
+                onFrame = { accessUnit, presentationTimeUs ->
+                    muxer.writeAudioAccessUnit(accessUnit, presentationTimeUs)
+                },
+                onActive = onAudioActive,
+                onError = onAudioError,
+            )
+        } else {
+            null
+        }
+        val audio = audioCandidate?.takeIf { it.prepare() }
+        if (audio == null) audioCandidate?.close()
+        muxer = H264MpegTsMuxer(output, includeAudio = audio != null)
+        audioEncoder = audio
     }
 
     fun start() {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MediaCodecMpegTsEncoder.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MediaCodecMpegTsEncoder.kt
@@ -1,0 +1,324 @@
+package com.playbridge.sender.cast.mirror
+
+import android.media.MediaCodec
+import android.media.MediaCodecInfo
+import android.media.MediaFormat
+import android.os.Build
+import android.os.Bundle
+import android.view.Surface
+import java.io.Closeable
+import java.io.IOException
+import java.io.OutputStream
+import java.nio.ByteBuffer
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Surface-input H.264 encoder with a small MPEG-TS muxer for low-latency mirroring. */
+internal class MediaCodecMpegTsEncoder(
+    width: Int,
+    height: Int,
+    bitrateBps: Int,
+    framesPerSecond: Int,
+    private val output: OutputStream,
+    private val onError: (Throwable) -> Unit,
+) : Closeable {
+    private val codec = MediaCodec.createEncoderByType(MIME_AVC)
+    private val running = AtomicBoolean(false)
+    private val closed = AtomicBoolean(false)
+    private val muxer = H264MpegTsMuxer(output)
+    private val drainThread = Thread(::drain, "PlayBridgeMirrorEncoder").apply { isDaemon = true }
+    private var codecConfig = ByteArray(0)
+    private var lastSyncRequestNs = 0L
+
+    val inputSurface: Surface
+
+    init {
+        require(width > 0 && height > 0)
+        require(bitrateBps > 0 && framesPerSecond > 0)
+        val format = MediaFormat.createVideoFormat(MIME_AVC, width, height).apply {
+            setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface)
+            setInteger(MediaFormat.KEY_BIT_RATE, bitrateBps)
+            setInteger(MediaFormat.KEY_FRAME_RATE, framesPerSecond)
+            setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, KEYFRAME_INTERVAL_SECONDS)
+            setInteger(MediaFormat.KEY_BITRATE_MODE, MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_CBR)
+            setInteger(MediaFormat.KEY_PROFILE, MediaCodecInfo.CodecProfileLevel.AVCProfileBaseline)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                setInteger(MediaFormat.KEY_PREPEND_HEADER_TO_SYNC_FRAMES, 1)
+            }
+        }
+        codec.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+        inputSurface = codec.createInputSurface()
+    }
+
+    fun start() {
+        if (!running.compareAndSet(false, true)) return
+        codec.start()
+        lastSyncRequestNs = System.nanoTime()
+        drainThread.start()
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        running.set(false)
+        if (drainThread.isAlive && Thread.currentThread() !== drainThread) {
+            drainThread.interrupt()
+            drainThread.join(STOP_TIMEOUT_MS)
+        }
+        runCatching { codec.stop() }
+        runCatching { codec.release() }
+        runCatching { inputSurface.release() }
+        runCatching { output.close() }
+    }
+
+    private fun drain() {
+        val info = MediaCodec.BufferInfo()
+        try {
+            while (running.get()) {
+                requestSyncFrameWhenDue()
+                when (val index = codec.dequeueOutputBuffer(info, DEQUEUE_TIMEOUT_US)) {
+                    MediaCodec.INFO_TRY_AGAIN_LATER -> Unit
+                    MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> updateCodecConfig(codec.outputFormat)
+                    else -> if (index >= 0) drainBuffer(index, info)
+                }
+            }
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        } catch (error: Throwable) {
+            if (!closed.get()) onError(error)
+        }
+    }
+
+    private fun updateCodecConfig(format: MediaFormat) {
+        val config = buildList {
+            format.getByteBuffer("csd-0")?.copyRemaining()?.let(::add)
+            format.getByteBuffer("csd-1")?.copyRemaining()?.let(::add)
+        }
+        codecConfig = config.fold(ByteArray(0), ByteArray::plus).toAnnexB()
+    }
+
+    private fun drainBuffer(index: Int, info: MediaCodec.BufferInfo) {
+        try {
+            if (info.size <= 0) return
+            val buffer = codec.getOutputBuffer(index) ?: return
+            buffer.position(info.offset)
+            buffer.limit(info.offset + info.size)
+            val encoded = ByteArray(info.size)
+            buffer.get(encoded)
+            if ((info.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+                codecConfig = encoded.toAnnexB()
+                return
+            }
+            val keyFrame = (info.flags and MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0
+            val accessUnit = encoded.toAnnexB()
+            val payload = if (keyFrame && codecConfig.isNotEmpty() && !accessUnit.hasParameterSets()) {
+                codecConfig + accessUnit
+            } else {
+                accessUnit
+            }
+            muxer.writeAccessUnit(payload, info.presentationTimeUs, keyFrame)
+        } finally {
+            codec.releaseOutputBuffer(index, false)
+        }
+    }
+
+    private fun requestSyncFrameWhenDue() {
+        val now = System.nanoTime()
+        if (now - lastSyncRequestNs < KEYFRAME_INTERVAL_NS) return
+        codec.setParameters(Bundle().apply {
+            putInt(MediaCodec.PARAMETER_KEY_REQUEST_SYNC_FRAME, 0)
+        })
+        lastSyncRequestNs = now
+    }
+
+    private companion object {
+        private const val MIME_AVC = "video/avc"
+        private const val KEYFRAME_INTERVAL_SECONDS = 1
+        private const val KEYFRAME_INTERVAL_NS = 1_000_000_000L
+        private const val DEQUEUE_TIMEOUT_US = 10_000L
+        private const val STOP_TIMEOUT_MS = 2_000L
+    }
+}
+
+private fun ByteBuffer.copyRemaining(): ByteArray {
+    val copy = duplicate()
+    return ByteArray(copy.remaining()).also(copy::get)
+}
+
+internal fun ByteArray.toAnnexB(): ByteArray {
+    if (hasAnnexBStartCode()) return this
+    val output = java.io.ByteArrayOutputStream(size + 32)
+    var offset = 0
+    while (offset + 4 <= size) {
+        val length = ((this[offset].toInt() and 0xff) shl 24) or
+            ((this[offset + 1].toInt() and 0xff) shl 16) or
+            ((this[offset + 2].toInt() and 0xff) shl 8) or
+            (this[offset + 3].toInt() and 0xff)
+        offset += 4
+        if (length <= 0 || offset + length > size) return this
+        output.write(ANNEX_B_START_CODE)
+        output.write(this, offset, length)
+        offset += length
+    }
+    return if (offset == size && output.size() > 0) output.toByteArray() else this
+}
+
+private fun ByteArray.hasAnnexBStartCode(): Boolean =
+    size >= 4 && this[0] == 0.toByte() && this[1] == 0.toByte() &&
+        (this[2] == 1.toByte() || (this[2] == 0.toByte() && this[3] == 1.toByte()))
+
+private fun ByteArray.hasParameterSets(): Boolean {
+    var offset = 0
+    var hasSps = false
+    var hasPps = false
+    while (offset + 4 < size) {
+        val nal = when {
+            this[offset] == 0.toByte() && this[offset + 1] == 0.toByte() && this[offset + 2] == 1.toByte() -> offset + 3
+            this[offset] == 0.toByte() && this[offset + 1] == 0.toByte() &&
+                this[offset + 2] == 0.toByte() && this[offset + 3] == 1.toByte() -> offset + 4
+            else -> {
+                offset++
+                continue
+            }
+        }
+        when (this[nal].toInt() and 0x1f) {
+            7 -> hasSps = true
+            8 -> hasPps = true
+        }
+        if (hasSps && hasPps) return true
+        offset = nal + 1
+    }
+    return false
+}
+
+/** Minimal single-program MPEG-TS muxer: PAT + PMT + one H.264 PES stream. */
+internal class H264MpegTsMuxer(private val output: OutputStream) {
+    private val continuity = IntArray(MAX_PID + 1)
+    private var wroteTables = false
+
+    @Synchronized
+    fun writeAccessUnit(accessUnit: ByteArray, presentationTimeUs: Long, keyFrame: Boolean) {
+        if (accessUnit.isEmpty()) return
+        if (!wroteTables || keyFrame) {
+            writePsi(PAT_PID, patSection())
+            writePsi(PMT_PID, pmtSection())
+            wroteTables = true
+        }
+        val pts90Khz = presentationTimeUs.coerceAtLeast(0L) * 90L / 1_000L
+        val pes = pesHeader(pts90Khz) + accessUnit
+        writePes(pes, pts90Khz, keyFrame)
+        output.flush()
+    }
+
+    private fun writePsi(pid: Int, section: ByteArray) {
+        val packet = ByteArray(TS_PACKET_BYTES) { 0xff.toByte() }
+        writeHeader(packet, pid, payloadStart = true, adaptationControl = 1)
+        packet[4] = 0
+        section.copyInto(packet, destinationOffset = 5)
+        output.write(packet)
+    }
+
+    private fun writePes(pes: ByteArray, pts90Khz: Long, keyFrame: Boolean) {
+        var offset = 0
+        var first = true
+        while (offset < pes.size) {
+            val packet = ByteArray(TS_PACKET_BYTES) { 0xff.toByte() }
+            val minimumAdaptationBytes = if (first) 8 else 0
+            val maximumPayload = TS_PAYLOAD_BYTES - minimumAdaptationBytes
+            val payloadBytes = minOf(pes.size - offset, maximumPayload)
+            val needsAdaptation = first || payloadBytes < TS_PAYLOAD_BYTES
+            writeHeader(packet, VIDEO_PID, payloadStart = first, adaptationControl = if (needsAdaptation) 3 else 1)
+            var payloadOffset = 4
+            if (needsAdaptation) {
+                val adaptationLength = TS_PAYLOAD_BYTES - payloadBytes - 1
+                packet[4] = adaptationLength.toByte()
+                if (adaptationLength > 0) {
+                    packet[5] = if (first && keyFrame) 0x50 else if (first) 0x10 else 0
+                    if (first) writePcr(packet, 6, pts90Khz)
+                }
+                payloadOffset = 5 + adaptationLength
+            }
+            pes.copyInto(packet, destinationOffset = payloadOffset, startIndex = offset, endIndex = offset + payloadBytes)
+            output.write(packet)
+            offset += payloadBytes
+            first = false
+        }
+    }
+
+    private fun writeHeader(packet: ByteArray, pid: Int, payloadStart: Boolean, adaptationControl: Int) {
+        packet[0] = 0x47
+        packet[1] = (((pid ushr 8) and 0x1f) or if (payloadStart) 0x40 else 0).toByte()
+        packet[2] = pid.toByte()
+        packet[3] = ((adaptationControl shl 4) or continuity[pid]).toByte()
+        continuity[pid] = (continuity[pid] + 1) and 0x0f
+    }
+
+    private fun writePcr(packet: ByteArray, offset: Int, pts90Khz: Long) {
+        val value = pts90Khz and PTS_MASK
+        packet[offset] = (value ushr 25).toByte()
+        packet[offset + 1] = (value ushr 17).toByte()
+        packet[offset + 2] = (value ushr 9).toByte()
+        packet[offset + 3] = (value ushr 1).toByte()
+        packet[offset + 4] = (((value and 1) shl 7) or 0x7e).toByte()
+        packet[offset + 5] = 0
+    }
+
+    private fun pesHeader(pts90Khz: Long): ByteArray = byteArrayOf(
+        0x00, 0x00, 0x01, 0xe0.toByte(), 0x00, 0x00,
+        0x80.toByte(), 0x80.toByte(), 0x05,
+        (0x21L or (((pts90Khz ushr 30) and 0x07) shl 1)).toByte(),
+        (pts90Khz ushr 22).toByte(),
+        (((pts90Khz ushr 14) and 0xfe) or 0x01).toByte(),
+        (pts90Khz ushr 7).toByte(),
+        (((pts90Khz shl 1) and 0xfe) or 0x01).toByte(),
+    )
+
+    private fun patSection(): ByteArray = psiWithCrc(
+        byteArrayOf(
+            0x00, 0xb0.toByte(), 0x0d,
+            0x00, 0x01, 0xc1.toByte(), 0x00, 0x00,
+            0x00, 0x01, (0xe0 or (PMT_PID ushr 8)).toByte(), PMT_PID.toByte(),
+        ),
+    )
+
+    private fun pmtSection(): ByteArray = psiWithCrc(
+        byteArrayOf(
+            0x02, 0xb0.toByte(), 0x12,
+            0x00, 0x01, 0xc1.toByte(), 0x00, 0x00,
+            (0xe0 or (VIDEO_PID ushr 8)).toByte(), VIDEO_PID.toByte(),
+            0xf0.toByte(), 0x00,
+            0x1b, (0xe0 or (VIDEO_PID ushr 8)).toByte(), VIDEO_PID.toByte(), 0xf0.toByte(), 0x00,
+        ),
+    )
+
+    private fun psiWithCrc(section: ByteArray): ByteArray {
+        val crc = mpegCrc32(section)
+        return section + byteArrayOf(
+            (crc ushr 24).toByte(),
+            (crc ushr 16).toByte(),
+            (crc ushr 8).toByte(),
+            crc.toByte(),
+        )
+    }
+
+    private companion object {
+        private const val TS_PACKET_BYTES = 188
+        private const val TS_PAYLOAD_BYTES = 184
+        private const val PAT_PID = 0x0000
+        private const val PMT_PID = 0x0100
+        private const val VIDEO_PID = 0x0101
+        private const val MAX_PID = 0x1fff
+        private const val PTS_MASK = (1L shl 33) - 1
+    }
+}
+
+internal fun mpegCrc32(bytes: ByteArray): Int {
+    var crc = -1
+    bytes.forEach { byte ->
+        crc = crc xor ((byte.toInt() and 0xff) shl 24)
+        repeat(8) {
+            crc = if ((crc and Int.MIN_VALUE) != 0) (crc shl 1) xor 0x04c11db7 else crc shl 1
+        }
+    }
+    return crc
+}
+
+private val ANNEX_B_START_CODE = byteArrayOf(0x00, 0x00, 0x00, 0x01)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MirrorFramePacer.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MirrorFramePacer.kt
@@ -91,7 +91,7 @@ internal class MirrorFramePacer(
 
     /**
      * Updates the VirtualDisplay producer size while the recorder's encoded
-     * landscape canvas remains fixed. Keeping the coded resolution stable
+     * 16:9 landscape canvas remains fixed. Keeping the coded resolution stable
      * prevents Google Cast from stalling on a mid-stream orientation change.
      */
     fun resizeInput(width: Int, height: Int) {
@@ -373,8 +373,11 @@ internal class MirrorFramePacer(
     }
 }
 
-internal fun externalMirrorEncoderSize(width: Int, height: Int): Pair<Int, Int> =
-    maxOf(width, height) to minOf(width, height)
+internal fun externalMirrorEncoderSize(width: Int, height: Int): Pair<Int, Int> {
+    val outputWidth = maxOf(width, height).coerceAtLeast(2).let { it - (it % 2) }
+    val outputHeight = (outputWidth * 9 / 16).coerceAtLeast(2).let { it - (it % 2) }
+    return outputWidth to outputHeight
+}
 
 internal fun mirrorFrameFitScale(
     inputWidth: Int,
@@ -385,9 +388,13 @@ internal fun mirrorFrameFitScale(
     val inputAspect = inputWidth.toFloat() / inputHeight
 
     val outputAspect = outputWidth.toFloat() / outputHeight
-    return if (inputAspect > outputAspect) {
+    val fitScale = if (inputAspect > outputAspect) {
         1f to (outputAspect / inputAspect)
     } else {
         (inputAspect / outputAspect) to 1f
     }
+    val safeScale = 1f - (EXTERNAL_MIRROR_SAFE_INSET_FRACTION * 2f)
+    return (fitScale.first * safeScale) to (fitScale.second * safeScale)
 }
+
+private const val EXTERNAL_MIRROR_SAFE_INSET_FRACTION = 0.05f

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MirrorFramePacer.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MirrorFramePacer.kt
@@ -226,6 +226,7 @@ internal class MirrorFramePacer(
         mvpMatrixLocation = GLES20.glGetUniformLocation(programId, "uMvpMatrix")
         textureMatrixLocation = GLES20.glGetUniformLocation(programId, "uTextureMatrix")
         GLES20.glViewport(0, 0, outputWidth, outputHeight)
+        GLES20.glClearColor(0f, 0f, 0f, 1f)
     }
 
     private fun updateMvpMatrix(inputWidth: Int, inputHeight: Int) {
@@ -240,6 +241,9 @@ internal class MirrorFramePacer(
     }
 
     private fun drawFrame() {
+        // Clear the fixed landscape encoder canvas before drawing a letterboxed
+        // portrait frame; otherwise pixels from the preceding landscape frame remain.
+        GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
         GLES20.glUseProgram(programId)
         GLES20.glUniformMatrix4fv(mvpMatrixLocation, 1, false, mvpMatrix, 0)
         GLES20.glUniformMatrix4fv(textureMatrixLocation, 1, false, textureMatrix, 0)
@@ -379,6 +383,7 @@ internal fun mirrorFrameFitScale(
     outputHeight: Int,
 ): Pair<Float, Float> {
     val inputAspect = inputWidth.toFloat() / inputHeight
+
     val outputAspect = outputWidth.toFloat() / outputHeight
     return if (inputAspect > outputAspect) {
         1f to (outputAspect / inputAspect)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MirrorFramePacer.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MirrorFramePacer.kt
@@ -1,0 +1,388 @@
+package com.playbridge.sender.cast.mirror
+
+import android.graphics.SurfaceTexture
+import android.opengl.EGL14
+import android.opengl.EGLConfig
+import android.opengl.EGLContext
+import android.opengl.EGLDisplay
+import android.opengl.EGLExt
+import android.opengl.EGLSurface
+import android.opengl.GLES11Ext
+import android.opengl.GLES20
+import android.opengl.Matrix
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Process
+import android.view.Surface
+import java.io.Closeable
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.FloatBuffer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Conflates display updates and renders the latest frame to MediaRecorder at a
+ * stable cadence. VirtualDisplay otherwise follows high-refresh displays in
+ * bursts and can stop producing samples while the screen is static.
+ */
+internal class MirrorFramePacer(
+    private val outputWidth: Int,
+    private val outputHeight: Int,
+    private val inputWidth: Int,
+    private val inputHeight: Int,
+    private val framesPerSecond: Int,
+    private val outputSurface: Surface,
+    private val onError: (Throwable) -> Unit,
+) : Closeable {
+    private val thread = HandlerThread("PlayBridgeMirrorFrames", Process.THREAD_PRIORITY_DISPLAY).apply { start() }
+    private val handler = Handler(thread.looper)
+    private val running = AtomicBoolean(false)
+    private val framePending = AtomicBoolean(false)
+    private val failed = AtomicBoolean(false)
+    private val closed = AtomicBoolean(false)
+    private val frameIntervalNs = 1_000_000_000L / framesPerSecond
+
+    private var eglDisplay: EGLDisplay = EGL14.EGL_NO_DISPLAY
+    private var eglContext: EGLContext = EGL14.EGL_NO_CONTEXT
+    private var eglSurface: EGLSurface = EGL14.EGL_NO_SURFACE
+    private var textureId = 0
+    private var programId = 0
+    private var positionLocation = -1
+    private var textureLocation = -1
+    private var mvpMatrixLocation = -1
+    private var textureMatrixLocation = -1
+    private var surfaceTexture: SurfaceTexture? = null
+    private var sourceSurface: Surface? = null
+    private var hasFrame = false
+    private var nextFrameNs = 0L
+    private val mvpMatrix = FloatArray(16)
+    private val textureMatrix = FloatArray(16)
+
+    val inputSurface: Surface
+        get() = checkNotNull(sourceSurface) { "Mirror input surface is unavailable" }
+
+    init {
+        require(outputWidth > 0 && outputHeight > 0)
+        require(inputWidth > 0 && inputHeight > 0)
+        require(framesPerSecond > 0)
+        val ready = CountDownLatch(1)
+        var setupError: Throwable? = null
+        handler.post {
+            runCatching { setup() }
+                .onFailure { setupError = it }
+            ready.countDown()
+        }
+        check(ready.await(SETUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) { "Timed out initializing mirror renderer" }
+        setupError?.let {
+            close()
+            throw IllegalStateException("Unable to initialize mirror renderer", it)
+        }
+        sourceSurface = Surface(checkNotNull(surfaceTexture))
+    }
+
+    fun start() {
+        if (running.compareAndSet(false, true)) {
+            nextFrameNs = 0L
+            handler.post(renderTask)
+        }
+    }
+
+    /**
+     * Updates the VirtualDisplay producer size while the recorder's encoded
+     * landscape canvas remains fixed. Keeping the coded resolution stable
+     * prevents Google Cast from stalling on a mid-stream orientation change.
+     */
+    fun resizeInput(width: Int, height: Int) {
+        if (width <= 0 || height <= 0 || closed.get()) return
+        handler.post {
+            surfaceTexture?.setDefaultBufferSize(width, height)
+            updateMvpMatrix(width, height)
+        }
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        running.set(false)
+        if (Thread.currentThread() === thread) {
+            releaseOnRenderThread()
+            return
+        }
+        val stopped = CountDownLatch(1)
+        if (handler.post {
+                runCatching { releaseOnRenderThread() }
+                stopped.countDown()
+            }
+        ) {
+            stopped.await(STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        }
+        if (thread.isAlive) thread.quitSafely()
+    }
+
+    private val renderTask = object : Runnable {
+        override fun run() {
+            if (!running.get()) return
+            runCatching { renderNextFrame() }
+                .onFailure(::reportFailure)
+            if (!running.get()) return
+
+            val nowNs = System.nanoTime()
+            if (nextFrameNs < nowNs - frameIntervalNs * MAX_CATCH_UP_FRAMES) {
+                nextFrameNs = nowNs
+            }
+            val delayMs = ((nextFrameNs - nowNs).coerceAtLeast(0L) / NANOS_PER_MILLISECOND)
+            handler.postDelayed(this, delayMs)
+        }
+    }
+
+    private fun renderNextFrame() {
+        check(EGL14.eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext)) {
+            "eglMakeCurrent failed: 0x${Integer.toHexString(EGL14.eglGetError())}"
+        }
+
+        val texture = checkNotNull(surfaceTexture)
+        if (framePending.getAndSet(false)) {
+            texture.updateTexImage()
+            texture.getTransformMatrix(textureMatrix)
+            hasFrame = true
+        }
+        if (!hasFrame) {
+            nextFrameNs = System.nanoTime() + frameIntervalNs
+            return
+        }
+
+        val presentationNs = if (nextFrameNs == 0L) System.nanoTime() else nextFrameNs
+        drawFrame()
+        EGLExt.eglPresentationTimeANDROID(eglDisplay, eglSurface, presentationNs)
+        check(EGL14.eglSwapBuffers(eglDisplay, eglSurface)) {
+            "eglSwapBuffers failed: 0x${Integer.toHexString(EGL14.eglGetError())}"
+        }
+        nextFrameNs = presentationNs + frameIntervalNs
+    }
+
+    private fun setup() {
+        eglDisplay = EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY)
+        check(eglDisplay != EGL14.EGL_NO_DISPLAY) { "Unable to get EGL display" }
+        val versions = IntArray(2)
+        check(EGL14.eglInitialize(eglDisplay, versions, 0, versions, 1)) { "Unable to initialize EGL" }
+
+        val attributes = intArrayOf(
+            EGL14.EGL_RED_SIZE, 8,
+            EGL14.EGL_GREEN_SIZE, 8,
+            EGL14.EGL_BLUE_SIZE, 8,
+            EGL14.EGL_RENDERABLE_TYPE, EGL14.EGL_OPENGL_ES2_BIT,
+            EGL14.EGL_SURFACE_TYPE, EGL14.EGL_WINDOW_BIT,
+            EGL_RECORDABLE_ANDROID, 1,
+            EGL14.EGL_NONE,
+        )
+        val configs = arrayOfNulls<EGLConfig>(1)
+        val configCount = IntArray(1)
+        check(EGL14.eglChooseConfig(eglDisplay, attributes, 0, configs, 0, 1, configCount, 0)) {
+            "Unable to choose EGL config"
+        }
+        val config = checkNotNull(configs.firstOrNull()).also {
+            check(configCount[0] > 0) { "No recordable EGL config" }
+        }
+
+        eglContext = EGL14.eglCreateContext(
+            eglDisplay,
+            config,
+            EGL14.EGL_NO_CONTEXT,
+            intArrayOf(EGL14.EGL_CONTEXT_CLIENT_VERSION, 2, EGL14.EGL_NONE),
+            0,
+        )
+        check(eglContext != EGL14.EGL_NO_CONTEXT) { "Unable to create EGL context" }
+        eglSurface = EGL14.eglCreateWindowSurface(
+            eglDisplay,
+            config,
+            outputSurface,
+            intArrayOf(EGL14.EGL_NONE),
+            0,
+        )
+        check(eglSurface != EGL14.EGL_NO_SURFACE) { "Unable to create recorder EGL surface" }
+        check(EGL14.eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext)) {
+            "Unable to activate recorder EGL surface"
+        }
+
+        val textures = IntArray(1)
+        GLES20.glGenTextures(1, textures, 0)
+        textureId = textures[0]
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textureId)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE)
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, 0)
+
+        surfaceTexture = SurfaceTexture(textureId).apply {
+            setDefaultBufferSize(inputWidth, inputHeight)
+            setOnFrameAvailableListener({ framePending.set(true) }, handler)
+        }
+        updateMvpMatrix(inputWidth, inputHeight)
+        programId = createProgram(VERTEX_SHADER, FRAGMENT_SHADER)
+        positionLocation = GLES20.glGetAttribLocation(programId, "aPosition")
+        textureLocation = GLES20.glGetAttribLocation(programId, "aTextureCoord")
+        mvpMatrixLocation = GLES20.glGetUniformLocation(programId, "uMvpMatrix")
+        textureMatrixLocation = GLES20.glGetUniformLocation(programId, "uTextureMatrix")
+        GLES20.glViewport(0, 0, outputWidth, outputHeight)
+    }
+
+    private fun updateMvpMatrix(inputWidth: Int, inputHeight: Int) {
+        val (scaleX, scaleY) = mirrorFrameFitScale(
+            inputWidth = inputWidth,
+            inputHeight = inputHeight,
+            outputWidth = outputWidth,
+            outputHeight = outputHeight,
+        )
+        Matrix.setIdentityM(mvpMatrix, 0)
+        Matrix.scaleM(mvpMatrix, 0, scaleX, -scaleY, 1f)
+    }
+
+    private fun drawFrame() {
+        GLES20.glUseProgram(programId)
+        GLES20.glUniformMatrix4fv(mvpMatrixLocation, 1, false, mvpMatrix, 0)
+        GLES20.glUniformMatrix4fv(textureMatrixLocation, 1, false, textureMatrix, 0)
+        GLES20.glEnableVertexAttribArray(positionLocation)
+        GLES20.glVertexAttribPointer(positionLocation, 2, GLES20.GL_FLOAT, false, 0, vertexBuffer)
+        GLES20.glEnableVertexAttribArray(textureLocation)
+        GLES20.glVertexAttribPointer(textureLocation, 2, GLES20.GL_FLOAT, false, 0, textureBuffer)
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textureId)
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, 0)
+        GLES20.glDisableVertexAttribArray(positionLocation)
+        GLES20.glDisableVertexAttribArray(textureLocation)
+        GLES20.glUseProgram(0)
+        checkGlError("draw mirror frame")
+    }
+
+    private fun releaseOnRenderThread() {
+        handler.removeCallbacksAndMessages(null)
+        surfaceTexture?.setOnFrameAvailableListener(null)
+        sourceSurface?.release()
+        sourceSurface = null
+        surfaceTexture?.release()
+        surfaceTexture = null
+
+        if (eglDisplay != EGL14.EGL_NO_DISPLAY) {
+            EGL14.eglMakeCurrent(
+                eglDisplay,
+                EGL14.EGL_NO_SURFACE,
+                EGL14.EGL_NO_SURFACE,
+                EGL14.EGL_NO_CONTEXT,
+            )
+            if (programId != 0) GLES20.glDeleteProgram(programId)
+            if (textureId != 0) GLES20.glDeleteTextures(1, intArrayOf(textureId), 0)
+            if (eglSurface != EGL14.EGL_NO_SURFACE) EGL14.eglDestroySurface(eglDisplay, eglSurface)
+            if (eglContext != EGL14.EGL_NO_CONTEXT) EGL14.eglDestroyContext(eglDisplay, eglContext)
+            EGL14.eglTerminate(eglDisplay)
+            EGL14.eglReleaseThread()
+        }
+        outputSurface.release()
+        eglDisplay = EGL14.EGL_NO_DISPLAY
+        eglContext = EGL14.EGL_NO_CONTEXT
+        eglSurface = EGL14.EGL_NO_SURFACE
+        thread.quitSafely()
+    }
+
+    private fun reportFailure(error: Throwable) {
+        if (!failed.compareAndSet(false, true)) return
+        running.set(false)
+        onError(error)
+    }
+
+    private fun createProgram(vertexSource: String, fragmentSource: String): Int {
+        val vertex = compileShader(GLES20.GL_VERTEX_SHADER, vertexSource)
+        val fragment = compileShader(GLES20.GL_FRAGMENT_SHADER, fragmentSource)
+        val program = GLES20.glCreateProgram()
+        GLES20.glAttachShader(program, vertex)
+        GLES20.glAttachShader(program, fragment)
+        GLES20.glLinkProgram(program)
+        val linked = IntArray(1)
+        GLES20.glGetProgramiv(program, GLES20.GL_LINK_STATUS, linked, 0)
+        val error = GLES20.glGetProgramInfoLog(program)
+        GLES20.glDeleteShader(vertex)
+        GLES20.glDeleteShader(fragment)
+        check(linked[0] == GLES20.GL_TRUE) { "Unable to link mirror shader: $error" }
+        return program
+    }
+
+    private fun compileShader(type: Int, source: String): Int {
+        val shader = GLES20.glCreateShader(type)
+        GLES20.glShaderSource(shader, source)
+        GLES20.glCompileShader(shader)
+        val compiled = IntArray(1)
+        GLES20.glGetShaderiv(shader, GLES20.GL_COMPILE_STATUS, compiled, 0)
+        val error = GLES20.glGetShaderInfoLog(shader)
+        check(compiled[0] == GLES20.GL_TRUE) {
+            GLES20.glDeleteShader(shader)
+            "Unable to compile mirror shader: $error"
+        }
+        return shader
+    }
+
+    private fun checkGlError(operation: String) {
+        val error = GLES20.glGetError()
+        check(error == GLES20.GL_NO_ERROR) { "$operation failed with GL error $error" }
+    }
+
+    private companion object {
+        private const val EGL_RECORDABLE_ANDROID = 0x3142
+        private const val SETUP_TIMEOUT_SECONDS = 3L
+        private const val STOP_TIMEOUT_SECONDS = 2L
+        private const val NANOS_PER_MILLISECOND = 1_000_000L
+        private const val MAX_CATCH_UP_FRAMES = 2L
+        private val vertexBuffer = floatBufferOf(-1f, -1f, 1f, -1f, -1f, 1f, 1f, 1f)
+        private val textureBuffer = floatBufferOf(0f, 1f, 1f, 1f, 0f, 0f, 1f, 0f)
+
+        private fun floatBufferOf(vararg values: Float): FloatBuffer =
+            ByteBuffer.allocateDirect(values.size * Float.SIZE_BYTES)
+                .order(ByteOrder.nativeOrder())
+                .asFloatBuffer()
+                .apply {
+                    put(values)
+                    position(0)
+                }
+
+        private const val VERTEX_SHADER = """
+            attribute vec4 aPosition;
+            attribute vec4 aTextureCoord;
+            uniform mat4 uMvpMatrix;
+            uniform mat4 uTextureMatrix;
+            varying vec2 vTextureCoord;
+            void main() {
+                gl_Position = uMvpMatrix * aPosition;
+                vTextureCoord = (uTextureMatrix * aTextureCoord).xy;
+            }
+        """
+
+        private const val FRAGMENT_SHADER = """
+            #extension GL_OES_EGL_image_external : require
+            precision mediump float;
+            varying vec2 vTextureCoord;
+            uniform samplerExternalOES sTexture;
+            void main() {
+                gl_FragColor = texture2D(sTexture, vTextureCoord);
+            }
+        """
+    }
+}
+
+internal fun externalMirrorEncoderSize(width: Int, height: Int): Pair<Int, Int> =
+    maxOf(width, height) to minOf(width, height)
+
+internal fun mirrorFrameFitScale(
+    inputWidth: Int,
+    inputHeight: Int,
+    outputWidth: Int,
+    outputHeight: Int,
+): Pair<Float, Float> {
+    val inputAspect = inputWidth.toFloat() / inputHeight
+    val outputAspect = outputWidth.toFloat() / outputHeight
+    return if (inputAspect > outputAspect) {
+        1f to (outputAspect / inputAspect)
+    } else {
+        (inputAspect / outputAspect) to 1f
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MpegTsJoinBuffer.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/MpegTsJoinBuffer.kt
@@ -1,0 +1,367 @@
+package com.playbridge.sender.cast.mirror
+
+import java.io.ByteArrayOutputStream
+
+internal data class MpegTsSegment(
+    val bytes: ByteArray,
+    val durationSeconds: Double,
+)
+
+/**
+ * Aligns MediaRecorder output to MPEG-TS packets and keeps only the latest
+ * independently decodable H.264 group for newly connected renderers.
+ *
+ * A byte-only ring can cover an unbounded amount of playback time when the
+ * captured screen is static. Starting each client at the latest IDR keeps the
+ * bootstrap both byte-bounded and time-bounded.
+ */
+internal class MpegTsJoinBuffer(private val capacityBytes: Int) {
+    private var remainder = ByteArray(0)
+    private var pmtPid: Int? = null
+    private var videoPid: Int? = null
+    private var patPacket: ByteArray? = null
+    private var pmtPacket: ByteArray? = null
+    private var codecConfigPackets: ByteArray? = null
+
+    private var hasDecodableGroup = false
+    private val group = ByteArrayOutputStream()
+    private val currentPesPackets = ByteArrayOutputStream()
+    private val currentPesPayload = ByteArrayOutputStream()
+    private var collectingVideoPes = false
+    private var currentPesHasIdr = false
+    private var currentPesHasCodecConfig = false
+    private var currentPesPts90Khz: Long? = null
+    private var groupStartPts90Khz: Long? = null
+    private val completedSegments = ArrayDeque<MpegTsSegment>()
+
+    init {
+        require(capacityBytes >= TS_PACKET_BYTES * 3)
+    }
+
+    /** Returns complete, sync-aligned TS packets that are safe to broadcast. */
+    @Synchronized
+    fun consume(source: ByteArray, count: Int): ByteArray {
+        if (count <= 0) return ByteArray(0)
+        require(count <= source.size)
+
+        val combined = ByteArray(remainder.size + count)
+        remainder.copyInto(combined)
+        source.copyInto(combined, remainder.size, 0, count)
+
+        var cursor = findSync(combined, 0)
+        if (cursor < 0) {
+            remainder = combined.copyOfRange(
+                (combined.size - (TS_PACKET_BYTES - 1)).coerceAtLeast(0),
+                combined.size,
+            )
+            return ByteArray(0)
+        }
+
+        val output = ByteArrayOutputStream(combined.size - cursor)
+        while (cursor + TS_PACKET_BYTES <= combined.size) {
+            if (combined[cursor] != TS_SYNC_BYTE) {
+                val next = findSync(combined, cursor + 1)
+                if (next < 0) break
+                cursor = next
+                continue
+            }
+            val packet = combined.copyOfRange(cursor, cursor + TS_PACKET_BYTES)
+            onPacket(packet)
+            output.write(packet)
+            cursor += TS_PACKET_BYTES
+        }
+
+        remainder = combined.copyOfRange(cursor, combined.size)
+        return output.toByteArray()
+    }
+
+    @Synchronized
+    fun snapshot(): ByteArray = if (hasDecodableGroup) group.toByteArray() else ByteArray(0)
+
+    @Synchronized
+    fun isReadyForJoin(): Boolean = hasDecodableGroup
+
+    @Synchronized
+    fun drainCompletedSegments(): List<MpegTsSegment> = buildList {
+        while (completedSegments.isNotEmpty()) add(completedSegments.removeFirst())
+    }
+
+    private fun onPacket(packet: ByteArray) {
+        val pid = packet.pid()
+        when (pid) {
+            PAT_PID -> {
+                patPacket = packet.copyOf()
+                parsePat(packet)?.let { pmtPid = it }
+            }
+
+            pmtPid -> {
+                pmtPacket = packet.copyOf()
+                parsePmt(packet)?.let { videoPid = it }
+            }
+        }
+
+        val isVideo = pid == videoPid
+        if (isVideo && packet.payloadUnitStart()) {
+            finishCurrentPes()
+            collectingVideoPes = true
+            currentPesHasIdr = false
+            currentPesHasCodecConfig = false
+            currentPesPts90Khz = packet.pesPts90Khz()
+            currentPesPackets.reset()
+            currentPesPayload.reset()
+        }
+
+        appendToGroup(packet)
+
+        if (!collectingVideoPes || currentPesHasIdr) return
+        currentPesPackets.write(packet)
+        if (isVideo) {
+            packet.videoElementaryPayload()?.let(currentPesPayload::write)
+            val elementaryBytes = currentPesPayload.toByteArray()
+            if (!currentPesHasCodecConfig && containsH264ParameterSets(elementaryBytes)) {
+                currentPesHasCodecConfig = true
+            }
+            if (containsH264Idr(elementaryBytes)) {
+                currentPesHasIdr = true
+                resetGroupAtCurrentPes()
+            }
+        }
+    }
+
+    private fun finishCurrentPes() {
+        if (currentPesHasCodecConfig && !currentPesHasIdr) {
+            codecConfigPackets = currentPesPackets.toByteArray()
+        }
+    }
+
+    private fun appendToGroup(packet: ByteArray) {
+        if (!hasDecodableGroup) return
+        if (group.size() + packet.size > capacityBytes) {
+            hasDecodableGroup = false
+            group.reset()
+            return
+        }
+        group.write(packet)
+    }
+
+    private fun resetGroupAtCurrentPes() {
+        val nextPts = currentPesPts90Khz
+        if (hasDecodableGroup && group.size() > currentPesPackets.size()) {
+            val completedBytes = group.toByteArray()
+                .copyOfRange(0, group.size() - currentPesPackets.size())
+            val duration = ptsDurationSeconds(groupStartPts90Khz, nextPts)
+            completedSegments += MpegTsSegment(
+                bytes = completedBytes,
+                durationSeconds = duration.coerceAtLeast(MIN_SEGMENT_SECONDS),
+            )
+        }
+        hasDecodableGroup = false
+        group.reset()
+        patPacket?.let(group::write)
+        pmtPacket?.let(group::write)
+        codecConfigPackets?.let { config ->
+            rewritePesTimestamps(config, nextPts)?.let(group::write)
+        }
+        val pesPackets = currentPesPackets.toByteArray()
+        if (group.size() + pesPackets.size > capacityBytes) return
+        group.write(pesPackets)
+        groupStartPts90Khz = nextPts
+        hasDecodableGroup = true
+    }
+
+    private fun ptsDurationSeconds(start: Long?, end: Long?): Double {
+        if (start == null || end == null) return DEFAULT_SEGMENT_SECONDS
+        val ticks = (end - start) and PTS_MASK
+        return ticks.toDouble() / PTS_TIMESCALE
+    }
+
+    private fun ByteArray.videoElementaryPayload(): ByteArray? {
+        var offset = payloadOffset() ?: return null
+        if (payloadUnitStart()) {
+            if (offset + 9 > size || this[offset] != 0.toByte() || this[offset + 1] != 0.toByte() ||
+                this[offset + 2] != 1.toByte()
+            ) {
+                return null
+            }
+            offset += 9 + (this[offset + 8].toInt() and 0xff)
+        }
+        if (offset >= size) return null
+        return copyOfRange(offset, size)
+    }
+
+    private fun ByteArray.pesPts90Khz(): Long? {
+        val offset = payloadOffset() ?: return null
+        if (!payloadUnitStart() || offset + 14 > size) return null
+        if (this[offset] != 0.toByte() || this[offset + 1] != 0.toByte() || this[offset + 2] != 1.toByte()) return null
+        if ((this[offset + 7].toInt() and 0x80) == 0) return null
+        val pts = offset + 9
+        return (
+            (((this[pts].toLong() ushr 1) and 0x07) shl 30) or
+                ((this[pts + 1].toLong() and 0xff) shl 22) or
+                (((this[pts + 2].toLong() ushr 1) and 0x7f) shl 15) or
+                ((this[pts + 3].toLong() and 0xff) shl 7) or
+                ((this[pts + 4].toLong() ushr 1) and 0x7f)
+            )
+    }
+
+    private fun rewritePesTimestamps(source: ByteArray, pts90Khz: Long?): ByteArray? {
+        if (pts90Khz == null) return source
+        val rewritten = source.copyOf()
+        var offset = 0
+        while (offset + TS_PACKET_BYTES <= rewritten.size) {
+            val packet = rewritten.copyOfRange(offset, offset + TS_PACKET_BYTES)
+            if (packet.pid() == videoPid && packet.payloadUnitStart()) {
+                val payload = packet.payloadOffset() ?: return rewritten
+                if (payload + 14 <= packet.size &&
+                    packet[payload] == 0.toByte() && packet[payload + 1] == 0.toByte() && packet[payload + 2] == 1.toByte()
+                ) {
+                    encodePts(rewritten, offset + payload + 9, pts90Khz)
+                    rewritePcrIfPresent(rewritten, offset, pts90Khz)
+                    return rewritten
+                }
+            }
+            offset += TS_PACKET_BYTES
+        }
+        return rewritten
+    }
+
+    private fun rewritePcrIfPresent(buffer: ByteArray, packetOffset: Int, pts90Khz: Long) {
+        val packet = buffer.copyOfRange(packetOffset, packetOffset + TS_PACKET_BYTES)
+        val adaptationControl = (packet[3].toInt() ushr 4) and 0x03
+        if (adaptationControl != 3 || packet[4].toInt() == 0 || (packet[5].toInt() and 0x10) == 0) return
+        encodePcr(buffer, packetOffset + 6, pts90Khz)
+    }
+
+    private fun encodePts(buffer: ByteArray, offset: Int, value: Long) {
+        val pts = value and PTS_MASK
+        buffer[offset] = (0x21L or (((pts ushr 30) and 0x07) shl 1)).toByte()
+        buffer[offset + 1] = (pts ushr 22).toByte()
+        buffer[offset + 2] = (((pts ushr 14) and 0xfe) or 0x01).toByte()
+        buffer[offset + 3] = (pts ushr 7).toByte()
+        buffer[offset + 4] = (((pts shl 1) and 0xfe) or 0x01).toByte()
+    }
+
+    private fun encodePcr(buffer: ByteArray, offset: Int, value: Long) {
+        val pcr = value and PTS_MASK
+        buffer[offset] = (pcr ushr 25).toByte()
+        buffer[offset + 1] = (pcr ushr 17).toByte()
+        buffer[offset + 2] = (pcr ushr 9).toByte()
+        buffer[offset + 3] = (pcr ushr 1).toByte()
+        buffer[offset + 4] = (((pcr and 1) shl 7) or 0x7e).toByte()
+        buffer[offset + 5] = 0
+    }
+
+    private fun parsePat(packet: ByteArray): Int? {
+        val section = packet.psiSection(TABLE_ID_PAT) ?: return null
+        val sectionLength = ((section[1].toInt() and 0x0f) shl 8) or (section[2].toInt() and 0xff)
+        val end = (3 + sectionLength - CRC_BYTES).coerceAtMost(section.size)
+        var offset = 8
+        while (offset + 4 <= end) {
+            val program = ((section[offset].toInt() and 0xff) shl 8) or (section[offset + 1].toInt() and 0xff)
+            val pid = ((section[offset + 2].toInt() and 0x1f) shl 8) or (section[offset + 3].toInt() and 0xff)
+            if (program != 0) return pid
+            offset += 4
+        }
+        return null
+    }
+
+    private fun parsePmt(packet: ByteArray): Int? {
+        val section = packet.psiSection(TABLE_ID_PMT) ?: return null
+        if (section.size < 12) return null
+        val sectionLength = ((section[1].toInt() and 0x0f) shl 8) or (section[2].toInt() and 0xff)
+        val end = (3 + sectionLength - CRC_BYTES).coerceAtMost(section.size)
+        val programInfoLength = ((section[10].toInt() and 0x0f) shl 8) or (section[11].toInt() and 0xff)
+        var offset = 12 + programInfoLength
+        while (offset + 5 <= end) {
+            val streamType = section[offset].toInt() and 0xff
+            val elementaryPid = ((section[offset + 1].toInt() and 0x1f) shl 8) or
+                (section[offset + 2].toInt() and 0xff)
+            val infoLength = ((section[offset + 3].toInt() and 0x0f) shl 8) or
+                (section[offset + 4].toInt() and 0xff)
+            if (streamType == STREAM_TYPE_H264) return elementaryPid
+            offset += 5 + infoLength
+        }
+        return null
+    }
+
+    private fun ByteArray.psiSection(expectedTableId: Int): ByteArray? {
+        var offset = payloadOffset() ?: return null
+        if (!payloadUnitStart() || offset >= size) return null
+        val pointer = this[offset].toInt() and 0xff
+        offset += 1 + pointer
+        if (offset + 3 > size || (this[offset].toInt() and 0xff) != expectedTableId) return null
+        return copyOfRange(offset, size)
+    }
+
+    private fun ByteArray.payloadOffset(): Int? {
+        val adaptationControl = (this[3].toInt() ushr 4) and 0x03
+        if (adaptationControl == 0 || adaptationControl == 2) return null
+        var offset = 4
+        if (adaptationControl == 3) {
+            offset += 1 + (this[4].toInt() and 0xff)
+        }
+        return offset.takeIf { it < size }
+    }
+
+    private fun ByteArray.pid(): Int = ((this[1].toInt() and 0x1f) shl 8) or (this[2].toInt() and 0xff)
+
+    private fun ByteArray.payloadUnitStart(): Boolean = (this[1].toInt() and 0x40) != 0
+
+    private fun findSync(bytes: ByteArray, from: Int): Int {
+        var offset = from
+        while (offset < bytes.size) {
+            if (bytes[offset] == TS_SYNC_BYTE &&
+                (offset + TS_PACKET_BYTES >= bytes.size || bytes[offset + TS_PACKET_BYTES] == TS_SYNC_BYTE)
+            ) {
+                return offset
+            }
+            offset++
+        }
+        return -1
+    }
+
+    private fun containsH264Idr(bytes: ByteArray): Boolean {
+        return h264NalTypes(bytes).any { it == H264_NAL_IDR }
+    }
+
+    private fun containsH264ParameterSets(bytes: ByteArray): Boolean {
+        val types = h264NalTypes(bytes)
+        return H264_NAL_SPS in types && H264_NAL_PPS in types
+    }
+
+    private fun h264NalTypes(bytes: ByteArray): Set<Int> {
+        val types = mutableSetOf<Int>()
+        var offset = 0
+        while (offset + 4 < bytes.size) {
+            val nalOffset = when {
+                bytes[offset] == 0.toByte() && bytes[offset + 1] == 0.toByte() && bytes[offset + 2] == 1.toByte() -> offset + 3
+                offset + 4 < bytes.size && bytes[offset] == 0.toByte() && bytes[offset + 1] == 0.toByte() &&
+                    bytes[offset + 2] == 0.toByte() && bytes[offset + 3] == 1.toByte() -> offset + 4
+                else -> {
+                    offset++
+                    continue
+                }
+            }
+            if (nalOffset < bytes.size) types += bytes[nalOffset].toInt() and 0x1f
+            offset = nalOffset + 1
+        }
+        return types
+    }
+
+    private companion object {
+        private const val TS_PACKET_BYTES = 188
+        private const val TS_SYNC_BYTE: Byte = 0x47
+        private const val PAT_PID = 0
+        private const val TABLE_ID_PAT = 0x00
+        private const val TABLE_ID_PMT = 0x02
+        private const val STREAM_TYPE_H264 = 0x1b
+        private const val H264_NAL_IDR = 5
+        private const val H264_NAL_SPS = 7
+        private const val H264_NAL_PPS = 8
+        private const val CRC_BYTES = 4
+        private const val PTS_MASK = (1L shl 33) - 1
+        private const val PTS_TIMESCALE = 90_000.0
+        private const val DEFAULT_SEGMENT_SECONDS = 2.0
+        private const val MIN_SEGMENT_SECONDS = 0.1
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/PlaybackAudioMpegTsEncoder.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/PlaybackAudioMpegTsEncoder.kt
@@ -22,13 +22,16 @@ internal class PlaybackAudioMpegTsEncoder private constructor(
     private val onError: (Throwable) -> Unit,
 ) : Closeable {
     private val running = AtomicBoolean(false)
+    private val prepared = AtomicBoolean(false)
     private val closed = AtomicBoolean(false)
     private val thread = Thread(::capture, "PlayBridgeMirrorAudio").apply { isDaemon = true }
     private var submittedFrames = 0L
     private var firstPresentationTimeUs = 0L
 
-    fun start() {
-        if (!running.compareAndSet(false, true)) return
+    /** Starts the platform capture synchronously so callers can advertise audio accurately. */
+    fun prepare(): Boolean {
+        if (closed.get()) return false
+        if (prepared.get()) return true
         try {
             codec.start()
             audioRecord.startRecording()
@@ -36,18 +39,24 @@ internal class PlaybackAudioMpegTsEncoder private constructor(
                 throw IOException("Playback audio capture did not enter the recording state")
             }
             firstPresentationTimeUs = System.nanoTime() / 1_000L
+            prepared.set(true)
             onActive()
-            thread.start()
+            return true
         } catch (error: Throwable) {
-            running.set(false)
             onError(error)
+            return false
         }
+    }
+
+    fun start() {
+        if (!prepared.get() || !running.compareAndSet(false, true)) return
+        thread.start()
     }
 
     override fun close() {
         if (!closed.compareAndSet(false, true)) return
         running.set(false)
-        runCatching { audioRecord.stop() }
+        if (prepared.get()) runCatching { audioRecord.stop() }
         if (thread.isAlive && Thread.currentThread() !== thread) {
             thread.interrupt()
             thread.join(STOP_TIMEOUT_MS)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/PlaybackAudioMpegTsEncoder.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/PlaybackAudioMpegTsEncoder.kt
@@ -1,0 +1,213 @@
+package com.playbridge.sender.cast.mirror
+
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaCodec
+import android.media.MediaCodecInfo
+import android.media.MediaFormat
+import android.media.projection.MediaProjection
+import android.os.Build
+import java.io.Closeable
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Captures permitted app playback and encodes AAC-LC frames for the external mirror transport. */
+internal class PlaybackAudioMpegTsEncoder private constructor(
+    private val audioRecord: AudioRecord,
+    private val codec: MediaCodec,
+    private val sampleRate: Int,
+    private val channelCount: Int,
+    private val onFrame: (ByteArray, Long) -> Unit,
+    private val onActive: () -> Unit,
+    private val onError: (Throwable) -> Unit,
+) : Closeable {
+    private val running = AtomicBoolean(false)
+    private val closed = AtomicBoolean(false)
+    private val thread = Thread(::capture, "PlayBridgeMirrorAudio").apply { isDaemon = true }
+    private var submittedFrames = 0L
+    private var firstPresentationTimeUs = 0L
+
+    fun start() {
+        if (!running.compareAndSet(false, true)) return
+        try {
+            codec.start()
+            audioRecord.startRecording()
+            if (audioRecord.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
+                throw IOException("Playback audio capture did not enter the recording state")
+            }
+            firstPresentationTimeUs = System.nanoTime() / 1_000L
+            onActive()
+            thread.start()
+        } catch (error: Throwable) {
+            running.set(false)
+            onError(error)
+        }
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        running.set(false)
+        runCatching { audioRecord.stop() }
+        if (thread.isAlive && Thread.currentThread() !== thread) {
+            thread.interrupt()
+            thread.join(STOP_TIMEOUT_MS)
+        }
+        runCatching { codec.stop() }
+        runCatching { codec.release() }
+        runCatching { audioRecord.release() }
+    }
+
+    private fun capture() {
+        val info = MediaCodec.BufferInfo()
+        try {
+            while (running.get()) {
+                feedInput()
+                drainOutput(info)
+            }
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        } catch (error: Throwable) {
+            if (!closed.get()) onError(error)
+        }
+    }
+
+    private fun feedInput() {
+        val index = codec.dequeueInputBuffer(DEQUEUE_TIMEOUT_US)
+        if (index < 0) return
+        val input = codec.getInputBuffer(index) ?: return
+        input.clear()
+        val bytesRead = audioRecord.read(input, input.remaining(), AudioRecord.READ_BLOCKING)
+        if (bytesRead < 0) throw IOException("Playback audio read failed: $bytesRead")
+        if (bytesRead == 0) {
+            codec.queueInputBuffer(index, 0, 0, presentationTimeUs(), 0)
+            return
+        }
+        codec.queueInputBuffer(index, 0, bytesRead, presentationTimeUs(), 0)
+        submittedFrames += bytesRead / (channelCount * PCM_BYTES_PER_SAMPLE)
+    }
+
+    private fun presentationTimeUs(): Long =
+        firstPresentationTimeUs + submittedFrames * 1_000_000L / sampleRate
+
+    private fun drainOutput(info: MediaCodec.BufferInfo) {
+        while (true) {
+            when (val index = codec.dequeueOutputBuffer(info, 0)) {
+                MediaCodec.INFO_TRY_AGAIN_LATER -> return
+                MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> Unit
+                else -> if (index >= 0) drainBuffer(index, info)
+            }
+        }
+    }
+
+    private fun drainBuffer(index: Int, info: MediaCodec.BufferInfo) {
+        try {
+            if (info.size <= 0 || (info.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) return
+            val buffer = codec.getOutputBuffer(index) ?: return
+            buffer.position(info.offset)
+            buffer.limit(info.offset + info.size)
+            val accessUnit = ByteArray(info.size)
+            buffer.get(accessUnit)
+            onFrame(adtsFrame(accessUnit, sampleRate, channelCount), info.presentationTimeUs)
+        } finally {
+            codec.releaseOutputBuffer(index, false)
+        }
+    }
+
+    companion object {
+        private const val MIME_AAC = "audio/mp4a-latm"
+        private const val SAMPLE_RATE = 48_000
+        private const val CHANNEL_COUNT = 2
+        private const val BITRATE_BPS = 128_000
+        private const val PCM_BYTES_PER_SAMPLE = 2
+        private const val DEQUEUE_TIMEOUT_US = 10_000L
+        private const val STOP_TIMEOUT_MS = 2_000L
+
+        fun create(
+            projection: MediaProjection,
+            onFrame: (ByteArray, Long) -> Unit,
+            onActive: () -> Unit,
+            onError: (Throwable) -> Unit,
+        ): PlaybackAudioMpegTsEncoder? {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return null
+            val minimumBuffer = AudioRecord.getMinBufferSize(
+                SAMPLE_RATE,
+                AudioFormat.CHANNEL_IN_STEREO,
+                AudioFormat.ENCODING_PCM_16BIT,
+            )
+            if (minimumBuffer <= 0) return null
+            val bufferSize = maxOf(minimumBuffer * 2, SAMPLE_RATE * CHANNEL_COUNT * PCM_BYTES_PER_SAMPLE / 10)
+            val factory = ScreenMirrorPlaybackAudioRecordFactory().apply { attachProjection(projection) }
+            val record = factory.createAudioRecord(
+                SAMPLE_RATE,
+                AudioFormat.CHANNEL_IN_STEREO,
+                AudioFormat.ENCODING_PCM_16BIT,
+                bufferSize,
+            ) ?: return null
+            val codec = runCatching {
+                MediaCodec.createEncoderByType(MIME_AAC).apply {
+                    configure(
+                        MediaFormat.createAudioFormat(MIME_AAC, SAMPLE_RATE, CHANNEL_COUNT).apply {
+                            setInteger(
+                                MediaFormat.KEY_AAC_PROFILE,
+                                MediaCodecInfo.CodecProfileLevel.AACObjectLC,
+                            )
+                            setInteger(MediaFormat.KEY_BIT_RATE, BITRATE_BPS)
+                            setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, bufferSize)
+                        },
+                        null,
+                        null,
+                        MediaCodec.CONFIGURE_FLAG_ENCODE,
+                    )
+                }
+            }.getOrElse {
+                record.release()
+                onError(it)
+                return null
+            }
+            return PlaybackAudioMpegTsEncoder(
+                audioRecord = record,
+                codec = codec,
+                sampleRate = SAMPLE_RATE,
+                channelCount = CHANNEL_COUNT,
+                onFrame = onFrame,
+                onActive = onActive,
+                onError = onError,
+            )
+        }
+    }
+}
+
+internal fun adtsFrame(accessUnit: ByteArray, sampleRate: Int, channelCount: Int): ByteArray {
+    require(channelCount in 1..7)
+    val frequencyIndex = when (sampleRate) {
+        96_000 -> 0
+        88_200 -> 1
+        64_000 -> 2
+        48_000 -> 3
+        44_100 -> 4
+        32_000 -> 5
+        24_000 -> 6
+        22_050 -> 7
+        16_000 -> 8
+        12_000 -> 9
+        11_025 -> 10
+        8_000 -> 11
+        7_350 -> 12
+        else -> throw IllegalArgumentException("Unsupported AAC sample rate: $sampleRate")
+    }
+    val frameLength = accessUnit.size + ADTS_HEADER_BYTES
+    require(frameLength <= 0x1fff)
+    return ByteArray(frameLength).apply {
+        this[0] = 0xff.toByte()
+        this[1] = 0xf1.toByte()
+        this[2] = ((AAC_LC_ADTS_PROFILE shl 6) or (frequencyIndex shl 2) or (channelCount ushr 2)).toByte()
+        this[3] = (((channelCount and 0x03) shl 6) or (frameLength ushr 11)).toByte()
+        this[4] = (frameLength ushr 3).toByte()
+        this[5] = (((frameLength and 0x07) shl 5) or 0x1f).toByte()
+        this[6] = 0xfc.toByte()
+        accessUnit.copyInto(this, destinationOffset = ADTS_HEADER_BYTES)
+    }
+}
+
+private const val ADTS_HEADER_BYTES = 7
+private const val AAC_LC_ADTS_PROFILE = 1

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/ScreenMirrorScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/ScreenMirrorScreen.kt
@@ -153,22 +153,15 @@ fun ScreenMirrorScreen(
                 )
             }
             Switch(
-                checked = deviceAudioEnabled && !externalSelected,
-                enabled = !state.isActive && !externalSelected && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q,
+                checked = deviceAudioEnabled,
+                enabled = !state.isActive && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q,
                 onCheckedChange = {
                     deviceAudioEnabled = it
                     audioNotice = null
                 },
             )
         }
-        if (externalSelected) {
-            Spacer(Modifier.height(6.dp))
-            Text(
-                "Google Cast and DLNA mirroring currently share video only.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        } else if (deviceAudioEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        if (deviceAudioEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             Spacer(Modifier.height(6.dp))
             Text(
                 "Android may label the required playback-capture permission as microphone access, " +
@@ -243,8 +236,7 @@ fun ScreenMirrorScreen(
                     audioNotice = null
                     val options = ScreenMirrorCoordinator.Options(
                         quality = selectedQuality,
-                        deviceAudio = !externalSelected &&
-                            deviceAudioEnabled &&
+                        deviceAudio = deviceAudioEnabled &&
                             Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q,
                     )
                     pendingOptions = options

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/ScreenMirrorScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/ScreenMirrorScreen.kt
@@ -43,19 +43,19 @@ import com.playbridge.sender.cast.CastSessionManager
 import com.playbridge.sender.connection.WebSocketClient
 import org.koin.compose.koinInject
 
-/** Hub destination for the Android-native, paired-receiver-only mirror flow. */
+/** Hub destination for WebRTC and external-receiver screen mirroring. */
 @Composable
 fun ScreenMirrorScreen(
     onBack: () -> Unit,
-    coordinator: ScreenMirrorCoordinator = koinInject(),
     webSocketClient: WebSocketClient = koinInject(),
     castSessionManager: CastSessionManager = koinInject(),
 ) {
     val context = LocalContext.current
-    val state by coordinator.state.collectAsState()
+    val state by castSessionManager.screenMirrorState.collectAsState()
     val connection by webSocketClient.connectionState.collectAsState()
     val capabilities by webSocketClient.tvCapabilitiesState.collectAsState()
     val route by castSessionManager.route.collectAsState()
+    val session by castSessionManager.sessionState.collectAsState()
     var qualityId by rememberSaveable { mutableStateOf(ScreenMirrorCoordinator.Quality.DEFAULT.id) }
     var deviceAudioEnabled by rememberSaveable {
         mutableStateOf(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
@@ -85,9 +85,16 @@ fun ScreenMirrorScreen(
         projectionLauncher.launch(projectionManager.createScreenCaptureIntent())
     }
     val connected = connection is WebSocketClient.ConnectionState.Connected
-    val supported = capabilities.screenMirrorWebRtc
-    val nativeReceiverSelected = route !is CastSessionManager.Route.External
-    val canStart = connected && supported && nativeReceiverSelected && !state.isActive
+    val nativeSupported = capabilities.screenMirrorWebRtc
+    val externalSelected = route is CastSessionManager.Route.External
+    val externalSupported = externalSelected &&
+        session.targetKind in setOf(
+            com.playbridge.sender.cast.TargetKind.GOOGLE_CAST,
+            com.playbridge.sender.cast.TargetKind.DLNA,
+        ) &&
+        com.playbridge.sender.cast.Capability.SCREEN_MIRROR in session.capabilities
+    val canStart = (if (externalSelected) externalSupported else connected && nativeSupported) &&
+        !state.isActive
 
     Column(
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(24.dp),
@@ -103,12 +110,21 @@ fun ScreenMirrorScreen(
         Text("Screen Mirror", style = MaterialTheme.typography.headlineMedium)
         Spacer(Modifier.height(8.dp))
         val description = when {
-            state.phase == ScreenMirrorCoordinator.Phase.MIRRORING -> "Mirroring to your PlayBridge TV"
+            state.phase == ScreenMirrorCoordinator.Phase.MIRRORING && externalSelected ->
+                "Mirroring to ${(route as CastSessionManager.Route.External).name}"
+            state.phase == ScreenMirrorCoordinator.Phase.MIRRORING ->
+                "Mirroring to your PlayBridge TV"
             state.isActive -> state.message ?: "Connecting to TV…"
+            state.phase == ScreenMirrorCoordinator.Phase.FAILED ->
+                state.message ?: "Could not start mirroring."
+            externalSelected && !externalSupported ->
+                "This external receiver does not support screen mirroring."
+            externalSelected && session.targetKind == com.playbridge.sender.cast.TargetKind.DLNA ->
+                "Share this phone’s screen using live MPEG-TS. DLNA support varies by TV."
+            externalSelected ->
+                "Share this phone’s screen using live HLS."
             !connected -> "Connect to a PlayBridge TV to start mirroring."
-            !nativeReceiverSelected -> "Select your PlayBridge TV instead of an external receiver to mirror."
-            !supported -> "This TV needs an update before it can receive WebRTC screen mirroring."
-            state.phase == ScreenMirrorCoordinator.Phase.FAILED -> state.message ?: "Could not start mirroring."
+            !nativeSupported -> "This TV needs an update before it can receive WebRTC screen mirroring."
             else -> "Share this phone’s screen directly with your PlayBridge TV."
         }
         Text(description, style = MaterialTheme.typography.bodyLarge)
@@ -137,15 +153,22 @@ fun ScreenMirrorScreen(
                 )
             }
             Switch(
-                checked = deviceAudioEnabled,
-                enabled = !state.isActive && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q,
+                checked = deviceAudioEnabled && !externalSelected,
+                enabled = !state.isActive && !externalSelected && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q,
                 onCheckedChange = {
                     deviceAudioEnabled = it
                     audioNotice = null
                 },
             )
         }
-        if (deviceAudioEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        if (externalSelected) {
+            Spacer(Modifier.height(6.dp))
+            Text(
+                "Google Cast and DLNA mirroring currently share video only.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else if (deviceAudioEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             Spacer(Modifier.height(6.dp))
             Text(
                 "Android may label the required playback-capture permission as microphone access, " +
@@ -209,7 +232,10 @@ fun ScreenMirrorScreen(
         )
         Spacer(Modifier.height(28.dp))
         if (state.isActive) {
-            Button(onClick = { coordinator.stop() }, modifier = Modifier.fillMaxWidth()) { Text("Stop mirroring") }
+            Button(
+                onClick = { castSessionManager.stopScreenMirror() },
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text("Stop mirroring") }
         } else {
             Button(
                 enabled = canStart,
@@ -217,7 +243,9 @@ fun ScreenMirrorScreen(
                     audioNotice = null
                     val options = ScreenMirrorCoordinator.Options(
                         quality = selectedQuality,
-                        deviceAudio = deviceAudioEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q,
+                        deviceAudio = !externalSelected &&
+                            deviceAudioEnabled &&
+                            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q,
                     )
                     pendingOptions = options
                     if (options.deviceAudio && ContextCompat.checkSelfPermission(

--- a/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
@@ -141,6 +141,13 @@ val appModule = module {
         )
     }
 
+    single {
+        com.playbridge.sender.cast.mirror.ExternalScreenMirrorCoordinator(
+            context = androidContext(),
+            appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+        )
+    }
+
     // 5a. CastSessionManager — process-wide owner of the active cast target (native/DLNA)
     //     and the CastSessionService foreground lifecycle.
     //     Single-threaded scope: the reconnect-supervisor state (attempt counter, job,
@@ -156,6 +163,7 @@ val appModule = module {
             discoveryRepository = get(),
             settingsRepository = get(),
             screenMirrorCoordinator = get(),
+            externalScreenMirrorCoordinator = get(),
         )
     }
 

--- a/mobile/android/app/src/test/java/com/playbridge/sender/cast/ExternalScreenMirrorRoutingTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/cast/ExternalScreenMirrorRoutingTest.kt
@@ -1,0 +1,39 @@
+package com.playbridge.sender.cast
+
+import com.playbridge.sender.cast.mirror.ExternalScreenMirrorCoordinator
+import com.playbridge.sender.cast.proxy.StreamRouteMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExternalScreenMirrorRoutingTest {
+    private val urls = ExternalScreenMirrorCoordinator.Urls(
+        hls = "http://192.168.1.4:1234/screen/token/index.m3u8",
+        continuousTs = "http://192.168.1.4:1234/screen/token/stream.ts",
+    )
+
+    @Test
+    fun `google cast receives live hls over the phone path`() {
+        val media = externalScreenMirrorMedia(TargetKind.GOOGLE_CAST, urls)
+
+        assertEquals(urls.hls, media.url)
+        assertEquals("application/x-mpegURL", media.mimeType)
+        assertEquals("LIVE", media.streamType)
+        assertEquals("mpeg2_ts", media.hlsVideoSegmentFormat)
+        assertEquals(StreamRouteMode.VIA_PHONE, media.effectiveRoute)
+        assertTrue(media.isScreenMirror)
+    }
+
+    @Test
+    fun `dlna receives the same mpeg ts capture as a continuous stream`() {
+        val media = externalScreenMirrorMedia(TargetKind.DLNA, urls)
+
+        assertEquals(urls.continuousTs, media.url)
+        assertEquals("video/mp2t", media.mimeType)
+        assertEquals("LIVE", media.streamType)
+        assertNull(media.hlsVideoSegmentFormat)
+        assertEquals(StreamRouteMode.VIA_PHONE, media.effectiveRoute)
+        assertTrue(media.isScreenMirror)
+    }
+}

--- a/mobile/android/app/src/test/java/com/playbridge/sender/cast/ExternalScreenMirrorRoutingTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/cast/ExternalScreenMirrorRoutingTest.kt
@@ -11,6 +11,7 @@ class ExternalScreenMirrorRoutingTest {
     private val urls = ExternalScreenMirrorCoordinator.Urls(
         hls = "http://192.168.1.4:1234/screen/token/index.m3u8",
         continuousTs = "http://192.168.1.4:1234/screen/token/stream.ts",
+        hasAudio = true,
     )
 
     @Test
@@ -21,6 +22,7 @@ class ExternalScreenMirrorRoutingTest {
         assertEquals("application/x-mpegURL", media.mimeType)
         assertEquals("LIVE", media.streamType)
         assertEquals("mpeg2_ts", media.hlsVideoSegmentFormat)
+        assertEquals("ts_aac", media.hlsSegmentFormat)
         assertEquals(StreamRouteMode.VIA_PHONE, media.effectiveRoute)
         assertTrue(media.isScreenMirror)
     }
@@ -33,6 +35,7 @@ class ExternalScreenMirrorRoutingTest {
         assertEquals("video/mp2t", media.mimeType)
         assertEquals("LIVE", media.streamType)
         assertNull(media.hlsVideoSegmentFormat)
+        assertNull(media.hlsSegmentFormat)
         assertEquals(StreamRouteMode.VIA_PHONE, media.effectiveRoute)
         assertTrue(media.isScreenMirror)
     }

--- a/mobile/android/app/src/test/java/com/playbridge/sender/cast/ExternalScreenMirrorRoutingTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/cast/ExternalScreenMirrorRoutingTest.kt
@@ -28,6 +28,17 @@ class ExternalScreenMirrorRoutingTest {
     }
 
     @Test
+    fun `google cast omits audio hint when playback capture did not start`() {
+        val media = externalScreenMirrorMedia(
+            TargetKind.GOOGLE_CAST,
+            urls.copy(hasAudio = false),
+        )
+
+        assertNull(media.hlsSegmentFormat)
+        assertEquals("mpeg2_ts", media.hlsVideoSegmentFormat)
+    }
+
+    @Test
     fun `dlna receives the same mpeg ts capture as a continuous stream`() {
         val media = externalScreenMirrorMedia(TargetKind.DLNA, urls)
 

--- a/mobile/android/app/src/test/java/com/playbridge/sender/cast/googlecast/GoogleCastNetworkBindingPolicyTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/cast/googlecast/GoogleCastNetworkBindingPolicyTest.kt
@@ -1,5 +1,6 @@
 package com.playbridge.sender.cast.googlecast
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -43,5 +44,11 @@ class GoogleCastNetworkBindingPolicyTest {
                 selectedNetworkHandle = 0L,
             ),
         )
+    }
+
+    @Test
+    fun `explicit live stream type is normalized for Cast Core`() {
+        assertEquals("LIVE", googleCastStreamType(explicit = "live", inferred = "BUFFERED"))
+        assertEquals("BUFFERED", googleCastStreamType(explicit = null, inferred = "BUFFERED"))
     }
 }

--- a/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/ExternalScreenMirrorTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/ExternalScreenMirrorTest.kt
@@ -1,0 +1,141 @@
+package com.playbridge.sender.cast.mirror
+
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExternalScreenMirrorTest {
+    @Test
+    fun `completed hls segment is keyframe aligned and timed from pts`() {
+        val pat = tsPacket(0, patPayload(0x100))
+        val pmt = tsPacket(0x100, pmtPayload(0x101))
+        val config = tsPacket(0x101, videoCodecConfigPes())
+        val firstIdr = tsPacket(0x101, videoPes(nalType = 5, marker = 0x11, pts = 0))
+        val delta = tsPacket(0x101, videoPes(nalType = 1, marker = 0x22, pts = 90_000))
+        val secondIdr = tsPacket(0x101, videoPes(nalType = 5, marker = 0x33, pts = 180_000))
+        val join = MpegTsJoinBuffer(capacityBytes = TS_PACKET_BYTES * 16)
+        val stream = pat + pmt + config + firstIdr + delta + secondIdr
+
+        join.consume(stream, stream.size)
+
+        val completed = join.drainCompletedSegments()
+        assertEquals(1, completed.size)
+        assertEquals(2.0, completed.single().durationSeconds, 0.001)
+        assertEquals(listOf(0, 0x100), completed.single().bytes.packetPids().take(2))
+        assertTrue(completed.single().bytes.contains(0x11.toByte()))
+        assertFalse(completed.single().bytes.contains(0x33.toByte()))
+        assertTrue(join.snapshot().contains(0x33.toByte()))
+    }
+
+    @Test
+    fun `live hls manifest advances media sequence and names retained segments`() {
+        val manifest = String(
+            buildMirrorHlsManifest(
+                listOf(
+                    MirrorHlsSegment(42, 1.25),
+                    MirrorHlsSegment(43, 1.75),
+                ),
+            )!!,
+            Charsets.UTF_8,
+        )
+
+        assertTrue(manifest.startsWith("#EXTM3U\n"))
+        assertTrue(manifest.contains("#EXT-X-TARGETDURATION:2\n"))
+        assertTrue(manifest.contains("#EXT-X-MEDIA-SEQUENCE:42\n"))
+        assertTrue(manifest.contains("#EXT-X-INDEPENDENT-SEGMENTS\n"))
+        assertTrue(manifest.contains("#EXTINF:1.250,\nsegment-42.ts\n"))
+        assertTrue(manifest.contains("#EXTINF:1.750,\nsegment-43.ts\n"))
+        assertFalse(manifest.contains("#EXT-X-ENDLIST"))
+        assertNull(buildMirrorHlsManifest(emptyList()))
+    }
+
+    @Test
+    fun `http responses expose cast cors and finite hls objects`() {
+        val playlist = "#EXTM3U\n".toByteArray()
+        val response = String(
+            MirrorHttpResponse.bytes("application/x-mpegURL", playlist, headOnly = false),
+            Charsets.US_ASCII,
+        )
+
+        assertTrue(response.startsWith("HTTP/1.1 200 OK\r\n"))
+        assertTrue(response.contains("Content-Type: application/x-mpegURL\r\n"))
+        assertTrue(response.contains("Content-Length: ${playlist.size}\r\n"))
+        assertTrue(response.contains("Access-Control-Allow-Origin: *\r\n"))
+        assertTrue(response.endsWith("#EXTM3U\n"))
+    }
+
+    @Test
+    fun `continuous client backlog is byte bounded`() {
+        val buffer = MirrorClientBuffer(capacityBytes = 5)
+
+        assertTrue(buffer.offer(byteArrayOf(1, 2, 3)))
+        assertFalse(buffer.offer(byteArrayOf(4, 5, 6)))
+        assertEquals(listOf<Byte>(1, 2, 3), buffer.poll(1, TimeUnit.MILLISECONDS)?.toList())
+        assertTrue(buffer.offer(byteArrayOf(4, 5, 6)))
+        buffer.close()
+        assertFalse(buffer.offer(byteArrayOf(7)))
+    }
+
+    private fun ByteArray.packetPids(): List<Int> = asList()
+        .chunked(TS_PACKET_BYTES)
+        .filter { it.size == TS_PACKET_BYTES }
+        .map { packet -> ((packet[1].toInt() and 0x1f) shl 8) or (packet[2].toInt() and 0xff) }
+
+    private fun tsPacket(pid: Int, payload: ByteArray): ByteArray =
+        ByteArray(TS_PACKET_BYTES) { 0xff.toByte() }.apply {
+            this[0] = 0x47
+            this[1] = (((pid ushr 8) and 0x1f) or 0x40).toByte()
+            this[2] = pid.toByte()
+            this[3] = 0x10
+            payload.copyInto(this, destinationOffset = 4, endIndex = payload.size.coerceAtMost(size - 4))
+        }
+
+    private fun patPayload(pmtPid: Int): ByteArray = byteArrayOf(
+        0x00,
+        0x00, 0xb0.toByte(), 0x0d,
+        0x00, 0x01, 0xc1.toByte(), 0x00, 0x00,
+        0x00, 0x01, (0xe0 or (pmtPid ushr 8)).toByte(), pmtPid.toByte(),
+        0x00, 0x00, 0x00, 0x00,
+    )
+
+    private fun pmtPayload(videoPid: Int): ByteArray = byteArrayOf(
+        0x00,
+        0x02, 0xb0.toByte(), 0x12,
+        0x00, 0x01, 0xc1.toByte(), 0x00, 0x00,
+        (0xe0 or (videoPid ushr 8)).toByte(), videoPid.toByte(),
+        0xf0.toByte(), 0x00,
+        0x1b, (0xe0 or (videoPid ushr 8)).toByte(), videoPid.toByte(), 0xf0.toByte(), 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    )
+
+    private fun videoCodecConfigPes(): ByteArray =
+        videoPesPrefix(0) + byteArrayOf(
+            0x00, 0x00, 0x00, 0x01, 0x67, 0x64,
+            0x00, 0x00, 0x00, 0x01, 0x68, 0xee.toByte(),
+        )
+
+    private fun videoPes(nalType: Int, marker: Int, pts: Long): ByteArray =
+        videoPesPrefix(pts) + byteArrayOf(
+            0x00, 0x00, 0x00, 0x01, (0x60 or nalType).toByte(), marker.toByte(),
+        )
+
+    private fun videoPesPrefix(pts: Long): ByteArray {
+        val value = pts and ((1L shl 33) - 1)
+        return byteArrayOf(
+            0x00, 0x00, 0x01, 0xe0.toByte(), 0x00, 0x00,
+            0x80.toByte(), 0x80.toByte(), 0x05,
+            (0x21L or (((value ushr 30) and 0x07) shl 1)).toByte(),
+            (value ushr 22).toByte(),
+            (((value ushr 14) and 0xfe) or 0x01).toByte(),
+            (value ushr 7).toByte(),
+            (((value shl 1) and 0xfe) or 0x01).toByte(),
+        )
+    }
+
+    private companion object {
+        private const val TS_PACKET_BYTES = 188
+    }
+}

--- a/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/ExternalScreenMirrorTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/ExternalScreenMirrorTest.kt
@@ -9,6 +9,31 @@ import org.junit.Test
 
 class ExternalScreenMirrorTest {
     @Test
+    fun `late callback from stopped generation cannot fail replacement mirror`() {
+        assertFalse(
+            shouldHandleExternalMirrorCallback(
+                callbackGeneration = 4,
+                currentGeneration = 6,
+                isActive = true,
+            ),
+        )
+        assertFalse(
+            shouldHandleExternalMirrorCallback(
+                callbackGeneration = 6,
+                currentGeneration = 6,
+                isActive = false,
+            ),
+        )
+        assertTrue(
+            shouldHandleExternalMirrorCallback(
+                callbackGeneration = 6,
+                currentGeneration = 6,
+                isActive = true,
+            ),
+        )
+    }
+
+    @Test
     fun `completed hls segment is keyframe aligned and timed from pts`() {
         val pat = tsPacket(0, patPayload(0x100))
         val pmt = tsPacket(0x100, pmtPayload(0x101))

--- a/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/MediaCodecMpegTsEncoderTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/MediaCodecMpegTsEncoderTest.kt
@@ -1,0 +1,86 @@
+package com.playbridge.sender.cast.mirror
+
+import java.io.ByteArrayOutputStream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MediaCodecMpegTsEncoderTest {
+    @Test
+    fun `length prefixed codec output is converted to annex b`() {
+        val encoded = byteArrayOf(
+            0, 0, 0, 2, 0x67, 0x01,
+            0, 0, 0, 2, 0x68, 0x02,
+        )
+
+        assertEquals(
+            listOf<Byte>(0, 0, 0, 1, 0x67, 0x01, 0, 0, 0, 1, 0x68, 0x02),
+            encoded.toAnnexB().toList(),
+        )
+    }
+
+    @Test
+    fun `first keyframe is immediately available to continuous clients`() {
+        val output = ByteArrayOutputStream()
+        val muxer = H264MpegTsMuxer(output)
+        val join = MpegTsJoinBuffer(capacityBytes = 256 * 1024)
+
+        muxer.writeAccessUnit(decodableKeyframe(marker = 0x11), presentationTimeUs = 0, keyFrame = true)
+        val firstGroup = output.toByteArray()
+        join.consume(firstGroup, firstGroup.size)
+
+        assertTrue(join.isReadyForJoin())
+        assertTrue(join.snapshot().contains(0x11.toByte()))
+        assertTrue(join.drainCompletedSegments().isEmpty())
+    }
+
+    @Test
+    fun `one second keyframes produce independent one second hls segments`() {
+        val output = ByteArrayOutputStream()
+        val muxer = H264MpegTsMuxer(output)
+        val join = MpegTsJoinBuffer(capacityBytes = 256 * 1024)
+        var consumed = 0
+
+        fun drainMuxerOutput() {
+            val bytes = output.toByteArray()
+            val newBytes = bytes.copyOfRange(consumed, bytes.size)
+            join.consume(newBytes, newBytes.size)
+            consumed = bytes.size
+        }
+
+        muxer.writeAccessUnit(decodableKeyframe(marker = 0x11), presentationTimeUs = 0, keyFrame = true)
+        drainMuxerOutput()
+        muxer.writeAccessUnit(deltaFrame(marker = 0x22), presentationTimeUs = 500_000, keyFrame = false)
+        drainMuxerOutput()
+        muxer.writeAccessUnit(decodableKeyframe(marker = 0x33), presentationTimeUs = 1_000_000, keyFrame = true)
+        drainMuxerOutput()
+
+        val segment = join.drainCompletedSegments().single()
+        assertEquals(1.0, segment.durationSeconds, 0.001)
+        assertTrue(segment.bytes.contains(0x11.toByte()))
+        assertTrue(segment.bytes.contains(0x22.toByte()))
+        assertFalse(segment.bytes.contains(0x33.toByte()))
+        assertEquals(listOf(0, 0x100), segment.bytes.packetPids().take(2))
+        assertTrue(segment.bytes.asList().chunked(TS_PACKET_BYTES).all { it.size == TS_PACKET_BYTES && it[0] == 0x47.toByte() })
+    }
+
+    private fun decodableKeyframe(marker: Int): ByteArray = byteArrayOf(
+        0, 0, 0, 1, 0x67, 0x42, 0x00, 0x1f,
+        0, 0, 0, 1, 0x68, 0xce.toByte(), 0x06, 0xe2.toByte(),
+        0, 0, 0, 1, 0x65, marker.toByte(),
+    )
+
+    private fun deltaFrame(marker: Int): ByteArray = byteArrayOf(
+        0, 0, 0, 1, 0x61, marker.toByte(),
+    )
+
+    private fun ByteArray.packetPids(): List<Int> = asList()
+        .chunked(TS_PACKET_BYTES)
+        .filter { it.size == TS_PACKET_BYTES }
+        .map { packet -> ((packet[1].toInt() and 0x1f) shl 8) or (packet[2].toInt() and 0xff) }
+
+    private companion object {
+        private const val TS_PACKET_BYTES = 188
+    }
+}

--- a/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/MediaCodecMpegTsEncoderTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/MediaCodecMpegTsEncoderTest.kt
@@ -64,6 +64,39 @@ class MediaCodecMpegTsEncoderTest {
         assertEquals(listOf(0, 0x100), segment.bytes.packetPids().take(2))
         assertTrue(segment.bytes.asList().chunked(TS_PACKET_BYTES).all { it.size == TS_PACKET_BYTES && it[0] == 0x47.toByte() })
     }
+    @Test
+    fun `aac audio is advertised and packetized in the shared transport`() {
+        val output = ByteArrayOutputStream()
+        val muxer = H264MpegTsMuxer(output, includeAudio = true)
+
+        muxer.writeAccessUnit(decodableKeyframe(marker = 0x11), presentationTimeUs = 1_000_000, keyFrame = true)
+        muxer.writeAudioAccessUnit(
+            adtsFrame(byteArrayOf(0x21, 0x22), sampleRate = 48_000, channelCount = 2),
+            presentationTimeUs = 1_000_000,
+        )
+
+        val packets = output.toByteArray().asList().chunked(TS_PACKET_BYTES)
+        val pmt = packets.first { it.pid() == PMT_PID }
+        assertEquals(0x1b, pmt[17].toInt() and 0xff)
+        assertEquals(0x0f, pmt[22].toInt() and 0xff)
+        assertTrue(packets.any { it.pid() == AUDIO_PID })
+    }
+
+    @Test
+    fun `adts header describes aac lc stereo at 48 khz`() {
+        val frame = adtsFrame(byteArrayOf(0x11, 0x22, 0x33), sampleRate = 48_000, channelCount = 2)
+
+        assertEquals(10, frame.size)
+        assertEquals(0xff, frame[0].toInt() and 0xff)
+        assertEquals(0xf1, frame[1].toInt() and 0xff)
+        assertEquals(1, (frame[2].toInt() ushr 6) and 0x03)
+        assertEquals(3, (frame[2].toInt() ushr 2) and 0x0f)
+        assertEquals(2, ((frame[2].toInt() and 0x01) shl 2) or ((frame[3].toInt() ushr 6) and 0x03))
+        assertEquals(10, ((frame[3].toInt() and 0x03) shl 11) or
+            ((frame[4].toInt() and 0xff) shl 3) or
+            ((frame[5].toInt() ushr 5) and 0x07))
+    }
+
 
     private fun decodableKeyframe(marker: Int): ByteArray = byteArrayOf(
         0, 0, 0, 1, 0x67, 0x42, 0x00, 0x1f,
@@ -79,8 +112,12 @@ class MediaCodecMpegTsEncoderTest {
         .chunked(TS_PACKET_BYTES)
         .filter { it.size == TS_PACKET_BYTES }
         .map { packet -> ((packet[1].toInt() and 0x1f) shl 8) or (packet[2].toInt() and 0xff) }
+    private fun List<Byte>.pid(): Int =
+        ((this[1].toInt() and 0x1f) shl 8) or (this[2].toInt() and 0xff)
 
     private companion object {
         private const val TS_PACKET_BYTES = 188
+        private const val PMT_PID = 0x0100
+        private const val AUDIO_PID = 0x0102
     }
 }

--- a/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/ScreenMirrorQualityTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/ScreenMirrorQualityTest.kt
@@ -51,24 +51,30 @@ class ScreenMirrorQualityTest {
     }
 
     @Test
-    fun `external encoder keeps a stable landscape canvas across rotation`() {
-        assertEquals(1_280 to 590, externalMirrorEncoderSize(590, 1_280))
-        assertEquals(1_280 to 590, externalMirrorEncoderSize(1_280, 590))
+    fun `external encoder keeps a stable standard canvas across rotation`() {
+        assertEquals(1_280 to 720, externalMirrorEncoderSize(590, 1_280))
+        assertEquals(1_280 to 720, externalMirrorEncoderSize(1_280, 590))
+        assertEquals(1_920 to 1_080, externalMirrorEncoderSize(886, 1_920))
     }
 
     @Test
-    fun `external frames fit across portrait landscape portrait sequence`() {
+    fun `external frames fit inside the receiver safe area across rotation`() {
         assertEquals(
-            0.2125f to 1f,
-            mirrorFrameFitScale(590, 1_280, 1_280, 590).let { (x, y) ->
-                x.round(4) to y
+            0.2333f to 0.9f,
+            mirrorFrameFitScale(590, 1_280, 1_280, 720).let { (x, y) ->
+                x.round(4) to y.round(4)
             },
         )
-        assertEquals(1f to 1f, mirrorFrameFitScale(1_280, 590, 1_280, 590))
         assertEquals(
-            0.2125f to 1f,
-            mirrorFrameFitScale(590, 1_280, 1_280, 590).let { (x, y) ->
-                x.round(4) to y
+            0.9f to 0.7375f,
+            mirrorFrameFitScale(1_280, 590, 1_280, 720).let { (x, y) ->
+                x.round(4) to y.round(4)
+            },
+        )
+        assertEquals(
+            0.2333f to 0.9f,
+            mirrorFrameFitScale(590, 1_280, 1_280, 720).let { (x, y) ->
+                x.round(4) to y.round(4)
             },
         )
     }

--- a/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/ScreenMirrorQualityTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/ScreenMirrorQualityTest.kt
@@ -49,4 +49,32 @@ class ScreenMirrorQualityTest {
             screenMirrorCaptureSize(2_400, 1_080, ScreenMirrorCoordinator.Quality.DEFAULT),
         )
     }
+
+    @Test
+    fun `external encoder keeps a stable landscape canvas across rotation`() {
+        assertEquals(1_280 to 590, externalMirrorEncoderSize(590, 1_280))
+        assertEquals(1_280 to 590, externalMirrorEncoderSize(1_280, 590))
+    }
+
+    @Test
+    fun `external portrait frames fit inside the stable landscape canvas`() {
+        val (scaleX, scaleY) = mirrorFrameFitScale(
+            inputWidth = 590,
+            inputHeight = 1_280,
+            outputWidth = 1_280,
+            outputHeight = 590,
+        )
+
+        assertEquals(0.2124f, scaleX, 0.0001f)
+        assertEquals(1f, scaleY, 0.0001f)
+        assertEquals(
+            1f to 1f,
+            mirrorFrameFitScale(
+                inputWidth = 1_280,
+                inputHeight = 590,
+                outputWidth = 1_280,
+                outputHeight = 590,
+            ),
+        )
+    }
 }

--- a/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/ScreenMirrorQualityTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/cast/mirror/ScreenMirrorQualityTest.kt
@@ -57,24 +57,25 @@ class ScreenMirrorQualityTest {
     }
 
     @Test
-    fun `external portrait frames fit inside the stable landscape canvas`() {
-        val (scaleX, scaleY) = mirrorFrameFitScale(
-            inputWidth = 590,
-            inputHeight = 1_280,
-            outputWidth = 1_280,
-            outputHeight = 590,
-        )
-
-        assertEquals(0.2124f, scaleX, 0.0001f)
-        assertEquals(1f, scaleY, 0.0001f)
+    fun `external frames fit across portrait landscape portrait sequence`() {
         assertEquals(
-            1f to 1f,
-            mirrorFrameFitScale(
-                inputWidth = 1_280,
-                inputHeight = 590,
-                outputWidth = 1_280,
-                outputHeight = 590,
-            ),
+            0.2125f to 1f,
+            mirrorFrameFitScale(590, 1_280, 1_280, 590).let { (x, y) ->
+                x.round(4) to y
+            },
+        )
+        assertEquals(1f to 1f, mirrorFrameFitScale(1_280, 590, 1_280, 590))
+        assertEquals(
+            0.2125f to 1f,
+            mirrorFrameFitScale(590, 1_280, 1_280, 590).let { (x, y) ->
+                x.round(4) to y
+            },
         )
     }
+
+}
+
+private fun Float.round(decimals: Int): Float {
+    val factor = Math.pow(10.0, decimals.toDouble()).toFloat()
+    return kotlin.math.round(this * factor) / factor
 }

--- a/protocol/docs/WSS_FLOW.md
+++ b/protocol/docs/WSS_FLOW.md
@@ -180,6 +180,10 @@ Most actions use `{"type":"command","action":"...","payload":{...}}`:
 | `browser` | Open a URL on a receiver with browser capability | Activates browser context |
 | `browser_control` | Refresh or toggle receiver ad blocking | Controls active browser |
 | `context_query` | Immediately after auth/reconnect or UI refresh | Receiver sends current context and state |
+| `screen_mirror_start` | Phone starts a WebRTC screen mirror after `auth_response.screenMirrorWebRtc=true` | Receiver creates a receive-only peer and replies `screen_mirror_ready` before the offer. Payload is `sessionId` (UUID) plus `protocolVersion: 1`. |
+| `screen_mirror_offer` | Phone sends the H.264 (optional Opus) SDP offer | Receiver sets remote SDP, flushes queued ICE, and replies `screen_mirror_answer` |
+| `screen_mirror_candidate` | Phone trickle-ICE (host UDP only) | Receiver adds the candidate or queues it until remote SDP is set |
+| `screen_mirror_stop` | Phone ends the session | Receiver tears down the peer and does not echo stop |
 
 Android receiver browser administration also uses standalone `user_script`, `user_script_query`,
 `user_agent`, and `user_agent_query` frames. Other receivers may ignore unsupported, well-formed
@@ -202,6 +206,10 @@ is not part of the canonical sender contract.
 | `player_settings` | Speed, adaptive quality ceiling, scaling, boost, subtitle offset, engine, and live capability changes |
 | `user_scripts` / `user_agents` | Response to Android browser administration queries |
 | `pong` | Response to application-level `ping` |
+| `screen_mirror_ready` | Peer + renderer/pipe created; sent before the phone offers |
+| `screen_mirror_answer` | Local SDP set after `screen_mirror_offer` |
+| `screen_mirror_candidate` | Local host UDP ICE for the answerer |
+| `screen_mirror_event` | `connected`, or `failed`/`stopped` plus a stable `reason` |
 
 Receivers must tolerate unknown JSON object properties for forward compatibility. Unknown
 message types/actions should be ignored or surfaced diagnostically, not treated as authenticated
@@ -226,6 +234,7 @@ advertised capabilities.
 | `context`, `status`, `playlist_status` | Receives | Receives | Receives | Sends | Sends | Sends |
 | `tracks` | Receives | Receives | Receives | Sends | Sends | Sends |
 | `player_settings` | Receives | Receives | Receives | Sends | Not currently sent | Not currently sent |
+| WebRTC screen mirror (`screenMirrorWebRtc` + v1 `protocolVersion`) | Sends | No | No | Handles | No | Handles |
 
 The Firefox/Chromium extension is not a WSS endpoint. It sends a restricted native-messaging
 request to PlayBridge Desktop; Desktop owns discovery, pairing, pinning, receiver selection, and


### PR DESCRIPTION
## Summary
- add phone screen mirroring to Google Cast and DLNA receivers
- encode a stable rotation-safe H.264 canvas and expose low-latency HLS and continuous MPEG-TS transports
- capture permitted Android playback audio, encode AAC-LC, and mux it into the shared MPEG-TS stream
- advertise Google Cast HLS audio as ts_aac and preserve device-audio state through the external route
- preserve Cast routing, network binding, lifecycle, and foreground-service behavior

## Verification
- focused screen-mirror, MPEG-TS/AAC transport, routing, and Google Cast network policy unit tests
- full phone Foss debug unit test suite
- Foss debug APK assembly and install on Samsung phone
- hardware smoke against Google Cast and DLNA receivers with video and audio

## Hardware results
- Google Cast initialized 48 kHz playback capture, loaded LIVE HLS with audio=ts_aac/video=mpeg2_ts, and reached PLAYING
- DLNA initialized 48 kHz playback capture and played the shared audiovisual MPEG-TS stream
- rotation remained active without restarting the receiver load

## Limitations
- Android playback-capture policy can silence protected apps
- receiver latency and DLNA compatibility remain device-dependent