### PR TITLE
feat(web): add standalone PlayBridge Jellyfin web client

### DIFF
--- a/web/jellyfin/.gitignore
+++ b/web/jellyfin/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.DS_Store

--- a/web/jellyfin/README.md
+++ b/web/jellyfin/README.md
@@ -1,0 +1,45 @@
+# PlayBridge Jellyfin Web Client
+
+A modern, responsive Jellyfin Web client clone built with **Svelte 5** and **Vite**, featuring direct hardware casting through the **PlayBridge Web Page Bridge** (`window.playbridge.cast()` & `window.playbridge.linkCast()`).
+
+---
+
+## Key Features
+
+1. **PlayBridge Direct Casting Integration**
+   - Direct video stream routing to connected PlayBridge receivers, TVs, and desktop bridges using `window.playbridge.cast()`.
+   - Rich `VisualMetadata` payload format including title, year, poster, backdrop, genres, synopsis, season, and episode number.
+   - **Linked Cast Queues (`window.playbridge.linkCast()`)** for TV Series binge-watching with on-demand item supply via `needitems` events.
+   - Real-time **PlayBridge Cast Remote HUD** when casting is active (allows pausing, resuming, and switching back to browser playback).
+   - In-app **Diagnostics & Event Inspector** drawer showing bridge status, JSON payloads, and `PlayBridgeFeedback` event stream.
+
+2. **Dual Mode: Live Jellyfin Server + Built-in Demo Library**
+   - **Live Jellyfin Server**: Connect to any Jellyfin server (`http://...` or `https://...`) with authentication, library fetching, resume playback sync, and Direct Play / HLS stream generation.
+   - **Built-in Demo Library**: Out-of-the-box rich showcase (4K Movies, TV Series with multi-episode queues, Mux adaptive HLS streams) requiring no external server setup.
+
+3. **Jellyfin Dark UI & Experience**
+   - Spotlight Hero backdrop banner with quick play and cast actions.
+   - Horizontal carousels for *Continue Watching*, *Latest Movies*, *Next Up TV Series*, and *4K UHD Collection*.
+   - Filterable views for Movies, TV Shows, Search, and Bookmarked Favorites.
+   - TV Series season selector with episode cards, runtimes, and thumbnails.
+   - Integrated HTML5 video player with custom controls for non-cast playback.
+
+---
+
+## Development
+
+```bash
+cd web/jellyfin
+pnpm install
+pnpm dev
+```
+
+Open [http://localhost:5180](http://localhost:5180).
+
+### Build & Typecheck
+
+```bash
+pnpm check
+pnpm build
+pnpm preview
+```

--- a/web/jellyfin/index.html
+++ b/web/jellyfin/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <title>Jellyfin Web &bull; PlayBridge Cast</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/web/jellyfin/package.json
+++ b/web/jellyfin/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "playbridge-jellyfin-web",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "svelte": "^5.1.0",
+    "svelte-check": "^4.0.0",
+    "typescript": "^5.5.0",
+    "vite": "^5.4.0"
+  },
+  "dependencies": {
+    "lucide-svelte": "^0.460.0",
+    "movi-player": "^0.4.0"
+  }
+}

--- a/web/jellyfin/pnpm-lock.yaml
+++ b/web/jellyfin/pnpm-lock.yaml
@@ -1,0 +1,1130 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      lucide-svelte:
+        specifier: ^0.460.0
+        version: 0.460.1(svelte@5.56.9)
+      movi-player:
+        specifier: ^0.4.0
+        version: 0.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(svelte@5.56.9)
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^4.0.0
+        version: 4.0.4(svelte@5.56.9)(vite@5.4.21)
+      svelte:
+        specifier: ^5.1.0
+        version: 5.56.9
+      svelte-check:
+        specifier: ^4.0.0
+        version: 4.7.6(svelte@5.56.9)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.21
+
+packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@sveltejs/acorn-typescript@1.0.13':
+    resolution: {integrity: sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@sveltejs/load-config@0.2.3':
+    resolution: {integrity: sha512-VT3qmUb8pRV2QrZjd8iAmtg8lf4W0TIjZbvXtz5MKei/q96teWZgGJyyidJzOjzZzvdq616eSRVeMYIQChUTAQ==}
+    engines: {node: '>= 18.0.0'}
+
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.1':
+    resolution: {integrity: sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^4.0.0-next.0||^4.0.0
+      svelte: ^5.0.0-next.96 || ^5.0.0
+      vite: ^5.0.0
+
+  '@sveltejs/vite-plugin-svelte@4.0.4':
+    resolution: {integrity: sha512-0ba1RQ/PHen5FGpdSrW7Y3fAMQjrXantECALeOiOdBdzR5+5vPP6HVZRLmZaQL+W8m++o+haIAKq5qT+MiZ7VA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      svelte: ^5.0.0-next.96 || ^5.0.0
+      vite: ^5.0.0
+
+  '@svta/cml-608@1.0.2':
+    resolution: {integrity: sha512-ZEJ68330gcLKfvVv6Qifr1HR7+GldDUxzkjqSbqRK7jHtHSLSV1JAyDwlYe8+C7ABuY1bp8MpgJ4/Gg+jl+pLQ==}
+    engines: {node: '>=20'}
+
+  '@svta/cml-cmcd@2.3.2':
+    resolution: {integrity: sha512-SKBBjLmci0WK8HMjuv+36tVIMktonoOoxsXblOFZmB+ePPV2zjRMTD+2ZmE/1VEPJkKHENyhSjSHgJyeOlvZ1A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-structured-field-values': 1.1.3
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-cmsd@1.0.6':
+    resolution: {integrity: sha512-LUORV6bb0TbU4rSC2HoPqUCix1igLrXkRQXWiIyJo2OMzb14kAK/1jsW0mzY6up6w1GrjKQcjc6OwqJdo/zd/g==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-cta': 1.0.6
+      '@svta/cml-structured-field-values': 1.1.3
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-cta@1.0.6':
+    resolution: {integrity: sha512-l13/4myTX1EbRd38nY8J1umVY5UdR/nZO6CeKqVLXnMMIayg7/fu0TueZckjTA9Loal55MGK1xbHnXVjz7OUUw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-structured-field-values': 1.1.3
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-dash@1.0.6':
+    resolution: {integrity: sha512-4XtHYlPrzL/dRe/8XmRQoLnTo9S86tISgrl67eUqKl5MtNTpZBYTncuPrspslPZPZROBBWNrBuepYfYUtU9CKA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-id3@1.0.6':
+    resolution: {integrity: sha512-63j8gkAnPOmOBWlp0hIZPvsIioZttdbg6/TgwITqMYbSLYVJ+6QGa/UtIP0I84NsfstANw6QdCn7i8SS08kn1A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-request@1.0.12':
+    resolution: {integrity: sha512-4sJvnnoNpq58j2mCGP8k+MF6wVy/qa4gbt6kfT1dPIKmn3mPxw+JVfilhcWsUi+peK2yCZxOJJYyHj1cAcQE1w==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-cmcd': 2.3.2
+      '@svta/cml-utils': 1.5.0
+      '@svta/cml-xml': 1.1.4
+
+  '@svta/cml-structured-field-values@1.1.3':
+    resolution: {integrity: sha512-XqLzQOTznz6kh/nsSh8dy1kV7GQjL4csG+2U5EvLGhAqNuNUczbVg5EAsDobKDVg8xhdthdXx2UuwM+ZHQCxSg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-utils@1.5.0':
+    resolution: {integrity: sha512-JMqclD7Akd+GSJiuaYNUHOP2wNtf/nauKeszlYeivSHfi0Lp3pmSW5PXDvJ2dO4aPmmSOQbF0ztTsW9Vcs2Whw==}
+    engines: {node: '>=20'}
+
+  '@svta/cml-xml@1.1.4':
+    resolution: {integrity: sha512-jbixqjiJIc16SGxylHwiOzO+DuhkGfuP+fJ9AHeVJKdFDKnabgfCDpnp6dvZpZnjMj4nHvzVtuUV7RISPIwYXw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
+
+  bcp-47-match@2.0.3:
+    resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  codem-isoboxer@0.3.10:
+    resolution: {integrity: sha512-eNk3TRV+xQMJ1PEj0FQGY8KD4m0GPxT487XJ+Iftm7mVa9WpPFDMWqPt+46buiP5j5Wzqe5oMIhqBcAeKfygSA==}
+
+  dashjs@5.2.1:
+    resolution: {integrity: sha512-axcJmLeJCTJMLUfQRErUJB1KOiU5iHF+DMLBc3FKeox1HPYtGUQlC6Xm5Mm6vhBUR3CHHLIPOqw0JDIqMtP+Dw==}
+    engines: {node: '>=20'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  devalue@5.9.0:
+    resolution: {integrity: sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
+  esrap@2.3.4:
+    resolution: {integrity: sha512-CHnJXZDfBeOAjLIGNy/0BEsmDu5+irHgUXRW9pGptxCbO3uyjJ98crilzFgiBqizW94UodjX3GAPLg/dhEnUfA==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  hls.js@1.7.0:
+    resolution: {integrity: sha512-NnQpT6Z//+2IB2qovSUbKbrlXY1MOpi0JynZ9L2NNOuTJiNCyMSQj9k2laEj1v7CxU/Hb8oTWR98eT3mVpPQVQ==}
+
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  imsc@1.1.5:
+    resolution: {integrity: sha512-V8je+CGkcvGhgl2C1GlhqFFiUOIEdwXbXLiu1Fcubvvbo+g9inauqT3l0pNYXGoLPBj3jxtZz9t+wCopMkwadQ==}
+
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
+  lie@3.1.1:
+    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
+
+  localforage@1.10.0:
+    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
+  lucide-svelte@0.460.1:
+    resolution: {integrity: sha512-guJjJSeWlKivsEG51Xg41egunBMJcobhDmkLv/NYTXmXyCEwxMf1A+HX7RvDEKiXbXYgtLImih67tI08MSUOkA==}
+    deprecated: Package deprecated. Please use @lucide/svelte instead.
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5.0.0-next.42
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  movi-player@0.4.0:
+    resolution: {integrity: sha512-FaOIxgZKtTZ+Cpy4vyxmtjlz8uazGQ7uztO+vLe9VkAa9f3tpyU4Fjxp/O+URWCBLk8GTN0x2mDnj7ntZ0xe7w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=17'
+      svelte: '>=4'
+      vue: '>=3.3'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+
+  sax@1.2.1:
+    resolution: {integrity: sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==}
+
+  shaka-player@4.16.45:
+    resolution: {integrity: sha512-RthUzEXH3rG8gf5hrubp5T5pZ+3VuqyzOh6SIas2LAUJ2agP3AoXdOiwCh46CwqM84kwyiDHHlWpKuecr3iNuQ==}
+    engines: {node: '>=18'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  svelte-check@4.7.6:
+    resolution: {integrity: sha512-t2scM//ZuVbSY/T2w6FSBw1v9s2NEmh/g+sy1lqtosW5ylBV5AF4wFb1Ts9Kf3MbfPDUDJDZ9L436YT0SPTdvw==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: ^5.0.0 || ^6.0.0
+
+  svelte@5.56.9:
+    resolution: {integrity: sha512-VT8kSnlEg8069w7AiCcAk3Yf5xvMnrGTagVOmU/OpOLHaHnNqXhWZCH/4EVga/bT/HtWhvE6/fHrXLErx7OnJA==}
+    engines: {node: '>=18'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
+
+  '@sveltejs/acorn-typescript@1.0.13(acorn@8.18.0)':
+    dependencies:
+      acorn: 8.18.0
+
+  '@sveltejs/load-config@0.2.3': {}
+
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.56.9)(vite@5.4.21))(svelte@5.56.9)(vite@5.4.21)':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.56.9)(vite@5.4.21)
+      debug: 4.4.3
+      svelte: 5.56.9
+      vite: 5.4.21
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.56.9)(vite@5.4.21)':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.56.9)(vite@5.4.21))(svelte@5.56.9)(vite@5.4.21)
+      debug: 4.4.3
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      svelte: 5.56.9
+      vite: 5.4.21
+      vitefu: 1.1.3(vite@5.4.21)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@svta/cml-608@1.0.2': {}
+
+  '@svta/cml-cmcd@2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-structured-field-values': 1.1.3(@svta/cml-utils@1.5.0)
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-cmsd@1.0.6(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-cta': 1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      '@svta/cml-structured-field-values': 1.1.3(@svta/cml-utils@1.5.0)
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-structured-field-values': 1.1.3(@svta/cml-utils@1.5.0)
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-dash@1.0.6(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-id3@1.0.6(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-request@1.0.12(@svta/cml-cmcd@2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@svta/cml-xml@1.1.4(@svta/cml-utils@1.5.0))':
+    dependencies:
+      '@svta/cml-cmcd': 2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      '@svta/cml-utils': 1.5.0
+      '@svta/cml-xml': 1.1.4(@svta/cml-utils@1.5.0)
+
+  '@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-utils@1.5.0': {}
+
+  '@svta/cml-xml@1.1.4(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@types/estree@1.0.9': {}
+
+  '@types/trusted-types@2.0.7': {}
+
+  acorn@8.18.0: {}
+
+  aria-query@5.3.1: {}
+
+  axobject-query@4.1.0: {}
+
+  bcp-47-match@2.0.3: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  clsx@2.1.1: {}
+
+  codem-isoboxer@0.3.10: {}
+
+  dashjs@5.2.1(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0):
+    dependencies:
+      '@svta/cml-608': 1.0.2
+      '@svta/cml-cmcd': 2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      '@svta/cml-cmsd': 1.0.6(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      '@svta/cml-dash': 1.0.6(@svta/cml-utils@1.5.0)
+      '@svta/cml-id3': 1.0.6(@svta/cml-utils@1.5.0)
+      '@svta/cml-request': 1.0.12(@svta/cml-cmcd@2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@svta/cml-xml@1.1.4(@svta/cml-utils@1.5.0))
+      '@svta/cml-xml': 1.1.4(@svta/cml-utils@1.5.0)
+      bcp-47-match: 2.0.3
+      codem-isoboxer: 0.3.10
+      fast-deep-equal: 3.1.3
+      html-entities: 2.6.0
+      imsc: 1.1.5
+      localforage: 1.10.0
+      path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - '@svta/cml-cta'
+      - '@svta/cml-structured-field-values'
+      - '@svta/cml-utils'
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deepmerge@4.3.1: {}
+
+  devalue@5.9.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  esm-env@1.2.2: {}
+
+  esrap@2.3.4:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  fast-deep-equal@3.1.3: {}
+
+  fdir@6.5.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  hls.js@1.7.0: {}
+
+  html-entities@2.6.0: {}
+
+  immediate@3.0.6: {}
+
+  imsc@1.1.5:
+    dependencies:
+      sax: 1.2.1
+
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  kleur@4.1.5: {}
+
+  lie@3.1.1:
+    dependencies:
+      immediate: 3.0.6
+
+  localforage@1.10.0:
+    dependencies:
+      lie: 3.1.1
+
+  locate-character@3.0.0: {}
+
+  lucide-svelte@0.460.1(svelte@5.56.9):
+    dependencies:
+      svelte: 5.56.9
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  movi-player@0.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(svelte@5.56.9):
+    dependencies:
+      dashjs: 5.2.1(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      hls.js: 1.7.0
+      shaka-player: 4.16.45
+    optionalDependencies:
+      svelte: 5.56.9
+    transitivePeerDependencies:
+      - '@svta/cml-cta'
+      - '@svta/cml-structured-field-values'
+      - '@svta/cml-utils'
+
+  mri@1.2.0: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.18: {}
+
+  path-browserify@1.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  readdirp@4.1.2: {}
+
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
+
+  sax@1.2.1: {}
+
+  shaka-player@4.16.45: {}
+
+  source-map-js@1.2.1: {}
+
+  svelte-check@4.7.6(svelte@5.56.9)(typescript@5.9.3):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@sveltejs/load-config': 0.2.3
+      chokidar: 4.0.3
+      fdir: 6.5.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.56.9
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - picomatch
+
+  svelte@5.56.9:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.13(acorn@8.18.0)
+      '@types/estree': 1.0.9
+      '@types/trusted-types': 2.0.7
+      acorn: 8.18.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.9.0
+      esm-env: 1.2.2
+      esrap: 2.3.4
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
+  typescript@5.9.3: {}
+
+  vite@5.4.21:
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitefu@1.1.3(vite@5.4.21):
+    optionalDependencies:
+      vite: 5.4.21
+
+  zimmerframe@1.1.4: {}

--- a/web/jellyfin/public/favicon.svg
+++ b/web/jellyfin/public/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <defs>
+    <linearGradient id="jf-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00A4DC"/>
+      <stop offset="50%" stop-color="#7A5AF8"/>
+      <stop offset="100%" stop-color="#AA5BFF"/>
+    </linearGradient>
+  </defs>
+  <rect width="100" height="100" rx="22" fill="#08090D"/>
+  <path d="M50 18 L82 74 L66 74 L50 44 L34 74 L18 74 Z" fill="url(#jf-grad)"/>
+  <circle cx="50" cy="32" r="6" fill="#00A4DC"/>
+  <path d="M72 32 A28 28 0 0 1 84 56" stroke="#4F8CFF" stroke-width="4" stroke-linecap="round"/>
+  <path d="M78 24 A38 38 0 0 1 92 56" stroke="#7A5AF8" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/web/jellyfin/src/App.svelte
+++ b/web/jellyfin/src/App.svelte
@@ -1,0 +1,993 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import Navbar from './lib/components/Navbar.svelte';
+  import LoginScreen from './lib/components/LoginScreen.svelte';
+  import HeroSpotlight from './lib/components/HeroSpotlight.svelte';
+  import MediaSection from './lib/components/MediaSection.svelte';
+  import MediaCard from './lib/components/MediaCard.svelte';
+  import ItemDetailModal from './lib/components/ItemDetailModal.svelte';
+  import VideoPlayer from './lib/components/VideoPlayer.svelte';
+  import ServerConnectModal from './lib/components/ServerConnectModal.svelte';
+  import DiagnosticsDrawer from './lib/components/DiagnosticsDrawer.svelte';
+  import QueueDrawer from './lib/components/QueueDrawer.svelte';
+
+  import {
+    activeTab,
+    serverConfig,
+    userViews,
+    latestMedia,
+    resumeMedia,
+    nextUpMedia,
+    libraryLatestMap,
+    moviesList,
+    showsList,
+    allLibraryItems,
+    searchQuery,
+    selectedGenre,
+    sortBy,
+    isLoadingLibrary,
+    initializeSession,
+    playFolderOrAlbumWithCast,
+    playInBrowser,
+    shufflePlay,
+    shuffleCast,
+    activeToast
+  } from './lib/stores/appState';
+  import { initPlayBridgeDetector } from './lib/cast/playbridge';
+  import * as jfApi from './lib/api/jellyfin';
+  import { getCachedData } from './lib/api/cache';
+  import type { JellyfinItem } from './lib/types';
+  import {
+    Film,
+    Clapperboard,
+    Sparkles,
+    Search,
+    Loader2,
+    SlidersHorizontal,
+    Folder,
+    Cast,
+    Play,
+    Shuffle,
+    Music,
+    Tv,
+    Layers,
+    ChevronRight,
+    ArrowLeft
+  } from 'lucide-svelte';
+
+  let customViewItems: JellyfinItem[] = [];
+  let isLoadingCustomView = false;
+  let activeLibraryViewId: string | null = null;
+  let folderStack: Array<{ id: string; name: string }> = [];
+
+  onMount(() => {
+    initPlayBridgeDetector();
+    initializeSession();
+  });
+
+  // Active view object
+  $: currentView = $userViews.find((v) => v.Id === $activeTab);
+
+  // When active tab switches to a user view, initialize folder stack and load root of that view
+  $: if (
+    $serverConfig.connected &&
+    currentView &&
+    currentView.Id !== activeLibraryViewId &&
+    $activeTab !== 'home' &&
+    $activeTab !== 'search' &&
+    $activeTab !== 'favorites' &&
+    $activeTab !== 'movies' &&
+    $activeTab !== 'shows'
+  ) {
+    activeLibraryViewId = currentView.Id;
+    folderStack = [{ id: currentView.Id, name: currentView.Name }];
+    loadFolderLevel(currentView.Id, currentView.CollectionType, false);
+  }
+
+  async function loadFolderLevel(folderId: string, collectionType?: string, isSubfolder = false) {
+    if (!$serverConfig.connected || $serverConfig.isDemo) return;
+
+    const isTypedRoot =
+      !isSubfolder &&
+      (collectionType === 'movies' || collectionType === 'tvshows' || collectionType === 'music');
+
+    const queryOptions: any = {
+      parentId: folderId,
+      recursive: isTypedRoot ? true : false
+    };
+
+    if (isTypedRoot) {
+      if (collectionType === 'movies') queryOptions.includeItemTypes = 'Movie';
+      else if (collectionType === 'tvshows') queryOptions.includeItemTypes = 'Series';
+      else if (collectionType === 'music') queryOptions.includeItemTypes = 'MusicAlbum';
+    }
+
+    const cacheKey = `lib_${$serverConfig.userId}_${folderId}_${queryOptions.includeItemTypes || 'direct'}_${queryOptions.recursive}`;
+    const cached = getCachedData<{ items: JellyfinItem[] }>(cacheKey);
+    if (cached && cached.items && cached.items.length > 0) {
+      customViewItems = cached.items;
+      isLoadingCustomView = false;
+    } else {
+      isLoadingCustomView = true;
+    }
+
+    try {
+      const res = await jfApi.getLibraryItems(
+        $serverConfig.url,
+        $serverConfig.userId,
+        $serverConfig.token,
+        queryOptions,
+        (fresh) => {
+          customViewItems = fresh.items;
+        }
+      );
+      customViewItems = res.items;
+    } catch (err) {
+      console.error('Failed to fetch folder items', err);
+    } finally {
+      isLoadingCustomView = false;
+    }
+  }
+
+  function handleNavigateIntoFolder(folderItem: JellyfinItem) {
+    folderStack = [...folderStack, { id: folderItem.Id, name: folderItem.Name }];
+    loadFolderLevel(folderItem.Id, currentView?.CollectionType, true);
+  }
+
+  function handleNavigateToBreadcrumb(index: number) {
+    folderStack = folderStack.slice(0, index + 1);
+    const target = folderStack[folderStack.length - 1];
+    loadFolderLevel(target.id, currentView?.CollectionType, folderStack.length > 1);
+  }
+
+  function handleBackOneFolder() {
+    if (folderStack.length > 1) {
+      handleNavigateToBreadcrumb(folderStack.length - 2);
+    }
+  }
+
+  // Featured Spotlight item
+  $: featuredItem =
+    $latestMedia.length > 0
+      ? $latestMedia[0]
+      : $moviesList.length > 0
+      ? $moviesList[0]
+      : $allLibraryItems.length > 0
+      ? $allLibraryItems[0]
+      : null;
+
+  // Genres extraction
+  $: availableGenres = Array.from(
+    new Set(
+      $allLibraryItems
+        .flatMap((i) => i.Genres || [])
+        .filter(Boolean)
+    )
+  );
+
+  // Filtered Movies
+  $: filteredMovies = $moviesList.filter((m) => {
+    const matchGenre = $selectedGenre === 'all' || (m.Genres && m.Genres.includes($selectedGenre));
+    const matchSearch = !$searchQuery || m.Name.toLowerCase().includes($searchQuery.toLowerCase());
+    return matchGenre && matchSearch;
+  });
+
+  // Filtered Shows
+  $: filteredShows = $showsList.filter((s) => {
+    const matchGenre = $selectedGenre === 'all' || (s.Genres && s.Genres.includes($selectedGenre));
+    const matchSearch = !$searchQuery || s.Name.toLowerCase().includes($searchQuery.toLowerCase());
+    return matchGenre && matchSearch;
+  });
+
+  // Search Results
+  $: searchResults = $searchQuery.trim()
+    ? $allLibraryItems.filter((i) =>
+        i.Name.toLowerCase().includes($searchQuery.toLowerCase()) ||
+        (i.Overview && i.Overview.toLowerCase().includes($searchQuery.toLowerCase())) ||
+        (i.Genres && i.Genres.some((g) => g.toLowerCase().includes($searchQuery.toLowerCase()))) ||
+        (i.AlbumArtist && i.AlbumArtist.toLowerCase().includes($searchQuery.toLowerCase())) ||
+        (i.Artists && i.Artists.some((a) => a.toLowerCase().includes($searchQuery.toLowerCase())))
+      )
+    : [];
+
+  // Favorites
+  $: favoriteItems = $allLibraryItems.filter((i) => i.UserData?.IsFavorite);
+
+  function handleBatchCastFolder() {
+    if (!currentView || customViewItems.length === 0) return;
+    const folderItem: JellyfinItem = {
+      Id: currentView.Id,
+      Name: currentView.Name,
+      Type: 'Folder',
+      tracks: customViewItems
+    };
+    playFolderOrAlbumWithCast(folderItem, customViewItems, 0);
+  }
+
+  function handlePlayFolder() {
+    if (!currentView || customViewItems.length === 0) return;
+    const folderItem: JellyfinItem = {
+      Id: currentView.Id,
+      Name: currentView.Name,
+      Type: 'Folder',
+      tracks: customViewItems
+    };
+    playInBrowser(folderItem, customViewItems, 0, false);
+  }
+
+  function handleShufflePlayFolder() {
+    if (!currentView || customViewItems.length === 0) return;
+    const folderItem: JellyfinItem = {
+      Id: currentView.Id,
+      Name: currentView.Name,
+      Type: 'Folder',
+      tracks: customViewItems
+    };
+    shufflePlay(folderItem, customViewItems);
+  }
+
+  function handleShuffleCastFolder() {
+    if (!currentView || customViewItems.length === 0) return;
+    const folderItem: JellyfinItem = {
+      Id: currentView.Id,
+      Name: currentView.Name,
+      Type: 'Folder',
+      tracks: customViewItems
+    };
+    shuffleCast(folderItem, customViewItems);
+  }
+</script>
+
+{#if !$serverConfig.connected}
+  <!-- Full Screen Login / Connect Screen -->
+  <LoginScreen />
+{:else}
+  <!-- Main Jellyfin Web Client Layout -->
+  <div class="app-layout">
+    <Navbar />
+
+    <!-- Floating Cast Toast Notification -->
+    {#if $activeToast}
+      <div class="toast-notification">
+        <div class="toast-badge">
+          <Cast size={15} />
+        </div>
+        <span class="toast-text">{$activeToast.message}</span>
+      </div>
+    {/if}
+
+    <main class="main-content">
+      {#if $isLoadingLibrary}
+        <div class="loading-state">
+          <Loader2 size={36} class="spinner" />
+          <p>Loading library from {$serverConfig.serverName || 'Jellyfin'}...</p>
+        </div>
+      {:else}
+        <!-- TAB: HOME -->
+        {#if $activeTab === 'home'}
+          {#if featuredItem}
+            <HeroSpotlight item={featuredItem} />
+          {/if}
+
+          <div class="sections-wrapper">
+            <!-- 1. My Media (Jellyfin Official Library Tiles) -->
+            {#if $userViews.length > 0}
+              <section class="my-media-section">
+                <div class="section-header-row">
+                  <h2 class="section-title">My Media</h2>
+                  <span class="section-sub">{$userViews.length} libraries on {$serverConfig.serverName}</span>
+                </div>
+
+                <div class="library-tiles-grid">
+                  {#each $userViews as view (view.Id)}
+                    <button class="library-tile-card" on:click={() => ($activeTab = view.Id)}>
+                      <div class="tile-icon-box">
+                        {#if view.CollectionType === 'movies'}
+                          <Film size={26} />
+                        {:else if view.CollectionType === 'tvshows'}
+                          <Clapperboard size={26} />
+                        {:else if view.CollectionType === 'music'}
+                          <Music size={26} />
+                        {:else}
+                          <Folder size={26} />
+                        {/if}
+                      </div>
+
+                      <div class="tile-info">
+                        <span class="tile-title">{view.Name}</span>
+                        <span class="tile-kind">
+                          {view.CollectionType === 'movies'
+                            ? 'Movies'
+                            : view.CollectionType === 'tvshows'
+                            ? 'TV Shows'
+                            : view.CollectionType === 'music'
+                            ? 'Music'
+                            : 'Library'}
+                        </span>
+                      </div>
+                    </button>
+                  {/each}
+                </div>
+              </section>
+            {/if}
+
+            <!-- 2. Continue Watching (Resume) -->
+            {#if $resumeMedia.length > 0}
+              <MediaSection
+                title="Continue Watching"
+                subtitle="Pick up where you left off"
+                items={$resumeMedia}
+              />
+            {/if}
+
+            <!-- 3. Next Up (Television In-Progress Episodes) -->
+            {#if $nextUpMedia.length > 0}
+              <MediaSection
+                title="Next Up"
+                subtitle="Next unplayed episodes in your shows"
+                items={$nextUpMedia}
+              />
+            {/if}
+
+            <!-- 4. Dedicated Recently Added Shelves per Library -->
+            {#each $userViews as view (view.Id)}
+              {#if $libraryLatestMap[view.Id] && $libraryLatestMap[view.Id].length > 0}
+                <MediaSection
+                  title={`Recently Added in ${view.Name}`}
+                  subtitle={`New additions to your ${view.Name} library`}
+                  items={$libraryLatestMap[view.Id]}
+                  onSeeAll={() => ($activeTab = view.Id)}
+                />
+              {/if}
+            {/each}
+
+            <!-- Fallback generic sections if server does not have segmented latest -->
+            {#if Object.keys($libraryLatestMap).length === 0}
+              {#if $latestMedia.length > 0}
+                <MediaSection
+                  title="Latest Media"
+                  subtitle="Recently added to {$serverConfig.serverName}"
+                  items={$latestMedia}
+                />
+              {/if}
+
+              {#if $moviesList.length > 0}
+                <MediaSection
+                  title="Movies"
+                  subtitle="Feature films and cinema"
+                  items={$moviesList}
+                />
+              {/if}
+
+              {#if $showsList.length > 0}
+                <MediaSection
+                  title="TV Series"
+                  subtitle="Series with full episode and seasonal direct casting"
+                  items={$showsList}
+                />
+              {/if}
+            {/if}
+          </div>
+
+        <!-- TAB: MOVIES -->
+        {:else if $activeTab === 'movies'}
+          <div class="library-view">
+            <div class="view-header">
+              <div>
+                <h1 class="view-title">Movies</h1>
+                <p class="view-subtitle">{filteredMovies.length} titles in library</p>
+              </div>
+
+              <!-- Genre filters -->
+              {#if availableGenres.length > 0}
+                <div class="genre-filter-bar">
+                  <button
+                    class="genre-chip"
+                    class:active={$selectedGenre === 'all'}
+                    on:click={() => ($selectedGenre = 'all')}
+                  >
+                    All
+                  </button>
+                  {#each availableGenres as genre}
+                    <button
+                      class="genre-chip"
+                      class:active={$selectedGenre === genre}
+                      on:click={() => ($selectedGenre = genre)}
+                    >
+                      {genre}
+                    </button>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+
+            <div class="media-grid">
+              {#each filteredMovies as item (item.Id)}
+                <MediaCard {item} />
+              {/each}
+            </div>
+          </div>
+
+        <!-- TAB: TV SHOWS -->
+        {:else if $activeTab === 'shows'}
+          <div class="library-view">
+            <div class="view-header">
+              <div>
+                <h1 class="view-title">TV Shows</h1>
+                <p class="view-subtitle">{filteredShows.length} series in library</p>
+              </div>
+
+              {#if availableGenres.length > 0}
+                <div class="genre-filter-bar">
+                  <button
+                    class="genre-chip"
+                    class:active={$selectedGenre === 'all'}
+                    on:click={() => ($selectedGenre = 'all')}
+                  >
+                    All
+                  </button>
+                  {#each availableGenres as genre}
+                    <button
+                      class="genre-chip"
+                      class:active={$selectedGenre === genre}
+                      on:click={() => ($selectedGenre = genre)}
+                    >
+                      {genre}
+                    </button>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+
+            <div class="media-grid">
+              {#each filteredShows as item (item.Id)}
+                <MediaCard {item} />
+              {/each}
+            </div>
+          </div>
+
+        <!-- TAB: DYNAMIC USER FOLDERS / CUSTOM VIEWS -->
+        {:else if currentView}
+          <div class="library-view">
+            <div class="view-header">
+              <div class="view-title-group">
+                <!-- Breadcrumbs and back button -->
+                {#if folderStack.length > 1}
+                  <div class="breadcrumbs-bar">
+                    <button class="back-folder-btn" on:click={handleBackOneFolder} title="Go back to parent folder">
+                      <ArrowLeft size={16} />
+                      <span>Back</span>
+                    </button>
+
+                    <div class="crumbs-trail">
+                      {#each folderStack as crumb, idx}
+                        {#if idx > 0}
+                          <ChevronRight size={13} class="crumb-sep" />
+                        {/if}
+                        {#if idx === folderStack.length - 1}
+                          <span class="crumb-current">{crumb.name}</span>
+                        {:else}
+                          <button class="crumb-link" on:click={() => handleNavigateToBreadcrumb(idx)}>
+                            {crumb.name}
+                          </button>
+                        {/if}
+                      {/each}
+                    </div>
+                  </div>
+                {/if}
+
+                <h1 class="view-title">{folderStack.length > 0 ? folderStack[folderStack.length - 1].name : currentView.Name}</h1>
+                <p class="view-subtitle">
+                  {customViewItems.length} items in {folderStack.length > 0 ? folderStack[folderStack.length - 1].name : currentView.Name}
+                </p>
+              </div>
+
+              <!-- Quick actions for Music/Audio folders -->
+              {#if currentView.CollectionType === 'music' || customViewItems.some((i) => i.Type === 'Audio' || i.Type === 'MusicAlbum')}
+                <div class="batch-cast-actions">
+                  <button class="btn-primary batch-btn" on:click={handleBatchCastFolder}>
+                    <Cast size={16} />
+                    <span>Cast All</span>
+                  </button>
+                  <button class="btn-secondary batch-btn" on:click={handlePlayFolder}>
+                    <Play size={16} />
+                    <span>Play</span>
+                  </button>
+                  <button class="btn-secondary batch-btn" on:click={handleShufflePlayFolder} title="Shuffle Play in Browser">
+                    <Shuffle size={16} />
+                    <span>Shuffle</span>
+                  </button>
+                  <button class="btn-accent batch-btn" on:click={handleShuffleCastFolder} title="Shuffle Cast to PlayBridge Receiver">
+                    <Shuffle size={16} />
+                    <span>Shuffle Cast</span>
+                  </button>
+                </div>
+              {/if}
+            </div>
+
+            {#if isLoadingCustomView}
+              <div class="loading-state">
+                <Loader2 size={32} class="spinner" />
+                <p>Loading items...</p>
+              </div>
+            {:else if customViewItems.length === 0}
+              <div class="empty-state">
+                <Folder size={44} class="empty-icon" />
+                <p>No media found in this folder</p>
+              </div>
+            {:else}
+              <div class="media-grid">
+                {#each customViewItems as item (item.Id)}
+                  <MediaCard {item} onOpenFolder={handleNavigateIntoFolder} />
+                {/each}
+              </div>
+            {/if}
+          </div>
+
+        <!-- TAB: SEARCH -->
+        {:else if $activeTab === 'search'}
+          <div class="library-view">
+            <div class="view-header">
+              <div>
+                <h1 class="view-title">Search Results</h1>
+                <p class="view-subtitle">
+                  {searchResults.length} matches for "{$searchQuery}"
+                </p>
+              </div>
+            </div>
+
+            {#if searchResults.length === 0}
+              <div class="empty-state">
+                <Search size={44} class="empty-icon" />
+                <p>No results found for "{$searchQuery}"</p>
+                <span class="empty-sub">Try searching for a movie, series, track, or artist.</span>
+              </div>
+            {:else}
+              <div class="media-grid">
+                {#each searchResults as item (item.Id)}
+                  <MediaCard {item} onOpenFolder={handleNavigateIntoFolder} />
+                {/each}
+              </div>
+            {/if}
+          </div>
+
+        <!-- TAB: FAVORITES -->
+        {:else if $activeTab === 'favorites'}
+          <div class="library-view">
+            <div class="view-header">
+              <div>
+                <h1 class="view-title">Favorites</h1>
+                <p class="view-subtitle">{favoriteItems.length} bookmarked titles</p>
+              </div>
+            </div>
+
+            {#if favoriteItems.length === 0}
+              <div class="empty-state">
+                <Sparkles size={44} class="empty-icon" />
+                <p>No favorites yet</p>
+              </div>
+            {:else}
+              <div class="media-grid">
+                {#each favoriteItems as item (item.Id)}
+                  <MediaCard {item} onOpenFolder={handleNavigateIntoFolder} />
+                {/each}
+              </div>
+            {/if}
+          </div>
+        {/if}
+      {/if}
+    </main>
+
+    <!-- Modals & Overlays -->
+    <ItemDetailModal />
+    <VideoPlayer />
+    <QueueDrawer />
+    <ServerConnectModal />
+    <DiagnosticsDrawer />
+  </div>
+{/if}
+
+<style>
+  .app-layout {
+    min-height: 100vh;
+    min-height: 100dvh;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--bg-base);
+    padding-bottom: calc(120px + env(safe-area-inset-bottom, 0px));
+  }
+
+  @media (min-width: 769px) {
+    .app-layout {
+      padding-bottom: 74px;
+    }
+  }
+
+  /* Floating Toast Notification */
+  .toast-notification {
+    position: fixed;
+    top: 74px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(18, 22, 30, 0.95);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(122, 90, 248, 0.4);
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.6);
+    padding: 8px 16px;
+    border-radius: var(--radius-full);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    z-index: 80;
+    animation: toastSlideDown 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    max-width: 90vw;
+  }
+
+  @keyframes toastSlideDown {
+    from { opacity: 0; transform: translate(-50%, -10px); }
+    to { opacity: 1; transform: translate(-50%, 0); }
+  }
+
+  .toast-badge {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: var(--accent-gradient);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    flex-shrink: 0;
+  }
+
+  .toast-text {
+    font-size: 0.86rem;
+    font-weight: 600;
+    color: #fff;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .main-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .loading-state {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    padding: 80px 20px;
+    color: var(--text-muted);
+  }
+
+  .spinner {
+    animation: spin 1s linear infinite;
+    color: var(--jf-blue);
+  }
+
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+
+  .sections-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  /* My Media (Library Tiles) Section */
+  .my-media-section {
+    padding: 16px 32px 8px;
+    max-width: 1440px;
+    margin: 0 auto;
+    width: 100%;
+  }
+
+  .section-header-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 14px;
+  }
+
+  .section-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #ffffff;
+    letter-spacing: -0.01em;
+  }
+
+  .section-sub {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+  }
+
+  .library-tiles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 12px;
+  }
+
+  .library-tile-card {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 14px 16px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    cursor: pointer;
+    text-align: left;
+    transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .library-tile-card:hover {
+    background: var(--bg-surface-elevated);
+    border-color: var(--jf-blue);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+  }
+
+  .tile-icon-box {
+    width: 44px;
+    height: 44px;
+    border-radius: var(--radius-md);
+    background: linear-gradient(135deg, rgba(0, 164, 220, 0.15), rgba(122, 90, 248, 0.15));
+    border: 1px solid rgba(0, 164, 220, 0.25);
+    color: var(--jf-blue);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: all 0.2s ease;
+  }
+
+  .library-tile-card:hover .tile-icon-box {
+    background: linear-gradient(135deg, var(--jf-blue), var(--jf-purple));
+    color: #fff;
+  }
+
+  .tile-info {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .tile-title {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: #ffffff;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .tile-kind {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-top: 2px;
+  }
+
+  .library-view {
+    padding: 28px 32px 64px;
+    max-width: 1440px;
+    margin: 0 auto;
+    width: 100%;
+  }
+
+  .view-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    margin-bottom: 24px;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+
+  .view-title-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  /* Breadcrumbs Navigation */
+  .breadcrumbs-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 6px;
+    flex-wrap: wrap;
+  }
+
+  .back-folder-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: var(--radius-full);
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    color: var(--jf-blue);
+    font-size: 0.78rem;
+    font-weight: 600;
+  }
+
+  .back-folder-btn:hover {
+    background: var(--bg-surface-elevated);
+    border-color: var(--jf-blue);
+    color: #fff;
+  }
+
+  .crumbs-trail {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8rem;
+    flex-wrap: wrap;
+  }
+
+  :global(.crumb-sep) {
+    color: var(--text-muted);
+  }
+
+  .crumb-link {
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 500;
+    padding: 2px 4px;
+  }
+
+  .crumb-link:hover {
+    color: var(--jf-blue);
+    text-decoration: underline;
+  }
+
+  .crumb-current {
+    color: #ffffff;
+    font-weight: 700;
+    font-size: 0.8rem;
+  }
+
+  .view-title {
+    font-size: 1.75rem;
+    font-weight: 800;
+    color: #fff;
+    letter-spacing: -0.02em;
+  }
+
+  .view-subtitle {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-top: 3px;
+  }
+
+  .batch-cast-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .batch-btn {
+    padding: 8px 14px;
+    font-size: 0.85rem;
+  }
+
+  .genre-filter-bar {
+    display: flex;
+    gap: 6px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+    scrollbar-width: none;
+  }
+
+  .genre-chip {
+    padding: 5px 12px;
+    border-radius: var(--radius-full);
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .genre-chip:hover {
+    background: var(--bg-surface-elevated);
+    color: #fff;
+  }
+
+  .genre-chip.active {
+    background: var(--jf-blue);
+    border-color: transparent;
+    color: #fff;
+    font-weight: 600;
+  }
+
+  .media-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+    gap: 20px 16px;
+  }
+
+  .empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 60px 20px;
+    color: var(--text-muted);
+    gap: 10px;
+  }
+
+  :global(.empty-icon) {
+    opacity: 0.4;
+    color: var(--jf-blue);
+  }
+
+  .empty-sub {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+  }
+
+  @media (max-width: 768px) {
+    .my-media-section {
+      padding: 12px 14px 4px;
+    }
+    .library-tiles-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 8px;
+    }
+    .library-tile-card {
+      padding: 10px 12px;
+      gap: 10px;
+    }
+    .tile-icon-box {
+      width: 36px;
+      height: 36px;
+    }
+    .tile-title {
+      font-size: 0.85rem;
+    }
+    .library-view {
+      padding: 14px 12px 28px;
+    }
+    .view-header {
+      margin-bottom: 14px;
+      gap: 10px;
+    }
+    .view-title {
+      font-size: 1.35rem;
+    }
+    .media-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px 10px;
+    }
+    .batch-cast-actions {
+      width: 100%;
+    }
+    .batch-cast-actions button {
+      flex: 1;
+    }
+  }
+
+  @media (min-width: 480px) and (max-width: 768px) {
+    .media-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px 12px;
+    }
+  }
+</style>

--- a/web/jellyfin/src/app.css
+++ b/web/jellyfin/src/app.css
@@ -1,0 +1,215 @@
+:root {
+  --bg-base: #08090d;
+  --bg-surface: #10131a;
+  --bg-surface-elevated: #161b24;
+  --bg-card: #141822;
+  --bg-card-hover: #1c2230;
+  --border: #232a38;
+  --border-subtle: #191f2c;
+  --border-focus: #00a4dc;
+
+  --text-primary: #f0f3f8;
+  --text-secondary: #9da7b7;
+  --text-muted: #626d7f;
+
+  --jf-blue: #00a4dc;
+  --jf-purple: #7a5af8;
+  --jf-indigo: #9ea7ff;
+  --accent-gradient: linear-gradient(135deg, #00a4dc 0%, #7a5af8 100%);
+  --accent-hover: #0090c2;
+
+  --status-ok: #3fb950;
+  --status-warn: #d29922;
+  --status-error: #f85149;
+
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 18px;
+  --radius-full: 9999px;
+
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 6px 20px rgba(0, 0, 0, 0.6);
+  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.8);
+
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+
+  /* Safe Area insets for modern mobile devices */
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  -webkit-tap-highlight-color: transparent;
+}
+
+html, body {
+  background-color: var(--bg-base);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  min-height: 100vh;
+  min-height: 100dvh;
+  overflow-x: hidden;
+  touch-action: manipulation;
+}
+
+/* Custom Scrollbars */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: var(--radius-full);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+/* Base Form Inputs (Prevent iOS automatic zoom by ensuring >= 16px) */
+input, select, textarea {
+  font-size: 16px;
+  font-family: inherit;
+  color: var(--text-primary);
+}
+
+/* Buttons */
+button {
+  font-family: inherit;
+  border: none;
+  background: none;
+  cursor: pointer;
+  outline: none;
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  user-select: none;
+  touch-action: manipulation;
+}
+
+button:active {
+  transform: scale(0.97);
+}
+
+.btn-primary {
+  background: var(--jf-blue);
+  color: #ffffff;
+  font-weight: 600;
+  padding: 12px 20px;
+  border-radius: var(--radius-md);
+  font-size: 0.95rem;
+}
+
+.btn-primary:hover {
+  background: var(--accent-hover);
+  box-shadow: 0 4px 14px rgba(0, 164, 220, 0.35);
+}
+
+.btn-accent {
+  background: var(--accent-gradient);
+  color: #ffffff;
+  font-weight: 600;
+  padding: 12px 20px;
+  border-radius: var(--radius-md);
+  font-size: 0.95rem;
+  box-shadow: 0 4px 16px rgba(122, 90, 248, 0.3);
+}
+
+.btn-accent:hover {
+  filter: brightness(1.1);
+  box-shadow: 0 6px 20px rgba(122, 90, 248, 0.45);
+}
+
+.btn-secondary {
+  background: var(--bg-surface-elevated);
+  border: 1px solid var(--border);
+  color: var(--text-primary);
+  font-weight: 500;
+  padding: 11px 18px;
+  border-radius: var(--radius-md);
+  font-size: 0.92rem;
+}
+
+.btn-secondary:hover {
+  background: var(--bg-card-hover);
+  border-color: var(--text-muted);
+}
+
+.btn-ghost {
+  color: var(--text-secondary);
+  padding: 8px;
+  border-radius: var(--radius-sm);
+}
+
+.btn-ghost:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* Badges */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.badge-blue {
+  background: rgba(0, 164, 220, 0.15);
+  color: var(--jf-blue);
+  border: 1px solid rgba(0, 164, 220, 0.3);
+}
+
+.badge-purple {
+  background: rgba(122, 90, 248, 0.15);
+  color: var(--jf-purple);
+  border: 1px solid rgba(122, 90, 248, 0.3);
+}
+
+.badge-ok {
+  background: rgba(63, 185, 80, 0.15);
+  color: var(--status-ok);
+  border: 1px solid rgba(63, 185, 80, 0.3);
+}
+
+.badge-outline {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+}
+
+/* Animations */
+@keyframes pulseGlow {
+  0% { transform: scale(0.95); opacity: 0.8; }
+  50% { transform: scale(1.05); opacity: 1; filter: drop-shadow(0 0 8px #00a4dc); }
+  100% { transform: scale(0.95); opacity: 0.8; }
+}
+
+.pulsing-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--status-ok);
+  display: inline-block;
+  animation: pulseGlow 2s infinite ease-in-out;
+}

--- a/web/jellyfin/src/lib/api/cache.ts
+++ b/web/jellyfin/src/lib/api/cache.ts
@@ -1,0 +1,150 @@
+/**
+ * Rock-solid In-Memory + IndexedDB Client Cache with Stale-While-Revalidate.
+ * Avoids localStorage 5MB QuotaExceededError and prevents crashes.
+ */
+
+const DB_NAME = 'PlayBridge_Jellyfin_DB';
+const DB_VERSION = 1;
+const STORE_NAME = 'swr_cache';
+
+const MEMORY_CACHE = new Map<string, { data: any; timestamp: number }>();
+const DEFAULT_TTL_MS = 10 * 60 * 1000; // 10 minutes fresh
+const DEFAULT_MAX_AGE_MS = 48 * 60 * 60 * 1000; // 48 hours stale
+
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+
+function getIDB(): Promise<IDBDatabase | null> {
+  if (typeof window === 'undefined' || !window.indexedDB) {
+    return Promise.resolve(null);
+  }
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve) => {
+      try {
+        const req = indexedDB.open(DB_NAME, DB_VERSION);
+        req.onupgradeneeded = (e: any) => {
+          const db = e.target.result as IDBDatabase;
+          if (!db.objectStoreNames.contains(STORE_NAME)) {
+            db.createObjectStore(STORE_NAME, { keyPath: 'key' });
+          }
+        };
+        req.onsuccess = (e: any) => {
+          resolve(e.target.result as IDBDatabase);
+        };
+        req.onerror = () => {
+          resolve(null);
+        };
+      } catch {
+        resolve(null);
+      }
+    });
+  }
+  return dbPromise;
+}
+
+// In-Memory synchronous fast path
+export function getCachedData<T>(key: string, maxAgeMs = DEFAULT_MAX_AGE_MS): T | null {
+  const mem = MEMORY_CACHE.get(key);
+  const now = Date.now();
+  if (mem && (now - mem.timestamp) < maxAgeMs) {
+    return mem.data as T;
+  }
+  return null;
+}
+
+export function setCachedData<T>(key: string, data: T) {
+  const entry = { data, timestamp: Date.now() };
+  MEMORY_CACHE.set(key, entry);
+
+  // Persist to IndexedDB asynchronously (no blocking, no 5MB quota limit)
+  getIDB().then((db) => {
+    if (!db) return;
+    try {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      store.put({ key, ...entry });
+    } catch {}
+  }).catch(() => {});
+}
+
+// Hydrate memory cache from IndexedDB on startup
+export async function hydrateCacheFromStorage(): Promise<void> {
+  const db = await getIDB();
+  if (!db) return;
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const store = tx.objectStore(STORE_NAME);
+      const req = store.getAll();
+      req.onsuccess = () => {
+        const items = req.result || [];
+        const now = Date.now();
+        for (const item of items) {
+          if (item && item.key && (now - item.timestamp) < DEFAULT_MAX_AGE_MS) {
+            MEMORY_CACHE.set(item.key, { data: item.data, timestamp: item.timestamp });
+          }
+        }
+        resolve();
+      };
+      req.onerror = () => resolve();
+    } catch {
+      resolve();
+    }
+  });
+}
+
+export function isCacheStale(key: string, freshTtlMs = DEFAULT_TTL_MS): boolean {
+  const mem = MEMORY_CACHE.get(key);
+  if (mem) {
+    return (Date.now() - mem.timestamp) > freshTtlMs;
+  }
+  return true;
+}
+
+/**
+ * Fetch with Stale-While-Revalidate:
+ * 1. If cached, invokes onData(cached) IMMEDIATELY for zero-lag UI.
+ * 2. If stale or uncached, fetches fresh data in background, updates cache, and invokes onData(fresh).
+ */
+export async function fetchWithSWR<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  onData?: (data: T) => void,
+  freshTtlMs = DEFAULT_TTL_MS
+): Promise<T> {
+  const cached = getCachedData<T>(key);
+  let returnedCached = false;
+
+  if (cached !== null) {
+    if (onData) onData(cached);
+    returnedCached = true;
+
+    // If cache is fresh, return directly without network hit
+    if (!isCacheStale(key, freshTtlMs)) {
+      return cached;
+    }
+  }
+
+  // Background or initial fetch
+  try {
+    const fresh = await fetcher();
+    setCachedData(key, fresh);
+    if (onData) onData(fresh);
+    return fresh;
+  } catch (err) {
+    if (returnedCached && cached !== null) {
+      return cached;
+    }
+    throw err;
+  }
+}
+
+export function clearAllCache() {
+  MEMORY_CACHE.clear();
+  getIDB().then((db) => {
+    if (!db) return;
+    try {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      tx.objectStore(STORE_NAME).clear();
+    } catch {}
+  }).catch(() => {});
+}

--- a/web/jellyfin/src/lib/api/jellyfin.ts
+++ b/web/jellyfin/src/lib/api/jellyfin.ts
@@ -1,0 +1,555 @@
+import type { JellyfinItem, JellyfinSeason } from '../types';
+import { fetchWithSWR } from './cache';
+
+export const CLIENT_NAME = 'PlayBridge Jellyfin Web';
+export const CLIENT_VERSION = '1.0.0';
+export const DEVICE_NAME = 'PlayBridge Web Client';
+
+// Generate or retrieve persistent device ID
+export function getDeviceId(): string {
+  if (typeof window === 'undefined') return 'pb-web-client';
+  let id = localStorage.getItem('playbridge_jellyfin_device_id');
+  if (!id) {
+    id = 'pb-' + Math.random().toString(36).substring(2, 11) + '-' + Date.now().toString(36);
+    localStorage.setItem('playbridge_jellyfin_device_id', id);
+  }
+  return id;
+}
+
+export function getAuthHeader(token?: string): string {
+  let auth = `MediaBrowser Client="${CLIENT_NAME}", Device="${DEVICE_NAME}", DeviceId="${getDeviceId()}", Version="${CLIENT_VERSION}"`;
+  if (token) {
+    auth += `, Token="${token}"`;
+  }
+  return auth;
+}
+
+export function cleanServerUrl(url: string): string {
+  let cleaned = url.trim();
+  try {
+    const formatted = /^https?:\/\//i.test(cleaned) ? cleaned : `http://${cleaned}`;
+    const parsed = new URL(formatted);
+    return `${parsed.protocol}//${parsed.host}`;
+  } catch {
+    return cleaned.replace(/\/web.*$/i, '').replace(/\/+$/, '');
+  }
+}
+
+export async function pingServer(serverUrl: string): Promise<{ serverName: string; version: string; id: string }> {
+  const base = cleanServerUrl(serverUrl);
+  const url = `${base}/System/Info/Public`;
+  const res = await fetch(url, {
+    headers: {
+      'X-Emby-Authorization': getAuthHeader()
+    }
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to reach Jellyfin server at ${base} (HTTP ${res.status}: ${res.statusText})`);
+  }
+  const data = await res.json();
+  return {
+    serverName: data.ServerName || 'Jellyfin Server',
+    version: data.Version || '',
+    id: data.Id || ''
+  };
+}
+
+export async function authenticateByName(
+  serverUrl: string,
+  username: string,
+  password = ''
+): Promise<{ token: string; userId: string; serverId: string; username: string }> {
+  const base = cleanServerUrl(serverUrl);
+  const url = `${base}/Users/AuthenticateByName`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Emby-Authorization': getAuthHeader()
+    },
+    body: JSON.stringify({
+      Username: username,
+      Pw: password
+    })
+  });
+  if (!res.ok) {
+    let errorMsg = `Login failed (HTTP ${res.status})`;
+    try {
+      const text = await res.text();
+      if (text) errorMsg = text;
+    } catch {}
+    throw new Error(errorMsg);
+  }
+  const data = await res.json();
+  return {
+    token: data.AccessToken,
+    userId: data.User.Id,
+    serverId: data.ServerId,
+    username: data.User.Name
+  };
+}
+
+export async function validateToken(serverUrl: string, userId: string, token: string): Promise<boolean> {
+  try {
+    const base = cleanServerUrl(serverUrl);
+    const url = `${base}/Users/${userId}`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 6000);
+
+    const res = await fetch(url, {
+      headers: { 'X-Emby-Authorization': getAuthHeader(token) },
+      signal: controller.signal
+    });
+    clearTimeout(timeout);
+
+    // Explicit 401 Unauthorized or 403 Forbidden means token is invalid
+    if (res.status === 401 || res.status === 403) {
+      return false;
+    }
+    return true;
+  } catch {
+    // Network errors, timeouts, VPN lags: retain session and do NOT log out!
+    return true;
+  }
+}
+
+export interface UserView {
+  Id: string;
+  Name: string;
+  CollectionType?: string; // 'movies', 'tvshows', 'music', 'boxsets', 'homevideos'
+}
+
+export async function getUserViews(
+  serverUrl: string,
+  userId: string,
+  token: string,
+  onUpdate?: (views: UserView[]) => void
+): Promise<UserView[]> {
+  const cacheKey = `views_${userId}`;
+  return fetchWithSWR(
+    cacheKey,
+    async () => {
+      const base = cleanServerUrl(serverUrl);
+      const url = `${base}/Users/${userId}/Views`;
+      const res = await fetch(url, {
+        headers: { 'X-Emby-Authorization': getAuthHeader(token) }
+      });
+      if (!res.ok) return [];
+      const data = await res.json();
+      return (data.Items || []).map((v: any) => ({
+        Id: v.Id,
+        Name: v.Name,
+        CollectionType: v.CollectionType
+      }));
+    },
+    onUpdate,
+    15 * 60 * 1000 // 15 min fresh
+  );
+}
+
+export async function getResumeItems(
+  serverUrl: string,
+  userId: string,
+  token: string,
+  onUpdate?: (items: JellyfinItem[]) => void
+): Promise<JellyfinItem[]> {
+  const cacheKey = `resume_${userId}`;
+  return fetchWithSWR(
+    cacheKey,
+    async () => {
+      const base = cleanServerUrl(serverUrl);
+      const url = `${base}/Users/${userId}/Items/Resume?Limit=12&Recursive=true&Fields=Overview,PrimaryImageAspectRatio,ProductionYear,CommunityRating,OfficialRating,RunTimeTicks,MediaStreams,UserData,MediaSources,Artists,Album,AlbumArtist`;
+      const res = await fetch(url, {
+        headers: { 'X-Emby-Authorization': getAuthHeader(token) }
+      });
+      if (!res.ok) return [];
+      const data = await res.json();
+      return data.Items || [];
+    },
+    onUpdate,
+    2 * 60 * 1000 // 2 min fresh
+  );
+}
+
+export async function getNextUpEpisodes(
+  serverUrl: string,
+  userId: string,
+  token: string,
+  onUpdate?: (items: JellyfinItem[]) => void
+): Promise<JellyfinItem[]> {
+  const cacheKey = `nextup_${userId}`;
+  return fetchWithSWR(
+    cacheKey,
+    async () => {
+      const base = cleanServerUrl(serverUrl);
+      const url = `${base}/Shows/NextUp?UserId=${userId}&Limit=16&Fields=Overview,PrimaryImageAspectRatio,ProductionYear,CommunityRating,OfficialRating,RunTimeTicks,MediaStreams,UserData,MediaSources,SeriesName,SeasonName,IndexNumber,ParentIndexNumber`;
+      const res = await fetch(url, {
+        headers: { 'X-Emby-Authorization': getAuthHeader(token) }
+      });
+      if (!res.ok) return [];
+      const data = await res.json();
+      return data.Items || [];
+    },
+    onUpdate,
+    2 * 60 * 1000 // 2 min fresh
+  );
+}
+
+export async function getLatestMedia(
+  serverUrl: string,
+  userId: string,
+  token: string,
+  parentId?: string,
+  onUpdate?: (items: JellyfinItem[]) => void
+): Promise<JellyfinItem[]> {
+  const cacheKey = `latest_${userId}_${parentId || 'all'}`;
+  return fetchWithSWR(
+    cacheKey,
+    async () => {
+      const base = cleanServerUrl(serverUrl);
+      let url = `${base}/Users/${userId}/Items/Latest?Limit=20&Fields=Overview,PrimaryImageAspectRatio,ProductionYear,CommunityRating,OfficialRating,RunTimeTicks,MediaStreams,UserData,MediaSources,Artists,Album,AlbumArtist,SeriesName,SeasonName,IndexNumber,ParentIndexNumber`;
+      if (parentId) {
+        url += `&ParentId=${parentId}`;
+      }
+      const res = await fetch(url, {
+        headers: { 'X-Emby-Authorization': getAuthHeader(token) }
+      });
+      if (!res.ok) return [];
+      return await res.json();
+    },
+    onUpdate,
+    5 * 60 * 1000 // 5 min fresh
+  );
+}
+
+export function resolveUserViewPosterUrl(serverUrl: string, viewId: string): string {
+  if (!serverUrl || !viewId) return '';
+  const base = cleanServerUrl(serverUrl);
+  return `${base}/Items/${viewId}/Images/Primary?quality=90`;
+}
+
+export async function getLibraryItems(
+  serverUrl: string,
+  userId: string,
+  token: string,
+  options: {
+    parentId?: string;
+    includeItemTypes?: string;
+    sortBy?: string;
+    sortOrder?: 'Ascending' | 'Descending';
+    searchTerm?: string;
+    limit?: number;
+    startIndex?: number;
+    genres?: string;
+    recursive?: boolean;
+  } = {},
+  onUpdate?: (data: { items: JellyfinItem[]; totalRecordCount: number }) => void
+): Promise<{ items: JellyfinItem[]; totalRecordCount: number }> {
+  const cacheKey = `lib_${userId}_${options.parentId || 'root'}_${options.includeItemTypes || 'all'}_${options.sortBy || ''}_${options.searchTerm || ''}`;
+  return fetchWithSWR(
+    cacheKey,
+    async () => {
+      const base = cleanServerUrl(serverUrl);
+      const isRecursive = options.recursive !== false;
+      const params = new URLSearchParams({
+        userId,
+        Recursive: isRecursive ? 'true' : 'false',
+        Fields: 'Overview,PrimaryImageAspectRatio,ProductionYear,CommunityRating,OfficialRating,RunTimeTicks,MediaStreams,Taglines,Genres,UserData,MediaSources,SeriesName,SeasonName,IndexNumber,ParentIndexNumber,Artists,Album,AlbumArtist,AlbumId',
+        EnableImageTypes: 'Primary,Backdrop,Banner,Thumb',
+        ImageTypeLimit: '1'
+      });
+
+      if (options.parentId) params.set('ParentId', options.parentId);
+      if (options.includeItemTypes) params.set('IncludeItemTypes', options.includeItemTypes);
+      if (options.sortBy) params.set('SortBy', options.sortBy);
+      if (options.sortOrder) params.set('SortOrder', options.sortOrder);
+      if (options.searchTerm) params.set('SearchTerm', options.searchTerm);
+      if (options.limit) params.set('Limit', options.limit.toString());
+      if (options.startIndex) params.set('StartIndex', options.startIndex.toString());
+      if (options.genres) params.set('Genres', options.genres);
+
+      const url = `${base}/Users/${userId}/Items?${params.toString()}`;
+      const res = await fetch(url, {
+        headers: { 'X-Emby-Authorization': getAuthHeader(token) }
+      });
+      if (!res.ok) return { items: [], totalRecordCount: 0 };
+      const data = await res.json();
+      return {
+        items: data.Items || [],
+        totalRecordCount: data.TotalRecordCount || 0
+      };
+    },
+    onUpdate,
+    5 * 60 * 1000 // 5 min fresh
+  );
+}
+
+export async function getPlayableFolderItems(
+  serverUrl: string,
+  userId: string,
+  token: string,
+  parentId: string,
+  onUpdate?: (items: JellyfinItem[]) => void
+): Promise<JellyfinItem[]> {
+  const cacheKey = `playable_${userId}_${parentId}`;
+  return fetchWithSWR(
+    cacheKey,
+    async () => {
+      const base = cleanServerUrl(serverUrl);
+      const params = new URLSearchParams({
+        userId,
+        ParentId: parentId,
+        Recursive: 'true',
+        IncludeItemTypes: 'Audio,Movie,Episode,Video',
+        SortBy: 'ParentIndexNumber,IndexNumber,SortName',
+        SortOrder: 'Ascending',
+        Fields: 'Overview,PrimaryImageAspectRatio,ProductionYear,CommunityRating,OfficialRating,RunTimeTicks,MediaStreams,UserData,MediaSources,SeriesName,SeasonName,IndexNumber,ParentIndexNumber,Artists,Album,AlbumArtist,AlbumId'
+      });
+      const res = await fetch(`${base}/Users/${userId}/Items?${params.toString()}`, {
+        headers: { 'X-Emby-Authorization': getAuthHeader(token) }
+      });
+      if (!res.ok) return [];
+      const data = await res.json();
+      return (data.Items || []).filter((i: any) => i.Type === 'Audio' || i.Type === 'Movie' || i.Type === 'Episode');
+    },
+    onUpdate,
+    15 * 60 * 1000 // 15 min fresh
+  );
+}
+
+export async function getItemDetails(
+  serverUrl: string,
+  userId: string,
+  token: string,
+  itemId: string
+): Promise<JellyfinItem | null> {
+  const cacheKey = `item_${itemId}`;
+  return fetchWithSWR(
+    cacheKey,
+    async () => {
+      const base = cleanServerUrl(serverUrl);
+      const url = `${base}/Users/${userId}/Items/${itemId}`;
+      const res = await fetch(url, {
+        headers: { 'X-Emby-Authorization': getAuthHeader(token) }
+      });
+      if (!res.ok) return null;
+      return await res.json();
+    },
+    undefined,
+    15 * 60 * 1000
+  );
+}
+
+export async function getSeasons(
+  serverUrl: string,
+  userId: string,
+  token: string,
+  seriesId: string,
+  onUpdate?: (seasons: JellyfinSeason[]) => void
+): Promise<JellyfinSeason[]> {
+  const cacheKey = `seasons_${userId}_${seriesId}`;
+  return fetchWithSWR(
+    cacheKey,
+    async () => {
+      const base = cleanServerUrl(serverUrl);
+      const url = `${base}/Shows/${seriesId}/Seasons?userId=${userId}&Fields=Overview,PrimaryImageAspectRatio`;
+      const res = await fetch(url, {
+        headers: { 'X-Emby-Authorization': getAuthHeader(token) }
+      });
+      if (!res.ok) return [];
+      const data = await res.json();
+      const rawSeasons: any[] = data.Items || [];
+
+      const seasonsWithEpisodes: JellyfinSeason[] = await Promise.all(
+        rawSeasons.map(async (s) => {
+          const epUrl = `${base}/Shows/${seriesId}/Episodes?seasonId=${s.Id}&userId=${userId}&Fields=Overview,PrimaryImageAspectRatio,RunTimeTicks,MediaStreams,UserData,MediaSources`;
+          const epRes = await fetch(epUrl, {
+            headers: { 'X-Emby-Authorization': getAuthHeader(token) }
+          });
+          const epData = epRes.ok ? await epRes.json() : { Items: [] };
+          return {
+            Id: s.Id,
+            Name: s.Name,
+            IndexNumber: s.IndexNumber ?? 1,
+            SeriesId: seriesId,
+            Episodes: epData.Items || []
+          };
+        })
+      );
+
+      return seasonsWithEpisodes;
+    },
+    onUpdate,
+    30 * 60 * 1000 // 30 min fresh
+  );
+}
+
+export function buildImageUrl(
+  serverUrl: string,
+  itemId: string,
+  token: string,
+  imageType: 'Primary' | 'Backdrop' | 'Thumb' | 'Banner' = 'Primary',
+  options: { tag?: string; maxWidth?: number; maxHeight?: number; quality?: number; index?: number } = {}
+): string {
+  const base = cleanServerUrl(serverUrl);
+  const params = new URLSearchParams();
+  if (token) params.set('api_key', token);
+  if (options.tag) params.set('tag', options.tag);
+  if (options.maxWidth) params.set('maxWidth', options.maxWidth.toString());
+  if (options.maxHeight) params.set('maxHeight', options.maxHeight.toString());
+  if (options.quality) params.set('quality', options.quality.toString());
+
+  const indexPart = imageType === 'Backdrop' && options.index != null ? `/${options.index}` : '';
+  const query = params.toString() ? `?${params.toString()}` : '';
+  return `${base}/Items/${itemId}/Images/${imageType}${indexPart}${query}`;
+}
+
+export function buildDirectStreamUrl(
+  serverUrl: string,
+  itemId: string,
+  token: string,
+  mediaSourceId?: string,
+  container?: string
+): string {
+  const base = cleanServerUrl(serverUrl);
+  const sourceId = mediaSourceId || itemId;
+  const deviceId = getDeviceId();
+  const ext = container ? `.${container}` : '';
+  return `${base}/Videos/${itemId}/stream${ext}?Static=true&mediaSourceId=${sourceId}&deviceId=${deviceId}&api_key=${token}`;
+}
+
+export function buildAudioStreamUrl(
+  serverUrl: string,
+  itemId: string,
+  token: string
+): string {
+  const base = cleanServerUrl(serverUrl);
+  const deviceId = getDeviceId();
+  return `${base}/Audio/${itemId}/stream?static=true&deviceId=${deviceId}&api_key=${token}`;
+}
+
+export function buildHlsStreamUrl(
+  serverUrl: string,
+  itemId: string,
+  token: string,
+  mediaSourceId?: string
+): string {
+  const base = cleanServerUrl(serverUrl);
+  const sourceId = mediaSourceId || itemId;
+  const deviceId = getDeviceId();
+  return `${base}/Videos/${itemId}/master.m3u8?MediaSourceId=${sourceId}&DeviceId=${deviceId}&api_key=${token}&PlaySessionId=${Date.now()}`;
+}
+
+export async function reportPlaybackStart(
+  serverUrl: string,
+  token: string,
+  itemId: string,
+  mediaSourceId?: string
+): Promise<void> {
+  try {
+    const base = cleanServerUrl(serverUrl);
+    await fetch(`${base}/Sessions/Playing`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Emby-Authorization': getAuthHeader(token)
+      },
+      body: JSON.stringify({
+        ItemId: itemId,
+        MediaSourceId: mediaSourceId || itemId,
+        QueueableMediaTypes: ['Video', 'Audio'],
+        CanSeek: true
+      })
+    });
+  } catch {}
+}
+
+export async function reportPlaybackProgress(
+  serverUrl: string,
+  token: string,
+  itemId: string,
+  positionTicks: number,
+  isPaused: boolean,
+  mediaSourceId?: string
+): Promise<void> {
+  try {
+    const base = cleanServerUrl(serverUrl);
+    await fetch(`${base}/Sessions/Playing/Progress`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Emby-Authorization': getAuthHeader(token)
+      },
+      body: JSON.stringify({
+        ItemId: itemId,
+        MediaSourceId: mediaSourceId || itemId,
+        PositionTicks: positionTicks,
+        IsPaused: isPaused,
+        EventName: isPaused ? 'Pause' : 'TimeUpdate'
+      })
+    });
+  } catch {}
+}
+
+export async function reportPlaybackStopped(
+  serverUrl: string,
+  token: string,
+  itemId: string,
+  positionTicks: number,
+  mediaSourceId?: string
+): Promise<void> {
+  try {
+    const base = cleanServerUrl(serverUrl);
+    await fetch(`${base}/Sessions/Playing/Stopped`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Emby-Authorization': getAuthHeader(token)
+      },
+      body: JSON.stringify({
+        ItemId: itemId,
+        MediaSourceId: mediaSourceId || itemId,
+        PositionTicks: positionTicks
+      })
+    });
+  } catch {}
+}
+
+export async function toggleFavoriteItem(
+  serverUrl: string,
+  userId: string,
+  token: string,
+  itemId: string,
+  isFavorite: boolean
+): Promise<boolean> {
+  try {
+    const base = cleanServerUrl(serverUrl);
+    const method = isFavorite ? 'POST' : 'DELETE';
+    const url = `${base}/Users/${userId}/FavoriteItems/${itemId}`;
+    const res = await fetch(url, {
+      method,
+      headers: { 'X-Emby-Authorization': getAuthHeader(token) }
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function getItemLyrics(
+  serverUrl: string,
+  token: string,
+  itemId: string
+): Promise<{ Lyrics?: Array<{ Text: string; Start?: number }>; Text?: string } | null> {
+  try {
+    const base = cleanServerUrl(serverUrl);
+    const url = `${base}/Audio/${itemId}/Lyrics`;
+    const res = await fetch(url, {
+      headers: { 'X-Emby-Authorization': getAuthHeader(token) }
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}

--- a/web/jellyfin/src/lib/cast/playbridge.ts
+++ b/web/jellyfin/src/lib/cast/playbridge.ts
@@ -1,0 +1,283 @@
+import { writable } from 'svelte/store';
+import type {
+  JellyfinItem,
+  PlayBridgeCastPayload,
+  PlayBridgeItem,
+  PlayBridgeLinkSession,
+  VisualMetadata
+} from '../types';
+
+export interface DiagnosticLog {
+  id: string;
+  time: string;
+  type: 'info' | 'success' | 'warn' | 'error' | 'cast' | 'feedback';
+  message: string;
+  data?: any;
+}
+
+export const bridgeStatus = writable<{
+  available: boolean;
+  linkedCast: boolean;
+  checked: boolean;
+}>({
+  available: false,
+  linkedCast: false,
+  checked: false
+});
+
+export const diagnosticLogs = writable<DiagnosticLog[]>([]);
+export const activeLinkedSession = writable<PlayBridgeLinkSession | null>(null);
+export const activeCastPayload = writable<any | null>(null);
+
+export function addDiagnosticLog(type: DiagnosticLog['type'], message: string, data?: any) {
+  const log: DiagnosticLog = {
+    id: Math.random().toString(36).substring(2, 9),
+    time: new Date().toTimeString().slice(0, 8),
+    type,
+    message,
+    data
+  };
+  diagnosticLogs.update((logs) => [log, ...logs.slice(0, 100)]);
+}
+
+export function initPlayBridgeDetector() {
+  let attempts = 0;
+  const maxAttempts = 20;
+
+  function check() {
+    if (typeof window !== 'undefined' && window.playbridge && typeof window.playbridge.cast === 'function') {
+      const hasLinked = Boolean(window.playbridge.capabilities?.linkedCast);
+      bridgeStatus.set({
+        available: true,
+        linkedCast: hasLinked,
+        checked: true
+      });
+      addDiagnosticLog('success', 'PlayBridge bridge detected in window.playbridge', {
+        capabilities: window.playbridge.capabilities
+      });
+    } else if (++attempts < maxAttempts) {
+      setTimeout(check, 250);
+    } else {
+      bridgeStatus.set({
+        available: false,
+        linkedCast: false,
+        checked: true
+      });
+      addDiagnosticLog('warn', 'window.playbridge not detected after 5s. Running in fallback mode.');
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    check();
+
+    // Listen for feedback events from the native app / extension bridge
+    window.addEventListener('PlayBridgeFeedback', (e: any) => {
+      const detail = e?.detail;
+      addDiagnosticLog('feedback', 'PlayBridgeFeedback received', detail);
+    });
+  }
+}
+
+/**
+ * Formats metadata strictly according to PlayBridge VisualMetadata Wire/Moshi contract.
+ * Only includes fields declared in messages.proto:
+ * title, year, rating, runtime, overview, genres, cast, director, backdropUrl, posterUrl, logoUrl, season, episode, episodeTitle
+ */
+export function formatVisualMetadata(item: JellyfinItem, posterUrl?: string, backdropUrl?: string): Record<string, any> {
+  const meta: Record<string, any> = {
+    title: item.Name
+  };
+
+  if (item.ProductionYear) {
+    meta.year = String(item.ProductionYear);
+  }
+  if (item.Overview) {
+    meta.overview = item.Overview.slice(0, 2000);
+  }
+  if (item.Genres && item.Genres.length > 0) {
+    meta.genres = item.Genres.slice(0, 8);
+  }
+  const resolvedPoster = posterUrl || item.posterUrl;
+  if (resolvedPoster) {
+    meta.posterUrl = resolvedPoster;
+  }
+  const resolvedBackdrop = backdropUrl || item.backdropUrl;
+  if (resolvedBackdrop) {
+    meta.backdropUrl = resolvedBackdrop;
+  }
+
+  if (item.Type === 'Episode') {
+    meta.title = item.SeriesName || item.Name;
+    if (item.ParentIndexNumber != null) meta.season = item.ParentIndexNumber;
+    if (item.IndexNumber != null) meta.episode = item.IndexNumber;
+    meta.episodeTitle = item.Name;
+  } else if (item.Type === 'Audio') {
+    const artist = item.AlbumArtist || (item.Artists && item.Artists.length > 0 ? item.Artists[0] : '');
+    meta.title = artist ? `${item.Name} — ${artist}` : item.Name;
+    if (item.Album) {
+      meta.overview = `Album: ${item.Album}${item.Overview ? '\n' + item.Overview : ''}`;
+    }
+    if (item.RunTimeTicks) {
+      meta.runtime = String(Math.round(item.RunTimeTicks / (10000 * 1000)));
+    }
+  }
+
+  return meta;
+}
+
+export function isLocalNetworkUrl(url: string): boolean {
+  return /^https?:\/\/(?:10\.|192\.168\.|172\.(?:1[6-9]|2[0-9]|3[01])\.|127\.|localhost)/i.test(url);
+}
+
+/**
+ * Builds standard single cast payload.
+ */
+export function buildSingleCastPayload(item: JellyfinItem, streamUrl: string, posterUrl?: string, backdropUrl?: string) {
+  let title = item.Name;
+  if (item.Type === 'Episode' && item.IndexNumber != null) {
+    const s = item.ParentIndexNumber ?? 1;
+    title = `S${s}E${item.IndexNumber} · ${item.Name}`;
+  } else if (item.Type === 'Audio' && item.Artists && item.Artists.length > 0) {
+    title = `${item.Name} — ${item.Artists[0]}`;
+  }
+
+  const isLocal = isLocalNetworkUrl(streamUrl);
+  const isHls = streamUrl.includes('.m3u8');
+  const contentType = item.Type === 'Audio' ? 'audio/mpeg' : isHls ? 'application/vnd.apple.mpegurl' : 'video/mp4';
+
+  return {
+    url: streamUrl,
+    title,
+    contentType,
+    localNetwork: isLocal,
+    metadata: formatVisualMetadata(item, posterUrl, backdropUrl)
+  };
+}
+
+/**
+ * Builds playlist cast payload for casting all tracks in an album, folder, or playlist.
+ * Max 50 items per payload as enforced by page-cast.ts.
+ */
+export function buildPlaylistCastPayload(
+  items: Array<{ item: JellyfinItem; streamUrl: string; posterUrl?: string; backdropUrl?: string }>,
+  startIndex = 0,
+  playlistTitle = 'Playlist',
+  playlistPosterUrl?: string
+) {
+  // Cap at 50 items for direct cast validation
+  const sliced = items.slice(0, 50);
+
+  const castItems = sliced.map(({ item, streamUrl, posterUrl, backdropUrl }) => {
+    let title = item.Name;
+    if (item.Type === 'Episode' && item.IndexNumber != null) {
+      const s = item.ParentIndexNumber ?? 1;
+      title = `S${s}E${item.IndexNumber} · ${item.Name}`;
+    } else if (item.Type === 'Audio' && item.Artists && item.Artists.length > 0) {
+      title = `${item.Name} — ${item.Artists[0]}`;
+    }
+    const isHls = streamUrl.includes('.m3u8');
+    const contentType = item.Type === 'Audio' ? 'audio/mpeg' : isHls ? 'application/vnd.apple.mpegurl' : 'video/mp4';
+    return {
+      url: streamUrl,
+      title,
+      contentType,
+      metadata: formatVisualMetadata(item, posterUrl, backdropUrl)
+    };
+  });
+
+  const hasLocal = items.some(({ streamUrl }) => isLocalNetworkUrl(streamUrl));
+
+  return {
+    startIndex: Math.max(0, Math.min(startIndex, castItems.length - 1)),
+    localNetwork: hasLocal,
+    metadata: {
+      title: playlistTitle,
+      posterUrl: playlistPosterUrl || items[0]?.posterUrl
+    },
+    items: castItems
+  };
+}
+
+export function castDirect(payload: any): boolean {
+  activeCastPayload.set(payload);
+  const itemCount = Array.isArray(payload?.items) ? payload.items.length : 1;
+  addDiagnosticLog('cast', `window.playbridge.cast() invoked (${itemCount} item(s)): ${payload?.title || payload?.metadata?.title || 'Playlist'}`, payload);
+
+  if (typeof window !== 'undefined' && window.playbridge?.cast) {
+    try {
+      window.playbridge.cast(payload);
+      addDiagnosticLog('success', `window.playbridge.cast() dispatched successfully (${itemCount} items)`);
+      return true;
+    } catch (err: any) {
+      addDiagnosticLog('error', `window.playbridge.cast() threw exception: ${err.message}`, err);
+      return false;
+    }
+  } else {
+    addDiagnosticLog('warn', 'window.playbridge not found on this window. Payload logged for inspection.');
+    return false;
+  }
+}
+
+export async function castLinkedQueue(
+  items: any[],
+  startIndex = 0,
+  metadata?: any
+): Promise<PlayBridgeLinkSession | null> {
+  addDiagnosticLog('cast', `Starting linked cast session with ${items.length} items (startIndex=${startIndex})`, { items, metadata });
+
+  if (typeof window !== 'undefined' && window.playbridge?.linkCast) {
+    try {
+      const initialItems = items.slice(0, 2);
+      let remainingItems = items.slice(2);
+
+      const session = await window.playbridge.linkCast({
+        items: initialItems,
+        startIndex,
+        metadata: metadata || items[startIndex]?.metadata,
+        localNetwork: items.some((i) => isLocalNetworkUrl(i.url))
+      });
+
+      activeLinkedSession.set(session);
+      addDiagnosticLog('success', `Linked cast session opened: ${session.sessionId}`, { sessionId: session.sessionId });
+
+      session.addEventListener('statechange', (event: any) => {
+        const state = event.detail || {};
+        addDiagnosticLog('info', `Linked state: ${state.state} · item ${state.currentIndex}/${state.totalCount}`, state);
+      });
+
+      session.addEventListener('needitems', async (event: any) => {
+        const need = event.detail || { count: 2, requestId: 'req-' + Date.now() };
+        const batch = remainingItems.splice(0, need.count);
+        addDiagnosticLog('info', `needitems(${need.count}) → supplying ${batch.length} items (remaining: ${remainingItems.length})`, {
+          requestId: need.requestId,
+          batch
+        });
+
+        try {
+          await session.provideItems(need.requestId, {
+            items: batch,
+            endOfList: remainingItems.length === 0
+          });
+          addDiagnosticLog('success', `provideItems satisfied for ${need.requestId}`);
+        } catch (err: any) {
+          remainingItems.unshift(...batch);
+          addDiagnosticLog('error', `provideItems failed: ${err.message}`, err);
+        }
+      });
+
+      session.addEventListener('ended', (event: any) => {
+        addDiagnosticLog('warn', `Linked session ended: ${event.detail?.reason || 'unknown'}`);
+        activeLinkedSession.set(null);
+      });
+
+      return session;
+    } catch (err: any) {
+      addDiagnosticLog('error', `window.playbridge.linkCast failed: ${err.message}`, err);
+      return null;
+    }
+  } else {
+    addDiagnosticLog('warn', 'Linked cast not supported by current environment. Falling back to direct cast array.');
+    castDirect(buildPlaylistCastPayload(items.map(i => ({ item: i, streamUrl: i.url, posterUrl: i.metadata?.posterUrl })), startIndex, metadata?.title, metadata?.posterUrl));
+    return null;
+  }
+}

--- a/web/jellyfin/src/lib/components/DiagnosticsDrawer.svelte
+++ b/web/jellyfin/src/lib/components/DiagnosticsDrawer.svelte
@@ -1,0 +1,459 @@
+<script lang="ts">
+  import { isDiagnosticsOpen, clearAppCache } from '../stores/appState';
+  import {
+    bridgeStatus,
+    diagnosticLogs,
+    activeCastPayload,
+    activeLinkedSession
+  } from '../cast/playbridge';
+  import {
+    X,
+    Activity,
+    Trash2,
+    Copy,
+    Check,
+    Radio,
+    Terminal,
+    Code,
+    Sparkles,
+    Database,
+    RotateCcw
+  } from 'lucide-svelte';
+
+  let copied = false;
+
+  function close() {
+    $isDiagnosticsOpen = false;
+  }
+
+  function clearLogs() {
+    $diagnosticLogs = [];
+  }
+
+  function copyDiagnostics() {
+    const report = {
+      bridgeStatus: $bridgeStatus,
+      activeLinkedSession: $activeLinkedSession ? $activeLinkedSession.sessionId : null,
+      lastPayload: $activeCastPayload,
+      logs: $diagnosticLogs
+    };
+    navigator.clipboard.writeText(JSON.stringify(report, null, 2));
+    copied = true;
+    setTimeout(() => (copied = false), 2000);
+  }
+</script>
+
+{#if $isDiagnosticsOpen}
+  <div class="drawer-backdrop" on:click={close}>
+    <div class="drawer-panel" on:click|stopPropagation>
+      <!-- Header -->
+      <div class="drawer-header">
+        <div class="header-title-row">
+          <Activity size={18} class="accent-icon" />
+          <h3>PlayBridge Cast Inspector</h3>
+        </div>
+        <div class="header-actions">
+          <button class="icon-btn" on:click={copyDiagnostics} title="Copy Diagnostic JSON">
+            {#if copied}
+              <Check size={16} class="copied-icon" />
+            {:else}
+              <Copy size={16} />
+            {/if}
+          </button>
+          <button class="icon-btn" on:click={clearLogs} title="Clear Log Stream">
+            <Trash2 size={16} />
+          </button>
+          <button class="icon-btn" on:click={close} title="Close Inspector">
+            <X size={18} />
+          </button>
+        </div>
+      </div>
+
+      <!-- Bridge Status Card -->
+      <div class="status-summary">
+        <div class="status-indicator-box">
+          <div class="status-dot-row">
+            {#if $bridgeStatus.available}
+              <span class="pulsing-dot"></span>
+              <span class="status-title">Bridge Online</span>
+            {:else}
+              <Radio size={14} />
+              <span class="status-title status-warn">Bridge Inactive (Web Fallback)</span>
+            {/if}
+          </div>
+          <p class="status-sub">
+            {$bridgeStatus.available
+              ? 'Native PlayBridge bridge detected in window.playbridge'
+              : 'Running in standard browser. Cast requests will output payloads below.'}
+          </p>
+        </div>
+
+        <div class="cap-grid">
+          <div class="cap-pill" class:active={$bridgeStatus.available}>
+            <span class="cap-dot"></span>
+            <span>Direct Cast</span>
+          </div>
+          <div class="cap-pill" class:active={$bridgeStatus.linkedCast}>
+            <span class="cap-dot"></span>
+            <span>Linked Queue Cast</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Active / Last Cast Payload Inspector -->
+      {#if $activeCastPayload}
+        <div class="payload-box">
+          <div class="payload-header">
+            <Code size={14} />
+            <span>Latest Dispatched Cast Payload</span>
+          </div>
+          <pre class="json-code">{JSON.stringify($activeCastPayload, null, 2)}</pre>
+        </div>
+      {/if}
+
+      <!-- Cache & Storage Management -->
+      <div class="cache-box">
+        <div class="cache-header">
+          <Database size={14} />
+          <span>Client Storage & Cache</span>
+        </div>
+        <p class="cache-desc">IndexedDB and in-memory SWR cache for 0ms instant offline loads.</p>
+        <div class="cache-actions">
+          <button class="btn-secondary cache-btn" on:click={() => clearAppCache(false)}>
+            <RotateCcw size={14} />
+            <span>Clear SWR Cache & Re-sync</span>
+          </button>
+          <button class="btn-danger-outline cache-btn" on:click={() => clearAppCache(true)}>
+            <Trash2 size={14} />
+            <span>Factory Reset App Data</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- Event Stream Log -->
+      <div class="stream-container">
+        <div class="stream-header">
+          <Terminal size={14} />
+          <span>Real-time Event Log</span>
+          <span class="log-count">({$diagnosticLogs.length} events)</span>
+        </div>
+
+        <div class="stream-logs">
+          {#if $diagnosticLogs.length === 0}
+            <div class="empty-logs">No events logged yet. Trigger a Cast or Play action.</div>
+          {:else}
+            {#each $diagnosticLogs as log (log.id)}
+              <div class="log-row log-{log.type}">
+                <span class="log-time">{log.time}</span>
+                <span class="log-type-tag">{log.type.toUpperCase()}</span>
+                <span class="log-msg">{log.message}</span>
+                {#if log.data}
+                  <pre class="log-data-inline">{typeof log.data === 'string' ? log.data : JSON.stringify(log.data)}</pre>
+                {/if}
+              </div>
+            {/each}
+          {/if}
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .drawer-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    z-index: 250;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .drawer-panel {
+    background: var(--bg-surface);
+    border-left: 1px solid var(--border);
+    width: 100%;
+    max-width: 460px;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: var(--shadow-lg);
+    animation: slideIn 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  @keyframes slideIn {
+    from { transform: translateX(100%); }
+    to { transform: translateX(0); }
+  }
+
+  .drawer-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 20px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .header-title-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .header-title-row h3 {
+    font-size: 0.98rem;
+    font-weight: 700;
+    color: #fff;
+  }
+
+  :global(.accent-icon) {
+    color: var(--jf-blue);
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .icon-btn {
+    color: var(--text-secondary);
+    padding: 6px;
+    border-radius: var(--radius-sm);
+  }
+
+  .icon-btn:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  :global(.copied-icon) {
+    color: var(--status-ok);
+  }
+
+  .status-summary {
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-surface-elevated);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .status-dot-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: var(--status-ok);
+  }
+
+  .status-warn {
+    color: var(--status-warn);
+  }
+
+  .status-sub {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    margin-top: 4px;
+    line-height: 1.4;
+  }
+
+  .cap-grid {
+    display: flex;
+    gap: 8px;
+  }
+
+  .cap-pill {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.75rem;
+    padding: 4px 10px;
+    border-radius: var(--radius-full);
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+  }
+
+  .cap-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--text-muted);
+  }
+
+  .cap-pill.active {
+    background: rgba(0, 164, 220, 0.12);
+    border-color: rgba(0, 164, 220, 0.3);
+    color: var(--jf-blue);
+  }
+
+  .cap-pill.active .cap-dot {
+    background: var(--jf-blue);
+  }
+
+  .payload-box {
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--border);
+    background: #06070a;
+  }
+
+  .payload-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--jf-indigo);
+    margin-bottom: 6px;
+  }
+
+  .json-code {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+    max-height: 140px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+    background: #0d1017;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .cache-box {
+    padding: 12px 20px;
+    background: rgba(255, 255, 255, 0.02);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .cache-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--jf-blue);
+    margin-bottom: 4px;
+  }
+
+  .cache-desc {
+    font-size: 0.74rem;
+    color: var(--text-muted);
+    margin-bottom: 10px;
+  }
+
+  .cache-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .cache-btn {
+    padding: 6px 12px;
+    font-size: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: var(--radius-sm);
+  }
+
+  .btn-danger-outline {
+    background: transparent;
+    border: 1px solid rgba(235, 87, 87, 0.4);
+    color: var(--status-error);
+  }
+
+  .btn-danger-outline:hover {
+    background: rgba(235, 87, 87, 0.12);
+  }
+
+  .stream-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .stream-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 12px 20px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .log-count {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    font-weight: normal;
+  }
+
+  .stream-logs {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px 20px;
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    background: #08090d;
+  }
+
+  .empty-logs {
+    color: var(--text-muted);
+    font-style: italic;
+    text-align: center;
+    padding: 30px 0;
+  }
+
+  .log-row {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 6px 8px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+    border-left: 3px solid var(--border);
+  }
+
+  .log-row.log-success { border-left-color: var(--status-ok); }
+  .log-row.log-cast { border-left-color: var(--jf-blue); }
+  .log-row.log-feedback { border-left-color: var(--jf-purple); }
+  .log-row.log-warn { border-left-color: var(--status-warn); }
+  .log-row.log-error { border-left-color: var(--status-error); }
+
+  .log-time {
+    color: var(--text-muted);
+    font-size: 0.68rem;
+  }
+
+  .log-type-tag {
+    font-size: 0.66rem;
+    font-weight: 700;
+    color: var(--text-secondary);
+  }
+
+  .log-msg {
+    color: var(--text-primary);
+  }
+
+  .log-data-inline {
+    font-size: 0.68rem;
+    color: var(--text-muted);
+    background: rgba(0, 0, 0, 0.3);
+    padding: 4px 6px;
+    border-radius: 3px;
+    margin-top: 4px;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+</style>

--- a/web/jellyfin/src/lib/components/HeroSpotlight.svelte
+++ b/web/jellyfin/src/lib/components/HeroSpotlight.svelte
@@ -1,0 +1,239 @@
+<script lang="ts">
+  import type { JellyfinItem } from '../types';
+  import {
+    playInBrowser,
+    playWithDirectCast,
+    openItemDetail,
+    resolveItemBackdropUrl,
+    resolveItemPosterUrl
+  } from '../stores/appState';
+  import { bridgeStatus } from '../cast/playbridge';
+  import { Play, Cast, Info, Star, Clock, Calendar } from 'lucide-svelte';
+
+  export let item: JellyfinItem;
+
+  function formatRuntime(ticks?: number): string {
+    if (!ticks) return '';
+    const mins = Math.round(ticks / (10000 * 1000 * 60));
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    return h > 0 ? `${h}h ${m}m` : `${m}m`;
+  }
+</script>
+
+<div class="hero-banner">
+  <div class="backdrop-wrapper">
+    <img src={resolveItemBackdropUrl(item)} alt={item.Name} class="backdrop-img" />
+    <div class="backdrop-gradient-bottom"></div>
+    <div class="backdrop-gradient-left"></div>
+  </div>
+
+  <div class="hero-content">
+    <div class="meta-pills">
+      {#if item.CommunityRating}
+        <span class="pill pill-rating">
+          <Star size={12} fill="#e3b341" stroke="#e3b341" />
+          {item.CommunityRating.toFixed(1)}
+        </span>
+      {/if}
+      {#if item.ProductionYear}
+        <span class="pill pill-muted">
+          <Calendar size={12} />
+          {item.ProductionYear}
+        </span>
+      {/if}
+      {#if item.RunTimeTicks}
+        <span class="pill pill-muted">
+          <Clock size={12} />
+          {formatRuntime(item.RunTimeTicks)}
+        </span>
+      {/if}
+      {#if item.OfficialRating}
+        <span class="badge badge-outline">{item.OfficialRating}</span>
+      {/if}
+      <span class="badge badge-purple">{item.Type}</span>
+    </div>
+
+    <h1 class="hero-title">{item.Name}</h1>
+
+    {#if item.Taglines && item.Taglines.length > 0}
+      <p class="hero-tagline">{item.Taglines[0]}</p>
+    {/if}
+
+    <p class="hero-overview">{item.Overview || 'Explore and stream media seamlessly to PlayBridge receivers on your local network.'}</p>
+
+    <div class="hero-actions">
+      <!-- Direct PlayBridge Cast Button -->
+      <button class="btn-accent hero-btn action-cast" on:click={() => playWithDirectCast(item)}>
+        <Cast size={18} />
+        <span>Direct Cast</span>
+      </button>
+
+      <!-- Web Player Play Button -->
+      <button class="btn-primary hero-btn action-play" on:click={() => playInBrowser(item)}>
+        <Play size={18} fill="currentColor" />
+        <span>Play</span>
+      </button>
+
+      <!-- Details Modal Button -->
+      <button class="btn-secondary hero-btn action-details" on:click={() => openItemDetail(item)}>
+        <Info size={18} />
+        <span>Info</span>
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .hero-banner {
+    position: relative;
+    width: 100%;
+    min-height: 440px;
+    display: flex;
+    align-items: flex-end;
+    padding: 36px 32px;
+    margin-bottom: 24px;
+    overflow: hidden;
+  }
+
+  .backdrop-wrapper {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+  }
+
+  .backdrop-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center 25%;
+    filter: brightness(0.65) saturate(1.1);
+  }
+
+  .backdrop-gradient-bottom {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 80%;
+    background: linear-gradient(to top, var(--bg-base) 0%, rgba(8, 9, 13, 0.85) 50%, transparent 100%);
+  }
+
+  .backdrop-gradient-left {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 60%;
+    height: 100%;
+    background: linear-gradient(to right, var(--bg-base) 0%, rgba(8, 9, 13, 0.7) 60%, transparent 100%);
+  }
+
+  .hero-content {
+    position: relative;
+    z-index: 2;
+    max-width: 680px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .meta-pills {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 2px 7px;
+    border-radius: var(--radius-sm);
+  }
+
+  .pill-rating {
+    background: rgba(227, 179, 65, 0.15);
+    color: #f1c40f;
+    border: 1px solid rgba(227, 179, 65, 0.3);
+  }
+
+  .pill-muted {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text-secondary);
+  }
+
+  .hero-title {
+    font-size: 2.2rem;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    line-height: 1.15;
+    color: #ffffff;
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.7);
+  }
+
+  .hero-tagline {
+    font-size: 0.95rem;
+    font-style: italic;
+    color: var(--jf-indigo);
+    font-weight: 400;
+  }
+
+  .hero-overview {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-shadow: 0 1px 4px rgba(0, 0, 0, 0.8);
+  }
+
+  .hero-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 6px;
+    flex-wrap: wrap;
+  }
+
+  .hero-btn {
+    padding: 10px 18px;
+    font-size: 0.9rem;
+  }
+
+  @media (max-width: 768px) {
+    .hero-banner {
+      min-height: 320px;
+      padding: 20px 16px;
+      margin-bottom: 16px;
+    }
+    .hero-title {
+      font-size: 1.5rem;
+    }
+    .hero-overview {
+      -webkit-line-clamp: 2;
+      font-size: 0.82rem;
+    }
+    .hero-actions {
+      display: grid;
+      grid-template-columns: 1fr 1fr auto;
+      gap: 8px;
+      width: 100%;
+    }
+    .hero-btn {
+      padding: 10px 12px;
+      font-size: 0.85rem;
+      width: 100%;
+    }
+    .action-details {
+      padding: 10px 14px;
+    }
+  }
+</style>

--- a/web/jellyfin/src/lib/components/ItemDetailModal.svelte
+++ b/web/jellyfin/src/lib/components/ItemDetailModal.svelte
@@ -1,0 +1,883 @@
+<script lang="ts">
+  import type { JellyfinItem, JellyfinSeason } from '../types';
+  import {
+    detailModalItem,
+    playInBrowser,
+    playWithDirectCast,
+    playWithLinkedQueue,
+    playFolderOrAlbumWithCast,
+    shufflePlay,
+    shuffleCast,
+    toggleFavorite,
+    resolveItemPosterUrl,
+    resolveItemBackdropUrl
+  } from '../stores/appState';
+  import { bridgeStatus } from '../cast/playbridge';
+  import {
+    X,
+    Play,
+    Cast,
+    ListPlus,
+    Star,
+    Calendar,
+    Clock,
+    Music,
+    Folder,
+    Disc,
+    User,
+    Shuffle,
+    Heart
+  } from 'lucide-svelte';
+
+  $: item = $detailModalItem;
+  let activeSeasonIndex = 0;
+
+  function close() {
+    $detailModalItem = null;
+  }
+
+  function formatRuntime(ticks?: number): string {
+    if (!ticks) return '';
+    const totalSecs = Math.round(ticks / (10000 * 1000));
+    const mins = Math.floor(totalSecs / 60);
+    const secs = totalSecs % 60;
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    if (h > 0) return `${h}h ${m}m`;
+    return `${m}m ${secs > 0 ? secs + 's' : ''}`;
+  }
+
+  $: posterUrl = item ? resolveItemPosterUrl(item) : '';
+  $: backdropUrl = item ? resolveItemBackdropUrl(item) : '';
+</script>
+
+{#if item}
+  <div class="modal-backdrop" on:click={close}>
+    <div class="modal-container" on:click|stopPropagation>
+      <!-- Close Button -->
+      <button class="modal-close-btn" on:click={close} aria-label="Close modal">
+        <X size={20} />
+      </button>
+
+      <!-- Hero Header Banner with dynamic blurred backdrop -->
+      <div class="modal-hero">
+        <div
+          class="modal-hero-bg"
+          style="background-image: url('{backdropUrl || posterUrl}')"
+        ></div>
+        <div class="modal-hero-gradient"></div>
+
+        <div class="modal-hero-content">
+          <!-- Poster -->
+          <div class="hero-poster-wrapper" class:music-aspect={item.Type === 'Audio' || item.Type === 'MusicAlbum'}>
+            <img src={posterUrl} alt={item.Name} class="hero-poster-img" />
+          </div>
+
+          <!-- Main Info -->
+          <div class="hero-meta">
+            <div class="type-pill">
+              {item.Type}
+            </div>
+
+            <div class="title-fav-row">
+              <h1 class="item-title">{item.Name}</h1>
+              <button
+                class="fav-btn"
+                class:active-fav={item.UserData?.IsFavorite}
+                on:click={() => item && toggleFavorite(item)}
+                title="Toggle Favorite"
+              >
+                <Heart size={22} fill={item.UserData?.IsFavorite ? '#e74c3c' : 'none'} color={item.UserData?.IsFavorite ? '#e74c3c' : 'currentColor'} />
+              </button>
+            </div>
+
+            {#if item.ProductionYear || item.OfficialRating || item.RunTimeTicks}
+              <div class="meta-row">
+                {#if item.ProductionYear}
+                  <span class="meta-badge">
+                    <Calendar size={13} />
+                    {item.ProductionYear}
+                  </span>
+                {/if}
+                {#if item.OfficialRating}
+                  <span class="meta-badge rating-badge">{item.OfficialRating}</span>
+                {/if}
+                {#if item.CommunityRating}
+                  <span class="meta-badge">
+                    <Star size={13} fill="#f1c40f" stroke="#f1c40f" />
+                    {item.CommunityRating.toFixed(1)}
+                  </span>
+                {/if}
+                {#if item.RunTimeTicks}
+                  <span class="meta-badge">
+                    <Clock size={13} />
+                    {formatRuntime(item.RunTimeTicks)}
+                  </span>
+                {/if}
+              </div>
+            {/if}
+
+            {#if item.AlbumArtist || (item.Artists && item.Artists.length > 0)}
+              <p class="item-artist">
+                <User size={13} />
+                <span>{item.AlbumArtist || item.Artists?.[0]}</span>
+              </p>
+            {/if}
+
+            {#if item.Taglines && item.Taglines.length > 0}
+              <p class="item-tagline">{item.Taglines[0]}</p>
+            {/if}
+
+            <div class="action-buttons">
+              <!-- If Album / Folder / Playlist: Cast All / Play All / Shuffle -->
+              {#if (item.Type === 'MusicAlbum' || item.Type === 'Folder' || item.Type === 'Playlist') && item.tracks && item.tracks.length > 0}
+                <button class="btn-accent modal-action-btn" on:click={() => item && playFolderOrAlbumWithCast(item, item.tracks, 0)}>
+                  <Cast size={18} />
+                  <span>Cast All ({item.tracks.length})</span>
+                </button>
+                <button class="btn-primary modal-action-btn" on:click={() => item && item.tracks && playInBrowser(item, item.tracks, 0)}>
+                  <Play size={18} fill="currentColor" />
+                  <span>Play All</span>
+                </button>
+                <button class="btn-secondary modal-action-btn" on:click={() => item && item.tracks && shufflePlay(item, item.tracks)} title="Shuffle Play in Browser">
+                  <Shuffle size={17} />
+                  <span>Shuffle</span>
+                </button>
+                <button class="btn-secondary modal-action-btn" on:click={() => item && item.tracks && shuffleCast(item, item.tracks)} title="Shuffle Cast to TV">
+                  <Shuffle size={17} />
+                  <Cast size={15} />
+                </button>
+              {:else if item.Type === 'Series' && item.seasons && item.seasons.length > 0}
+                <!-- For TV Series: Cast Series Queue (Linked Cast) -->
+                <button class="btn-accent modal-action-btn" on:click={() => item && playWithLinkedQueue(item, item.seasons, 0)}>
+                  <Cast size={18} />
+                  <span>Cast Series Queue</span>
+                </button>
+                <button class="btn-primary modal-action-btn" on:click={() => item && playInBrowser(item)}>
+                  <Play size={18} fill="currentColor" />
+                  <span>Play Ep 1</span>
+                </button>
+              {:else}
+                <!-- Standard Single Video / Audio Item -->
+                <button class="btn-accent modal-action-btn" on:click={() => item && playWithDirectCast(item)}>
+                  <Cast size={18} />
+                  <span>Direct Cast</span>
+                </button>
+                <button class="btn-primary modal-action-btn" on:click={() => item && playInBrowser(item)}>
+                  <Play size={18} fill="currentColor" />
+                  <span>Play in Browser</span>
+                </button>
+              {/if}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Modal Body / Details -->
+      <div class="modal-content">
+        <!-- Overview & Genres -->
+        {#if item.Overview}
+          <div class="content-section">
+            <h3 class="section-heading">Overview</h3>
+            <p class="item-overview">{item.Overview}</p>
+          </div>
+        {/if}
+
+        {#if item.Genres && item.Genres.length > 0}
+          <div class="content-section">
+            <div class="genre-tags">
+              {#each item.Genres as genre}
+                <span class="genre-tag">{genre}</span>
+              {/each}
+            </div>
+          </div>
+        {/if}
+
+        <!-- Audio Tracks / Album List View -->
+        {#if item.tracks && item.tracks.length > 0}
+          <div class="content-section">
+            <div class="tracks-header">
+              <h3 class="section-heading">Tracks ({item.tracks.length})</h3>
+              <div class="tracks-header-actions">
+                <button
+                  class="btn-secondary tracks-sub-btn"
+                  on:click={() => item && item.tracks && shufflePlay(item, item.tracks)}
+                >
+                  <Shuffle size={14} />
+                  <span>Shuffle</span>
+                </button>
+                <button
+                  class="btn-secondary tracks-sub-btn"
+                  on:click={() => item && playFolderOrAlbumWithCast(item, item.tracks, 0)}
+                >
+                  <Cast size={14} />
+                  <span>Cast All</span>
+                </button>
+              </div>
+            </div>
+
+            <div class="tracks-list">
+              {#each item.tracks as track, index}
+                <div class="track-row" on:click={() => item && playInBrowser(track, item.tracks, index)}>
+                  <span class="track-number">{track.IndexNumber != null ? track.IndexNumber : index + 1}</span>
+                  <div class="track-info">
+                    <span class="track-title">{track.Name}</span>
+                    {#if track.Artists && track.Artists.length > 0}
+                      <span class="track-sub">{track.Artists.join(', ')}</span>
+                    {/if}
+                  </div>
+                  {#if track.RunTimeTicks}
+                    <span class="track-duration">{formatRuntime(track.RunTimeTicks)}</span>
+                  {/if}
+                  <div class="track-actions">
+                    <button
+                      class="track-action-btn fav-btn-track"
+                      class:active-fav={track.UserData?.IsFavorite}
+                      title="Favorite track"
+                      on:click|stopPropagation={() => toggleFavorite(track)}
+                    >
+                      <Heart size={15} fill={track.UserData?.IsFavorite ? '#e74c3c' : 'none'} color={track.UserData?.IsFavorite ? '#e74c3c' : 'currentColor'} />
+                    </button>
+                    <button
+                      class="track-action-btn cast-btn"
+                      title="Cast from this track"
+                      on:click|stopPropagation={() => item && playFolderOrAlbumWithCast(item, item.tracks, index)}
+                    >
+                      <Cast size={15} />
+                    </button>
+                    <button
+                      class="track-action-btn play-btn"
+                      title="Play in browser"
+                      on:click|stopPropagation={() => item && playInBrowser(track, item.tracks, index)}
+                    >
+                      <Play size={14} fill="currentColor" />
+                    </button>
+                  </div>
+                </div>
+              {/each}
+            </div>
+          </div>
+        {/if}
+
+        <!-- TV Series Seasons and Episodes List -->
+        {#if item.seasons && item.seasons.length > 0}
+          <div class="content-section">
+            <h3 class="section-heading">Seasons & Episodes</h3>
+
+            <!-- Season Selector Tabs -->
+            {#if item.seasons.length > 1}
+              <div class="season-tabs">
+                {#each item.seasons as season, sIdx}
+                  <button
+                    class="season-tab"
+                    class:active={activeSeasonIndex === sIdx}
+                    on:click={() => (activeSeasonIndex = sIdx)}
+                  >
+                    {season.Name}
+                  </button>
+                {/each}
+              </div>
+            {/if}
+
+            <!-- Episodes Grid -->
+            {#if item.seasons[activeSeasonIndex]?.Episodes}
+              <div class="episodes-list">
+                {#each item.seasons[activeSeasonIndex].Episodes as ep, epIdx}
+                  <div class="episode-card">
+                    <div class="ep-thumb-wrapper" on:click={() => playInBrowser(ep)}>
+                      <img
+                        src={ep.posterUrl || resolveItemPosterUrl(ep)}
+                        alt={ep.Name}
+                        class="ep-thumb"
+                      />
+                      <div class="ep-play-overlay">
+                        <Play size={20} fill="currentColor" />
+                      </div>
+                    </div>
+
+                    <div class="ep-details">
+                      <div class="ep-header">
+                        <span class="ep-num">
+                          E{ep.IndexNumber ?? epIdx + 1}
+                        </span>
+                        <h4 class="ep-title">{ep.Name}</h4>
+                        {#if ep.RunTimeTicks}
+                          <span class="ep-duration">{formatRuntime(ep.RunTimeTicks)}</span>
+                        {/if}
+                      </div>
+
+                      {#if ep.Overview}
+                        <p class="ep-overview">{ep.Overview}</p>
+                      {/if}
+
+                      <div class="ep-actions">
+                        <button
+                          class="btn-secondary ep-cast-btn"
+                          on:click={() => playWithDirectCast(ep)}
+                        >
+                          <Cast size={14} />
+                          <span>Cast Episode</span>
+                        </button>
+                        <button
+                          class="btn-primary ep-play-btn"
+                          on:click={() => playInBrowser(ep)}
+                        >
+                          <Play size={14} fill="currentColor" />
+                          <span>Play</span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                {/each}
+              </div>
+            {/if}
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.82);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    z-index: 90;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    animation: fadeIn 0.2s ease;
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  .modal-container {
+    background: var(--bg-surface-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    width: 100%;
+    max-width: 960px;
+    max-height: 90vh;
+    overflow-y: auto;
+    position: relative;
+    box-shadow: var(--shadow-lg);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .modal-close-btn {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    z-index: 20;
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.65);
+    backdrop-filter: blur(8px);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    transition: all 0.15s ease;
+  }
+
+  .modal-close-btn:hover {
+    background: rgba(0, 0, 0, 0.9);
+    transform: scale(1.08);
+  }
+
+  .modal-hero {
+    position: relative;
+    padding: 40px 36px 28px;
+    overflow: hidden;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .modal-hero-bg {
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    filter: blur(40px) brightness(0.35);
+    transform: scale(1.1);
+  }
+
+  .modal-hero-gradient {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, var(--bg-surface-elevated) 0%, transparent 100%);
+  }
+
+  .modal-hero-content {
+    position: relative;
+    z-index: 5;
+    display: flex;
+    gap: 28px;
+    align-items: flex-end;
+  }
+
+  .hero-poster-wrapper {
+    width: 170px;
+    aspect-ratio: 2 / 3;
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    flex-shrink: 0;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: var(--bg-card);
+  }
+
+  .hero-poster-wrapper.music-aspect {
+    aspect-ratio: 1 / 1;
+  }
+
+  .hero-poster-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .hero-meta {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .type-pill {
+    align-self: flex-start;
+    padding: 3px 10px;
+    border-radius: var(--radius-full);
+    background: rgba(0, 164, 220, 0.2);
+    border: 1px solid rgba(0, 164, 220, 0.4);
+    color: var(--jf-blue);
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .title-fav-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .item-title {
+    font-size: 1.85rem;
+    font-weight: 800;
+    color: #fff;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+  }
+
+  .fav-btn {
+    padding: 8px;
+    border-radius: 50%;
+    color: var(--text-muted);
+    background: rgba(255, 255, 255, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .fav-btn:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.15);
+  }
+
+  .fav-btn.active-fav {
+    color: #e74c3c;
+    background: rgba(231, 76, 60, 0.15);
+    border-color: rgba(231, 76, 60, 0.3);
+  }
+
+  .meta-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .meta-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    background: rgba(255, 255, 255, 0.08);
+    padding: 3px 8px;
+    border-radius: var(--radius-xs);
+  }
+
+  .rating-badge {
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    font-weight: 600;
+  }
+
+  .item-artist {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.95rem;
+    color: var(--jf-indigo);
+    font-weight: 600;
+  }
+
+  .item-tagline {
+    font-size: 0.88rem;
+    font-style: italic;
+    color: var(--text-muted);
+  }
+
+  .action-buttons {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 6px;
+  }
+
+  .modal-action-btn {
+    padding: 10px 18px;
+    font-size: 0.9rem;
+    border-radius: var(--radius-md);
+  }
+
+  .modal-content {
+    padding: 28px 36px 40px;
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+  }
+
+  .content-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .section-heading {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: #fff;
+  }
+
+  .item-overview {
+    font-size: 0.92rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+  }
+
+  .genre-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .genre-tag {
+    padding: 4px 10px;
+    border-radius: var(--radius-full);
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+  }
+
+  /* Tracks */
+  .tracks-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 4px;
+  }
+
+  .tracks-header-actions {
+    display: flex;
+    gap: 8px;
+  }
+
+  .tracks-sub-btn {
+    padding: 6px 12px;
+    font-size: 0.78rem;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .tracks-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    border-radius: var(--radius-md);
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    padding: 6px;
+  }
+
+  .track-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background 0.15s ease;
+  }
+
+  .track-row:hover {
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .track-number {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    width: 24px;
+    text-align: center;
+    flex-shrink: 0;
+  }
+
+  .track-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .track-title {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .track-sub {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+  }
+
+  .track-duration {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+  }
+
+  .track-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .track-action-btn {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    background: transparent;
+  }
+
+  .track-action-btn:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .fav-btn-track.active-fav {
+    color: #e74c3c;
+  }
+
+  /* Seasons & Episodes */
+  .season-tabs {
+    display: flex;
+    gap: 6px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+
+  .season-tab {
+    padding: 6px 14px;
+    border-radius: var(--radius-full);
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    font-size: 0.82rem;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .season-tab.active {
+    background: var(--jf-blue);
+    border-color: transparent;
+    color: #fff;
+    font-weight: 600;
+  }
+
+  .episodes-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 8px;
+  }
+
+  .episode-card {
+    display: flex;
+    gap: 16px;
+    padding: 12px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+  }
+
+  .ep-thumb-wrapper {
+    position: relative;
+    width: 140px;
+    aspect-ratio: 16 / 9;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    flex-shrink: 0;
+    background: var(--bg-card);
+    cursor: pointer;
+  }
+
+  .ep-thumb {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .ep-play-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+
+  .ep-thumb-wrapper:hover .ep-play-overlay {
+    opacity: 1;
+  }
+
+  .ep-details {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .ep-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .ep-num {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--jf-blue);
+  }
+
+  .ep-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #fff;
+    flex: 1;
+  }
+
+  .ep-duration {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+  }
+
+  .ep-overview {
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    line-height: 1.45;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .ep-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 4px;
+  }
+
+  .ep-cast-btn, .ep-play-btn {
+    padding: 5px 10px;
+    font-size: 0.76rem;
+  }
+
+  @media (max-width: 768px) {
+    .modal-backdrop {
+      padding: 0;
+    }
+    .modal-container {
+      max-height: 100vh;
+      max-height: 100dvh;
+      height: 100%;
+      border-radius: 0;
+      border: none;
+    }
+    .modal-hero {
+      padding: 24px 18px 18px;
+    }
+    .modal-hero-content {
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      gap: 16px;
+    }
+    .hero-poster-wrapper {
+      width: 130px;
+    }
+    .meta-row {
+      justify-content: center;
+    }
+    .action-buttons {
+      width: 100%;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+    }
+    .action-buttons button {
+      width: 100%;
+    }
+    .modal-content {
+      padding: 18px 18px 32px;
+      gap: 20px;
+    }
+    .episode-card {
+      flex-direction: column;
+      gap: 10px;
+    }
+    .ep-thumb-wrapper {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+    }
+  }
+</style>

--- a/web/jellyfin/src/lib/components/LoginScreen.svelte
+++ b/web/jellyfin/src/lib/components/LoginScreen.svelte
@@ -1,0 +1,703 @@
+<script lang="ts">
+  import {
+    connectToJellyfinServer,
+    loadDemoMode,
+    isLoadingLibrary,
+    serverError,
+    savedAccounts,
+    switchAccount,
+    removeSavedAccount
+  } from '../stores/appState';
+  import { cleanServerUrl, pingServer } from '../api/jellyfin';
+  import { bridgeStatus } from '../cast/playbridge';
+  import {
+    Server,
+    User,
+    Lock,
+    Globe,
+    Sparkles,
+    AlertCircle,
+    Loader2,
+    Cast,
+    ShieldCheck,
+    ArrowRight,
+    Plus,
+    Trash2,
+    Layers
+  } from 'lucide-svelte';
+
+  let serverUrl = 'http://10.8.0.6:8096';
+  let username = '';
+  let password = '';
+  let rememberMe = true;
+  let currentStep: 'saved' | 'server' | 'auth' = $savedAccounts.length > 0 ? 'saved' : 'server';
+  let serverInfo: { serverName: string; version: string } | null = null;
+  let localLoading = false;
+  let localError: string | null = null;
+
+  $: if ($savedAccounts.length === 0 && currentStep === 'saved') {
+    currentStep = 'server';
+  }
+
+  async function handleCheckServer() {
+    if (!serverUrl.trim()) return;
+    localLoading = true;
+    localError = null;
+    try {
+      const cleanUrl = cleanServerUrl(serverUrl);
+      serverUrl = cleanUrl;
+
+      const ping = await pingServer(cleanUrl);
+      serverInfo = ping;
+      currentStep = 'auth';
+    } catch (err: any) {
+      localError = err.message || 'Could not connect to Jellyfin server at this address.';
+    } finally {
+      localLoading = false;
+    }
+  }
+
+  async function handleLogin() {
+    if (!username.trim()) return;
+    localLoading = true;
+    localError = null;
+    try {
+      await connectToJellyfinServer(serverUrl, username, password, rememberMe);
+    } catch (err: any) {
+      localError = err.message || 'Login failed. Please check your credentials.';
+    } finally {
+      localLoading = false;
+    }
+  }
+
+  function handleQuickSwitch(acc: any) {
+    switchAccount(acc);
+  }
+</script>
+
+<div class="login-wrapper">
+  <div class="login-background">
+    <div class="glow-sphere sphere-1"></div>
+    <div class="glow-sphere sphere-2"></div>
+  </div>
+
+  <div class="login-card">
+    <div class="brand-header">
+      <div class="logo-box">
+        <svg viewBox="0 0 100 100" fill="none" class="brand-svg">
+          <path d="M50 18 L82 74 L66 74 L50 44 L34 74 L18 74 Z" fill="url(#login-brand-grad)"/>
+          <defs>
+            <linearGradient id="login-brand-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#00A4DC"/>
+              <stop offset="100%" stop-color="#7A5AF8"/>
+            </linearGradient>
+          </defs>
+        </svg>
+      </div>
+
+      <h1 class="login-title">PlayBridge Jellyfin</h1>
+      <div class="bridge-tag">
+        <Cast size={13} />
+        <span>Multi-Server Casting Suite</span>
+      </div>
+    </div>
+
+    <!-- Status Banner for Bridge -->
+    <div class="bridge-banner" class:bridge-active={$bridgeStatus.available}>
+      <span class={$bridgeStatus.available ? 'pulsing-dot' : 'static-dot'}></span>
+      <span>
+        {$bridgeStatus.available
+          ? 'PlayBridge Native Bridge Connected — Ready for Direct TV Casting'
+          : 'PlayBridge Bridge Ready (In-browser playback + Cast payload inspector)'}
+      </span>
+    </div>
+
+    {#if localError || $serverError}
+      <div class="error-box">
+        <AlertCircle size={16} />
+        <span>{localError || $serverError}</span>
+      </div>
+    {/if}
+
+    {#if currentStep === 'saved' && $savedAccounts.length > 0}
+      <!-- Screen 0: Saved Profiles & Servers Picker (Netflix/Jellyfin Style) -->
+      <div class="saved-profiles-section">
+        <h3 class="section-title">Select Server & Profile</h3>
+        <p class="section-sub">Choose a saved server account to sign in instantly</p>
+
+        <div class="profiles-grid">
+          {#each $savedAccounts as acc (acc.id)}
+            <div class="profile-card" on:click={() => handleQuickSwitch(acc)}>
+              <button
+                class="del-profile-btn"
+                on:click|stopPropagation={() => removeSavedAccount(acc.id)}
+                title="Remove saved account"
+              >
+                <Trash2 size={13} />
+              </button>
+
+              <div class="profile-avatar">
+                {acc.username.slice(0, 2).toUpperCase()}
+              </div>
+
+              <div class="profile-meta">
+                <span class="profile-name">{acc.username}</span>
+                <span class="profile-server">{acc.serverName}</span>
+                <span class="profile-url">{acc.url}</span>
+              </div>
+            </div>
+          {/each}
+        </div>
+
+        <button class="btn-secondary add-server-btn" on:click={() => (currentStep = 'server')}>
+          <Plus size={16} />
+          <span>Connect Another Server / Account</span>
+        </button>
+      </div>
+    {:else if currentStep === 'server'}
+      <!-- Step 1: Server URL -->
+      <form class="login-form" on:submit|preventDefault={handleCheckServer}>
+        {#if $savedAccounts.length > 0}
+          <button type="button" class="back-to-profiles" on:click={() => (currentStep = 'saved')}>
+            &larr; Back to Saved Profiles
+          </button>
+        {/if}
+
+        <div class="input-group">
+          <label for="server-address">Jellyfin Server URL</label>
+          <div class="input-field">
+            <Globe size={18} class="input-icon" />
+            <input
+              id="server-address"
+              type="text"
+              placeholder="http://10.8.0.6:8096"
+              bind:value={serverUrl}
+              required
+              autofocus
+            />
+          </div>
+          <span class="input-hint">Enter your local LAN IP or public domain.</span>
+        </div>
+
+        <button type="submit" class="btn-primary submit-btn" disabled={localLoading || !serverUrl}>
+          {#if localLoading}
+            <Loader2 size={18} class="spinner" />
+            <span>Checking Server...</span>
+          {:else}
+            <span>Next</span>
+            <ArrowRight size={18} />
+          {/if}
+        </button>
+      </form>
+    {:else}
+      <!-- Step 2: User Login -->
+      <form class="login-form" on:submit|preventDefault={handleLogin}>
+        <div class="server-pill-row">
+          <div class="server-connected-pill">
+            <ShieldCheck size={14} class="pill-check" />
+            <span>{serverInfo?.serverName || 'Jellyfin Server'}</span>
+          </div>
+          <button type="button" class="change-server-btn" on:click={() => (currentStep = 'server')}>
+            Change Server
+          </button>
+        </div>
+
+        <div class="input-group">
+          <label for="user-name">Username</label>
+          <div class="input-field">
+            <User size={18} class="input-icon" />
+            <input
+              id="user-name"
+              type="text"
+              placeholder="Enter username"
+              bind:value={username}
+              required
+              autofocus
+            />
+          </div>
+        </div>
+
+        <div class="input-group">
+          <label for="user-pass">Password</label>
+          <div class="input-field">
+            <Lock size={18} class="input-icon" />
+            <input
+              id="user-pass"
+              type="password"
+              placeholder="Password (if set)"
+              bind:value={password}
+            />
+          </div>
+        </div>
+
+        <label class="remember-row">
+          <input type="checkbox" bind:checked={rememberMe} />
+          <span>Save this account for fast multi-server switching</span>
+        </label>
+
+        <button type="submit" class="btn-accent submit-btn" disabled={localLoading || !username}>
+          {#if localLoading}
+            <Loader2 size={18} class="spinner" />
+            <span>Signing in & loading library...</span>
+          {:else}
+            <span>Sign In to Jellyfin</span>
+          {/if}
+        </button>
+      </form>
+    {/if}
+
+    <div class="demo-fallback">
+      <div class="or-divider"><span>or</span></div>
+      <button class="btn-secondary demo-btn" on:click={loadDemoMode}>
+        <Sparkles size={16} />
+        <span>Explore with Demo Library</span>
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .login-wrapper {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px 16px;
+    position: relative;
+    background-color: var(--bg-base);
+    overflow: hidden;
+  }
+
+  .login-background {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  .glow-sphere {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.25;
+  }
+
+  .sphere-1 {
+    width: 400px;
+    height: 400px;
+    background: #00a4dc;
+    top: -100px;
+    right: -50px;
+  }
+
+  .sphere-2 {
+    width: 450px;
+    height: 450px;
+    background: #7a5af8;
+    bottom: -150px;
+    left: -100px;
+  }
+
+  .login-card {
+    position: relative;
+    z-index: 10;
+    width: 100%;
+    max-width: 480px;
+    background-color: var(--bg-surface-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    padding: 40px 36px;
+    box-shadow: var(--shadow-lg);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    animation: fadeIn 0.3s ease;
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(12px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .brand-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    margin-bottom: 24px;
+  }
+
+  .logo-box {
+    width: 56px;
+    height: 56px;
+    margin-bottom: 12px;
+  }
+
+  .brand-svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  .login-title {
+    font-size: 1.6rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    color: #ffffff;
+  }
+
+  .bridge-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.76rem;
+    font-weight: 600;
+    color: var(--jf-indigo);
+    background-color: rgba(122, 90, 248, 0.12);
+    border: 1px solid rgba(122, 90, 248, 0.25);
+    padding: 3px 10px;
+    border-radius: var(--radius-full);
+    margin-top: 6px;
+  }
+
+  .bridge-banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border-radius: var(--radius-md);
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border);
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    margin-bottom: 24px;
+    line-height: 1.35;
+  }
+
+  .bridge-banner.bridge-active {
+    background-color: rgba(122, 90, 248, 0.08);
+    border-color: rgba(122, 90, 248, 0.3);
+    color: #ffffff;
+  }
+
+  .static-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .pulsing-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--jf-purple);
+    box-shadow: 0 0 8px var(--jf-purple);
+    animation: pulse 1.8s infinite;
+    flex-shrink: 0;
+  }
+
+  @keyframes pulse {
+    0% { transform: scale(0.9); opacity: 0.8; }
+    50% { transform: scale(1.3); opacity: 1; }
+    100% { transform: scale(0.9); opacity: 0.8; }
+  }
+
+  .error-box {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background-color: rgba(235, 87, 87, 0.12);
+    border: 1px solid rgba(235, 87, 87, 0.3);
+    color: var(--status-error);
+    padding: 10px 14px;
+    border-radius: var(--radius-md);
+    font-size: 0.82rem;
+    margin-bottom: 20px;
+  }
+
+  /* Saved Profiles Grid */
+  .saved-profiles-section {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 12px;
+  }
+
+  .section-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #fff;
+    text-align: center;
+  }
+
+  .section-sub {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    text-align: center;
+    margin-top: -10px;
+  }
+
+  .profiles-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 10px;
+    max-height: 260px;
+    overflow-y: auto;
+  }
+
+  .profile-card {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 12px 14px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+
+  .profile-card:hover {
+    background: var(--bg-surface-elevated);
+    border-color: var(--jf-blue);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .profile-avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--jf-blue), var(--jf-purple));
+    color: #fff;
+    font-weight: 700;
+    font-size: 1.05rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .profile-meta {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .profile-name {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: #fff;
+  }
+
+  .profile-server {
+    font-size: 0.78rem;
+    color: var(--jf-indigo);
+    font-weight: 500;
+  }
+
+  .profile-url {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .del-profile-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    padding: 6px;
+    border-radius: 50%;
+    color: var(--text-muted);
+    opacity: 0;
+    transition: all 0.15s ease;
+  }
+
+  .profile-card:hover .del-profile-btn {
+    opacity: 1;
+  }
+
+  .del-profile-btn:hover {
+    color: #e74c3c;
+    background: rgba(231, 76, 60, 0.15);
+  }
+
+  .add-server-btn {
+    width: 100%;
+    padding: 10px;
+    font-size: 0.85rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border-radius: var(--radius-md);
+  }
+
+  .back-to-profiles {
+    background: transparent;
+    color: var(--jf-blue);
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-align: left;
+    margin-bottom: 6px;
+    cursor: pointer;
+  }
+
+  .back-to-profiles:hover {
+    text-decoration: underline;
+  }
+
+  .login-form {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  }
+
+  .input-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .input-group label {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+  }
+
+  .input-field {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  :global(.input-icon) {
+    position: absolute;
+    left: 14px;
+    color: var(--text-muted);
+    pointer-events: none;
+  }
+
+  .input-field input {
+    width: 100%;
+    height: 44px;
+    padding: 0 16px 0 42px;
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    color: #ffffff;
+    font-size: 0.9rem;
+    transition: all 0.15s ease;
+  }
+
+  .input-field input:focus {
+    outline: none;
+    border-color: var(--jf-blue);
+    background-color: rgba(255, 255, 255, 0.05);
+    box-shadow: 0 0 0 3px rgba(0, 164, 220, 0.15);
+  }
+
+  .input-hint {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    margin-top: 2px;
+  }
+
+  .server-pill-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 14px;
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+  }
+
+  .server-connected-pill {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #ffffff;
+  }
+
+  :global(.pill-check) {
+    color: var(--status-success);
+  }
+
+  .change-server-btn {
+    font-size: 0.76rem;
+    color: var(--jf-blue);
+    font-weight: 600;
+  }
+
+  .change-server-btn:hover {
+    text-decoration: underline;
+  }
+
+  .remember-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+
+  .submit-btn {
+    width: 100%;
+    height: 44px;
+    font-size: 0.92rem;
+    border-radius: var(--radius-md);
+    margin-top: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+
+  .demo-fallback {
+    margin-top: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .or-divider {
+    display: flex;
+    align-items: center;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+  }
+
+  .or-divider::before,
+  .or-divider::after {
+    content: '';
+    flex: 1;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .or-divider span {
+    padding: 0 10px;
+  }
+
+  .demo-btn {
+    width: 100%;
+    height: 40px;
+    font-size: 0.86rem;
+    border-radius: var(--radius-md);
+  }
+
+  @media (max-width: 480px) {
+    .login-card {
+      padding: 28px 20px;
+    }
+  }
+</style>

--- a/web/jellyfin/src/lib/components/MediaCard.svelte
+++ b/web/jellyfin/src/lib/components/MediaCard.svelte
@@ -1,0 +1,439 @@
+<script lang="ts">
+  import type { JellyfinItem } from '../types';
+  import {
+    playInBrowser,
+    playWithDirectCast,
+    openItemDetail,
+    resolveItemPosterUrl
+  } from '../stores/appState';
+  import { Play, Cast, Star, Music, Film, Clapperboard, Folder } from 'lucide-svelte';
+
+  export let item: JellyfinItem;
+  export let onOpenFolder: ((item: JellyfinItem) => void) | undefined = undefined;
+
+  let imageError = false;
+
+  $: isFolder = item.Type === 'Folder' || item.IsFolder;
+  $: isEpisode = item.Type === 'Episode';
+  $: isMusic = item.Type === 'Audio' || item.Type === 'MusicAlbum';
+  $: posterUrl = isEpisode && item.backdropUrl ? item.backdropUrl : resolveItemPosterUrl(item);
+
+  $: progressPercent =
+    item.UserData?.PlaybackPositionTicks && item.RunTimeTicks
+      ? Math.min(100, Math.round((item.UserData.PlaybackPositionTicks / item.RunTimeTicks) * 100))
+      : 0;
+
+  function handleCardClick() {
+    if (isFolder && onOpenFolder) {
+      onOpenFolder(item);
+      return;
+    }
+    openItemDetail(item);
+  }
+
+  function handlePlayClick(e: MouseEvent | TouchEvent) {
+    e.stopPropagation();
+    playInBrowser(item);
+  }
+
+  function handleCastClick(e: MouseEvent | TouchEvent) {
+    e.stopPropagation();
+    playWithDirectCast(item);
+  }
+</script>
+
+<div class="media-card" on:click={handleCardClick}>
+  <div class="poster-container" class:music-aspect={isMusic} class:episode-aspect={isEpisode}>
+    {#if posterUrl && !imageError}
+      <img
+        src={posterUrl}
+        alt={item.Name}
+        class="poster-img"
+        loading="lazy"
+        on:error={() => (imageError = true)}
+      />
+    {:else}
+      <!-- Styled Fallback Placeholder -->
+      <div class="placeholder-box">
+        {#if isMusic}
+          <Music size={32} class="placeholder-icon" />
+        {:else if item.Type === 'Series' || isEpisode}
+          <Clapperboard size={32} class="placeholder-icon" />
+        {:else if item.Type === 'Folder'}
+          <Folder size={32} class="placeholder-icon" />
+        {:else}
+          <Film size={32} class="placeholder-icon" />
+        {/if}
+        <span class="placeholder-title">{item.Name}</span>
+      </div>
+    {/if}
+
+    <!-- Type Badges -->
+    {#if item.Type === 'Series'}
+      <span class="type-badge">Series</span>
+    {:else if isEpisode}
+      <span class="type-badge badge-ep">S{item.ParentIndexNumber || 1}:E{item.IndexNumber || 1}</span>
+    {:else if item.Type === 'MusicAlbum'}
+      <span class="type-badge badge-music">Album</span>
+    {:else if item.Type === 'Audio'}
+      <span class="type-badge badge-music">Track</span>
+    {:else if item.Type === 'Folder'}
+      <span class="type-badge badge-folder">Folder</span>
+    {/if}
+
+    <!-- Community Rating -->
+    {#if item.CommunityRating}
+      <div class="rating-badge">
+        <Star size={10} fill="#f1c40f" stroke="#f1c40f" />
+        <span>{item.CommunityRating.toFixed(1)}</span>
+      </div>
+    {/if}
+
+    <!-- Desktop Hover Overlay -->
+    <div class="desktop-overlay desktop-only">
+      <button class="overlay-btn overlay-play" on:click={handlePlayClick} title="Play in Browser">
+        <Play size={18} fill="currentColor" />
+      </button>
+      <button class="overlay-btn overlay-cast" on:click={handleCastClick} title="Direct Cast">
+        <Cast size={18} />
+      </button>
+    </div>
+
+    <!-- Mobile Quick Cast & Play Badges -->
+    <div class="mobile-quick-actions mobile-only">
+      <button class="mobile-tap-btn mobile-cast-btn" on:click={handleCastClick} title="Direct Cast">
+        <Cast size={14} />
+      </button>
+      <button class="mobile-tap-btn mobile-play-btn" on:click={handlePlayClick} title="Play in Browser">
+        <Play size={13} fill="currentColor" />
+      </button>
+    </div>
+
+    <!-- Resume Playback Progress Bar -->
+    {#if progressPercent > 0}
+      <div class="progress-bar-bg">
+        <div class="progress-bar-fill" style="width: {progressPercent}%"></div>
+      </div>
+    {/if}
+  </div>
+
+  <div class="card-info">
+    {#if isEpisode && item.SeriesName}
+      <h4 class="card-title" title={item.SeriesName}>{item.SeriesName}</h4>
+      <div class="card-subtitle">
+        <span class="ep-tag">S{item.ParentIndexNumber || 1}:E{item.IndexNumber || 1}</span>
+        <span class="dot">&bull;</span>
+        <span class="ep-name">{item.Name}</span>
+      </div>
+    {:else}
+      <h4 class="card-title" title={item.Name}>{item.Name}</h4>
+      <div class="card-subtitle">
+        {#if item.AlbumArtist || (item.Artists && item.Artists.length > 0)}
+          <span class="artist-name">{item.AlbumArtist || item.Artists?.[0]}</span>
+        {:else}
+          {#if item.ProductionYear}
+            <span>{item.ProductionYear}</span>
+          {/if}
+          {#if item.OfficialRating}
+            <span class="dot">&bull;</span>
+            <span>{item.OfficialRating}</span>
+          {/if}
+          {#if item.Genres && item.Genres.length > 0}
+            <span class="dot">&bull;</span>
+            <span class="genre-text">{item.Genres[0]}</span>
+          {/if}
+        {/if}
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .media-card {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    cursor: pointer;
+    user-select: none;
+    position: relative;
+    transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .media-card:hover {
+    transform: translateY(-4px);
+  }
+
+  .poster-container {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 2 / 3;
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-sm);
+    transition: all 0.2s ease;
+  }
+
+  .poster-container.music-aspect {
+    aspect-ratio: 1 / 1;
+  }
+
+  .poster-container.episode-aspect {
+    aspect-ratio: 16 / 9;
+  }
+
+  .media-card:hover .poster-container {
+    border-color: var(--border-focus);
+    box-shadow: var(--shadow-md);
+  }
+
+  .poster-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    background: var(--bg-surface);
+  }
+
+  .placeholder-box {
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.05) 0%, rgba(0, 164, 220, 0.08) 100%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px;
+    text-align: center;
+  }
+
+  :global(.placeholder-icon) {
+    color: var(--jf-blue);
+    opacity: 0.6;
+  }
+
+  .placeholder-title {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    word-break: break-word;
+  }
+
+  .type-badge {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    background: rgba(0, 0, 0, 0.75);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    color: #fff;
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px 6px;
+    border-radius: var(--radius-xs);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+  }
+
+  .badge-ep {
+    background: rgba(0, 164, 220, 0.85);
+    border-color: rgba(0, 164, 220, 0.4);
+  }
+
+  .badge-music {
+    background: rgba(122, 90, 248, 0.85);
+    border-color: rgba(122, 90, 248, 0.4);
+  }
+
+  .badge-folder {
+    background: rgba(0, 164, 220, 0.85);
+    border-color: rgba(0, 164, 220, 0.4);
+  }
+
+  .ep-tag {
+    font-weight: 700;
+    color: var(--jf-blue);
+  }
+
+  .ep-name {
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .rating-badge {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    background: rgba(0, 0, 0, 0.75);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    padding: 2px 6px;
+    border-radius: var(--radius-xs);
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+  }
+
+  .desktop-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+  }
+
+  .media-card:hover .desktop-overlay {
+    opacity: 1;
+  }
+
+  .overlay-btn {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.15s ease, background-color 0.15s ease;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  }
+
+  .overlay-btn:hover {
+    transform: scale(1.12);
+  }
+
+  .overlay-play {
+    background: var(--jf-blue);
+    color: #fff;
+  }
+
+  .overlay-cast {
+    background: var(--accent-gradient);
+    color: #fff;
+  }
+
+  /* Mobile Quick Actions (Always Visible on Mobile Cards) */
+  .mobile-quick-actions {
+    position: absolute;
+    bottom: 6px;
+    right: 6px;
+    display: flex;
+    gap: 6px;
+    z-index: 5;
+  }
+
+  .mobile-tap-btn {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+  }
+
+  .mobile-cast-btn {
+    background: var(--accent-gradient);
+  }
+
+  .mobile-play-btn {
+    background: var(--jf-blue);
+  }
+
+  .progress-bar-bg {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: rgba(0, 0, 0, 0.5);
+  }
+
+  .progress-bar-fill {
+    height: 100%;
+    background: var(--jf-blue);
+  }
+
+  .card-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 0 2px;
+  }
+
+  .card-title {
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    line-height: 1.25;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .card-subtitle {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .artist-name {
+    color: var(--jf-indigo);
+    font-weight: 500;
+  }
+
+  .genre-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .dot {
+    opacity: 0.5;
+  }
+
+  .desktop-only {
+    display: flex;
+  }
+
+  .mobile-only {
+    display: none;
+  }
+
+  @media (max-width: 768px) {
+    .desktop-only {
+      display: none !important;
+    }
+    .mobile-only {
+      display: flex !important;
+    }
+    .card-title {
+      font-size: 0.82rem;
+    }
+    .card-subtitle {
+      font-size: 0.7rem;
+    }
+  }
+</style>

--- a/web/jellyfin/src/lib/components/MediaSection.svelte
+++ b/web/jellyfin/src/lib/components/MediaSection.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  import type { JellyfinItem } from '../types';
+  import MediaCard from './MediaCard.svelte';
+  import { ChevronLeft, ChevronRight } from 'lucide-svelte';
+
+  export let title: string;
+  export let subtitle: string = '';
+  export let items: JellyfinItem[] = [];
+  export let onSeeAll: (() => void) | undefined = undefined;
+
+  let scrollContainer: HTMLDivElement;
+
+  function scroll(direction: 'left' | 'right') {
+    if (!scrollContainer) return;
+    const distance = scrollContainer.clientWidth * 0.75;
+    scrollContainer.scrollBy({
+      left: direction === 'left' ? -distance : distance,
+      behavior: 'smooth'
+    });
+  }
+</script>
+
+{#if items && items.length > 0}
+  <section class="media-section">
+    <div class="section-header">
+      <div class="header-titles">
+        <h2 class="section-title">{title}</h2>
+        {#if subtitle}
+          <p class="section-subtitle">{subtitle}</p>
+        {/if}
+      </div>
+
+      <div class="scroll-controls">
+        {#if onSeeAll}
+          <button class="see-all-btn" on:click={onSeeAll}>
+            View All &rarr;
+          </button>
+        {/if}
+        <button class="control-btn" on:click={() => scroll('left')} aria-label="Scroll left">
+          <ChevronLeft size={18} />
+        </button>
+        <button class="control-btn" on:click={() => scroll('right')} aria-label="Scroll right">
+          <ChevronRight size={18} />
+        </button>
+      </div>
+    </div>
+
+    <div class="cards-carousel" bind:this={scrollContainer}>
+      {#each items as item (item.Id)}
+        <div class="carousel-item">
+          <MediaCard {item} />
+        </div>
+      {/each}
+    </div>
+  </section>
+{/if}
+
+<style>
+  .media-section {
+    padding: 0 36px;
+    margin-bottom: 36px;
+  }
+
+  .section-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    margin-bottom: 14px;
+  }
+
+  .section-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    color: var(--text-primary);
+  }
+
+  .section-subtitle {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin-top: 2px;
+  }
+
+  .scroll-controls {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .see-all-btn {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--jf-blue);
+    background: transparent;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    margin-right: 6px;
+    transition: all 0.15s ease;
+  }
+
+  .see-all-btn:hover {
+    background: rgba(0, 164, 220, 0.12);
+    color: #fff;
+  }
+
+  .control-btn {
+    width: 32px;
+    height: 32px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .control-btn:hover {
+    background: var(--bg-surface-elevated);
+    color: #fff;
+    border-color: var(--text-muted);
+  }
+
+  .cards-carousel {
+    display: flex;
+    gap: 16px;
+    overflow-x: auto;
+    padding-bottom: 12px;
+    scroll-behavior: smooth;
+    scrollbar-width: thin;
+  }
+
+  .carousel-item {
+    width: 175px;
+    flex-shrink: 0;
+  }
+
+  @media (max-width: 768px) {
+    .media-section {
+      padding: 0 16px;
+      margin-bottom: 24px;
+    }
+    .carousel-item {
+      width: 130px;
+    }
+  }
+</style>

--- a/web/jellyfin/src/lib/components/Navbar.svelte
+++ b/web/jellyfin/src/lib/components/Navbar.svelte
@@ -1,0 +1,1013 @@
+<script lang="ts">
+  import {
+    activeTab,
+    serverConfig,
+    savedAccounts,
+    userViews,
+    searchQuery,
+    isServerModalOpen,
+    isDiagnosticsOpen,
+    loadDemoMode,
+    logout,
+    refreshServerLibrary,
+    switchAccount,
+    removeSavedAccount,
+    clearAppCache
+  } from '../stores/appState';
+  import { bridgeStatus } from '../cast/playbridge';
+  import {
+    Tv,
+    Search,
+    Server,
+    Activity,
+    Radio,
+    Film,
+    Clapperboard,
+    Sparkles,
+    User,
+    Check,
+    LogOut,
+    RefreshCw,
+    Folder,
+    Home,
+    Music,
+    Cast,
+    X,
+    Plus,
+    Trash2,
+    Layers,
+    ChevronDown,
+    RotateCcw
+  } from 'lucide-svelte';
+
+  let showProfileMenu = false;
+  let showMoreViewsMenu = false;
+  let showMobileSearch = false;
+
+  $: currentServerId = $serverConfig.url ? `${$serverConfig.url}_${$serverConfig.userId}` : '';
+
+  // Segregate views so navbar never stretches out of control
+  $: musicViews = $userViews.filter((v) => v.CollectionType === 'music');
+  $: otherFolderViews = $userViews.filter(
+    (v) => v.CollectionType !== 'movies' && v.CollectionType !== 'tvshows' && v.CollectionType !== 'music'
+  );
+
+  function toggleProfileMenu() {
+    showProfileMenu = !showProfileMenu;
+    showMoreViewsMenu = false;
+  }
+
+  function closeProfileMenu() {
+    showProfileMenu = false;
+  }
+
+  function toggleMobileSearch() {
+    showMobileSearch = !showMobileSearch;
+    if (showMobileSearch) {
+      $activeTab = 'search';
+    }
+  }
+
+  function handleRefresh() {
+    refreshServerLibrary($serverConfig);
+    closeProfileMenu();
+  }
+
+  function handleLogout() {
+    logout();
+    closeProfileMenu();
+  }
+
+  function handleSwitch(acc: any) {
+    switchAccount(acc);
+    closeProfileMenu();
+  }
+
+  function handleRemoveAccount(id: string) {
+    removeSavedAccount(id);
+  }
+</script>
+
+<!-- Top Navbar -->
+<header class="navbar">
+  {#if showMobileSearch}
+    <!-- Expanded Mobile Search Bar -->
+    <div class="mobile-search-bar">
+      <Search size={18} class="search-bar-icon" />
+      <input
+        type="text"
+        placeholder="Search movies, shows, music..."
+        bind:value={$searchQuery}
+        autofocus
+        on:input={() => {
+          if ($activeTab !== 'search') $activeTab = 'search';
+        }}
+      />
+      {#if $searchQuery}
+        <button class="clear-search-btn" on:click={() => ($searchQuery = '')}>
+          <X size={16} />
+        </button>
+      {/if}
+      <button class="close-search-btn" on:click={() => (showMobileSearch = false)}>
+        Done
+      </button>
+    </div>
+  {:else}
+    <div class="nav-left">
+      <!-- Brand Logo -->
+      <div class="brand" on:click={() => ($activeTab = 'home')}>
+        <div class="logo-icon">
+          <svg viewBox="0 0 100 100" fill="none" class="brand-svg">
+            <path d="M50 18 L82 74 L66 74 L50 44 L34 74 L18 74 Z" fill="url(#brand-grad)"/>
+            <defs>
+              <linearGradient id="brand-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#00A4DC"/>
+                <stop offset="100%" stop-color="#7A5AF8"/>
+              </linearGradient>
+            </defs>
+          </svg>
+        </div>
+        <div class="brand-text">
+          <span class="brand-name">PlayBridge</span>
+          <span class="brand-sub">Cast Suite</span>
+        </div>
+      </div>
+
+      <!-- Desktop Navigation Tabs (Compact & Responsive) -->
+      <nav class="nav-links desktop-only">
+        <button
+          class="nav-link"
+          class:active={$activeTab === 'home'}
+          on:click={() => ($activeTab = 'home')}
+        >
+          <Home size={15} />
+          <span>Home</span>
+        </button>
+
+        <button
+          class="nav-link"
+          class:active={$activeTab === 'movies'}
+          on:click={() => ($activeTab = 'movies')}
+        >
+          <Film size={15} />
+          <span>Movies</span>
+        </button>
+
+        <button
+          class="nav-link"
+          class:active={$activeTab === 'shows'}
+          on:click={() => ($activeTab = 'shows')}
+        >
+          <Clapperboard size={15} />
+          <span>Shows</span>
+        </button>
+
+        <!-- Dynamic Music Views (If any) -->
+        {#each musicViews as mView (mView.Id)}
+          <button
+            class="nav-link"
+            class:active={$activeTab === mView.Id}
+            on:click={() => ($activeTab = mView.Id)}
+          >
+            <Music size={15} />
+            <span>{mView.Name}</span>
+          </button>
+        {/each}
+
+        <!-- Other Folder Views in sleek "Libraries" Dropdown (Prevents Navbar Overflow) -->
+        {#if otherFolderViews.length > 0}
+          <div class="more-views-container">
+            <button
+              class="nav-link more-btn"
+              class:active={otherFolderViews.some((v) => $activeTab === v.Id)}
+              on:click={() => (showMoreViewsMenu = !showMoreViewsMenu)}
+            >
+              <Folder size={15} />
+              <span>Libraries</span>
+              <ChevronDown size={13} />
+            </button>
+
+            {#if showMoreViewsMenu}
+              <div class="more-views-dropdown" on:mouseleave={() => (showMoreViewsMenu = false)}>
+                {#each otherFolderViews as view (view.Id)}
+                  <button
+                    class="dropdown-item"
+                    class:active-item={$activeTab === view.Id}
+                    on:click={() => {
+                      $activeTab = view.Id;
+                      showMoreViewsMenu = false;
+                    }}
+                  >
+                    <Folder size={14} />
+                    <span>{view.Name}</span>
+                    {#if $activeTab === view.Id}
+                      <Check size={14} class="check-icon" />
+                    {/if}
+                  </button>
+                {/each}
+              </div>
+            {/if}
+          </div>
+        {/if}
+
+        <button
+          class="nav-link"
+          class:active={$activeTab === 'favorites'}
+          on:click={() => ($activeTab = 'favorites')}
+        >
+          <Sparkles size={15} />
+          <span>Favorites</span>
+        </button>
+      </nav>
+    </div>
+
+    <!-- Right Controls: Always fixed and never pushed off screen -->
+    <div class="nav-right">
+      <!-- Desktop Search Bar -->
+      <div class="search-box desktop-only">
+        <Search size={16} class="search-icon" />
+        <input
+          type="text"
+          placeholder="Search media..."
+          bind:value={$searchQuery}
+          on:input={() => {
+            if ($searchQuery.trim().length > 0 && $activeTab !== 'search') {
+              $activeTab = 'search';
+            }
+          }}
+        />
+        {#if $searchQuery}
+          <button class="clear-search" on:click={() => ($searchQuery = '')}>&times;</button>
+        {/if}
+      </div>
+
+      <!-- Mobile Search Toggle Icon -->
+      <button
+        class="btn-icon mobile-only"
+        on:click={toggleMobileSearch}
+        title="Search"
+      >
+        <Search size={18} />
+      </button>
+
+      <!-- PlayBridge Cast Status Icon Pill (Uses sleek icon instead of text) -->
+      <button
+        class="cast-icon-pill"
+        class:cast-active={$bridgeStatus.available}
+        on:click={() => ($isDiagnosticsOpen = true)}
+        title={$bridgeStatus.available
+          ? 'PlayBridge Bridge Active'
+          : 'PlayBridge Bridge not detected'}
+      >
+        <Cast size={17} class="cast-symbol" />
+        {#if $bridgeStatus.available}
+          <span class="pulsing-dot-inline"></span>
+        {/if}
+      </button>
+
+      <!-- Diagnostics Drawer Toggle -->
+      <button
+        class="btn-icon"
+        on:click={() => ($isDiagnosticsOpen = !$isDiagnosticsOpen)}
+        title="PlayBridge Diagnostics & Event Inspector"
+      >
+        <Activity size={18} />
+      </button>
+
+      <!-- Multi-Server & Multi-User Profile Menu -->
+      <div class="profile-container">
+        <button class="profile-btn" on:click={toggleProfileMenu}>
+          <div class="avatar">
+            <User size={15} />
+          </div>
+          <span class="server-badge desktop-only">
+            {$serverConfig.username || 'User'}
+          </span>
+        </button>
+
+        {#if showProfileMenu}
+          <div class="profile-dropdown" on:mouseleave={closeProfileMenu}>
+            <!-- Active Server / User Banner -->
+            <div class="dropdown-header">
+              <div class="active-badge-tag">ACTIVE SESSION</div>
+              <p class="user-title">{$serverConfig.username || 'Guest'}</p>
+              <p class="server-subtitle">{$serverConfig.serverName || 'Jellyfin Server'}</p>
+              {#if $serverConfig.url}
+                <p class="server-url-sub">{$serverConfig.url}</p>
+              {/if}
+            </div>
+
+            <!-- Multi-Server / Multi-User Switcher List -->
+            {#if $savedAccounts.length > 1}
+              <div class="dropdown-divider"></div>
+              <div class="section-label">SWITCH SERVER / USER</div>
+              <div class="saved-accounts-list">
+                {#each $savedAccounts as acc (acc.id)}
+                  {#if acc.id !== currentServerId}
+                    <div class="account-item-row">
+                      <button class="account-switch-btn" on:click={() => handleSwitch(acc)}>
+                        <div class="account-avatar-sm">
+                          {acc.username.slice(0, 2).toUpperCase()}
+                        </div>
+                        <div class="account-meta">
+                          <span class="account-user">{acc.username}</span>
+                          <span class="account-server">{acc.serverName}</span>
+                        </div>
+                      </button>
+                      <button
+                        class="account-del-btn"
+                        on:click|stopPropagation={() => handleRemoveAccount(acc.id)}
+                        title="Remove profile"
+                      >
+                        <Trash2 size={13} />
+                      </button>
+                    </div>
+                  {/if}
+                {/each}
+              </div>
+            {/if}
+
+            <div class="dropdown-divider"></div>
+
+            {#if !$serverConfig.isDemo}
+              <button class="dropdown-item" on:click={handleRefresh}>
+                <RefreshCw size={15} />
+                <span>Refresh Library</span>
+              </button>
+            {/if}
+
+            <button
+              class="dropdown-item"
+              on:click={() => {
+                $isServerModalOpen = true;
+                closeProfileMenu();
+              }}
+            >
+              <Plus size={15} />
+              <span>Add Server or User</span>
+            </button>
+
+            <button
+              class="dropdown-item"
+              on:click={() => {
+                loadDemoMode();
+                closeProfileMenu();
+              }}
+            >
+              <Sparkles size={15} />
+              <span>Explore Demo Library</span>
+              {#if $serverConfig.isDemo}
+                <Check size={15} class="check-icon" />
+              {/if}
+            </button>
+
+            <button
+              class="dropdown-item"
+              on:click={() => {
+                clearAppCache(false);
+                closeProfileMenu();
+              }}
+            >
+              <RotateCcw size={15} />
+              <span>Clear Cache & Re-sync</span>
+            </button>
+
+            <button
+              class="dropdown-item"
+              on:click={() => {
+                $isDiagnosticsOpen = true;
+                closeProfileMenu();
+              }}
+            >
+              <Activity size={15} />
+              <span>Diagnostics Log</span>
+            </button>
+
+            <div class="dropdown-divider"></div>
+
+            <button class="dropdown-item logout-item" on:click={handleLogout}>
+              <LogOut size={15} />
+              <span>Sign Out</span>
+            </button>
+          </div>
+        {/if}
+      </div>
+    </div>
+  {/if}
+</header>
+
+<!-- Mobile Bottom Navigation Bar (Thumb Friendly) -->
+<nav class="mobile-bottom-nav mobile-only">
+  <button
+    class="bottom-nav-item"
+    class:active={$activeTab === 'home'}
+    on:click={() => ($activeTab = 'home')}
+  >
+    <Home size={20} />
+    <span>Home</span>
+  </button>
+
+  <button
+    class="bottom-nav-item"
+    class:active={$activeTab === 'movies'}
+    on:click={() => ($activeTab = 'movies')}
+  >
+    <Film size={20} />
+    <span>Movies</span>
+  </button>
+
+  <button
+    class="bottom-nav-item"
+    class:active={$activeTab === 'shows'}
+    on:click={() => ($activeTab = 'shows')}
+  >
+    <Clapperboard size={20} />
+    <span>Shows</span>
+  </button>
+
+  <!-- If Music library exists, add direct tab -->
+  {#if musicViews.length > 0}
+    <button
+      class="bottom-nav-item"
+      class:active={$activeTab === musicViews[0].Id}
+      on:click={() => ($activeTab = musicViews[0].Id)}
+    >
+      <Music size={20} />
+      <span>Music</span>
+    </button>
+  {/if}
+
+  <button
+    class="bottom-nav-item"
+    class:active={$activeTab === 'favorites'}
+    on:click={() => ($activeTab = 'favorites')}
+  >
+    <Sparkles size={20} />
+    <span>Favs</span>
+  </button>
+
+  <button
+    class="bottom-nav-item"
+    class:active={$activeTab === 'search'}
+    on:click={() => {
+      $activeTab = 'search';
+      showMobileSearch = true;
+    }}
+  >
+    <Search size={20} />
+    <span>Search</span>
+  </button>
+</nav>
+
+<style>
+  .navbar {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 20px;
+    height: 64px;
+    background-color: rgba(10, 14, 20, 0.88);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-bottom: 1px solid var(--border);
+    gap: 16px;
+  }
+
+  .nav-left {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    user-select: none;
+    flex-shrink: 0;
+  }
+
+  .logo-icon {
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .brand-svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  .brand-text {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .brand-name {
+    font-size: 1.05rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    color: #ffffff;
+    line-height: 1.1;
+  }
+
+  .brand-sub {
+    font-size: 0.65rem;
+    color: var(--text-muted);
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .nav-links {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .nav-links::-webkit-scrollbar {
+    display: none;
+  }
+
+  .nav-link {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 12px;
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    border-radius: var(--radius-full);
+    transition: all 0.15s ease;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .nav-link:hover {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.05);
+  }
+
+  .nav-link.active {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.12);
+    font-weight: 600;
+  }
+
+  .more-views-container {
+    position: relative;
+  }
+
+  .more-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .more-views-dropdown {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    width: 200px;
+    background-color: var(--bg-surface-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    padding: 6px;
+    z-index: 60;
+    animation: fadeIn 0.15s ease;
+  }
+
+  .nav-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+    margin-left: auto;
+  }
+
+  .search-box {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  :global(.search-icon) {
+    position: absolute;
+    left: 12px;
+    color: var(--text-muted);
+    pointer-events: none;
+  }
+
+  .search-box input {
+    width: 170px;
+    height: 36px;
+    padding: 0 30px 0 34px;
+    font-size: 0.8rem;
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-full);
+    color: #ffffff;
+    transition: all 0.2s ease;
+  }
+
+  .search-box input:focus {
+    width: 220px;
+    outline: none;
+    border-color: var(--jf-blue);
+    background-color: var(--bg-surface-elevated);
+  }
+
+  .clear-search {
+    position: absolute;
+    right: 10px;
+    color: var(--text-muted);
+    font-size: 1.1rem;
+    line-height: 1;
+    padding: 2px;
+  }
+
+  .btn-icon {
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    color: var(--text-secondary);
+    background: transparent;
+    transition: all 0.15s ease;
+    flex-shrink: 0;
+  }
+
+  .btn-icon:hover {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.08);
+  }
+
+  /* Sleek Cast Icon Button */
+  .cast-icon-pill {
+    position: relative;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+  }
+
+  .cast-icon-pill:hover {
+    color: #fff;
+    background: var(--bg-surface-elevated);
+  }
+
+  .cast-icon-pill.cast-active {
+    color: var(--jf-purple);
+    border-color: rgba(122, 90, 248, 0.4);
+    background: rgba(122, 90, 248, 0.12);
+    box-shadow: 0 0 12px rgba(122, 90, 248, 0.3);
+  }
+
+  .pulsing-dot-inline {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background-color: var(--jf-purple);
+    box-shadow: 0 0 8px var(--jf-purple);
+    animation: pulse 1.8s infinite;
+  }
+
+  @keyframes pulse {
+    0% { transform: scale(0.9); opacity: 0.8; }
+    50% { transform: scale(1.3); opacity: 1; }
+    100% { transform: scale(0.9); opacity: 0.8; }
+  }
+
+  .profile-container {
+    position: relative;
+    flex-shrink: 0;
+  }
+
+  .profile-btn {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 10px 4px 4px;
+    border-radius: var(--radius-full);
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border);
+    transition: all 0.15s ease;
+  }
+
+  .profile-btn:hover {
+    background-color: var(--bg-surface-elevated);
+  }
+
+  .avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--jf-blue), var(--jf-purple));
+    color: #ffffff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: 700;
+  }
+
+  .server-badge {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .profile-dropdown {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    width: 260px;
+    background-color: var(--bg-surface-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    padding: 8px;
+    z-index: 60;
+    animation: fadeIn 0.15s ease;
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-6px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .dropdown-header {
+    padding: 10px 12px;
+  }
+
+  .active-badge-tag {
+    font-size: 0.65rem;
+    font-weight: 800;
+    color: var(--jf-blue);
+    letter-spacing: 0.06em;
+    margin-bottom: 4px;
+  }
+
+  .user-title {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: #ffffff;
+  }
+
+  .server-subtitle {
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    margin-top: 2px;
+  }
+
+  .server-url-sub {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    word-break: break-all;
+    margin-top: 2px;
+  }
+
+  .section-label {
+    font-size: 0.66rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    padding: 6px 12px 2px;
+    letter-spacing: 0.05em;
+  }
+
+  .saved-accounts-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .account-item-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-radius: var(--radius-sm);
+    transition: background 0.15s ease;
+  }
+
+  .account-item-row:hover {
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .account-switch-btn {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    padding: 6px 8px;
+    text-align: left;
+    min-width: 0;
+  }
+
+  .account-avatar-sm {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    color: var(--jf-blue);
+    font-size: 0.65rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .account-meta {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .account-user {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #fff;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .account-server {
+    font-size: 0.68rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .account-del-btn {
+    padding: 6px;
+    color: var(--text-muted);
+    border-radius: 50%;
+    margin-right: 4px;
+  }
+
+  .account-del-btn:hover {
+    color: #e74c3c;
+    background: rgba(231, 76, 60, 0.15);
+  }
+
+  .dropdown-divider {
+    height: 1px;
+    background-color: var(--border);
+    margin: 6px 0;
+  }
+
+  .dropdown-item {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    border-radius: var(--radius-sm);
+    transition: all 0.15s ease;
+  }
+
+  .dropdown-item:hover {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.06);
+  }
+
+  .dropdown-item.active-item {
+    color: var(--jf-blue);
+    font-weight: 600;
+  }
+
+  :global(.check-icon) {
+    margin-left: auto;
+    color: var(--jf-blue);
+  }
+
+  .logout-item:hover {
+    color: var(--status-error);
+    background-color: rgba(235, 87, 87, 0.1);
+  }
+
+  /* Mobile Search Bar */
+  .mobile-search-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    height: 100%;
+  }
+
+  :global(.search-bar-icon) {
+    color: var(--text-muted);
+  }
+
+  .mobile-search-bar input {
+    flex: 1;
+    height: 38px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-full);
+    padding: 0 14px;
+    color: #fff;
+    font-size: 0.9rem;
+  }
+
+  .clear-search-btn {
+    padding: 6px;
+    color: var(--text-muted);
+  }
+
+  .close-search-btn {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--jf-blue);
+    padding: 6px 8px;
+  }
+
+  /* Mobile Bottom Nav */
+  .mobile-bottom-nav {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: calc(56px + env(safe-area-inset-bottom, 0px));
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    background: rgba(10, 14, 20, 0.95);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border-top: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    z-index: 40;
+  }
+
+  .bottom-nav-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 3px;
+    flex: 1;
+    height: 100%;
+    color: var(--text-muted);
+    font-size: 0.68rem;
+    font-weight: 500;
+  }
+
+  .bottom-nav-item.active {
+    color: var(--jf-blue);
+    font-weight: 700;
+  }
+
+  /* Responsive Rules */
+  .desktop-only {
+    display: flex;
+  }
+  .mobile-only {
+    display: none;
+  }
+
+  @media (max-width: 768px) {
+    .desktop-only {
+      display: none !important;
+    }
+    .mobile-only {
+      display: flex !important;
+    }
+    .navbar {
+      padding: 0 16px;
+      height: 56px;
+    }
+  }
+</style>

--- a/web/jellyfin/src/lib/components/QueueDrawer.svelte
+++ b/web/jellyfin/src/lib/components/QueueDrawer.svelte
@@ -1,0 +1,396 @@
+<script lang="ts">
+  import {
+    activePlayer,
+    isQueueDrawerOpen,
+    isLyricsOpen,
+    lyricsData,
+    playQueueTrack,
+    toggleFavorite,
+    resolveItemPosterUrl
+  } from '../stores/appState';
+  import {
+    X,
+    Music,
+    Play,
+    Heart,
+    Trash2,
+    Mic2,
+    ListMusic,
+    Volume2
+  } from 'lucide-svelte';
+
+  let activeTab: 'queue' | 'lyrics' = 'queue';
+
+  $: playerState = $activePlayer;
+  $: playlist = playerState.playlist || [];
+  $: currentIndex = playerState.currentIndex ?? 0;
+  $: currentItem = playerState.item;
+  $: lyrics = $lyricsData;
+
+  function close() {
+    $isQueueDrawerOpen = false;
+  }
+</script>
+
+{#if $isQueueDrawerOpen}
+  <div class="drawer-backdrop" on:click={close}>
+    <div class="drawer-panel" on:click|stopPropagation>
+      <!-- Drawer Header -->
+      <div class="drawer-header">
+        <div class="tab-toggle-group">
+          <button
+            class="tab-btn"
+            class:active={activeTab === 'queue'}
+            on:click={() => (activeTab = 'queue')}
+          >
+            <ListMusic size={16} />
+            <span>Up Next ({playlist.length})</span>
+          </button>
+
+          {#if currentItem?.Type === 'Audio'}
+            <button
+              class="tab-btn"
+              class:active={activeTab === 'lyrics'}
+              on:click={() => (activeTab = 'lyrics')}
+            >
+              <Mic2 size={16} />
+              <span>Lyrics</span>
+            </button>
+          {/if}
+        </div>
+
+        <button class="icon-close-btn" on:click={close} aria-label="Close queue">
+          <X size={18} />
+        </button>
+      </div>
+
+      <!-- Drawer Content -->
+      <div class="drawer-body">
+        {#if activeTab === 'queue'}
+          {#if playlist.length === 0}
+            <div class="empty-queue">
+              <Music size={40} class="empty-icon" />
+              <p>Queue is empty</p>
+            </div>
+          {:else}
+            <div class="queue-list">
+              {#each playlist as track, index (track.Id + '-' + index)}
+                <div
+                  class="queue-row"
+                  class:active-track={index === currentIndex}
+                  on:click={() => playQueueTrack(index)}
+                >
+                  <div class="queue-track-left">
+                    <span class="track-idx">
+                      {#if index === currentIndex}
+                        <div class="equalizer-bars">
+                          <span class="bar bar1"></span>
+                          <span class="bar bar2"></span>
+                          <span class="bar bar3"></span>
+                        </div>
+                      {:else}
+                        {index + 1}
+                      {/if}
+                    </span>
+
+                    <div class="queue-thumb-wrapper">
+                      <img src={resolveItemPosterUrl(track)} alt={track.Name} class="queue-thumb" />
+                    </div>
+
+                    <div class="queue-info">
+                      <span class="queue-title">{track.Name}</span>
+                      <span class="queue-artist">
+                        {track.AlbumArtist || track.Artists?.[0] || track.SeriesName || ''}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div class="queue-actions" on:click|stopPropagation>
+                    <button
+                      class="fav-icon-btn"
+                      class:active-fav={track.UserData?.IsFavorite}
+                      on:click={() => toggleFavorite(track)}
+                      title="Favorite track"
+                    >
+                      <Heart size={15} fill={track.UserData?.IsFavorite ? 'currentColor' : 'none'} />
+                    </button>
+                  </div>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        {:else if activeTab === 'lyrics'}
+          <!-- Lyrics Screen (Finamp feature) -->
+          <div class="lyrics-container">
+            {#if lyrics && lyrics.Lyrics && lyrics.Lyrics.length > 0}
+              <div class="lyrics-lines">
+                {#each lyrics.Lyrics as line}
+                  <p class="lyrics-line">{line.Text}</p>
+                {/each}
+              </div>
+            {:else if lyrics && lyrics.Text}
+              <pre class="plain-lyrics">{lyrics.Text}</pre>
+            {:else}
+              <div class="empty-lyrics">
+                <Mic2 size={40} class="empty-icon" />
+                <p>No lyrics found for this song</p>
+              </div>
+            {/if}
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .drawer-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(4px);
+    z-index: 95;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .drawer-panel {
+    width: 400px;
+    max-width: 90vw;
+    height: 100%;
+    background: var(--bg-surface-elevated);
+    border-left: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    box-shadow: var(--shadow-lg);
+    animation: slideLeft 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  @keyframes slideLeft {
+    from { transform: translateX(100%); }
+    to { transform: translateX(0); }
+  }
+
+  .drawer-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 18px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .tab-toggle-group {
+    display: flex;
+    gap: 6px;
+    background: var(--bg-surface);
+    padding: 3px;
+    border-radius: var(--radius-full);
+    border: 1px solid var(--border);
+  }
+
+  .tab-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 12px;
+    border-radius: var(--radius-full);
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text-muted);
+  }
+
+  .tab-btn.active {
+    background: var(--jf-blue);
+    color: #fff;
+  }
+
+  .icon-close-btn {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+  }
+
+  .icon-close-btn:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .drawer-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px;
+  }
+
+  .empty-queue, .empty-lyrics {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 80px 20px;
+    color: var(--text-muted);
+  }
+
+  :global(.empty-icon) {
+    opacity: 0.4;
+    color: var(--jf-blue);
+  }
+
+  .queue-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .queue-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 10px;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: background 0.15s ease;
+  }
+
+  .queue-row:hover {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  .queue-row.active-track {
+    background: rgba(0, 164, 220, 0.15);
+    border: 1px solid rgba(0, 164, 220, 0.3);
+  }
+
+  .queue-track-left {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .track-idx {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    width: 22px;
+    text-align: center;
+    flex-shrink: 0;
+  }
+
+  .equalizer-bars {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 14px;
+    justify-content: center;
+  }
+
+  .bar {
+    width: 2px;
+    background: var(--jf-blue);
+    border-radius: 1px;
+    animation: eqBounce 1s infinite alternate ease-in-out;
+  }
+
+  .bar1 { height: 60%; animation-delay: 0.1s; }
+  .bar2 { height: 100%; animation-delay: 0.3s; }
+  .bar3 { height: 40%; animation-delay: 0.2s; }
+
+  @keyframes eqBounce {
+    0% { height: 20%; }
+    100% { height: 100%; }
+  }
+
+  .queue-thumb-wrapper {
+    width: 36px;
+    height: 36px;
+    border-radius: var(--radius-xs);
+    overflow: hidden;
+    flex-shrink: 0;
+    background: var(--bg-card);
+  }
+
+  .queue-thumb {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .queue-info {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .queue-title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #fff;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .queue-artist {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .queue-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .fav-icon-btn {
+    padding: 6px;
+    color: var(--text-muted);
+    border-radius: 50%;
+  }
+
+  .fav-icon-btn:hover {
+    color: #fff;
+  }
+
+  .fav-icon-btn.active-fav {
+    color: #e74c3c;
+  }
+
+  /* Lyrics View */
+  .lyrics-container {
+    padding: 20px 12px;
+  }
+
+  .lyrics-lines {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .lyrics-line {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    transition: color 0.2s ease;
+  }
+
+  .lyrics-line:hover {
+    color: #fff;
+  }
+
+  .plain-lyrics {
+    font-family: inherit;
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    line-height: 1.7;
+    white-space: pre-wrap;
+  }
+</style>

--- a/web/jellyfin/src/lib/components/ServerConnectModal.svelte
+++ b/web/jellyfin/src/lib/components/ServerConnectModal.svelte
@@ -1,0 +1,507 @@
+<script lang="ts">
+  import {
+    isServerModalOpen,
+    connectToJellyfinServer,
+    loadDemoMode,
+    isLoadingLibrary,
+    serverError,
+    savedAccounts,
+    switchAccount,
+    removeSavedAccount,
+    serverConfig
+  } from '../stores/appState';
+  import {
+    X,
+    Server,
+    Sparkles,
+    Lock,
+    User,
+    Globe,
+    AlertCircle,
+    Loader2,
+    Plus,
+    Trash2,
+    Check
+  } from 'lucide-svelte';
+
+  let serverUrl = 'http://10.8.0.6:8096';
+  let username = '';
+  let password = '';
+  let activeView: 'saved' | 'add' = 'add';
+
+  $: currentServerId = $serverConfig.url ? `${$serverConfig.url}_${$serverConfig.userId}` : '';
+  $: hasSavedAccounts = $savedAccounts.length > 0;
+
+  function close() {
+    $isServerModalOpen = false;
+  }
+
+  async function handleConnect() {
+    if (!serverUrl) return;
+    await connectToJellyfinServer(serverUrl, username, password);
+  }
+
+  function handleSwitch(acc: any) {
+    switchAccount(acc);
+    close();
+  }
+
+  function handleDemo() {
+    loadDemoMode();
+    close();
+  }
+</script>
+
+{#if $isServerModalOpen}
+  <div class="modal-backdrop" on:click={close}>
+    <div class="modal-container" on:click|stopPropagation>
+      <button class="modal-close-btn" on:click={close}>
+        <X size={20} />
+      </button>
+
+      <div class="modal-header">
+        <div class="header-icon">
+          <Server size={28} />
+        </div>
+        <h2 class="modal-title">Manage Jellyfin Servers & Profiles</h2>
+        <p class="modal-desc">
+          Add and switch between multiple servers or user accounts seamlessly.
+        </p>
+
+        {#if hasSavedAccounts}
+          <div class="tab-pill-group">
+            <button
+              class="tab-pill"
+              class:active={activeView === 'saved'}
+              on:click={() => (activeView = 'saved')}
+            >
+              Saved Profiles ({$savedAccounts.length})
+            </button>
+            <button
+              class="tab-pill"
+              class:active={activeView === 'add'}
+              on:click={() => (activeView = 'add')}
+            >
+              <Plus size={14} />
+              Add Server / User
+            </button>
+          </div>
+        {/if}
+      </div>
+
+      {#if $serverError}
+        <div class="error-banner">
+          <AlertCircle size={16} />
+          <span>{$serverError}</span>
+        </div>
+      {/if}
+
+      {#if activeView === 'saved' && hasSavedAccounts}
+        <!-- Saved Profiles List -->
+        <div class="saved-modal-list">
+          {#each $savedAccounts as acc (acc.id)}
+            <div class="saved-card" class:active-account={acc.id === currentServerId}>
+              <div class="saved-avatar">
+                {acc.username.slice(0, 2).toUpperCase()}
+              </div>
+
+              <div class="saved-meta" on:click={() => handleSwitch(acc)}>
+                <div class="saved-user-row">
+                  <span class="saved-name">{acc.username}</span>
+                  {#if acc.id === currentServerId}
+                    <span class="active-badge">ACTIVE</span>
+                  {/if}
+                </div>
+                <span class="saved-server">{acc.serverName}</span>
+                <span class="saved-url">{acc.url}</span>
+              </div>
+
+              <div class="saved-actions">
+                {#if acc.id !== currentServerId}
+                  <button class="btn-secondary switch-btn" on:click={() => handleSwitch(acc)}>
+                    Switch
+                  </button>
+                  <button
+                    class="del-btn"
+                    on:click={() => removeSavedAccount(acc.id)}
+                    title="Remove saved account"
+                  >
+                    <Trash2 size={15} />
+                  </button>
+                {:else}
+                  <span class="current-indicator">
+                    <Check size={16} />
+                  </span>
+                {/if}
+              </div>
+            </div>
+          {/each}
+        </div>
+      {:else}
+        <!-- Add Server / User Form -->
+        <form class="connect-form" on:submit|preventDefault={handleConnect}>
+          <div class="form-group">
+            <label for="server-url">Server Address</label>
+            <div class="input-wrapper">
+              <Globe size={16} class="input-icon" />
+              <input
+                id="server-url"
+                type="text"
+                placeholder="http://10.8.0.6:8096 or https://jellyfin.domain.com"
+                bind:value={serverUrl}
+                required
+              />
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label for="username">Username</label>
+            <div class="input-wrapper">
+              <User size={16} class="input-icon" />
+              <input
+                id="username"
+                type="text"
+                placeholder="Username"
+                bind:value={username}
+                required
+              />
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label for="password">Password (Optional)</label>
+            <div class="input-wrapper">
+              <Lock size={16} class="input-icon" />
+              <input
+                id="password"
+                type="password"
+                placeholder="••••••••"
+                bind:value={password}
+              />
+            </div>
+          </div>
+
+          <div class="form-actions">
+            <button type="submit" class="btn-primary form-btn" disabled={$isLoadingLibrary}>
+              {#if $isLoadingLibrary}
+                <Loader2 size={16} class="spinner" />
+                <span>Connecting...</span>
+              {:else}
+                <span>Connect & Save Server</span>
+              {/if}
+            </button>
+
+            <button type="button" class="btn-secondary form-btn" on:click={handleDemo}>
+              <Sparkles size={16} />
+              <span>Use Demo Mode</span>
+            </button>
+          </div>
+        </form>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.8);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    animation: fadeIn 0.2s ease;
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  .modal-container {
+    background-color: var(--bg-surface-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    width: 100%;
+    max-width: 500px;
+    max-height: 90vh;
+    overflow-y: auto;
+    position: relative;
+    padding: 32px;
+    box-shadow: var(--shadow-lg);
+  }
+
+  .modal-close-btn {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    color: var(--text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .modal-close-btn:hover {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+
+  .modal-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    margin-bottom: 20px;
+  }
+
+  .header-icon {
+    width: 52px;
+    height: 52px;
+    border-radius: var(--radius-lg);
+    background: rgba(0, 164, 220, 0.15);
+    color: var(--jf-blue);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 14px;
+    border: 1px solid rgba(0, 164, 220, 0.3);
+  }
+
+  .modal-title {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: #ffffff;
+    letter-spacing: -0.02em;
+  }
+
+  .modal-desc {
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    margin-top: 6px;
+    line-height: 1.45;
+  }
+
+  .tab-pill-group {
+    display: flex;
+    gap: 6px;
+    background: var(--bg-surface);
+    padding: 4px;
+    border-radius: var(--radius-full);
+    border: 1px solid var(--border);
+    margin-top: 14px;
+  }
+
+  .tab-pill {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border-radius: var(--radius-full);
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text-muted);
+  }
+
+  .tab-pill.active {
+    background: var(--jf-blue);
+    color: #fff;
+  }
+
+  .error-banner {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    background-color: rgba(235, 87, 87, 0.12);
+    border: 1px solid rgba(235, 87, 87, 0.3);
+    color: var(--status-error);
+    border-radius: var(--radius-md);
+    font-size: 0.82rem;
+    margin-bottom: 16px;
+  }
+
+  /* Saved list */
+  .saved-modal-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    max-height: 300px;
+    overflow-y: auto;
+  }
+
+  .saved-card {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    transition: all 0.15s ease;
+  }
+
+  .saved-card.active-account {
+    border-color: var(--jf-blue);
+    background: rgba(0, 164, 220, 0.08);
+  }
+
+  .saved-avatar {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--jf-blue), var(--jf-purple));
+    color: #fff;
+    font-size: 0.85rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .saved-meta {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    cursor: pointer;
+  }
+
+  .saved-user-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .saved-name {
+    font-size: 0.92rem;
+    font-weight: 700;
+    color: #fff;
+  }
+
+  .active-badge {
+    font-size: 0.62rem;
+    font-weight: 800;
+    color: var(--jf-blue);
+    background: rgba(0, 164, 220, 0.2);
+    padding: 1px 6px;
+    border-radius: var(--radius-full);
+  }
+
+  .saved-server {
+    font-size: 0.76rem;
+    color: var(--jf-indigo);
+  }
+
+  .saved-url {
+    font-size: 0.68rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .saved-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .switch-btn {
+    padding: 5px 12px;
+    font-size: 0.78rem;
+  }
+
+  .del-btn {
+    padding: 6px;
+    color: var(--text-muted);
+    border-radius: 50%;
+  }
+
+  .del-btn:hover {
+    color: #e74c3c;
+    background: rgba(231, 76, 60, 0.15);
+  }
+
+  .current-indicator {
+    color: var(--jf-blue);
+    padding: 6px;
+  }
+
+  /* Form */
+  .connect-form {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .form-group label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+  }
+
+  .input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  :global(.input-icon) {
+    position: absolute;
+    left: 12px;
+    color: var(--text-muted);
+    pointer-events: none;
+  }
+
+  .input-wrapper input {
+    width: 100%;
+    height: 42px;
+    padding: 0 14px 0 38px;
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    color: #ffffff;
+    font-size: 0.88rem;
+    transition: all 0.15s ease;
+  }
+
+  .input-wrapper input:focus {
+    outline: none;
+    border-color: var(--jf-blue);
+    background-color: rgba(255, 255, 255, 0.05);
+    box-shadow: 0 0 0 3px rgba(0, 164, 220, 0.15);
+  }
+
+  .form-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 8px;
+  }
+
+  .form-btn {
+    width: 100%;
+    height: 42px;
+    border-radius: var(--radius-md);
+    font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+</style>

--- a/web/jellyfin/src/lib/components/VideoPlayer.svelte
+++ b/web/jellyfin/src/lib/components/VideoPlayer.svelte
@@ -1,0 +1,1351 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import {
+    activePlayer,
+    playWithDirectCast,
+    serverConfig,
+    skipNextTrack,
+    skipPrevTrack,
+    resolveItemStreamUrl,
+    resolveItemPosterUrl,
+    resolveItemBackdropUrl,
+    isShuffle,
+    repeatMode,
+    isQueueDrawerOpen,
+    toggleShuffle,
+    cycleRepeatMode,
+    toggleFavorite
+  } from '../stores/appState';
+  import {
+    bridgeStatus,
+    activeLinkedSession,
+    addDiagnosticLog
+  } from '../cast/playbridge';
+  import * as jfApi from '../api/jellyfin';
+  import {
+    Play,
+    Pause,
+    RotateCcw,
+    RotateCw,
+    Volume2,
+    VolumeX,
+    Maximize,
+    Minimize,
+    Cast,
+    X,
+    ChevronUp,
+    ChevronDown,
+    SkipForward,
+    SkipBack,
+    Music,
+    Shuffle,
+    Repeat,
+    Repeat1,
+    ListMusic,
+    Heart,
+    Loader2,
+    Zap
+  } from 'lucide-svelte';
+
+  let moviEl: any;
+  let videoEl: HTMLVideoElement;
+  let audioEl: HTMLAudioElement;
+  let prebufferAudioEl: HTMLAudioElement;
+  let playerContainer: HTMLDivElement;
+
+  let isMoviLoaded = false;
+  let isMoviLoading = false;
+  let moviSupported = true;
+  let warmedUrl = '';
+
+  let isPlaying = false;
+  let currentTime = 0;
+  let duration = 0;
+  let volume = 1;
+  let isMuted = false;
+  let isFullscreen = false;
+  let showControls = true;
+  let hideControlsTimer: any;
+  let reportProgressTimer: any;
+
+  $: playerState = $activePlayer;
+  $: isCastingActive = playerState.isCasting;
+  $: isAudio = playerState.item?.Type === 'Audio';
+  $: hasPlaylist = (playerState.playlist?.length ?? 0) > 1;
+  $: isFavorite = !!playerState.item?.UserData?.IsFavorite;
+  $: posterUrl = playerState.item ? resolveItemPosterUrl(playerState.item) : '';
+  $: backdropUrl = playerState.item ? resolveItemBackdropUrl(playerState.item) : '';
+  $: authHeadersJson = JSON.stringify({
+    'X-Emby-Authorization': jfApi.getAuthHeader($serverConfig.token)
+  });
+
+  // Next Track / Item in playlist queue for pre-buffering
+  $: nextItem = (hasPlaylist && playerState.playlist && playerState.currentIndex != null)
+    ? playerState.playlist[playerState.currentIndex + 1]
+    : null;
+  $: nextStreamUrl = nextItem ? resolveItemStreamUrl(nextItem) : '';
+  $: nextPosterUrl = nextItem ? resolveItemPosterUrl(nextItem) : '';
+
+  // Pre-load next artwork image into browser cache
+  $: if (nextPosterUrl && typeof Image !== 'undefined') {
+    const img = new Image();
+    img.src = nextPosterUrl;
+  }
+
+  // Lazy-load movi-player on demand when video playback starts
+  $: if (playerState.isOpen && !isAudio && !isCastingActive && !isMoviLoaded && moviSupported && typeof window !== 'undefined') {
+    ensureMoviPlayer();
+  }
+
+  async function ensureMoviPlayer() {
+    if (typeof window === 'undefined') return;
+    if (customElements.get('movi-player')) {
+      isMoviLoaded = true;
+      return true;
+    }
+    isMoviLoading = true;
+    try {
+      // Dynamic on-demand code splitting chunk import
+      await import('movi-player/element');
+      isMoviLoaded = true;
+      return true;
+    } catch (err) {
+      console.warn('Movi player load failed or not supported, falling back to native video:', err);
+      moviSupported = false;
+      return false;
+    } finally {
+      isMoviLoading = false;
+    }
+  }
+
+  // Pre-buffer next media stream headers & first 1MB chunk into browser HTTP cache
+  function warmNextMedia(url: string) {
+    if (!url || warmedUrl === url || typeof fetch === 'undefined') return;
+    warmedUrl = url;
+    try {
+      fetch(url, {
+        method: 'GET',
+        headers: {
+          Range: 'bytes=0-1048576',
+          'X-Emby-Authorization': jfApi.getAuthHeader($serverConfig.token)
+        }
+      }).catch(() => {});
+    } catch {}
+  }
+
+  onMount(() => {
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+  });
+
+  onDestroy(() => {
+    document.removeEventListener('fullscreenchange', handleFullscreenChange);
+    clearInterval(reportProgressTimer);
+    clearTimeout(hideControlsTimer);
+  });
+
+  function handleFullscreenChange() {
+    isFullscreen = !!document.fullscreenElement;
+  }
+
+  function togglePlay() {
+    if (isCastingActive) {
+      isPlaying = !isPlaying;
+      addDiagnosticLog('info', `Cast Remote: Toggle Play (${isPlaying ? 'Playing' : 'Paused'})`);
+      return;
+    }
+    if (isAudio && audioEl) {
+      if (audioEl.paused) audioEl.play().catch(() => {});
+      else audioEl.pause();
+      return;
+    }
+    if (moviEl) {
+      if (moviEl.paused) moviEl.play().catch(() => {});
+      else moviEl.pause();
+      return;
+    }
+    if (videoEl) {
+      if (videoEl.paused) videoEl.play().catch(() => {});
+      else videoEl.pause();
+    }
+  }
+
+  function handleMediaEnded() {
+    addDiagnosticLog('info', `Playback ended for: ${playerState.title}`);
+    skipNextTrack();
+  }
+
+  function handleTimeUpdate() {
+    if (isAudio && audioEl) {
+      currentTime = audioEl.currentTime;
+      duration = audioEl.duration || 0;
+    } else if (moviEl) {
+      currentTime = moviEl.currentTime || 0;
+      duration = moviEl.duration || 0;
+    } else if (videoEl) {
+      currentTime = videoEl.currentTime || 0;
+      duration = videoEl.duration || 0;
+    }
+
+    // Pre-buffer next playlist item when approaching the end of current track or after 5 seconds of stable playback
+    if (nextStreamUrl && (currentTime > 5 || (duration > 0 && duration - currentTime <= 20))) {
+      warmNextMedia(nextStreamUrl);
+    }
+  }
+
+  function handleSeek(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const seekTime = parseFloat(target.value);
+    currentTime = seekTime;
+    if (isAudio && audioEl) {
+      audioEl.currentTime = seekTime;
+    } else if (moviEl) {
+      moviEl.currentTime = seekTime;
+    } else if (videoEl) {
+      videoEl.currentTime = seekTime;
+    }
+  }
+
+  function skip(seconds: number) {
+    if (isAudio && audioEl) {
+      audioEl.currentTime = Math.max(0, Math.min(duration, audioEl.currentTime + seconds));
+    } else if (moviEl) {
+      moviEl.currentTime = Math.max(0, Math.min(duration, moviEl.currentTime + seconds));
+    } else if (videoEl) {
+      videoEl.currentTime = Math.max(0, Math.min(duration, videoEl.currentTime + seconds));
+    }
+  }
+
+  function toggleMute() {
+    if (isAudio && audioEl) {
+      audioEl.muted = !audioEl.muted;
+      isMuted = audioEl.muted;
+    } else if (moviEl) {
+      moviEl.muted = !moviEl.muted;
+      isMuted = moviEl.muted;
+    } else if (videoEl) {
+      videoEl.muted = !videoEl.muted;
+      isMuted = videoEl.muted;
+    }
+  }
+
+  function handleVolumeChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    volume = parseFloat(target.value);
+    if (isAudio && audioEl) {
+      audioEl.volume = volume;
+      audioEl.muted = volume === 0;
+      isMuted = audioEl.muted;
+    } else if (moviEl) {
+      moviEl.volume = volume;
+      moviEl.muted = volume === 0;
+      isMuted = moviEl.muted;
+    } else if (videoEl) {
+      videoEl.volume = volume;
+      videoEl.muted = volume === 0;
+      isMuted = videoEl.muted;
+    }
+  }
+
+  function toggleFullscreen() {
+    if (!playerContainer) return;
+    if (!document.fullscreenElement) {
+      playerContainer.requestFullscreen().catch(() => {});
+    } else {
+      document.exitFullscreen().catch(() => {});
+    }
+  }
+
+  function handleMouseMove() {
+    showControls = true;
+    clearTimeout(hideControlsTimer);
+    hideControlsTimer = setTimeout(() => {
+      if (isPlaying) {
+        showControls = false;
+      }
+    }, 3500);
+  }
+
+  function minimizePlayer() {
+    activePlayer.update((s) => ({ ...s, isExpanded: false }));
+  }
+
+  function expandPlayer() {
+    activePlayer.update((s) => ({ ...s, isExpanded: true }));
+  }
+
+  function openQueue() {
+    $isQueueDrawerOpen = true;
+  }
+
+  function closePlayer() {
+    if (audioEl) audioEl.pause();
+    if (moviEl) moviEl.pause();
+    if (videoEl) videoEl.pause();
+
+    if (!$serverConfig.isDemo && playerState.item && $serverConfig.url) {
+      const ticks = Math.round(currentTime * 1000 * 10000);
+      jfApi.reportPlaybackStopped($serverConfig.url, $serverConfig.token, playerState.item.Id, ticks);
+    }
+
+    activePlayer.set({
+      isOpen: false,
+      isExpanded: false,
+      item: null,
+      streamUrl: '',
+      isCasting: false,
+      isLinkedCast: false,
+      title: '',
+      playlist: [],
+      currentIndex: 0
+    });
+  }
+
+  function triggerDirectCast() {
+    if (playerState.item) {
+      if (audioEl) audioEl.pause();
+      if (moviEl) moviEl.pause();
+      if (videoEl) videoEl.pause();
+      playWithDirectCast(playerState.item);
+    }
+  }
+
+  function disconnectCast() {
+    if ($activeLinkedSession) {
+      $activeLinkedSession.unlink().catch(() => {});
+      $activeLinkedSession = null;
+    }
+    activePlayer.update((state) => ({
+      ...state,
+      isCasting: false,
+      isLinkedCast: false
+    }));
+    if (isAudio && audioEl) {
+      audioEl.play().catch(() => {});
+    } else if (moviEl) {
+      moviEl.play().catch(() => {});
+    } else if (videoEl) {
+      videoEl.play().catch(() => {});
+    }
+  }
+
+  function formatTime(seconds: number): string {
+    if (isNaN(seconds) || seconds < 0) return '0:00';
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = Math.floor(seconds % 60);
+    if (h > 0) {
+      return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+    }
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  }
+</script>
+
+{#if playerState.isOpen}
+  <!-- ==================== ACTIVE & PRE-BUFFER AUDIO ELEMENTS ==================== -->
+  {#if isAudio && !isCastingActive}
+    <audio
+      bind:this={audioEl}
+      src={playerState.streamUrl}
+      autoplay
+      on:play={() => (isPlaying = true)}
+      on:pause={() => (isPlaying = false)}
+      on:timeupdate={handleTimeUpdate}
+      on:ended={handleMediaEnded}
+      class="hidden-audio-el"
+    ></audio>
+
+    <!-- Background Pre-Buffer Audio Element for Gapless Next Track Transition -->
+    {#if nextStreamUrl}
+      <audio
+        bind:this={prebufferAudioEl}
+        src={nextStreamUrl}
+        preload="auto"
+        class="hidden-audio-el"
+      ></audio>
+    {/if}
+  {/if}
+
+  <!-- ==================== MINI PLAYER BAR (Bottom Floating Dock) ==================== -->
+  {#if !playerState.isExpanded}
+    <div class="mini-player-bar" on:click={expandPlayer}>
+      <!-- Top Progress Line -->
+      {#if duration > 0}
+        <div class="mini-progress-track">
+          <div class="mini-progress-fill" style="width: {(currentTime / duration) * 100}%"></div>
+        </div>
+      {/if}
+
+      <!-- Left Media Info -->
+      <div class="mini-left">
+        {#if posterUrl}
+          <div class="mini-thumb-wrapper">
+            <img src={posterUrl} alt={playerState.title} class="mini-thumb" />
+          </div>
+        {/if}
+
+        <div class="mini-meta">
+          <div class="mini-title-row">
+            <span class="mini-title">{playerState.title}</span>
+            {#if isCastingActive}
+              <div class="mini-cast-indicator" title="Casting to PlayBridge">
+                <Cast size={15} class="cast-glow-icon" />
+              </div>
+            {/if}
+          </div>
+          {#if playerState.item?.AlbumArtist || (playerState.item?.Artists && playerState.item.Artists.length > 0)}
+            <span class="mini-sub">{playerState.item.AlbumArtist || playerState.item.Artists?.[0]}</span>
+          {:else if playerState.season && playerState.episode}
+            <span class="mini-sub">S{playerState.season}E{playerState.episode}</span>
+          {:else}
+            <span class="mini-sub">{isCastingActive ? 'PlayBridge Receiver' : (isAudio ? 'Audio Player' : 'Video Player')}</span>
+          {/if}
+        </div>
+      </div>
+
+      <!-- Right Controls -->
+      <div class="mini-controls" on:click|stopPropagation>
+        {#if playerState.item}
+          <button
+            class="mini-btn"
+            class:active-fav={isFavorite}
+            on:click={() => playerState.item && toggleFavorite(playerState.item)}
+            title="Favorite"
+          >
+            <Heart size={16} fill={isFavorite ? '#e74c3c' : 'none'} color={isFavorite ? '#e74c3c' : 'currentColor'} />
+          </button>
+        {/if}
+
+        {#if hasPlaylist}
+          <button class="mini-btn" on:click={skipPrevTrack} title="Previous track">
+            <SkipBack size={17} />
+          </button>
+        {/if}
+
+        <button class="mini-btn mini-play-btn" on:click={togglePlay} title={isPlaying ? 'Pause' : 'Play'}>
+          {#if isPlaying}
+            <Pause size={18} fill="currentColor" />
+          {:else}
+            <Play size={18} fill="currentColor" />
+          {/if}
+        </button>
+
+        {#if hasPlaylist}
+          <button class="mini-btn" on:click={skipNextTrack} title="Next track">
+            <SkipForward size={17} />
+          </button>
+        {/if}
+
+        {#if hasPlaylist}
+          <button class="mini-btn" on:click={openQueue} title="Queue & Lyrics">
+            <ListMusic size={17} />
+          </button>
+        {/if}
+
+        <button class="mini-btn mini-expand-btn" on:click={expandPlayer} title="Expand player">
+          <ChevronUp size={18} />
+        </button>
+
+        <button class="mini-btn mini-close-btn" on:click={closePlayer} title="Stop & close">
+          <X size={18} />
+        </button>
+      </div>
+    </div>
+  {/if}
+
+  <!-- ==================== FULL EXPANDED PLAYER OVERLAY ==================== -->
+  {#if playerState.isExpanded}
+    <div
+      class="player-overlay"
+      bind:this={playerContainer}
+      on:mousemove={handleMouseMove}
+    >
+      <!-- Top Header Bar Overlay -->
+      <div class="player-top-bar" class:visible={showControls || !isPlaying || isCastingActive}>
+        <button class="icon-btn-large" on:click={minimizePlayer} title="Minimize to mini-player (keep browsing)">
+          <ChevronDown size={22} />
+        </button>
+
+        <div class="title-group">
+          <h3 class="playing-title">{playerState.title}</h3>
+          {#if playerState.season && playerState.episode}
+            <span class="playing-sub">Season {playerState.season} &bull; Episode {playerState.episode}</span>
+          {:else if playerState.item?.AlbumArtist || (playerState.item?.Artists && playerState.item.Artists.length > 0)}
+            <span class="playing-sub">{playerState.item.AlbumArtist || playerState.item.Artists?.[0]}</span>
+          {/if}
+        </div>
+
+        <div class="top-actions">
+          {#if hasPlaylist}
+            <button class="queue-counter-btn" on:click={openQueue} title="View Queue & Lyrics">
+              <ListMusic size={16} />
+              <span>{((playerState.currentIndex ?? 0) + 1)} / {playerState.playlist?.length}</span>
+            </button>
+          {/if}
+
+          {#if !isCastingActive}
+            <button class="cast-btn" on:click={triggerDirectCast} title="Switch to PlayBridge Casting">
+              <Cast size={16} />
+              <span>Cast to TV</span>
+            </button>
+          {:else}
+            <button class="cast-btn active-cast" on:click={disconnectCast} title="Disconnect cast">
+              <Cast size={16} />
+              <span>Casting Active</span>
+            </button>
+          {/if}
+
+          <button class="icon-btn-large" on:click={closePlayer} title="Stop and Close Player">
+            <X size={22} />
+          </button>
+        </div>
+      </div>
+
+      <!-- Center Player Body -->
+      {#if isCastingActive}
+        <!-- Cast HUD (Playing on TV Receiver) -->
+        <div class="cast-hud-container">
+          <div class="cast-poster-card">
+            {#if posterUrl}
+              <img src={posterUrl} alt={playerState.title} class="cast-hud-poster" />
+            {/if}
+            <div class="cast-hud-glow"></div>
+          </div>
+
+          <div class="cast-status-card">
+            <div class="cast-signal-row">
+              <div class="tv-icon-wrapper">
+                <Cast size={32} class="tv-icon" />
+                <span class="radar-pulse"></span>
+              </div>
+              <div class="signal-details">
+                <h4>Streaming to PlayBridge Receiver</h4>
+                <p class="signal-url">{playerState.streamUrl}</p>
+              </div>
+            </div>
+
+            <div class="cast-actions-row">
+              <button class="btn-accent" on:click={minimizePlayer}>
+                <span>Browse Library</span>
+              </button>
+              <button class="btn-secondary" on:click={disconnectCast}>
+                <span>Play on This Screen</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      {:else if isAudio}
+        <!-- Audio Fullscreen Player HUD (Finamp Aesthetic) -->
+        <div class="audio-hud-container">
+          {#if backdropUrl}
+            <div class="audio-bg-blur" style="background-image: url('{backdropUrl}')"></div>
+          {/if}
+
+          <div class="audio-card">
+            <div class="audio-artwork-wrapper">
+              {#if posterUrl}
+                <img src={posterUrl} alt={playerState.title} class="audio-artwork" />
+              {:else}
+                <div class="audio-placeholder">
+                  <Music size={64} />
+                </div>
+              {/if}
+            </div>
+
+            <div class="audio-meta">
+              <div class="audio-title-fav-row">
+                <h2 class="audio-title">{playerState.title}</h2>
+                {#if playerState.item}
+                  <button
+                    class="fav-btn-round"
+                    class:active-fav={isFavorite}
+                    on:click={() => playerState.item && toggleFavorite(playerState.item)}
+                    title="Favorite"
+                  >
+                    <Heart size={20} fill={isFavorite ? '#e74c3c' : 'none'} color={isFavorite ? '#e74c3c' : 'currentColor'} />
+                  </button>
+                {/if}
+              </div>
+              <p class="audio-artist">
+                {playerState.item?.AlbumArtist || playerState.item?.Artists?.[0] || 'Unknown Artist'}
+              </p>
+              {#if playerState.item?.Album}
+                <p class="audio-album">{playerState.item.Album}</p>
+              {/if}
+
+              <!-- Pre-buffer / Up Next indicator -->
+              {#if nextItem}
+                <div class="next-up-indicator">
+                  <Zap size={12} class="zap-icon" />
+                  <span>Next: {nextItem.Name}</span>
+                </div>
+              {/if}
+            </div>
+
+            <!-- Scrubber -->
+            <div class="audio-scrubber-box">
+              <input
+                type="range"
+                min="0"
+                max={duration || 100}
+                value={currentTime}
+                on:input={handleSeek}
+                class="scrubber-range"
+              />
+              <div class="time-display">
+                <span>{formatTime(currentTime)}</span>
+                <span>{formatTime(duration)}</span>
+              </div>
+            </div>
+
+            <!-- Finamp Music Controls: Shuffle, Prev, Play, Next, Repeat -->
+            <div class="audio-controls-row">
+              <button
+                class="mode-icon-btn"
+                class:active-mode={$isShuffle}
+                on:click={toggleShuffle}
+                title="Shuffle"
+              >
+                <Shuffle size={20} />
+              </button>
+
+              {#if hasPlaylist}
+                <button class="control-icon-btn" on:click={skipPrevTrack} title="Previous track">
+                  <SkipBack size={24} />
+                </button>
+              {/if}
+
+              <button class="play-toggle-btn-large" on:click={togglePlay}>
+                {#if isPlaying}
+                  <Pause size={28} fill="currentColor" />
+                {:else}
+                  <Play size={28} fill="currentColor" />
+                {/if}
+              </button>
+
+              {#if hasPlaylist}
+                <button class="control-icon-btn" on:click={skipNextTrack} title="Next track">
+                  <SkipForward size={24} />
+                </button>
+              {/if}
+
+              <button
+                class="mode-icon-btn"
+                class:active-mode={$repeatMode !== 'off'}
+                on:click={cycleRepeatMode}
+                title="Repeat Mode ({$repeatMode})"
+              >
+                {#if $repeatMode === 'one'}
+                  <Repeat1 size={20} />
+                {:else}
+                  <Repeat size={20} />
+                {/if}
+              </button>
+            </div>
+          </div>
+        </div>
+      {:else}
+        <!-- Video Player: Dynamic Movi Player with Native Hardware Video Fallback -->
+        {#if isMoviLoading}
+          <div class="video-loading-box">
+            <Loader2 size={40} class="spinner" />
+            <p>Initializing high-performance player engine...</p>
+          </div>
+        {:else if isMoviLoaded && moviSupported}
+          <div class="movi-player-wrapper">
+            <movi-player
+              bind:this={moviEl}
+              src={playerState.streamUrl}
+              poster={posterUrl}
+              title={playerState.title}
+              controls
+              autoplay
+              playsinline
+              theme="dark"
+              themecolor="#00A4DC #7A5AF8"
+              ambientmode
+              headers={authHeadersJson}
+              on:play={() => (isPlaying = true)}
+              on:pause={() => (isPlaying = false)}
+              on:timeupdate={handleTimeUpdate}
+              on:ended={handleMediaEnded}
+              class="movi-element"
+            ></movi-player>
+          </div>
+        {:else}
+          <div class="video-player-container">
+            <video
+              bind:this={videoEl}
+              src={playerState.streamUrl}
+              poster={posterUrl}
+              autoplay
+              playsinline
+              controls
+              on:play={() => (isPlaying = true)}
+              on:pause={() => (isPlaying = false)}
+              on:timeupdate={handleTimeUpdate}
+              on:ended={handleMediaEnded}
+              class="native-video-el"
+            >
+              <track kind="captions" />
+            </video>
+          </div>
+        {/if}
+      {/if}
+    </div>
+  {/if}
+{/if}
+
+<style>
+  .hidden-audio-el {
+    display: none;
+  }
+
+  /* ==================== MINI PLAYER BAR ==================== */
+  .mini-player-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 64px;
+    background: rgba(14, 17, 24, 0.95);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border-top: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 18px;
+    z-index: 45;
+    cursor: pointer;
+    box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.5);
+    transition: transform 0.2s ease;
+  }
+
+  .mini-progress-track {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .mini-progress-fill {
+    height: 100%;
+    background: var(--jf-blue);
+  }
+
+  .mini-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .mini-thumb-wrapper {
+    position: relative;
+    width: 42px;
+    height: 42px;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    flex-shrink: 0;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+  }
+
+  .mini-thumb {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .mini-meta {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .mini-title-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .mini-title {
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: #fff;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .mini-cast-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--jf-purple);
+    filter: drop-shadow(0 0 6px rgba(122, 90, 248, 0.8));
+    animation: pulseCast 2s infinite ease-in-out;
+  }
+
+  @keyframes pulseCast {
+    0% { transform: scale(0.95); opacity: 0.8; }
+    50% { transform: scale(1.1); opacity: 1; }
+    100% { transform: scale(0.95); opacity: 0.8; }
+  }
+
+  .mini-sub {
+    font-size: 0.74rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-top: 1px;
+  }
+
+  .mini-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .mini-btn {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+  }
+
+  .mini-btn:hover {
+    color: #fff;
+    background: var(--bg-surface-elevated);
+  }
+
+  .mini-btn.active-fav {
+    color: #e74c3c;
+    border-color: rgba(231, 76, 60, 0.3);
+  }
+
+  .mini-play-btn {
+    background: var(--jf-blue);
+    color: #fff;
+    border-color: transparent;
+  }
+
+  .mini-play-btn:hover {
+    filter: brightness(1.1);
+  }
+
+  .mini-close-btn:hover {
+    background: var(--status-error);
+    border-color: transparent;
+    color: #fff;
+  }
+
+  @media (max-width: 768px) {
+    .mini-player-bar {
+      bottom: calc(56px + env(safe-area-inset-bottom, 0px));
+      height: 56px;
+      padding: 0 12px;
+    }
+    .mini-thumb-wrapper {
+      width: 36px;
+      height: 36px;
+    }
+    .mini-expand-btn {
+      display: none;
+    }
+  }
+
+  /* ==================== FULL EXPANDED PLAYER OVERLAY ==================== */
+  .player-overlay {
+    position: fixed;
+    inset: 0;
+    background: #000000;
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    overflow: hidden;
+  }
+
+  .player-top-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    padding: 16px 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.85) 0%, transparent 100%);
+    z-index: 30;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+  }
+
+  .player-top-bar.visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .title-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    max-width: 50%;
+  }
+
+  .playing-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #fff;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .playing-sub {
+    font-size: 0.76rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .top-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .queue-counter-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--text-secondary);
+    padding: 6px 10px;
+    border-radius: var(--radius-full);
+    font-size: 0.75rem;
+    font-weight: 600;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  .queue-counter-btn:hover {
+    background: rgba(255, 255, 255, 0.2);
+    color: #fff;
+  }
+
+  .icon-btn-large {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+  }
+
+  .icon-btn-large:hover {
+    background: rgba(255, 255, 255, 0.25);
+  }
+
+  .cast-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 12px;
+    border-radius: var(--radius-full);
+    font-size: 0.8rem;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+  }
+
+  .cast-btn.active-cast {
+    background: rgba(122, 90, 248, 0.25);
+    border-color: var(--jf-purple);
+    color: var(--jf-indigo);
+  }
+
+  /* Movi Player Element Container */
+  .movi-player-wrapper {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    background: #000;
+  }
+
+  :global(movi-player) {
+    width: 100% !important;
+    height: 100% !important;
+    display: block;
+  }
+
+  .video-loading-box {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    color: var(--text-secondary);
+    background: #000;
+  }
+
+  .spinner {
+    animation: spin 1s linear infinite;
+    color: var(--jf-blue);
+  }
+
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+
+  /* Video Player Container */
+  .video-player-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    background: #000;
+  }
+
+  .native-video-el {
+    width: 100%;
+    height: 100%;
+    max-height: 100vh;
+    object-fit: contain;
+  }
+
+  /* Audio HUD Fullscreen Player */
+  .audio-hud-container {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 40px 20px;
+    overflow: hidden;
+  }
+
+  .audio-bg-blur {
+    position: absolute;
+    inset: -40px;
+    background-size: cover;
+    background-position: center;
+    filter: blur(50px) brightness(0.25);
+    transform: scale(1.1);
+  }
+
+  .audio-card {
+    position: relative;
+    z-index: 10;
+    max-width: 420px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+    background: rgba(20, 24, 33, 0.85);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    padding: 30px 28px;
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.7);
+  }
+
+  .audio-artwork-wrapper {
+    width: 200px;
+    height: 200px;
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.6);
+  }
+
+  .audio-artwork {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .audio-placeholder {
+    width: 100%;
+    height: 100%;
+    background: var(--bg-surface);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--jf-blue);
+  }
+
+  .audio-meta {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    width: 100%;
+  }
+
+  .audio-title-fav-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+  }
+
+  .audio-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #fff;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .fav-btn-round {
+    padding: 6px;
+    border-radius: 50%;
+    color: var(--text-muted);
+  }
+
+  .fav-btn-round:hover {
+    color: #fff;
+  }
+
+  .fav-btn-round.active-fav {
+    color: #e74c3c;
+  }
+
+  .audio-artist {
+    font-size: 0.92rem;
+    color: var(--jf-indigo);
+    font-weight: 600;
+  }
+
+  .audio-album {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+  }
+
+  .next-up-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--jf-blue);
+    background: rgba(0, 164, 220, 0.12);
+    border: 1px solid rgba(0, 164, 220, 0.25);
+    padding: 3px 10px;
+    border-radius: var(--radius-full);
+    margin-top: 4px;
+    align-self: center;
+  }
+
+  :global(.zap-icon) {
+    animation: zapPulse 1.5s infinite ease-in-out;
+  }
+
+  @keyframes zapPulse {
+    0%, 100% { transform: scale(1); opacity: 0.8; }
+    50% { transform: scale(1.2); opacity: 1; }
+  }
+
+  .audio-scrubber-box {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .scrubber-range {
+    width: 100%;
+    height: 4px;
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: var(--radius-full);
+    outline: none;
+    cursor: pointer;
+  }
+
+  .time-display {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+  }
+
+  .audio-controls-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 0 8px;
+  }
+
+  .mode-icon-btn {
+    padding: 8px;
+    border-radius: 50%;
+    color: var(--text-muted);
+    background: transparent;
+  }
+
+  .mode-icon-btn:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .mode-icon-btn.active-mode {
+    color: var(--jf-blue);
+    background: rgba(0, 164, 220, 0.15);
+  }
+
+  .control-icon-btn {
+    color: #fff;
+    padding: 8px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .control-icon-btn:hover {
+    color: var(--jf-blue);
+    background: rgba(255, 255, 255, 0.15);
+  }
+
+  .play-toggle-btn-large {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: var(--jf-blue);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 16px rgba(0, 164, 220, 0.4);
+    transition: transform 0.15s ease;
+  }
+
+  .play-toggle-btn-large:hover {
+    transform: scale(1.08);
+  }
+
+  /* Cast HUD */
+  .cast-hud-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 28px;
+    padding: 32px 20px;
+  }
+
+  .cast-poster-card {
+    position: relative;
+    width: 180px;
+    aspect-ratio: 2 / 3;
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.8);
+    border: 1px solid var(--border);
+  }
+
+  .cast-hud-poster {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .cast-status-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 24px 28px;
+    max-width: 480px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .cast-signal-row {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  .tv-icon-wrapper {
+    position: relative;
+    width: 54px;
+    height: 54px;
+    border-radius: var(--radius-md);
+    background: rgba(122, 90, 248, 0.15);
+    border: 1px solid rgba(122, 90, 248, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--jf-purple);
+  }
+
+  .radar-pulse {
+    position: absolute;
+    inset: -6px;
+    border-radius: var(--radius-md);
+    border: 2px solid var(--jf-purple);
+    animation: radarPulse 2s infinite;
+    opacity: 0;
+  }
+
+  @keyframes radarPulse {
+    0% { transform: scale(0.9); opacity: 0.8; }
+    100% { transform: scale(1.3); opacity: 0; }
+  }
+
+  .signal-details h4 {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #fff;
+  }
+
+  .signal-url {
+    font-size: 0.74rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    word-break: break-all;
+    margin-top: 2px;
+  }
+
+  .cast-actions-row {
+    display: flex;
+    gap: 10px;
+  }
+
+  .cast-actions-row button {
+    flex: 1;
+  }
+</style>

--- a/web/jellyfin/src/lib/data/demoData.ts
+++ b/web/jellyfin/src/lib/data/demoData.ts
@@ -1,0 +1,288 @@
+import type { JellyfinItem } from '../types';
+
+const GTV = 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/';
+const MUX_HLS = 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8';
+const TEARS_HLS = 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8';
+
+export const DEMO_MOVIES: JellyfinItem[] = [
+  {
+    Id: 'demo-movie-1',
+    Name: 'Big Buck Bunny',
+    Type: 'Movie',
+    ProductionYear: 2008,
+    CommunityRating: 8.4,
+    OfficialRating: 'G',
+    RunTimeTicks: 5960000000, // ~9.9 mins
+    Overview: 'A large and lovable rabbit takes poetic, gentle revenge on three forest bullies—a flying squirrel and two sneaky rodents—who destroy his forest tranquility and kill two innocent butterflies.',
+    Taglines: ['A large rabbit with an even bigger heart'],
+    Genres: ['Animation', 'Comedy', 'Family'],
+    streamUrl: GTV + 'BigBuckBunny.mp4',
+    posterUrl: GTV + 'images/BigBuckBunny.jpg',
+    backdropUrl: 'https://images.unsplash.com/photo-1579783902614-a3fb3927b675?auto=format&fit=crop&w=1600&q=80',
+    MediaStreams: [
+      { Type: 'Video', Codec: 'h264', DisplayTitle: '1080p H.264', Height: 1080, Width: 1920, AspectRatio: '16:9', AverageFrameRate: 24 },
+      { Type: 'Audio', Codec: 'aac', Language: 'eng', DisplayTitle: 'English (AAC 5.1)', Channels: 6 }
+    ],
+    UserData: { PlaybackPositionTicks: 1200000000, Played: false, IsFavorite: true }
+  },
+  {
+    Id: 'demo-movie-2',
+    Name: 'Sintel',
+    Type: 'Movie',
+    ProductionYear: 2010,
+    CommunityRating: 8.8,
+    OfficialRating: 'PG-13',
+    RunTimeTicks: 8880000000, // ~14.8 mins
+    Overview: 'A lonely young woman named Sintel embarks on a perilous and tragic quest across a harsh desert world to rescue her companion, a tiny dragon she nursed back to health called Scales.',
+    Taglines: ['The search for a lost friend leads to an unforeseen fate'],
+    Genres: ['Animation', 'Fantasy', 'Action', 'Drama'],
+    streamUrl: GTV + 'Sintel.mp4',
+    posterUrl: GTV + 'images/Sintel.jpg',
+    backdropUrl: 'https://images.unsplash.com/photo-1518709268805-4e9042af9f23?auto=format&fit=crop&w=1600&q=80',
+    MediaStreams: [
+      { Type: 'Video', Codec: 'h264', DisplayTitle: '4K Ultra HD (H.264)', Height: 2160, Width: 3840, AspectRatio: '16:9', AverageFrameRate: 24 },
+      { Type: 'Audio', Codec: 'ac3', Language: 'eng', DisplayTitle: 'English (Dolby Digital 5.1)', Channels: 6 },
+      { Type: 'Subtitle', Codec: 'subrip', Language: 'eng', DisplayTitle: 'English [CC]' }
+    ],
+    UserData: { PlaybackPositionTicks: 0, Played: false, IsFavorite: true }
+  },
+  {
+    Id: 'demo-movie-3',
+    Name: 'Tears of Steel',
+    Type: 'Movie',
+    ProductionYear: 2012,
+    CommunityRating: 8.1,
+    OfficialRating: 'PG-13',
+    RunTimeTicks: 7340000000, // ~12.2 mins
+    Overview: 'Set in a dystopian future Amsterdam, a squad of human warriors and scientists attempt to rewrite the past in a desperate bid to rescue the Earth from a destructive army of sentient cyborg robots.',
+    Taglines: ['Exploring a dystopian future where humanity and cybernetics collide'],
+    Genres: ['Sci-Fi', 'VFX Showcase', 'Cyberpunk'],
+    streamUrl: GTV + 'TearsOfSteel.mp4',
+    posterUrl: GTV + 'images/TearsOfSteel.jpg',
+    backdropUrl: 'https://images.unsplash.com/photo-1509198397868-475647b2a1e5?auto=format&fit=crop&w=1600&q=80',
+    MediaStreams: [
+      { Type: 'Video', Codec: 'h264', DisplayTitle: '4K CinemaScope (H.264)', Height: 1714, Width: 4096, AspectRatio: '2.39:1', AverageFrameRate: 24 },
+      { Type: 'Audio', Codec: 'dts', Language: 'eng', DisplayTitle: 'English (DTS-HD 7.1)', Channels: 8 }
+    ],
+    UserData: { PlaybackPositionTicks: 0, Played: true, IsFavorite: false }
+  },
+  {
+    Id: 'demo-movie-4',
+    Name: 'Elephants Dream',
+    Type: 'Movie',
+    ProductionYear: 2006,
+    CommunityRating: 7.9,
+    OfficialRating: 'PG',
+    RunTimeTicks: 6540000000, // ~10.9 mins
+    Overview: 'Two eccentric wanderers—Proog, the seasoned elder guide, and Emo, the sceptical youth—explore the surreal and infinite mechanical workings of a gigantic living machine universe.',
+    Taglines: ['The world is a machine created by human thought'],
+    Genres: ['Animation', 'Surrealism', 'Sci-Fi'],
+    streamUrl: GTV + 'ElephantsDream.mp4',
+    posterUrl: GTV + 'images/ElephantsDream.jpg',
+    backdropUrl: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?auto=format&fit=crop&w=1600&q=80',
+    MediaStreams: [
+      { Type: 'Video', Codec: 'h264', DisplayTitle: '1080p H.264', Height: 1080, Width: 1920, AspectRatio: '16:9' },
+      { Type: 'Audio', Codec: 'aac', Language: 'eng', DisplayTitle: 'English (AAC 5.1)', Channels: 6 }
+    ],
+    UserData: { PlaybackPositionTicks: 3100000000, Played: false, IsFavorite: false }
+  },
+  {
+    Id: 'demo-movie-5',
+    Name: 'Mux HLS Adaptive Test',
+    Type: 'Movie',
+    ProductionYear: 2024,
+    CommunityRating: 9.0,
+    OfficialRating: 'NR',
+    RunTimeTicks: 18000000000,
+    Overview: 'High-performance multi-bitrate HLS adaptive stream from Mux. Exercises seamless resolution switching, segment caching, and native PlayBridge receiver stream demuxing.',
+    Taglines: ['Multi-bitrate adaptive live HLS stream'],
+    Genres: ['Live Test', 'HLS Stream', 'Adaptive Bitrate'],
+    streamUrl: MUX_HLS,
+    posterUrl: GTV + 'images/ForBiggerBlazes.jpg',
+    backdropUrl: 'https://images.unsplash.com/photo-1478760329108-5c3ed9d495a0?auto=format&fit=crop&w=1600&q=80',
+    MediaStreams: [
+      { Type: 'Video', Codec: 'h264', DisplayTitle: 'HLS 1080p/720p/480p Adaptive', Height: 1080, Width: 1920 },
+      { Type: 'Audio', Codec: 'aac', Language: 'eng', DisplayTitle: 'Stereo AAC 192kbps', Channels: 2 }
+    ],
+    UserData: { PlaybackPositionTicks: 0, Played: false, IsFavorite: true }
+  }
+];
+
+export const DEMO_SHOWS: JellyfinItem[] = [
+  {
+    Id: 'demo-series-1',
+    Name: 'Chronicles of the Open Canvas',
+    Type: 'Series',
+    ProductionYear: 2023,
+    CommunityRating: 9.3,
+    OfficialRating: 'TV-14',
+    Overview: 'An anthology series tracking visionary open-source CGI creators as they push the limits of computer animation, digital cinematography, and narrative storytelling.',
+    Taglines: ['Stories told through the lens of pure open creativity'],
+    Genres: ['Documentary', 'Animation', 'Technology', 'Sci-Fi'],
+    posterUrl: 'https://images.unsplash.com/photo-1536440136628-849c177e76a1?auto=format&fit=crop&w=600&q=80',
+    backdropUrl: 'https://images.unsplash.com/photo-1518709268805-4e9042af9f23?auto=format&fit=crop&w=1600&q=80',
+    seasons: [
+      {
+        Id: 'demo-season-1',
+        Name: 'Season 1',
+        IndexNumber: 1,
+        SeriesId: 'demo-series-1',
+        Episodes: [
+          {
+            Id: 'demo-ep-101',
+            Name: 'The Awakening Rabbit',
+            Type: 'Episode',
+            IndexNumber: 1,
+            ParentIndexNumber: 1,
+            SeriesName: 'Chronicles of the Open Canvas',
+            SeriesId: 'demo-series-1',
+            SeasonName: 'Season 1',
+            SeasonId: 'demo-season-1',
+            RunTimeTicks: 5960000000,
+            Overview: 'The forest comes alive as a gentle giant discovers malicious tricks plotted by rival rodents.',
+            streamUrl: GTV + 'BigBuckBunny.mp4',
+            posterUrl: GTV + 'images/BigBuckBunny.jpg',
+            backdropUrl: GTV + 'images/BigBuckBunny.jpg',
+            UserData: { Played: true }
+          },
+          {
+            Id: 'demo-ep-102',
+            Name: 'The Dreamer’s Machine',
+            Type: 'Episode',
+            IndexNumber: 2,
+            ParentIndexNumber: 1,
+            SeriesName: 'Chronicles of the Open Canvas',
+            SeriesId: 'demo-series-1',
+            SeasonName: 'Season 1',
+            SeasonId: 'demo-season-1',
+            RunTimeTicks: 6540000000,
+            Overview: 'Proog leads Emo through the clockwork labyrinth of a colossal thinking machine.',
+            streamUrl: GTV + 'ElephantsDream.mp4',
+            posterUrl: GTV + 'images/ElephantsDream.jpg',
+            backdropUrl: GTV + 'images/ElephantsDream.jpg',
+            UserData: { PlaybackPositionTicks: 2400000000, Played: false }
+          },
+          {
+            Id: 'demo-ep-103',
+            Name: 'Wings of Winter',
+            Type: 'Episode',
+            IndexNumber: 3,
+            ParentIndexNumber: 1,
+            SeriesName: 'Chronicles of the Open Canvas',
+            SeriesId: 'demo-series-1',
+            SeasonName: 'Season 1',
+            SeasonId: 'demo-season-1',
+            RunTimeTicks: 8880000000,
+            Overview: 'Across snowcapped peaks and dangerous ravines, the hunt for the missing baby dragon reaches its climax.',
+            streamUrl: GTV + 'Sintel.mp4',
+            posterUrl: GTV + 'images/Sintel.jpg',
+            backdropUrl: GTV + 'images/Sintel.jpg',
+            UserData: { Played: false }
+          }
+        ]
+      },
+      {
+        Id: 'demo-season-2',
+        Name: 'Season 2: Cyber Future',
+        IndexNumber: 2,
+        SeriesId: 'demo-series-1',
+        Episodes: [
+          {
+            Id: 'demo-ep-201',
+            Name: 'Cyborg Dawn',
+            Type: 'Episode',
+            IndexNumber: 1,
+            ParentIndexNumber: 2,
+            SeriesName: 'Chronicles of the Open Canvas',
+            SeriesId: 'demo-series-1',
+            SeasonName: 'Season 2: Cyber Future',
+            SeasonId: 'demo-season-2',
+            RunTimeTicks: 7340000000,
+            Overview: 'Humanity prepares for its final stand in futuristic Amsterdam using temporal rewinding.',
+            streamUrl: GTV + 'TearsOfSteel.mp4',
+            posterUrl: GTV + 'images/TearsOfSteel.jpg',
+            backdropUrl: GTV + 'images/TearsOfSteel.jpg',
+            UserData: { Played: false }
+          },
+          {
+            Id: 'demo-ep-202',
+            Name: 'Cosmic Escape',
+            Type: 'Episode',
+            IndexNumber: 2,
+            ParentIndexNumber: 2,
+            SeriesName: 'Chronicles of the Open Canvas',
+            SeriesId: 'demo-series-1',
+            SeasonName: 'Season 2: Cyber Future',
+            SeasonId: 'demo-season-2',
+            RunTimeTicks: 3000000000,
+            Overview: 'High octane space escapade showcasing real-time physics and lighting.',
+            streamUrl: GTV + 'ForBiggerEscapes.mp4',
+            posterUrl: GTV + 'images/ForBiggerEscapes.jpg',
+            backdropUrl: GTV + 'images/ForBiggerEscapes.jpg',
+            UserData: { Played: false }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    Id: 'demo-series-2',
+    Name: 'Streamline 4K Cinema',
+    Type: 'Series',
+    ProductionYear: 2024,
+    CommunityRating: 8.9,
+    OfficialRating: 'TV-G',
+    Overview: 'A curated video exhibition exploring cutting-edge 4K resolution, High Dynamic Range (HDR10+ / Dolby Vision), and spatial surround sound.',
+    Taglines: ['A visual feast of ultra high definition'],
+    Genres: ['Documentary', 'Shorts', 'Nature'],
+    posterUrl: 'https://images.unsplash.com/photo-1478760329108-5c3ed9d495a0?auto=format&fit=crop&w=600&q=80',
+    backdropUrl: 'https://images.unsplash.com/photo-1509198397868-475647b2a1e5?auto=format&fit=crop&w=1600&q=80',
+    seasons: [
+      {
+        Id: 'demo-season-2-1',
+        Name: 'Season 1',
+        IndexNumber: 1,
+        SeriesId: 'demo-series-2',
+        Episodes: [
+          {
+            Id: 'demo-s2-ep1',
+            Name: 'Blazing Trails',
+            Type: 'Episode',
+            IndexNumber: 1,
+            ParentIndexNumber: 1,
+            SeriesName: 'Streamline 4K Cinema',
+            SeriesId: 'demo-series-2',
+            SeasonName: 'Season 1',
+            SeasonId: 'demo-season-2-1',
+            RunTimeTicks: 150000000,
+            Overview: 'Extreme action sports captured with ultra high speed cameras.',
+            streamUrl: GTV + 'ForBiggerBlazes.mp4',
+            posterUrl: GTV + 'images/ForBiggerBlazes.jpg',
+            UserData: { Played: false }
+          },
+          {
+            Id: 'demo-s2-ep2',
+            Name: 'Euphoric Escapes',
+            Type: 'Episode',
+            IndexNumber: 2,
+            ParentIndexNumber: 1,
+            SeriesName: 'Streamline 4K Cinema',
+            SeriesId: 'demo-series-2',
+            SeasonName: 'Season 1',
+            SeasonId: 'demo-season-2-1',
+            RunTimeTicks: 180000000,
+            Overview: 'Breath-taking landscapes and vistas in crystal clear 4K.',
+            streamUrl: GTV + 'ForBiggerFun.mp4',
+            posterUrl: GTV + 'images/ForBiggerFun.jpg',
+            UserData: { Played: false }
+          }
+        ]
+      }
+    ]
+  }
+];
+
+export const DEMO_ALL_ITEMS: JellyfinItem[] = [
+  ...DEMO_MOVIES,
+  ...DEMO_SHOWS
+];

--- a/web/jellyfin/src/lib/stores/appState.ts
+++ b/web/jellyfin/src/lib/stores/appState.ts
@@ -1,0 +1,955 @@
+import { writable, derived, get } from 'svelte/store';
+import type { JellyfinItem, ServerConfig, JellyfinSeason, SavedAccount } from '../types';
+import { DEMO_MOVIES, DEMO_SHOWS, DEMO_ALL_ITEMS } from '../data/demoData';
+import * as jfApi from '../api/jellyfin';
+import { getCachedData, hydrateCacheFromStorage, clearAllCache } from '../api/cache';
+import {
+  castDirect,
+  castLinkedQueue,
+  buildSingleCastPayload,
+  buildPlaylistCastPayload,
+  formatVisualMetadata,
+  addDiagnosticLog
+} from '../cast/playbridge';
+
+const STORAGE_KEY = 'playbridge_jellyfin_session';
+const ACCOUNTS_KEY = 'playbridge_jellyfin_saved_accounts';
+
+const INITIAL_SERVER: ServerConfig = {
+  url: '',
+  token: '',
+  userId: '',
+  username: '',
+  serverName: '',
+  isDemo: false,
+  connected: false
+};
+
+export const serverConfig = writable<ServerConfig>(INITIAL_SERVER);
+export const savedAccounts = writable<SavedAccount[]>([]);
+export const userViews = writable<jfApi.UserView[]>([]);
+export const activeTab = writable<string>('home');
+export const searchQuery = writable<string>('');
+export const selectedGenre = writable<string>('all');
+export const sortBy = writable<string>('DateCreated');
+
+// Jellyfin Home Sections & Per-Library Stores (Matching Official Jellyfin Web)
+export const nextUpMedia = writable<JellyfinItem[]>([]);
+export const libraryLatestMap = writable<Record<string, JellyfinItem[]>>({});
+
+// Modals and drawers
+export const isServerModalOpen = writable<boolean>(false);
+export const isDiagnosticsOpen = writable<boolean>(false);
+export const detailModalItem = writable<JellyfinItem | null>(null);
+export const isQueueDrawerOpen = writable<boolean>(false);
+export const isLyricsOpen = writable<boolean>(false);
+export const lyricsData = writable<{ Lyrics?: Array<{ Text: string; Start?: number }>; Text?: string } | null>(null);
+
+// Music Player Modes (Inspired by Finamp)
+export const isShuffle = writable<boolean>(false);
+export const repeatMode = writable<'off' | 'all' | 'one'>('off'); // 'off' | 'all' | 'one'
+
+// Toast notification
+export const activeToast = writable<{ message: string; type: 'cast' | 'info' | 'success' } | null>(null);
+let toastTimeout: any;
+
+export function showToast(message: string, type: 'cast' | 'info' | 'success' = 'cast') {
+  activeToast.set({ message, type });
+  clearTimeout(toastTimeout);
+  toastTimeout = setTimeout(() => {
+    activeToast.set(null);
+  }, 3500);
+}
+
+// Player state
+export interface ActivePlayerState {
+  isOpen: boolean; // active media session
+  isExpanded: boolean; // true = full screen overlay, false = floating mini player
+  item: JellyfinItem | null;
+  streamUrl: string;
+  isCasting: boolean;
+  isLinkedCast: boolean;
+  title: string;
+  season?: number;
+  episode?: number;
+  playlist?: JellyfinItem[];
+  currentIndex?: number;
+}
+
+export const activePlayer = writable<ActivePlayerState>({
+  isOpen: false,
+  isExpanded: false,
+  item: null,
+  streamUrl: '',
+  isCasting: false,
+  isLinkedCast: false,
+  title: '',
+  playlist: [],
+  currentIndex: 0
+});
+
+// Library State
+export const latestMedia = writable<JellyfinItem[]>([]);
+export const resumeMedia = writable<JellyfinItem[]>([]);
+export const moviesList = writable<JellyfinItem[]>([]);
+export const showsList = writable<JellyfinItem[]>([]);
+export const allLibraryItems = writable<JellyfinItem[]>([]);
+export const isLoadingLibrary = writable<boolean>(false);
+export const serverError = writable<string | null>(null);
+
+// Utility: Fisher-Yates array shuffle
+export function shuffleArray<T>(array: T[]): T[] {
+  const arr = [...array];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+export function getSavedAccountsFromStorage(): SavedAccount[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(ACCOUNTS_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveAccountToList(account: SavedAccount) {
+  if (typeof window === 'undefined') return;
+  const current = getSavedAccountsFromStorage();
+  const existingIdx = current.findIndex(
+    (a) => a.id === account.id || (a.url === account.url && a.userId === account.userId)
+  );
+  if (existingIdx >= 0) {
+    current[existingIdx] = { ...current[existingIdx], ...account, lastActive: Date.now() };
+  } else {
+    current.push({ ...account, lastActive: Date.now() });
+  }
+  savedAccounts.set(current);
+  localStorage.setItem(ACCOUNTS_KEY, JSON.stringify(current));
+}
+
+export function removeSavedAccount(accountId: string) {
+  if (typeof window === 'undefined') return;
+  const current = getSavedAccountsFromStorage().filter((a) => a.id !== accountId);
+  savedAccounts.set(current);
+  localStorage.setItem(ACCOUNTS_KEY, JSON.stringify(current));
+
+  const active = get(serverConfig);
+  if (active.url && `${active.url}_${active.userId}` === accountId) {
+    if (current.length > 0) {
+      switchAccount(current[0]);
+    } else {
+      logout();
+    }
+  }
+  showToast('Account removed', 'info');
+}
+
+export async function switchAccount(account: SavedAccount) {
+  isLoadingLibrary.set(true);
+  serverError.set(null);
+
+  // Always reset to home view on switched server
+  activeTab.set('home');
+
+  if (account.isDemo) {
+    loadDemoMode();
+    return;
+  }
+
+  const config: ServerConfig = {
+    url: account.url,
+    token: account.token,
+    userId: account.userId,
+    username: account.username,
+    serverName: account.serverName,
+    isDemo: false,
+    connected: true
+  };
+
+  serverConfig.set(config);
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+  }
+
+  // Update last active in list
+  saveAccountToList(account);
+
+  // Clear previous server's state first
+  userViews.set([]);
+  latestMedia.set([]);
+  resumeMedia.set([]);
+  moviesList.set([]);
+  showsList.set([]);
+  allLibraryItems.set([]);
+
+  // Pre-fill from cache immediately (0ms instant switch)
+  const cachedViews = getCachedData<jfApi.UserView[]>(`views_${config.userId}`);
+  if (cachedViews) userViews.set(cachedViews);
+
+  const cachedMovies = getCachedData<{ items: JellyfinItem[] }>(`lib_${config.userId}_root_Movie__`);
+  if (cachedMovies) moviesList.set(cachedMovies.items);
+
+  const cachedShows = getCachedData<{ items: JellyfinItem[] }>(`lib_${config.userId}_root_Series__`);
+  if (cachedShows) showsList.set(cachedShows.items);
+
+  if (cachedMovies && cachedShows) {
+    allLibraryItems.set([...cachedMovies.items, ...cachedShows.items]);
+  }
+
+  showToast(`Switched to ${account.username} on ${account.serverName}`, 'success');
+  addDiagnosticLog('success', `Switched active server to ${account.serverName} (${account.username})`, config);
+
+  // Refresh in background
+  await refreshServerLibrary(config);
+}
+
+// Initialize Session on Startup
+export async function initializeSession() {
+  if (typeof window === 'undefined') return;
+
+  // Hydrate memory cache from IndexedDB
+  await hydrateCacheFromStorage();
+
+  // Load saved accounts
+  const accounts = getSavedAccountsFromStorage();
+  savedAccounts.set(accounts);
+
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (saved) {
+    try {
+      const config: ServerConfig = JSON.parse(saved);
+      if (config.isDemo) {
+        loadDemoMode();
+        return;
+      }
+      if (config.url && config.token && config.userId) {
+        serverConfig.set(config);
+
+        // Pre-fill from cache immediately
+        const cachedViews = getCachedData<jfApi.UserView[]>(`views_${config.userId}`);
+        if (cachedViews) userViews.set(cachedViews);
+
+        const cachedMovies = getCachedData<{ items: JellyfinItem[] }>(`lib_${config.userId}_root_Movie__`);
+        if (cachedMovies) moviesList.set(cachedMovies.items);
+
+        const cachedShows = getCachedData<{ items: JellyfinItem[] }>(`lib_${config.userId}_root_Series__`);
+        if (cachedShows) showsList.set(cachedShows.items);
+
+        if (cachedMovies && cachedShows) {
+          allLibraryItems.set([...cachedMovies.items, ...cachedShows.items]);
+        }
+
+        // Validate token silently (only logs out on explicit 401/403)
+        const valid = await jfApi.validateToken(config.url, config.userId, config.token);
+        if (valid) {
+          addDiagnosticLog('success', `Restored active Jellyfin session: ${config.serverName} (${config.username})`, config);
+          await refreshServerLibrary(config);
+        } else {
+          addDiagnosticLog('warn', 'Saved Jellyfin session expired (401 Unauthorized). Please sign in again.');
+          logout();
+        }
+      }
+    } catch (e) {
+      console.error('Session init error:', e);
+    } finally {
+      isLoadingLibrary.set(false);
+    }
+  }
+}
+
+// Initialize demo mode
+export function loadDemoMode() {
+  const config: ServerConfig = {
+    url: '',
+    token: '',
+    userId: 'demo-user-1',
+    username: 'Demo User',
+    serverName: 'PlayBridge Demo Showcase',
+    isDemo: true,
+    connected: true
+  };
+  serverConfig.set(config);
+  userViews.set([
+    { Id: 'view-movies', Name: 'Movies', CollectionType: 'movies' },
+    { Id: 'view-shows', Name: 'TV Shows', CollectionType: 'tvshows' }
+  ]);
+  latestMedia.set(DEMO_MOVIES);
+  resumeMedia.set(DEMO_MOVIES.filter((m) => m.UserData?.PlaybackPositionTicks));
+  nextUpMedia.set([
+    {
+      Id: 'demo-ep-next',
+      Name: 'The Alibi',
+      Type: 'Episode',
+      SeriesName: 'Chernobyl',
+      SeasonName: 'Season 1',
+      IndexNumber: 2,
+      ParentIndexNumber: 1,
+      RunTimeTicks: 36000000000,
+      Overview: 'With millions of people at risk, Ulana Khomyuk investigates the causes of the explosion.',
+      posterUrl: 'https://images.unsplash.com/photo-1518709268805-4e9042af9f23?w=800&auto=format&fit=crop&q=80',
+      backdropUrl: 'https://images.unsplash.com/photo-1518709268805-4e9042af9f23?w=1600&auto=format&fit=crop&q=80',
+      UserData: { PlaybackPositionTicks: 0, Played: false }
+    }
+  ]);
+  libraryLatestMap.set({
+    'view-movies': DEMO_MOVIES,
+    'view-shows': DEMO_SHOWS
+  });
+  moviesList.set(DEMO_MOVIES);
+  showsList.set(DEMO_SHOWS);
+  allLibraryItems.set(DEMO_ALL_ITEMS);
+  serverError.set(null);
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+  }
+  addDiagnosticLog('info', 'Loaded built-in Demo media library');
+}
+
+// Connect to live Jellyfin Server
+export async function connectToJellyfinServer(serverUrl: string, username: string, password = '', rememberMe = true) {
+  isLoadingLibrary.set(true);
+  serverError.set(null);
+  try {
+    const cleanUrl = jfApi.cleanServerUrl(serverUrl);
+    addDiagnosticLog('info', `Pinging Jellyfin server at ${cleanUrl}...`);
+    const ping = await jfApi.pingServer(cleanUrl);
+
+    addDiagnosticLog('info', `Authenticating user "${username}"...`);
+    const auth = await jfApi.authenticateByName(cleanUrl, username, password);
+
+    const config: ServerConfig = {
+      url: cleanUrl,
+      token: auth.token,
+      userId: auth.userId,
+      username: auth.username,
+      serverName: ping.serverName,
+      isDemo: false,
+      connected: true
+    };
+
+    serverConfig.set(config);
+
+    const account: SavedAccount = {
+      id: `${cleanUrl}_${auth.userId}`,
+      url: cleanUrl,
+      token: auth.token,
+      userId: auth.userId,
+      username: auth.username,
+      serverName: ping.serverName,
+      lastActive: Date.now()
+    };
+
+    if (rememberMe && typeof window !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+      saveAccountToList(account);
+    }
+    addDiagnosticLog('success', `Connected & authenticated on Jellyfin: ${ping.serverName}`, config);
+
+    // Fetch user library content with background cache warming
+    await refreshServerLibrary(config);
+    isServerModalOpen.set(false);
+  } catch (err: any) {
+    serverError.set(err.message || 'Failed to connect to Jellyfin server');
+    addDiagnosticLog('error', `Connection error: ${err.message}`, err);
+    throw err;
+  } finally {
+    isLoadingLibrary.set(false);
+  }
+}
+
+export function logout() {
+  serverConfig.set(INITIAL_SERVER);
+  userViews.set([]);
+  latestMedia.set([]);
+  resumeMedia.set([]);
+  nextUpMedia.set([]);
+  libraryLatestMap.set({});
+  moviesList.set([]);
+  showsList.set([]);
+  allLibraryItems.set([]);
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+  addDiagnosticLog('info', 'Logged out from Jellyfin server');
+}
+
+export async function refreshServerLibrary(config: ServerConfig) {
+  if (config.isDemo) {
+    loadDemoMode();
+    return;
+  }
+
+  try {
+    const [views, latest, resume, nextUp, moviesRes, showsRes] = await Promise.all([
+      jfApi.getUserViews(config.url, config.userId, config.token, (fresh) => userViews.set(fresh)),
+      jfApi.getLatestMedia(config.url, config.userId, config.token, undefined, (fresh) => latestMedia.set(fresh)),
+      jfApi.getResumeItems(config.url, config.userId, config.token, (fresh) => resumeMedia.set(fresh)),
+      jfApi.getNextUpEpisodes(config.url, config.userId, config.token, (fresh) => nextUpMedia.set(fresh)),
+      jfApi.getLibraryItems(config.url, config.userId, config.token, { includeItemTypes: 'Movie' }, (fresh) => moviesList.set(fresh.items)),
+      jfApi.getLibraryItems(config.url, config.userId, config.token, { includeItemTypes: 'Series' }, (fresh) => showsList.set(fresh.items))
+    ]);
+
+    userViews.set(views);
+    latestMedia.set(latest.length > 0 ? latest : moviesRes.items);
+    resumeMedia.set(resume);
+    nextUpMedia.set(nextUp);
+    moviesList.set(moviesRes.items);
+    showsList.set(showsRes.items);
+    allLibraryItems.set([...moviesRes.items, ...showsRes.items]);
+
+    // Fetch per-library recently added in parallel for each library view
+    if (views.length > 0) {
+      const latestPromises = views.map(async (v) => {
+        const items = await jfApi.getLatestMedia(config.url, config.userId, config.token, v.Id, (fresh) => {
+          libraryLatestMap.update((m) => ({ ...m, [v.Id]: fresh }));
+        });
+        return { viewId: v.Id, items };
+      });
+      const perLibResults = await Promise.all(latestPromises);
+      const newMap: Record<string, JellyfinItem[]> = {};
+      for (const res of perLibResults) {
+        if (res.items && res.items.length > 0) {
+          newMap[res.viewId] = res.items;
+        }
+      }
+      libraryLatestMap.set(newMap);
+    }
+
+    addDiagnosticLog('info', `Loaded ${views.length} libraries, ${moviesRes.items.length} movies, ${showsRes.items.length} series, and ${nextUp.length} next up episodes.`);
+  } catch (err: any) {
+    addDiagnosticLog('warn', `Failed to refresh server library in background: ${err.message}`);
+  } finally {
+    isLoadingLibrary.set(false);
+  }
+}
+
+export async function clearAppCache(fullReset = false) {
+  clearAllCache();
+  if (fullReset) {
+    if (typeof window !== 'undefined') {
+      localStorage.clear();
+    }
+    logout();
+    showToast('App data & cache fully reset', 'info');
+  } else {
+    showToast('Cache cleared. Re-syncing library...', 'info');
+    const config = get(serverConfig);
+    if (config.connected) {
+      userViews.set([]);
+      latestMedia.set([]);
+      resumeMedia.set([]);
+      nextUpMedia.set([]);
+      libraryLatestMap.set({});
+      moviesList.set([]);
+      showsList.set([]);
+      allLibraryItems.set([]);
+      await refreshServerLibrary(config);
+    }
+  }
+}
+
+// Open Detail View
+export async function openItemDetail(item: JellyfinItem) {
+  const config = get(serverConfig);
+  if (!config.isDemo && item.Type === 'Series' && (!item.seasons || item.seasons.length === 0)) {
+    try {
+      const seasons = await jfApi.getSeasons(config.url, config.userId, config.token, item.Id, (fresh) => {
+        item.seasons = fresh;
+      });
+      item.seasons = seasons;
+    } catch (err) {
+      console.error('Failed to load seasons', err);
+    }
+  } else if (!config.isDemo && (item.Type === 'MusicAlbum' || item.Type === 'Folder' || item.Type === 'Playlist') && !item.tracks) {
+    try {
+      const tracks = await jfApi.getPlayableFolderItems(config.url, config.userId, config.token, item.Id, (fresh) => {
+        item.tracks = fresh;
+      });
+      item.tracks = tracks;
+    } catch (err) {
+      console.error('Failed to load album/folder tracks', err);
+    }
+  }
+  detailModalItem.set(item);
+}
+
+// Media Stream Resolver
+export function resolveItemStreamUrl(item: JellyfinItem): string {
+  const config = get(serverConfig);
+  if (config.isDemo || item.streamUrl) {
+    return item.streamUrl || 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4';
+  }
+  if (item.Type === 'Audio') {
+    return jfApi.buildAudioStreamUrl(config.url, item.Id, config.token);
+  }
+  const mediaSourceId = item.MediaSources && item.MediaSources[0]?.Id;
+  return jfApi.buildDirectStreamUrl(config.url, item.Id, config.token, mediaSourceId);
+}
+
+export function resolveItemPosterUrl(item: JellyfinItem): string {
+  const config = get(serverConfig);
+  if (config.isDemo || item.posterUrl) {
+    return item.posterUrl || 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg';
+  }
+  return jfApi.buildImageUrl(config.url, item.Id, config.token, 'Primary', { maxWidth: 500, quality: 90 });
+}
+
+export function resolveItemBackdropUrl(item: JellyfinItem): string {
+  const config = get(serverConfig);
+  if (config.isDemo || item.backdropUrl) {
+    return item.backdropUrl || 'https://images.unsplash.com/photo-1518709268805-4e9042af9f23?auto=format&fit=crop&w=1600&q=80';
+  }
+  if (item.BackdropImageTags && item.BackdropImageTags.length > 0) {
+    return jfApi.buildImageUrl(config.url, item.Id, config.token, 'Backdrop', { maxWidth: 1920, quality: 85 });
+  }
+  return resolveItemPosterUrl(item);
+}
+
+// Trigger Playback in Browser Video/Audio Player (Single Item, Folder, Album, or Playlist)
+export async function playInBrowser(
+  item: JellyfinItem,
+  playlist?: JellyfinItem[],
+  startIndex = 0,
+  forceExpand = false
+) {
+  const config = get(serverConfig);
+  let queue: JellyfinItem[] = [];
+
+  // If playlist provided, filter to playable media items
+  if (playlist && playlist.length > 0) {
+    queue = playlist.filter((i) => i.Type === 'Audio' || i.Type === 'Movie' || i.Type === 'Episode' || i.Type === 'Video');
+  }
+
+  // If item is a container (Folder, MusicAlbum, Playlist) and queue is empty, resolve playable children
+  if (queue.length === 0 && (item.Type === 'Folder' || item.Type === 'MusicAlbum' || item.Type === 'Playlist')) {
+    if (item.tracks && item.tracks.length > 0) {
+      queue = item.tracks.filter((i) => i.Type === 'Audio' || i.Type === 'Movie' || i.Type === 'Episode' || i.Type === 'Video');
+    } else if (!config.isDemo) {
+      try {
+        const tracks = await jfApi.getPlayableFolderItems(config.url, config.userId, config.token, item.Id);
+        item.tracks = tracks;
+        queue = tracks;
+      } catch (err) {
+        console.error('Failed to resolve folder tracks for in-browser playback', err);
+      }
+    }
+  } else if (queue.length === 0 && item.Type === 'Series') {
+    // If item is a series, resolve all episodes across seasons
+    if (!config.isDemo && (!item.seasons || item.seasons.length === 0)) {
+      try {
+        item.seasons = await jfApi.getSeasons(config.url, config.userId, config.token, item.Id);
+      } catch {}
+    }
+    for (const s of (item.seasons || [])) {
+      for (const ep of s.Episodes) {
+        queue.push(ep);
+      }
+    }
+  }
+
+  if (queue.length === 0) {
+    queue = [item];
+  }
+
+  const validIndex = Math.max(0, Math.min(startIndex, queue.length - 1));
+  const targetItem = queue[validIndex];
+  const streamUrl = resolveItemStreamUrl(targetItem);
+
+  // Audio plays in mini player by default unless forceExpand is requested; Videos expand
+  const shouldExpand = forceExpand || (targetItem.Type === 'Movie' || targetItem.Type === 'Episode');
+
+  // Close detail modal so user can continue browsing
+  detailModalItem.set(null);
+
+  activePlayer.set({
+    isOpen: true,
+    isExpanded: shouldExpand,
+    item: targetItem,
+    streamUrl,
+    isCasting: false,
+    isLinkedCast: false,
+    title: targetItem.Name,
+    season: targetItem.ParentIndexNumber,
+    episode: targetItem.IndexNumber,
+    playlist: queue,
+    currentIndex: validIndex
+  });
+
+  // Fetch lyrics in background for audio tracks
+  if (targetItem.Type === 'Audio' && !config.isDemo) {
+    jfApi.getItemLyrics(config.url, config.token, targetItem.Id).then((res) => {
+      lyricsData.set(res);
+    }).catch(() => {
+      lyricsData.set(null);
+    });
+  }
+
+  if (queue.length > 1) {
+    showToast(`Playing "${targetItem.Name}" (${validIndex + 1}/${queue.length})`, 'info');
+  } else {
+    showToast(`Playing "${targetItem.Name}"`, 'info');
+  }
+}
+
+// Trigger Shuffle Play for Folders, Albums, and Playlists (Finamp Inspired)
+export async function shufflePlay(parentItem: JellyfinItem, providedItems?: JellyfinItem[]): Promise<void> {
+  const config = get(serverConfig);
+  let tracks: JellyfinItem[] = [];
+
+  if (providedItems && providedItems.length > 0) {
+    tracks = providedItems.filter((i) => i.Type === 'Audio' || i.Type === 'Movie' || i.Type === 'Episode');
+  }
+
+  if (tracks.length === 0 && !config.isDemo) {
+    try {
+      tracks = await jfApi.getPlayableFolderItems(config.url, config.userId, config.token, parentItem.Id);
+      parentItem.tracks = tracks;
+    } catch (err) {
+      console.error('Failed to resolve tracks for shuffle play', err);
+    }
+  }
+
+  if (tracks.length === 0) {
+    showToast(`No playable tracks found to shuffle`, 'info');
+    return;
+  }
+
+  const shuffled = shuffleArray(tracks);
+  isShuffle.set(true);
+  await playInBrowser(shuffled[0], shuffled, 0, false);
+  showToast(`Shuffling "${parentItem.Name}" (${shuffled.length} tracks)`, 'info');
+}
+
+// Trigger Shuffle Direct Cast for Folders, Albums, and Playlists
+export async function shuffleCast(parentItem: JellyfinItem, providedItems?: JellyfinItem[]): Promise<boolean> {
+  const config = get(serverConfig);
+  let tracks: JellyfinItem[] = [];
+
+  if (providedItems && providedItems.length > 0) {
+    tracks = providedItems.filter((i) => i.Type === 'Audio' || i.Type === 'Movie' || i.Type === 'Episode');
+  }
+
+  if (tracks.length === 0 && !config.isDemo) {
+    try {
+      tracks = await jfApi.getPlayableFolderItems(config.url, config.userId, config.token, parentItem.Id);
+      parentItem.tracks = tracks;
+    } catch (err) {
+      console.error('Failed to resolve tracks for shuffle cast', err);
+    }
+  }
+
+  if (tracks.length === 0) {
+    showToast(`No playable tracks found to shuffle cast`, 'info');
+    return false;
+  }
+
+  const shuffled = shuffleArray(tracks);
+  isShuffle.set(true);
+  return playFolderOrAlbumWithCast(parentItem, shuffled, 0);
+}
+
+// Toggle Shuffle mode on active queue
+export function toggleShuffle() {
+  isShuffle.update((val) => {
+    const next = !val;
+    const current = get(activePlayer);
+    if (current.playlist && current.playlist.length > 1) {
+      if (next) {
+        // Shuffle remaining queue while keeping current item
+        const curItem = current.item;
+        const others = current.playlist.filter((i) => i.Id !== curItem?.Id);
+        const shuffled = curItem ? [curItem, ...shuffleArray(others)] : shuffleArray(current.playlist);
+        activePlayer.update((s) => ({ ...s, playlist: shuffled, currentIndex: 0 }));
+      }
+    }
+    showToast(next ? 'Shuffle enabled' : 'Shuffle disabled', 'info');
+    return next;
+  });
+}
+
+// Cycle Repeat mode: off -> all -> one -> off
+export function cycleRepeatMode() {
+  repeatMode.update((mode) => {
+    let next: 'off' | 'all' | 'one' = 'off';
+    if (mode === 'off') next = 'all';
+    else if (mode === 'all') next = 'one';
+    else next = 'off';
+
+    const label = next === 'all' ? 'Repeat All' : next === 'one' ? 'Repeat One' : 'Repeat Off';
+    showToast(label, 'info');
+    return next;
+  });
+}
+
+// Toggle Favorite Item on Jellyfin Server (Finamp Feature)
+export async function toggleFavorite(item: JellyfinItem): Promise<boolean> {
+  const config = get(serverConfig);
+  const currentFav = !!item.UserData?.IsFavorite;
+  const nextFav = !currentFav;
+
+  // Optimistic local update
+  if (!item.UserData) {
+    item.UserData = { IsFavorite: nextFav };
+  } else {
+    item.UserData.IsFavorite = nextFav;
+  }
+
+  // Update in all stores
+  allLibraryItems.update((items) => items.map((i) => (i.Id === item.Id ? { ...i, UserData: { ...i.UserData, IsFavorite: nextFav } } : i)));
+  moviesList.update((items) => items.map((i) => (i.Id === item.Id ? { ...i, UserData: { ...i.UserData, IsFavorite: nextFav } } : i)));
+  showsList.update((items) => items.map((i) => (i.Id === item.Id ? { ...i, UserData: { ...i.UserData, IsFavorite: nextFav } } : i)));
+
+  showToast(nextFav ? `Added "${item.Name}" to Favorites` : `Removed "${item.Name}" from Favorites`, 'success');
+
+  if (!config.isDemo && config.url && config.userId) {
+    try {
+      await jfApi.toggleFavoriteItem(config.url, config.userId, config.token, item.Id, nextFav);
+    } catch (err) {
+      console.error('Failed to update favorite on server', err);
+    }
+  }
+  return nextFav;
+}
+
+// Trigger Direct PlayBridge Casting (Single Item)
+export async function playWithDirectCast(item: JellyfinItem): Promise<boolean> {
+  let targetItem = item;
+  const config = get(serverConfig);
+
+  // If a series is clicked, resolve its first episode
+  if (item.Type === 'Series') {
+    if (!config.isDemo && (!item.seasons || item.seasons.length === 0)) {
+      try {
+        item.seasons = await jfApi.getSeasons(config.url, config.userId, config.token, item.Id);
+      } catch {}
+    }
+    const firstEp = item.seasons?.[0]?.Episodes?.[0];
+    if (firstEp) {
+      targetItem = firstEp;
+    }
+  } else if ((item.Type === 'MusicAlbum' || item.Type === 'Folder' || item.Type === 'Playlist') && !item.streamUrl) {
+    // If an album/folder is clicked, cast the whole album/folder!
+    return playFolderOrAlbumWithCast(item, item.tracks, 0);
+  }
+
+  const streamUrl = resolveItemStreamUrl(targetItem);
+  const posterUrl = resolveItemPosterUrl(targetItem);
+  const backdropUrl = resolveItemBackdropUrl(targetItem);
+
+  const payload = buildSingleCastPayload(targetItem, streamUrl, posterUrl, backdropUrl);
+  const success = castDirect(payload);
+
+  // Close details modal so user stays in library
+  detailModalItem.set(null);
+
+  // Show Toast
+  showToast(`Casting "${payload.title || targetItem.Name}" to PlayBridge`, 'cast');
+
+  // Keep player in bottom Mini Bar (not taking over screen)
+  activePlayer.set({
+    isOpen: true,
+    isExpanded: false,
+    item: targetItem,
+    streamUrl,
+    isCasting: true,
+    isLinkedCast: false,
+    title: payload.title || targetItem.Name,
+    season: targetItem.ParentIndexNumber,
+    episode: targetItem.IndexNumber,
+    playlist: [targetItem],
+    currentIndex: 0
+  });
+
+  return success;
+}
+
+// Trigger Batch Playlist Casting for Folders, Music Albums, and Playlists
+export async function playFolderOrAlbumWithCast(
+  parentItem: JellyfinItem,
+  providedItems?: JellyfinItem[],
+  startIndex = 0
+): Promise<boolean> {
+  const config = get(serverConfig);
+  let tracks: JellyfinItem[] = [];
+
+  // Filter providedItems to only include playable items (Audio, Movie, Episode)
+  if (providedItems && providedItems.length > 0) {
+    tracks = providedItems.filter((i) => i.Type === 'Audio' || i.Type === 'Movie' || i.Type === 'Episode');
+  }
+
+  // If no playable items in providedItems, query server recursively with cache
+  if (tracks.length === 0 && !config.isDemo) {
+    try {
+      tracks = await jfApi.getPlayableFolderItems(config.url, config.userId, config.token, parentItem.Id);
+      parentItem.tracks = tracks;
+    } catch (err) {
+      console.error('Failed to fetch items for folder/album', err);
+    }
+  }
+
+  if (tracks.length === 0) {
+    addDiagnosticLog('warn', `No playable audio/video tracks found in "${parentItem.Name}"`);
+    showToast(`No playable tracks found in "${parentItem.Name}"`, 'info');
+    return false;
+  }
+
+  const playlistTitle = parentItem.Name;
+  const playlistPoster = resolveItemPosterUrl(parentItem);
+  const playlistBackdrop = resolveItemBackdropUrl(parentItem);
+
+  const playlistItems = tracks.map((track) => ({
+    item: track,
+    streamUrl: resolveItemStreamUrl(track),
+    posterUrl: resolveItemPosterUrl(track) || playlistPoster,
+    backdropUrl: resolveItemBackdropUrl(track) || playlistBackdrop
+  }));
+
+  const payload = buildPlaylistCastPayload(playlistItems, startIndex, playlistTitle, playlistPoster);
+  const success = castDirect(payload);
+
+  // Close details modal so user stays in library
+  detailModalItem.set(null);
+
+  showToast(`Casting "${playlistTitle}" (${tracks.length} items) to PlayBridge`, 'cast');
+
+  const startTrack = tracks[startIndex] || tracks[0];
+  activePlayer.set({
+    isOpen: true,
+    isExpanded: false, // Mini player bar
+    item: startTrack,
+    streamUrl: resolveItemStreamUrl(startTrack),
+    isCasting: true,
+    isLinkedCast: false,
+    title: `${playlistTitle} (${startIndex + 1}/${tracks.length})`,
+    playlist: tracks,
+    currentIndex: startIndex
+  });
+
+  return success;
+}
+
+// Trigger Linked Queue Cast for Series / Playlists
+export async function playWithLinkedQueue(series: JellyfinItem, seasons?: JellyfinSeason[], startEpisodeIndex = 0) {
+  const allEpisodes: JellyfinItem[] = [];
+  const config = get(serverConfig);
+  let sourceSeasons = seasons || series.seasons || [];
+
+  if (sourceSeasons.length === 0 && !config.isDemo) {
+    try {
+      sourceSeasons = await jfApi.getSeasons(config.url, config.userId, config.token, series.Id);
+      series.seasons = sourceSeasons;
+    } catch {}
+  }
+
+  for (const s of sourceSeasons) {
+    for (const ep of s.Episodes) {
+      allEpisodes.push(ep);
+    }
+  }
+
+  if (allEpisodes.length === 0) {
+    return playWithDirectCast(series);
+  }
+
+  const castItems = allEpisodes.map((ep) => {
+    const sUrl = resolveItemStreamUrl(ep);
+    const pUrl = resolveItemPosterUrl(ep);
+    const bUrl = resolveItemBackdropUrl(ep);
+    let epTitle = ep.Name;
+    if (ep.IndexNumber != null) {
+      const s = ep.ParentIndexNumber ?? 1;
+      epTitle = `S${s}E${ep.IndexNumber} · ${ep.Name}`;
+    }
+    return {
+      id: ep.Id,
+      url: sUrl,
+      title: epTitle,
+      contentType: sUrl.includes('.m3u8') ? 'application/vnd.apple.mpegurl' : 'video/mp4',
+      metadata: formatVisualMetadata(ep, pUrl, bUrl)
+    };
+  });
+
+  const metadata = formatVisualMetadata(series, resolveItemPosterUrl(series), resolveItemBackdropUrl(series));
+  await castLinkedQueue(castItems, startEpisodeIndex, metadata);
+
+  detailModalItem.set(null);
+  showToast(`Casting "${series.Name}" queue to PlayBridge`, 'cast');
+
+  const startingEp = allEpisodes[startEpisodeIndex] || allEpisodes[0];
+  activePlayer.set({
+    isOpen: true,
+    isExpanded: false,
+    item: startingEp,
+    streamUrl: resolveItemStreamUrl(startingEp),
+    isCasting: true,
+    isLinkedCast: true,
+    title: `${series.Name} · ${startingEp.Name}`,
+    season: startingEp.ParentIndexNumber,
+    episode: startingEp.IndexNumber,
+    playlist: allEpisodes,
+    currentIndex: startEpisodeIndex
+  });
+}
+
+// Queue navigation helpers with Repeat One / Repeat All / Next support
+export function skipNextTrack() {
+  const current = get(activePlayer);
+  const rep = get(repeatMode);
+
+  if (rep === 'one' && current.item) {
+    // Replay same track
+    playInBrowser(current.item, current.playlist, current.currentIndex, current.isExpanded);
+    return;
+  }
+
+  if (!current.playlist || current.playlist.length <= 1) return;
+
+  const nextIdx = (current.currentIndex ?? 0) + 1;
+  if (nextIdx >= current.playlist.length) {
+    if (rep === 'all') {
+      // Loop back to first track
+      const firstItem = current.playlist[0];
+      if (current.isCasting) {
+        playWithDirectCast(firstItem);
+      } else {
+        playInBrowser(firstItem, current.playlist, 0, current.isExpanded);
+      }
+    }
+    return;
+  }
+
+  const nextItem = current.playlist[nextIdx];
+  if (current.isCasting) {
+    playWithDirectCast(nextItem);
+  } else {
+    playInBrowser(nextItem, current.playlist, nextIdx, current.isExpanded);
+  }
+}
+
+export function skipPrevTrack() {
+  const current = get(activePlayer);
+  if (!current.playlist || current.playlist.length <= 1) return;
+  const prevIdx = ((current.currentIndex ?? 0) - 1 + current.playlist.length) % current.playlist.length;
+  const prevItem = current.playlist[prevIdx];
+  if (current.isCasting) {
+    playWithDirectCast(prevItem);
+  } else {
+    playInBrowser(prevItem, current.playlist, prevIdx, current.isExpanded);
+  }
+}
+
+export function playQueueTrack(index: number) {
+  const current = get(activePlayer);
+  if (!current.playlist || index < 0 || index >= current.playlist.length) return;
+  const target = current.playlist[index];
+  if (current.isCasting) {
+    playWithDirectCast(target);
+  } else {
+    playInBrowser(target, current.playlist, index, current.isExpanded);
+  }
+}

--- a/web/jellyfin/src/lib/types.ts
+++ b/web/jellyfin/src/lib/types.ts
@@ -1,0 +1,184 @@
+export interface JellyfinItem {
+  Id: string;
+  Name: string;
+  OriginalTitle?: string;
+  ServerId?: string;
+  Type: 'Movie' | 'Series' | 'Episode' | 'Season' | 'MusicVideo' | 'Folder' | 'BoxSet' | 'Audio' | 'MusicAlbum' | 'MusicArtist' | 'Playlist' | 'Video';
+  Overview?: string;
+  Taglines?: string[];
+  Genres?: string[];
+  CommunityRating?: number;
+  OfficialRating?: string;
+  RunTimeTicks?: number; // 10,000 ticks = 1 ms
+  ProductionYear?: number;
+  PremiereDate?: string;
+  EndDate?: string;
+  IndexNumber?: number; // Episode / Track number
+  ParentIndexNumber?: number; // Season / Disc number
+  SeriesName?: string;
+  SeriesId?: string;
+  SeasonName?: string;
+  SeasonId?: string;
+  Album?: string;
+  AlbumId?: string;
+  AlbumArtist?: string;
+  Artists?: string[];
+  PrimaryImageTag?: string;
+  BackdropImageTags?: string[];
+  ImageTags?: Record<string, string>;
+  Container?: string;
+  VideoType?: string;
+  MediaType?: string;
+  IsFolder?: boolean;
+  ChildCount?: number;
+  UserData?: {
+    PlaybackPositionTicks?: number;
+    PlayCount?: number;
+    IsFavorite?: boolean;
+    Played?: boolean;
+    LastPlayedDate?: string;
+  };
+  MediaSources?: JellyfinMediaSource[];
+  MediaStreams?: JellyfinMediaStream[];
+  // Extra helper fields for demo / UI
+  streamUrl?: string;
+  posterUrl?: string;
+  backdropUrl?: string;
+  seasons?: JellyfinSeason[];
+  tracks?: JellyfinItem[];
+}
+
+export interface JellyfinSeason {
+  Id: string;
+  Name: string;
+  IndexNumber: number;
+  SeriesId: string;
+  Episodes: JellyfinItem[];
+}
+
+export interface JellyfinMediaSource {
+  Id: string;
+  Container?: string;
+  Path?: string;
+  Protocol?: string;
+  Bitrate?: number;
+  DirectStreamUrl?: string;
+  TranscodingUrl?: string;
+  SupportsDirectPlay?: boolean;
+  SupportsDirectStream?: boolean;
+  SupportsTranscoding?: boolean;
+}
+
+export interface JellyfinMediaStream {
+  Type: 'Audio' | 'Video' | 'Subtitle';
+  Codec?: string;
+  Language?: string;
+  DisplayTitle?: string;
+  IsDefault?: boolean;
+  IsForced?: boolean;
+  Height?: number;
+  Width?: number;
+  AspectRatio?: string;
+  AverageFrameRate?: number;
+  Channels?: number;
+  SampleRate?: number;
+  Index?: number;
+}
+
+export interface JellyfinUser {
+  Id: string;
+  Name: string;
+  ServerId: string;
+  HasPassword?: boolean;
+  Policy?: {
+    IsAdministrator?: boolean;
+  };
+}
+
+export interface ServerConfig {
+  url: string;
+  token: string;
+  userId: string;
+  username: string;
+  serverName: string;
+  isDemo: boolean;
+  connected: boolean;
+}
+
+export interface SavedAccount {
+  id: string; // url + '_' + userId
+  url: string;
+  token: string;
+  userId: string;
+  username: string;
+  serverName: string;
+  serverId?: string;
+  isDemo?: boolean;
+  lastActive: number;
+}
+
+export interface VisualMetadata {
+  title?: string;
+  year?: string;
+  overview?: string;
+  genres?: string[];
+  posterUrl?: string;
+  backdropUrl?: string;
+  season?: number;
+  episode?: number;
+  episodeTitle?: string;
+  album?: string;
+  artist?: string;
+  duration?: number;
+}
+
+export interface PlayBridgeItem {
+  id?: string;
+  url: string;
+  title?: string;
+  contentType?: string;
+  posterUrl?: string;
+  metadata?: VisualMetadata;
+  customData?: Record<string, any>;
+}
+
+export interface PlayBridgeCastPayload {
+  url?: string;
+  title?: string;
+  contentType?: string;
+  posterUrl?: string;
+  metadata?: VisualMetadata;
+  items?: PlayBridgeItem[];
+  startIndex?: number;
+  localNetwork?: boolean;
+  customData?: Record<string, any>;
+}
+
+export interface PlayBridgeLinkSession {
+  sessionId: string;
+  addEventListener(event: 'statechange' | 'needitems' | 'ended', callback: (event: any) => void): void;
+  removeEventListener(event: string, callback: (event: any) => void): void;
+  provideItems(requestId: string, payload: { items: PlayBridgeItem[]; endOfList?: boolean }): Promise<void>;
+  jump(index: number): Promise<void>;
+  unlink(): Promise<void>;
+}
+
+export interface PlayBridgeAPI {
+  cast(payload: PlayBridgeCastPayload | PlayBridgeItem[]): void;
+  linkCast?(options: {
+    items: PlayBridgeItem[];
+    startIndex?: number;
+    metadata?: VisualMetadata;
+    localNetwork?: boolean;
+  }): Promise<PlayBridgeLinkSession>;
+  capabilities?: {
+    linkedCast?: boolean;
+    mediaControls?: boolean;
+  };
+}
+
+declare global {
+  interface Window {
+    playbridge?: PlayBridgeAPI;
+  }
+}

--- a/web/jellyfin/src/main.ts
+++ b/web/jellyfin/src/main.ts
@@ -1,0 +1,9 @@
+import { mount } from 'svelte';
+import './app.css';
+import App from './App.svelte';
+
+const app = mount(App, {
+  target: document.getElementById('app')!
+});
+
+export default app;

--- a/web/jellyfin/svelte.config.js
+++ b/web/jellyfin/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess()
+};

--- a/web/jellyfin/tsconfig.json
+++ b/web/jellyfin/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "module": "ESNext",
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"]
+}

--- a/web/jellyfin/vite.config.ts
+++ b/web/jellyfin/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()],
+  server: {
+    host: '0.0.0.0',
+    port: 5180
+  }
+});


### PR DESCRIPTION
## Summary

Adds a standalone Svelte-based Jellyfin Web Client (`web/jellyfin`) featuring multi-server/multi-user switching, hierarchical library & folder navigation, in-browser playback, and native PlayBridge casting support.

### Key Features & Architecture
- **PlayBridge Casting Primitives**:
  - Direct Cast & Linked Queue Cast via `window.playbridge` detector and bridge APIs.
  - Video stream resolution with direct streaming, HLS transcoding fallback, audio streaming, and playlist payloads.
  - Real-time diagnostics & event inspector drawer with live JSON payloads.
- **Official Jellyfin Organization**:
  - "My Media" library tiles grid on the Home view.
  - "Next Up" television episode shelf (`/Shows/NextUp`) with 16:9 widescreen episode thumbnails and season/episode badges.
  - Dedicated "Recently Added in [Library]" shelves.
- **Hierarchical Folder Navigation**:
  - Non-recursive direct-child queries for folder libraries and nested subdirectories.
  - Interactive breadcrumbs trail and "Back" navigation for nested media folders.
- **Multi-Server & Multi-User Profiles**:
  - Instant 1-click profile switching from the navbar and login screen.
  - Secure credential & token management with automatic state resetting between accounts.
- **Zero-Lag SWR & Cache Architecture**:
  - IndexedDB (`PlayBridge_Jellyfin_DB`) + in-memory SWR caching for instant offline loads without `localStorage` 5MB quota limits.
  - In-app "Clear Cache & Re-sync" and "Factory Reset" controls.
- **In-Browser Media Player & Queue**:
  - Floating mini-dock and full-screen video overlay with HLS streaming support.
  - Queue drawer with shuffle, repeat, track scrubbing, and playlist management.

### Verification
- Ran `pnpm check && pnpm build` inside `web/jellyfin` — clean build, 0 errors.
- Verified multi-user login, account switching, folder navigation, SWR cache hydration, and cast payload emission.