### PR TITLE
🛡️ Sentinel: [HIGH] Fix SEC-004 plaintext token storage on Apple TV

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,7 @@
 **Vulnerability:** The Android TV app's `SystemWebViewEngine` had `allowContentAccess` set to `true`. This is a critical security misconfiguration because it allows the arbitrary web content loaded into the system WebView to access and read local content provider data via `content://` URIs on the device, potentially exposing sensitive application data or internal processes (e.g. `PlayerProcessBridgeProvider`).
 **Learning:** Just as `allowFileAccess` is dangerous, `allowContentAccess` is equally risky when a WebView acts as a browser to navigate to untrusted arbitrary URLs. It unnecessarily expands the attack surface.
 **Prevention:** Explicitly configure `allowContentAccess = false` on all WebViews that handle remote, untrusted content to prevent access to the application's ContentProviders.
+## 2024-08-14 - SEC-004: Inconsistent Bearer Token Storage on Apple TV
+**Vulnerability:** Apple TV receiver stores bearer tokens in plaintext in UserDefaults (SEC-004 in docs/SECURITY_GAPS.md).
+**Learning:** Legacy paired device structures and Codable compatibility issues make migration of these structs challenging if not carefully done. The original plaintext tokens need to be removed as they authenticate, but old encoded devices must not crash parsing.
+**Prevention:** Always serialize sensitive authorization verifiers, not the raw tokens themselves, starting from v1. Handle migration using separate legacy/hash storage and optional struct properties for old fields.

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Models/PairedDevice.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Models/PairedDevice.swift
@@ -4,6 +4,7 @@ struct PairedDevice: Codable, Identifiable {
     var id: String { deviceUUID }
     let deviceUUID: String
     let deviceName: String
-    let token: String
+    var token: String?
+    var tokenVerifier: String?
     var lastConnected: Date
 }

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
@@ -28,6 +28,12 @@ struct ConnectionHandshake {
 
 // MARK: - Server Logic
 class WebSocketServer: ObservableObject {
+    private func hashToken(_ token: String) -> String {
+        let data = token.data(using: .utf8) ?? Data()
+        let digest = SasCrypto.sha256(data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
     private var tlsListener: NWListener?
     private var connectedConnections: [NWConnection] = []
     private var historyStore: HistoryStore?
@@ -54,6 +60,7 @@ class WebSocketServer: ObservableObject {
 
     var deviceName: String { UIDevice.current.name }
     private let authorizedTokensKey = "pb_authorized_tokens"
+    private let authorizedTokenVerifiersKey = "pb_authorized_token_verifiers"
     private let deviceUUIDKey = "pb_device_uuid"
     private let pairedDevicesKey = "pb_paired_devices"
     private let receiverPortKey = "pb_receiver_port"
@@ -95,6 +102,11 @@ class WebSocketServer: ObservableObject {
     private var authorizedTokens: Set<String> {
         get { Set(UserDefaults.standard.stringArray(forKey: authorizedTokensKey) ?? []) }
         set { UserDefaults.standard.set(Array(newValue), forKey: authorizedTokensKey) }
+    }
+
+    private var authorizedTokenVerifiers: Set<String> {
+        get { Set(UserDefaults.standard.stringArray(forKey: authorizedTokenVerifiersKey) ?? []) }
+        set { UserDefaults.standard.set(Array(newValue), forKey: authorizedTokenVerifiersKey) }
     }
 
     /// Re-broadcasts `playlist_status` whenever the queue changes — including index moves
@@ -644,14 +656,16 @@ class WebSocketServer: ObservableObject {
         autoTimeoutWork = nil
 
         let token = UUID().uuidString
-        var tokens = authorizedTokens
-        tokens.insert(token)
-        authorizedTokens = tokens
+        let tokenHash = hashToken(token)
+        var verifiers = authorizedTokenVerifiers
+        verifiers.insert(tokenHash)
+        authorizedTokenVerifiers = verifiers
 
         let device = PairedDevice(
             deviceUUID: handshake.deviceUUID,
             deviceName: handshake.deviceName,
-            token: token,
+            token: nil,
+            tokenVerifier: tokenHash,
             lastConnected: Date()
         )
         savePairedDevice(device)
@@ -785,7 +799,46 @@ class WebSocketServer: ObservableObject {
             send(json: ["type": "auth_response", "success": false], to: connection)
             return
         }
-        if authorizedTokens.contains(msg.token) {
+
+        let tokenHash = hashToken(msg.token)
+        var isAuthorized = false
+
+        if authorizedTokenVerifiers.contains(tokenHash) {
+            isAuthorized = true
+
+            // Just in case it's still in authorizedTokens during migration overlapping states
+            var legacyTokens = authorizedTokens
+            if legacyTokens.remove(msg.token) != nil {
+                authorizedTokens = legacyTokens
+
+                var devices = storedPairedDevices
+                if let idx = devices.firstIndex(where: { $0.token == msg.token }) {
+                    devices[idx].token = nil
+                    devices[idx].tokenVerifier = tokenHash
+                    storedPairedDevices = devices
+                }
+            }
+        } else if authorizedTokens.contains(msg.token) {
+            isAuthorized = true
+
+            // Migrate legacy token
+            var verifiers = authorizedTokenVerifiers
+            verifiers.insert(tokenHash)
+            authorizedTokenVerifiers = verifiers
+
+            var legacyTokens = authorizedTokens
+            legacyTokens.remove(msg.token)
+            authorizedTokens = legacyTokens
+
+            var devices = storedPairedDevices
+            if let idx = devices.firstIndex(where: { $0.token == msg.token }) {
+                devices[idx].token = nil
+                devices[idx].tokenVerifier = tokenHash
+                storedPairedDevices = devices
+            }
+        }
+
+        if isAuthorized {
             updateLastConnected(token: msg.token)
             completeAuth(from: connection, token: msg.token)
         } else {
@@ -836,24 +889,37 @@ class WebSocketServer: ObservableObject {
         var devices = storedPairedDevices
         devices.removeAll { $0.deviceUUID == device.deviceUUID }
         storedPairedDevices = devices
-        var tokens = authorizedTokens
-        tokens.remove(device.token)
-        authorizedTokens = tokens
+        if let t = device.token {
+            var tokens = authorizedTokens
+            tokens.remove(t)
+            authorizedTokens = tokens
+
+            var verifiers = authorizedTokenVerifiers
+            verifiers.remove(hashToken(t))
+            authorizedTokenVerifiers = verifiers
+        }
+        if let tv = device.tokenVerifier {
+            var verifiers = authorizedTokenVerifiers
+            verifiers.remove(tv)
+            authorizedTokenVerifiers = verifiers
+        }
     }
 
     func forgetAllDevices() {
         storedPairedDevices = []
         authorizedTokens = []
+        authorizedTokenVerifiers = []
         DispatchQueue.main.async { self.pairedDevicesList = [] }
     }
 
     private func updateLastConnected(token: String) {
         var devices = storedPairedDevices
-        if let idx = devices.firstIndex(where: { $0.token == token }) {
+        let tokenHash = hashToken(token)
+        if let idx = devices.firstIndex(where: { $0.tokenVerifier == tokenHash || $0.token == token }) {
             let d = devices[idx]
             devices[idx] = PairedDevice(
                 deviceUUID: d.deviceUUID, deviceName: d.deviceName,
-                token: token, lastConnected: Date()
+                token: d.token, tokenVerifier: d.tokenVerifier, lastConnected: Date()
             )
             storedPairedDevices = devices
         }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Apple TV WSS receiver stored plaintext bearer tokens in UserDefaults.
🎯 Impact: Attackers with local or backup access could recover full reusable auth credentials for replay attacks.
🔧 Fix: Changed storage to hold SHA256 hashed verifiers. Migrated older plaintext pairings on-the-fly when they successfully authenticate.
✅ Verification: Review code and check local UserDefaults. Tests were bypassed since xcodebuild wasn't available in sandbox but manual parsing code was verified.

---
*PR created automatically by Jules for task [2932734500241880405](https://jules.google.com/task/2932734500241880405) started by @playbridgeapp*