### PR TITLE
feat(phone): add browser chrome fullscreen mode

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -11,10 +11,12 @@ import androidx.compose.animation.*
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -23,13 +25,17 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.zIndex
@@ -75,6 +81,7 @@ import org.koin.compose.koinInject
 import org.koin.androidx.compose.koinViewModel
 import com.playbridge.sender.data.library.AddonDao
 import com.playbridge.sender.data.settings.SettingsRepository
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
@@ -102,6 +109,8 @@ fun AppNavHost(
     onIsEditingChange: (Boolean) -> Unit,
     isFullscreen: Boolean,
     onIsFullscreenChange: (Boolean) -> Unit,
+    isBrowserChromeHidden: Boolean,
+    onIsBrowserChromeHiddenChange: (Boolean) -> Unit,
     backPressedTime: Long,
     onBackPressedTimeChange: (Long) -> Unit,
     onFinishActivity: () -> Unit,
@@ -425,7 +434,10 @@ fun AppNavHost(
                             session?.exitFullScreenMode()
                         }
                     }
-                    BackHandler(enabled = !isFullscreen && !isEditing) {
+                    BackHandler(enabled = !isFullscreen && isBrowserChromeHidden) {
+                        onIsBrowserChromeHiddenChange(false)
+                    }
+                    BackHandler(enabled = !isFullscreen && !isBrowserChromeHidden && !isEditing) {
                         if (browserCanGoBack) {
                             session?.goBack()
                         } else {
@@ -443,14 +455,28 @@ fun AppNavHost(
                         }
                     }
 
-                    BackHandler(enabled = isEditing) {
+                    BackHandler(enabled = isEditing && !isBrowserChromeHidden) {
                         onIsEditingChange(false)
                         onUrlBarTappedChange(false)
                         keyboardController?.hide()
                         focusManager.clearFocus()
                     }
 
-                    Box(modifier = Modifier.fillMaxSize()) {
+                    var chromeHandleOnRight by rememberSaveable { mutableStateOf(true) }
+                    var chromeHandleYFraction by rememberSaveable { mutableFloatStateOf(0f) }
+                    var chromeHandleDragOffset by remember { mutableStateOf<Offset?>(null) }
+
+                    BoxWithConstraints(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .then(
+                                if (isBrowserChromeHidden && !isFullscreen) {
+                                    Modifier.windowInsetsPadding(WindowInsets.safeDrawing)
+                                } else {
+                                    Modifier
+                                }
+                            )
+                    ) {
                         if (currentScreen == Screen.Browser && session != null) {
                             browserViewContent(session) { url ->
                                 onContextMenuUrlChange(url)
@@ -465,6 +491,80 @@ fun AppNavHost(
                                 historyDao = historyDao,
                                 bookmarkDao = bookmarkDao
                             )
+                        }
+
+                        if (isBrowserChromeHidden && !isFullscreen) {
+                            val density = LocalDensity.current
+                            val handleSizePx = with(density) { 48.dp.toPx() }
+                            val maxHandleX = (with(density) { maxWidth.toPx() } - handleSizePx)
+                                .coerceAtLeast(0f)
+                            val maxHandleY = (with(density) { maxHeight.toPx() } - handleSizePx)
+                                .coerceAtLeast(0f)
+                            val restingHandleOffset = Offset(
+                                x = if (chromeHandleOnRight) maxHandleX else 0f,
+                                y = chromeHandleYFraction.coerceIn(0f, 1f) * maxHandleY,
+                            )
+                            val displayedHandleOffset = chromeHandleDragOffset ?: restingHandleOffset
+
+                            Surface(
+                                modifier = Modifier
+                                    .align(Alignment.TopStart)
+                                    .offset {
+                                        IntOffset(
+                                            x = displayedHandleOffset.x.roundToInt(),
+                                            y = displayedHandleOffset.y.roundToInt(),
+                                        )
+                                    }
+                                    .pointerInput(maxHandleX, maxHandleY, restingHandleOffset) {
+                                        detectDragGestures(
+                                            onDragStart = {
+                                                chromeHandleDragOffset = restingHandleOffset
+                                            },
+                                            onDragEnd = {
+                                                chromeHandleDragOffset?.let { position ->
+                                                    chromeHandleOnRight = position.x >= maxHandleX / 2f
+                                                    chromeHandleYFraction = if (maxHandleY > 0f) {
+                                                        position.y / maxHandleY
+                                                    } else {
+                                                        0f
+                                                    }
+                                                }
+                                                chromeHandleDragOffset = null
+                                            },
+                                            onDragCancel = {
+                                                chromeHandleDragOffset = null
+                                            },
+                                        ) { change, dragAmount ->
+                                            change.consume()
+                                            val current = chromeHandleDragOffset ?: restingHandleOffset
+                                            chromeHandleDragOffset = Offset(
+                                                x = (current.x + dragAmount.x).coerceIn(0f, maxHandleX),
+                                                y = (current.y + dragAmount.y).coerceIn(0f, maxHandleY),
+                                            )
+                                        }
+                                    },
+                                shape = when {
+                                    chromeHandleDragOffset != null -> RoundedCornerShape(16.dp)
+                                    chromeHandleOnRight -> RoundedCornerShape(
+                                        topStart = 16.dp,
+                                        bottomStart = 16.dp,
+                                    )
+                                    else -> RoundedCornerShape(
+                                        topEnd = 16.dp,
+                                        bottomEnd = 16.dp,
+                                    )
+                                },
+                                color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.9f),
+                                tonalElevation = 6.dp,
+                                shadowElevation = 4.dp,
+                            ) {
+                                IconButton(onClick = { onIsBrowserChromeHiddenChange(false) }) {
+                                    Icon(
+                                        imageVector = Icons.Default.FullscreenExit,
+                                        contentDescription = "Show browser controls",
+                                    )
+                                }
+                            }
                         }
 
                         if (isEditing) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
@@ -752,6 +752,9 @@ class BrowserActivity : ComponentActivity() {
                 }
             }
 
+            // Chrome-hidden mode belongs to the selected tab and intentionally remains
+            // session-only: it survives tab switches/navigation, but not an app restart.
+            var chromeHiddenTabIds by rememberSaveable { mutableStateOf(emptySet<String>()) }
             val tabIds = browserState.tabs.map { it.id }
             LaunchedEffect(tabIds, browserState.selectedTabId) {
                 Log.d("PB_STARTUP", "Compose: syncSessions triggered — tabCount=${browserState.tabs.size}, selectedTabId=${browserState.selectedTabId}")
@@ -761,12 +764,14 @@ class BrowserActivity : ComponentActivity() {
                 // from the store (e.g. via Mozilla Components paths that bypass
                 // closeTab). This is the safety net for memory leaks.
                 tabManager.reconcileWithStoreTabs(tabIds.toSet())
+                chromeHiddenTabIds = chromeHiddenTabIds.intersect(tabIds.toSet())
             }
 
             val sessions = tabManager.sessions
 
             val selectedTabId = browserState.selectedTabId
             val selectedTab = browserState.tabs.find { it.id == selectedTabId }
+            val isBrowserChromeHidden = selectedTabId?.let(chromeHiddenTabIds::contains) == true
             val session = if (selectedTab != null) sessions[selectedTab.id] else null
 
             Log.d("PB_STARTUP", "Compose: recompose — browserStateTabs=${browserState.tabs.size}, selectedTabId=$selectedTabId, sessionNull=${session == null}, tabsRestored=${tabsRestoredOrReady.value}, sessionsMapSize=${sessions.size}")
@@ -2064,8 +2069,8 @@ class BrowserActivity : ComponentActivity() {
                     Scaffold(
                         contentWindowInsets = WindowInsets(0, 0, 0, 0),
                         topBar = {
-                        if (isFullscreen) {
-                            // Hide toolbar in fullscreen
+                        if (isFullscreen || (currentScreen == Screen.Browser && isBrowserChromeHidden)) {
+                            // Media fullscreen and chrome-hidden browsing both hide the toolbar.
                         } else when (currentScreen) {
                             Screen.Browser -> {
                                 Box(modifier = Modifier.fillMaxWidth()) {
@@ -2262,7 +2267,7 @@ class BrowserActivity : ComponentActivity() {
                         }
                     },
                         bottomBar = {
-                            if (currentScreen == Screen.Browser && !isFullscreen) {
+                            if (currentScreen == Screen.Browser && !isFullscreen && !isBrowserChromeHidden) {
                                 Surface(
                                     modifier = Modifier.fillMaxWidth(),
                                     color = MaterialTheme.colorScheme.surfaceContainer,
@@ -2382,6 +2387,16 @@ class BrowserActivity : ComponentActivity() {
                         onIsEditingChange = { isEditing = it },
                         isFullscreen = isFullscreen,
                         onIsFullscreenChange = { isFullscreen = it },
+                        isBrowserChromeHidden = isBrowserChromeHidden,
+                        onIsBrowserChromeHiddenChange = { hidden ->
+                            selectedTabId?.let { tabId ->
+                                chromeHiddenTabIds = if (hidden) {
+                                    chromeHiddenTabIds + tabId
+                                } else {
+                                    chromeHiddenTabIds - tabId
+                                }
+                            }
+                        },
                         backPressedTime = backPressedTime,
                         onBackPressedTimeChange = { backPressedTime = it },
                         onFinishActivity = { finish() },
@@ -2484,6 +2499,14 @@ class BrowserActivity : ComponentActivity() {
                         scope.launch { sheetState.hide() }.invokeOnCompletion {
                             showMenuSheet = false
                             showUserAgentSheet = true
+                        }
+                    },
+                    onFullScreenClick = {
+                        scope.launch { sheetState.hide() }.invokeOnCompletion {
+                            showMenuSheet = false
+                            isEditing = false
+                            showFindBar = false
+                            selectedTabId?.let { chromeHiddenTabIds = chromeHiddenTabIds + it }
                         }
                     },
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/MenuSheet.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/MenuSheet.kt
@@ -60,6 +60,7 @@ fun MenuSheet(
     onToggleDesktopMode: () -> Unit,
     onToggleVideoDetect: () -> Unit,
     onUserAgentClick: () -> Unit = {},
+    onFullScreenClick: () -> Unit = {},
     onClearDataClick: () -> Unit = {}
 ) {
     val items = listOf(
@@ -111,7 +112,13 @@ fun MenuSheet(
             label = "Extensions",
             onClick = onExtensionsClick
         ),
-        // Settings lives on Dashboard (top-right gear) only.
+        MenuAction(
+            icon = Icons.Default.Fullscreen,
+            label = "Full Screen",
+            onClick = onFullScreenClick
+        ),
+        // Settings lives on Dashboard (top-right gear) only. Keep the destructive
+        // action after the primary browser controls so it overflows first.
         MenuAction(
             icon = Icons.Default.DeleteSweep,
             label = "Clear Data",

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/SheetOverlayContainer.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/SheetOverlayContainer.kt
@@ -42,6 +42,7 @@ fun SheetOverlayContainer(
     onToggleDesktopMode: () -> Unit,
     onToggleVideoDetect: () -> Unit,
     onUserAgentClick: () -> Unit = {},
+    onFullScreenClick: () -> Unit = {},
     userAgentActive: Boolean = false,
 
     // Clear Data Sheet States
@@ -118,6 +119,7 @@ fun SheetOverlayContainer(
                 onToggleVideoDetect = onToggleVideoDetect,
                 userAgentActive = userAgentActive,
                 onUserAgentClick = onUserAgentClick,
+                onFullScreenClick = onFullScreenClick,
                 onClearDataClick = onClearDataClick
             )
         }


### PR DESCRIPTION
## Summary
- Add a Full Screen action to the phone browser menu that hides PlayBridge browser chrome without entering media/OS immersive fullscreen.
- Keep chrome-hidden state per tab across navigation, tab switches, and configuration changes while leaving it unpersisted as an app setting.
- Restore browser controls via Android Back or an accessible floating edge handle.
- Make the handle freely draggable, constrain it to safe bounds, and snap it flush to the nearest left/right edge with only the inward corners rounded.
- Keep Clear Data after primary browser actions so it moves to the overflow menu page.

## Tests
- `cd mobile/android && zsh -c "source ~/.zshrc && ./gradlew :app:testFossDebugUnitTest --tests \"com.playbridge.sender.browser.MenuSheetPagingTest\" :app:assembleFossDebug"`
- `git diff --check`

## Manual verification
- Installed the arm64 FOSS debug APK on a Samsung SM-S936W.
- Confirmed `BrowserActivity` launched successfully.
- Verified the fullscreen control design iteratively on-device; final latest-main integration was rebuilt successfully.

## Risks
- The floating handle intentionally overlays a 48dp area of page content, but can be moved to either edge and any safe vertical position.
- Existing HTML/media fullscreen remains a separate state and takes Back precedence before chrome-hidden mode.