### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix plaintext token storage in Apple TV receiver

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,13 @@
 **Vulnerability:** The Android TV app's `SystemWebViewEngine` had `allowContentAccess` set to `true`. This is a critical security misconfiguration because it allows the arbitrary web content loaded into the system WebView to access and read local content provider data via `content://` URIs on the device, potentially exposing sensitive application data or internal processes (e.g. `PlayerProcessBridgeProvider`).
 **Learning:** Just as `allowFileAccess` is dangerous, `allowContentAccess` is equally risky when a WebView acts as a browser to navigate to untrusted arbitrary URLs. It unnecessarily expands the attack surface.
 **Prevention:** Explicitly configure `allowContentAccess = false` on all WebViews that handle remote, untrusted content to prevent access to the application's ContentProviders.
+
+## 2025-02-09 - Plaintext Token Storage in Apple TV App
+**Vulnerability:** The Apple TV app's `WebSocketServer` stored plaintext bearer tokens for paired devices in `UserDefaults` and authorized connections using exact matches. These stored tokens could be extracted from preferences or device backups and reused to gain unauthorized sender privileges.
+**Learning:** Ordinary application preferences like `UserDefaults` are not a secure secret store, and retaining a plaintext copy of tokens after issuance introduces persistent credentials that are highly portable.
+**Prevention:** Always convert newly generated and incoming secrets to hashed token verifiers (e.g. SHA-256) before saving them to `UserDefaults` and using them in server state lookups. The plaintext token should only ever exist ephemerally during issuance and initial client transmission.
+
+## 2025-02-09 - Missed Verifier Argument in Apple TV App Token Migration
+**Vulnerability:** While mitigating SEC-004 (hashed token storage), `approvePairing` correctly hashed the token but called `completeAuth` with the plaintext `token` instead of `tokenVerifier`. The subsequent `handleAuth` exchange attempts to double-hash.
+**Learning:** During token migrations or generation where multiple versions (plaintext and hash) exist in scope, functions down the execution path can inadvertently re-bind to the original value, breaking state alignment across the system.
+**Prevention:** Follow through all state updates within the function block that consume the token and assert they strictly receive the hashed `tokenVerifier` when representing server-side storage identity.

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
@@ -644,14 +644,16 @@ class WebSocketServer: ObservableObject {
         autoTimeoutWork = nil
 
         let token = UUID().uuidString
+        let tokenVerifier = computeTokenVerifier(token: token)
+
         var tokens = authorizedTokens
-        tokens.insert(token)
+        tokens.insert(tokenVerifier)
         authorizedTokens = tokens
 
         let device = PairedDevice(
             deviceUUID: handshake.deviceUUID,
             deviceName: handshake.deviceName,
-            token: token,
+            token: tokenVerifier,
             lastConnected: Date()
         )
         savePairedDevice(device)
@@ -709,7 +711,7 @@ class WebSocketServer: ObservableObject {
         lockoutUntil.removeValue(forKey: ip)
         
         inProgressHandshakes.removeValue(forKey: ObjectIdentifier(connection))
-        completeAuth(from: connection, token: token, sendAuthResponse: false)
+        completeAuth(from: connection, token: tokenVerifier, sendAuthResponse: false)
         pendingPairingRequest = nil
     }
 
@@ -785,9 +787,17 @@ class WebSocketServer: ObservableObject {
             send(json: ["type": "auth_response", "success": false], to: connection)
             return
         }
-        if authorizedTokens.contains(msg.token) {
-            updateLastConnected(token: msg.token)
-            completeAuth(from: connection, token: msg.token)
+
+        let tokenVerifier = computeTokenVerifier(token: msg.token)
+
+        if authorizedTokens.contains(tokenVerifier) {
+            updateLastConnected(token: tokenVerifier)
+            completeAuth(from: connection, token: tokenVerifier)
+        } else if authorizedTokens.contains(msg.token) {
+            // Found a legacy plaintext token; update it to the hashed verifier.
+            migrateLegacyToken(token: msg.token)
+            updateLastConnected(token: tokenVerifier)
+            completeAuth(from: connection, token: tokenVerifier)
         } else {
             send(json: ["type": "auth_response", "success": false], to: connection)
         }
@@ -817,6 +827,35 @@ class WebSocketServer: ObservableObject {
                 self.broadcastPlaylistStatus()
             }
             NotificationCenter.default.post(name: Self.resyncRequest, object: nil)
+        }
+    }
+
+    // MARK: - Token Security
+
+    private func computeTokenVerifier(token: String) -> String {
+        let data = Data(token.utf8)
+        let hash = SasCrypto.sha256(data)
+        return hash.base64EncodedString()
+    }
+
+    private func migrateLegacyToken(token: String) {
+        let verifier = computeTokenVerifier(token: token)
+
+        var tokens = authorizedTokens
+        tokens.remove(token)
+        tokens.insert(verifier)
+        authorizedTokens = tokens
+
+        var devices = storedPairedDevices
+        if let idx = devices.firstIndex(where: { $0.token == token }) {
+            let d = devices[idx]
+            devices[idx] = PairedDevice(
+                deviceUUID: d.deviceUUID,
+                deviceName: d.deviceName,
+                token: verifier,
+                lastConnected: d.lastConnected
+            )
+            storedPairedDevices = devices
         }
     }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The Apple TV application stored authentication tokens for paired sender devices as plaintext in `UserDefaults` and authorized connections based on exact plaintext match (SEC-004). Preferences are not a secure storage mechanism and can be exposed through local access or backups, allowing attackers to steal tokens and gain unauthorized access to the receiver.
🎯 Impact: An attacker who compromised the Apple TV's file system or backups could extract persistent sender tokens and establish authorized WebSocket sessions at will, impersonating the victim's device without re-pairing.
🔧 Fix: Upgraded token generation and storage. `approvePairing` now immediately hashes newly generated UUID tokens with SHA-256 before saving them to `authorizedTokens` and the `PairedDevice` record, only sending the plaintext copy to the client via `credentials`. `handleAuth` was updated to hash incoming tokens and verify against the stored hash. An automatic migration path was introduced to transparently hash existing legacy plaintext tokens upon their next successful use.
✅ Verification: Review the diff for `WebSocketServer.swift` to ensure tokens are securely hashed and migration correctly upgrades legacy values. Run standard CI test pipelines.

---
*PR created automatically by Jules for task [2511738112985846301](https://jules.google.com/task/2511738112985846301) started by @playbridgeapp*