### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix plaintext token storage in Apple TV app

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The Android TV app's `SystemWebViewEngine` had `allowContentAccess` set to `true`. This is a critical security misconfiguration because it allows the arbitrary web content loaded into the system WebView to access and read local content provider data via `content://` URIs on the device, potentially exposing sensitive application data or internal processes (e.g. `PlayerProcessBridgeProvider`).
 **Learning:** Just as `allowFileAccess` is dangerous, `allowContentAccess` is equally risky when a WebView acts as a browser to navigate to untrusted arbitrary URLs. It unnecessarily expands the attack surface.
 **Prevention:** Explicitly configure `allowContentAccess = false` on all WebViews that handle remote, untrusted content to prevent access to the application's ContentProviders.
+
+## 2026-08-16 - Plaintext Bearer Token Storage in Apple TV
+**Vulnerability:** The Apple TV app's `WebSocketServer` previously stored bearer authentication tokens in plaintext in `UserDefaults`. This is a medium-risk vulnerability (SEC-004) where an attacker gaining local access or backups could extract tokens and authenticate as the paired sender.
+**Learning:** Legacy preferences storage mechanisms (like `UserDefaults`) are not safe places to store high-entropy bearer tokens. If you must use them instead of a secure vault (like Keychain), the tokens must be stored only as non-reversible hashed verifiers, using constant-time comparison algorithms for authorization.
+**Prevention:** Store hashes of secrets instead of plaintext values when persisting to disk, unless the secret must be used in a form requiring the raw value (which is not the case for an authentication verifier).

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Models/PairedDevice.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Models/PairedDevice.swift
@@ -4,6 +4,7 @@ struct PairedDevice: Codable, Identifiable {
     var id: String { deviceUUID }
     let deviceUUID: String
     let deviceName: String
-    let token: String
+    var token: String
+    var tokenVerifier: String?
     var lastConnected: Date
 }

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
@@ -54,6 +54,7 @@ class WebSocketServer: ObservableObject {
 
     var deviceName: String { UIDevice.current.name }
     private let authorizedTokensKey = "pb_authorized_tokens"
+    private let authorizedTokenVerifiersKey = "pb_authorized_token_verifiers"
     private let deviceUUIDKey = "pb_device_uuid"
     private let pairedDevicesKey = "pb_paired_devices"
     private let receiverPortKey = "pb_receiver_port"
@@ -95,6 +96,54 @@ class WebSocketServer: ObservableObject {
     private var authorizedTokens: Set<String> {
         get { Set(UserDefaults.standard.stringArray(forKey: authorizedTokensKey) ?? []) }
         set { UserDefaults.standard.set(Array(newValue), forKey: authorizedTokensKey) }
+    }
+
+    private var authorizedTokenVerifiers: Set<String> {
+        get { Set(UserDefaults.standard.stringArray(forKey: authorizedTokenVerifiersKey) ?? []) }
+        set { UserDefaults.standard.set(Array(newValue), forKey: authorizedTokenVerifiersKey) }
+    }
+
+    private func hashToken(_ token: String) -> String {
+        guard let data = token.data(using: .utf8) else { return "" }
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func isTokenAuthorized(token: String) -> Bool {
+        let verifier = hashToken(token)
+
+        // Fast path: check new hash set
+        if authorizedTokenVerifiers.contains(verifier) {
+            return true
+        }
+
+        // Legacy path: migrate if found in old plaintext set
+        var legacyTokens = authorizedTokens
+        if legacyTokens.remove(token) != nil {
+            // Update token lists
+            authorizedTokens = legacyTokens
+            var verifiers = authorizedTokenVerifiers
+            verifiers.insert(verifier)
+            authorizedTokenVerifiers = verifiers
+
+            // Migrate paired device records
+            var devices = storedPairedDevices
+            var changed = false
+            for i in 0..<devices.count {
+                if devices[i].token == token {
+                    devices[i].token = ""
+                    devices[i].tokenVerifier = verifier
+                    changed = true
+                }
+            }
+            if changed {
+                storedPairedDevices = devices
+            }
+
+            return true
+        }
+
+        return false
     }
 
     /// Re-broadcasts `playlist_status` whenever the queue changes — including index moves
@@ -644,14 +693,16 @@ class WebSocketServer: ObservableObject {
         autoTimeoutWork = nil
 
         let token = UUID().uuidString
-        var tokens = authorizedTokens
-        tokens.insert(token)
-        authorizedTokens = tokens
+        let verifier = hashToken(token)
+        var verifiers = authorizedTokenVerifiers
+        verifiers.insert(verifier)
+        authorizedTokenVerifiers = verifiers
 
         let device = PairedDevice(
             deviceUUID: handshake.deviceUUID,
             deviceName: handshake.deviceName,
-            token: token,
+            token: "",
+            tokenVerifier: verifier,
             lastConnected: Date()
         )
         savePairedDevice(device)
@@ -785,7 +836,7 @@ class WebSocketServer: ObservableObject {
             send(json: ["type": "auth_response", "success": false], to: connection)
             return
         }
-        if authorizedTokens.contains(msg.token) {
+        if isTokenAuthorized(token: msg.token) {
             updateLastConnected(token: msg.token)
             completeAuth(from: connection, token: msg.token)
         } else {
@@ -836,24 +887,38 @@ class WebSocketServer: ObservableObject {
         var devices = storedPairedDevices
         devices.removeAll { $0.deviceUUID == device.deviceUUID }
         storedPairedDevices = devices
-        var tokens = authorizedTokens
-        tokens.remove(device.token)
-        authorizedTokens = tokens
+
+        if let verifier = device.tokenVerifier {
+            var verifiers = authorizedTokenVerifiers
+            verifiers.remove(verifier)
+            authorizedTokenVerifiers = verifiers
+        }
+        if !device.token.isEmpty {
+            var tokens = authorizedTokens
+            tokens.remove(device.token)
+            authorizedTokens = tokens
+
+            var verifiers = authorizedTokenVerifiers
+            verifiers.remove(hashToken(device.token))
+            authorizedTokenVerifiers = verifiers
+        }
     }
 
     func forgetAllDevices() {
         storedPairedDevices = []
         authorizedTokens = []
+        authorizedTokenVerifiers = []
         DispatchQueue.main.async { self.pairedDevicesList = [] }
     }
 
     private func updateLastConnected(token: String) {
         var devices = storedPairedDevices
-        if let idx = devices.firstIndex(where: { $0.token == token }) {
+        let verifier = hashToken(token)
+        if let idx = devices.firstIndex(where: { $0.tokenVerifier == verifier || $0.token == token }) {
             let d = devices[idx]
             devices[idx] = PairedDevice(
                 deviceUUID: d.deviceUUID, deviceName: d.deviceName,
-                token: token, lastConnected: Date()
+                token: d.token, tokenVerifier: d.tokenVerifier, lastConnected: Date()
             )
             storedPairedDevices = devices
         }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix plaintext token storage in Apple TV app

🚨 Severity: MEDIUM (SEC-004)
💡 Vulnerability: The Apple TV receiver stored authorized bearer authentication tokens in plaintext within UserDefaults and the PairedDevice records. If accessed via local device inspection or backup, these could be extracted to mimic paired senders.
🎯 Impact: Theft of an original token permits authentication as the paired sender.
🔧 Fix:
- Added a `tokenVerifier` field to `PairedDevice` (as an Optional to avoid Codable breaks for existing devices).
- Changed `WebSocketServer` to hash generated tokens using `CryptoKit`'s `SHA256` before storing them.
- Implemented an `isTokenAuthorized` function that verifies hashes.
- Included an on-the-fly migration that translates older plaintext stored tokens into hashes upon read and clears the plaintext records.
✅ Verification: `xcodebuild -workspace "tv/apple/PlayBridge TV.xcworkspace" -scheme "PlayBridge TV" test` validates correct compilation and any associated unit tests.

---
*PR created automatically by Jules for task [331341819751133793](https://jules.google.com/task/331341819751133793) started by @playbridgeapp*