### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix plaintext bearer token storage in Apple TV

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The Android TV app's `SystemWebViewEngine` had `allowContentAccess` set to `true`. This is a critical security misconfiguration because it allows the arbitrary web content loaded into the system WebView to access and read local content provider data via `content://` URIs on the device, potentially exposing sensitive application data or internal processes (e.g. `PlayerProcessBridgeProvider`).
 **Learning:** Just as `allowFileAccess` is dangerous, `allowContentAccess` is equally risky when a WebView acts as a browser to navigate to untrusted arbitrary URLs. It unnecessarily expands the attack surface.
 **Prevention:** Explicitly configure `allowContentAccess = false` on all WebViews that handle remote, untrusted content to prevent access to the application's ContentProviders.
+
+## 2026-07-22 - Insecure storage of pairing tokens in UserDefaults (Apple TV)
+**Vulnerability:** The Apple TV app previously stored bearer tokens in plaintext within `UserDefaults`. Since `UserDefaults` data is not encrypted at rest and is included in device backups, this could expose the tokens.
+**Learning:** Always compute a secure hash (e.g., using SHA256) of bearer tokens and store only the resulting `tokenVerifier` instead of the plaintext token, when using standard OS preferences storage.
+**Prevention:** When saving authentication tokens to `UserDefaults` (or equivalent plain storage), store only a cryptographically secure hash of the token to mitigate credential theft.

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Models/PairedDevice.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Models/PairedDevice.swift
@@ -4,6 +4,7 @@ struct PairedDevice: Codable, Identifiable {
     var id: String { deviceUUID }
     let deviceUUID: String
     let deviceName: String
-    let token: String
+    var token: String
+    var tokenVerifier: String?
     var lastConnected: Date
 }

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
@@ -97,6 +97,11 @@ class WebSocketServer: ObservableObject {
         set { UserDefaults.standard.set(Array(newValue), forKey: authorizedTokensKey) }
     }
 
+    private var authorizedTokenVerifiers: Set<String> {
+        get { Set(UserDefaults.standard.stringArray(forKey: "authorizedTokenVerifiers") ?? []) }
+        set { UserDefaults.standard.set(Array(newValue), forKey: "authorizedTokenVerifiers") }
+    }
+
     /// Re-broadcasts `playlist_status` whenever the queue changes — including index moves
     /// driven by the player UI (next/jump), which never pass through the server.
     private var playlistCancellable: AnyCancellable?
@@ -644,14 +649,16 @@ class WebSocketServer: ObservableObject {
         autoTimeoutWork = nil
 
         let token = UUID().uuidString
-        var tokens = authorizedTokens
-        tokens.insert(token)
-        authorizedTokens = tokens
+        let verifier = hashToken(token)
+        var verifiers = authorizedTokenVerifiers
+        verifiers.insert(verifier)
+        authorizedTokenVerifiers = verifiers
 
         let device = PairedDevice(
             deviceUUID: handshake.deviceUUID,
             deviceName: handshake.deviceName,
-            token: token,
+            token: "",
+            tokenVerifier: verifier,
             lastConnected: Date()
         )
         savePairedDevice(device)
@@ -780,12 +787,47 @@ class WebSocketServer: ObservableObject {
         }
     }
 
+    func isTokenAuthorized(_ token: String) -> Bool {
+        let verifier = hashToken(token)
+        var verifiers = authorizedTokenVerifiers
+        var legacyTokens = authorizedTokens
+        var devices = storedPairedDevices
+
+        if verifiers.contains(verifier) {
+            if legacyTokens.contains(token) {
+                legacyTokens.remove(token)
+                authorizedTokens = legacyTokens
+            }
+            if let idx = devices.firstIndex(where: { $0.token == token }) {
+                devices[idx].token = ""
+                devices[idx].tokenVerifier = verifier
+                storedPairedDevices = devices
+            }
+            return true
+        }
+
+        if legacyTokens.contains(token) {
+            legacyTokens.remove(token)
+            verifiers.insert(verifier)
+            authorizedTokens = legacyTokens
+            authorizedTokenVerifiers = verifiers
+            if let idx = devices.firstIndex(where: { $0.token == token }) {
+                devices[idx].token = ""
+                devices[idx].tokenVerifier = verifier
+                storedPairedDevices = devices
+            }
+            return true
+        }
+
+        return false
+    }
+
     private func handleAuth(_ msg: Playbridge_AuthMessage, from connection: NWConnection) {
         guard msg.hasToken else {
             send(json: ["type": "auth_response", "success": false], to: connection)
             return
         }
-        if authorizedTokens.contains(msg.token) {
+        if isTokenAuthorized(msg.token) {
             updateLastConnected(token: msg.token)
             completeAuth(from: connection, token: msg.token)
         } else {
@@ -822,6 +864,12 @@ class WebSocketServer: ObservableObject {
 
     // MARK: - Paired Device Management
 
+    func hashToken(_ token: String) -> String {
+        let data = Data(token.utf8)
+        let hash = SasCrypto.sha256(data)
+        return hash.map { String(format: "%02x", $0) }.joined()
+    }
+
     private func savePairedDevice(_ device: PairedDevice) {
         var devices = storedPairedDevices
         if let idx = devices.firstIndex(where: { $0.deviceUUID == device.deviceUUID }) {
@@ -837,23 +885,35 @@ class WebSocketServer: ObservableObject {
         devices.removeAll { $0.deviceUUID == device.deviceUUID }
         storedPairedDevices = devices
         var tokens = authorizedTokens
-        tokens.remove(device.token)
+        if !device.token.isEmpty {
+            tokens.remove(device.token)
+        }
         authorizedTokens = tokens
+        var verifiers = authorizedTokenVerifiers
+        if let verifier = device.tokenVerifier, !verifier.isEmpty {
+            verifiers.remove(verifier)
+        }
+        if !device.token.isEmpty {
+            verifiers.remove(hashToken(device.token))
+        }
+        authorizedTokenVerifiers = verifiers
     }
 
     func forgetAllDevices() {
         storedPairedDevices = []
         authorizedTokens = []
+        authorizedTokenVerifiers = []
         DispatchQueue.main.async { self.pairedDevicesList = [] }
     }
 
     private func updateLastConnected(token: String) {
+        let verifier = hashToken(token)
         var devices = storedPairedDevices
-        if let idx = devices.firstIndex(where: { $0.token == token }) {
+        if let idx = devices.firstIndex(where: { $0.token == token || $0.tokenVerifier == verifier }) {
             let d = devices[idx]
             devices[idx] = PairedDevice(
                 deviceUUID: d.deviceUUID, deviceName: d.deviceName,
-                token: token, lastConnected: Date()
+                token: d.token, tokenVerifier: d.tokenVerifier, lastConnected: Date()
             )
             storedPairedDevices = devices
         }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Hash bearer tokens in Apple TV `UserDefaults`

🚨 Severity: CRITICAL
💡 Vulnerability: The Apple TV app stored plaintext bearer tokens in `UserDefaults`. Since this storage is not encrypted and can be included in backups, local access or backup extraction could allow an attacker to obtain tokens and authenticate as a paired sender. This resolves SEC-004 for Apple TV.
🎯 Impact: An attacker could steal tokens and control the TV receiver.
🔧 Fix:
- Changed `PairedDevice` to use `var token` and added `var tokenVerifier: String?` for backward compatibility.
- Added `authorizedTokenVerifiers` property and `hashToken` function (using `SasCrypto.sha256`) to `WebSocketServer`.
- Updated authentication logic (`approvePairing`, `handleAuth`, `updateLastConnected`, `forgetDevice`) to hash the token and store only the verifier.
- Added a seamless migration path in `isTokenAuthorized` to upgrade legacy plaintext tokens to hashed verifiers on next use.
✅ Verification: Code logic visually verified. Tests could not be run as standard xcodebuild is unavailable in the Linux sandbox environment.

---
*PR created automatically by Jules for task [9368455715412115603](https://jules.google.com/task/9368455715412115603) started by @playbridgeapp*