### PR TITLE
fix(apple-tv): protect persisted pairing tokens

### DIFF
--- a/docs/SECURITY_GAPS.md
+++ b/docs/SECURITY_GAPS.md
@@ -150,8 +150,9 @@ validator with identical allow/reject results.
 
 ### SEC-004: Bearer-token storage is inconsistent
 
-**Affected:** Desktop sender, Android TV receiver, Apple TV receiver. Desktop
-receiver is partially compliant because it stores SHA-256 token verifiers.
+**Affected:** Desktop sender and Android TV receiver. Desktop receiver is
+partially compliant because it stores SHA-256 token verifiers. Apple TV stores
+only verifier-backed receiver credentials and eagerly migrates legacy records.
 
 **Risk:** Theft of an original token permits authentication as the paired sender
 when the attacker can reach the receiver. Ordinary preferences are not a secret
@@ -163,8 +164,9 @@ store and may be exposed through local access or backups.
   `SharedPreferences`.
 - Android TV `PairingStore.kt` stores authorized plaintext token sets and paired
   device records in Preferences DataStore.
-- Apple TV `WebSocketServer.swift` stores authorized tokens and paired device
-  records, including tokens, in `UserDefaults`.
+- Apple TV `WebSocketServer.swift` stores SHA-256 token verifiers, rewrites
+  legacy paired-device records without their plaintext token, and removes the
+  legacy authorized-token preference during startup.
 - Android phone uses Keystore-backed protection and Apple phone uses Keychain;
   these are the model for their respective sender platforms.
 

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Models/PairedDevice.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Models/PairedDevice.swift
@@ -4,6 +4,49 @@ struct PairedDevice: Codable, Identifiable {
     var id: String { deviceUUID }
     let deviceUUID: String
     let deviceName: String
-    let token: String
+    let tokenVerifier: String
     var lastConnected: Date
+
+    init(
+        deviceUUID: String,
+        deviceName: String,
+        tokenVerifier: String,
+        lastConnected: Date
+    ) {
+        self.deviceUUID = deviceUUID
+        self.deviceName = deviceName
+        self.tokenVerifier = tokenVerifier
+        self.lastConnected = lastConnected
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case deviceUUID
+        case deviceName
+        case token
+        case tokenVerifier
+        case lastConnected
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        deviceUUID = try container.decode(String.self, forKey: .deviceUUID)
+        deviceName = try container.decode(String.self, forKey: .deviceName)
+        lastConnected = try container.decode(Date.self, forKey: .lastConnected)
+
+        if let verifier = try container.decodeIfPresent(String.self, forKey: .tokenVerifier),
+           !verifier.isEmpty {
+            tokenVerifier = verifier
+        } else {
+            let legacyToken = try container.decode(String.self, forKey: .token)
+            tokenVerifier = PairingCredentialState.hashToken(legacyToken)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(deviceUUID, forKey: .deviceUUID)
+        try container.encode(deviceName, forKey: .deviceName)
+        try container.encode(tokenVerifier, forKey: .tokenVerifier)
+        try container.encode(lastConnected, forKey: .lastConnected)
+    }
 }

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Models/PairingCredentialState.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Models/PairingCredentialState.swift
@@ -1,0 +1,96 @@
+import CryptoKit
+import Foundation
+
+struct PairingCredentialState {
+    private(set) var pairedDevices: [PairedDevice]
+    private(set) var authorizedTokenVerifiers: Set<String>
+
+    init(
+        pairedDevices: [PairedDevice] = [],
+        authorizedTokenVerifiers: Set<String> = []
+    ) {
+        self.pairedDevices = pairedDevices
+        self.authorizedTokenVerifiers = authorizedTokenVerifiers
+    }
+
+    static func migrated(
+        pairedDevices: [PairedDevice],
+        legacyAuthorizedTokens: Set<String>,
+        authorizedTokenVerifiers: Set<String>
+    ) -> PairingCredentialState {
+        let pairedVerifiers = Set(
+            pairedDevices.map(\.tokenVerifier).filter { !$0.isEmpty }
+        )
+        let migratedVerifiers = Set(legacyAuthorizedTokens.map(hashToken))
+
+        // Authorization must always remain associated with a visible paired-device
+        // record so stale credentials can be revoked from the TV UI.
+        let validVerifiers = authorizedTokenVerifiers
+            .union(migratedVerifiers)
+            .intersection(pairedVerifiers)
+
+        return PairingCredentialState(
+            pairedDevices: pairedDevices,
+            authorizedTokenVerifiers: validVerifiers
+        )
+    }
+
+    static func hashToken(_ token: String) -> String {
+        SHA256.hash(data: Data(token.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    func isTokenAuthorized(_ token: String) -> Bool {
+        authorizedTokenVerifiers.contains(Self.hashToken(token))
+    }
+
+    mutating func authorize(
+        deviceUUID: String,
+        deviceName: String,
+        token: String,
+        connectedAt: Date = Date()
+    ) {
+        let verifier = Self.hashToken(token)
+
+        if let existingIndex = pairedDevices.firstIndex(where: { $0.deviceUUID == deviceUUID }) {
+            authorizedTokenVerifiers.remove(pairedDevices[existingIndex].tokenVerifier)
+            pairedDevices[existingIndex] = PairedDevice(
+                deviceUUID: deviceUUID,
+                deviceName: deviceName,
+                tokenVerifier: verifier,
+                lastConnected: connectedAt
+            )
+        } else {
+            pairedDevices.append(PairedDevice(
+                deviceUUID: deviceUUID,
+                deviceName: deviceName,
+                tokenVerifier: verifier,
+                lastConnected: connectedAt
+            ))
+        }
+
+        authorizedTokenVerifiers.insert(verifier)
+    }
+
+    mutating func forgetDevice(deviceUUID: String) {
+        let removedVerifiers = pairedDevices
+            .filter { $0.deviceUUID == deviceUUID }
+            .map(\.tokenVerifier)
+        pairedDevices.removeAll { $0.deviceUUID == deviceUUID }
+        authorizedTokenVerifiers.subtract(removedVerifiers)
+    }
+
+    mutating func forgetAllDevices() {
+        pairedDevices.removeAll()
+        authorizedTokenVerifiers.removeAll()
+    }
+
+    mutating func updateLastConnected(token: String, connectedAt: Date = Date()) {
+        let verifier = Self.hashToken(token)
+        guard let index = pairedDevices.firstIndex(where: { $0.tokenVerifier == verifier }) else {
+            return
+        }
+        pairedDevices[index].lastConnected = connectedAt
+    }
+}

--- a/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
+++ b/tv/apple/PlayBridge TV/PlayBridge TV/Network/WebSocketServer.swift
@@ -53,7 +53,8 @@ class WebSocketServer: ObservableObject {
     @Published var wssPort: UInt16?
 
     var deviceName: String { UIDevice.current.name }
-    private let authorizedTokensKey = "pb_authorized_tokens"
+    private let legacyAuthorizedTokensKey = "pb_authorized_tokens"
+    private let authorizedTokenVerifiersKey = "pb_authorized_token_verifiers"
     private let deviceUUIDKey = "pb_device_uuid"
     private let pairedDevicesKey = "pb_paired_devices"
     private let receiverPortKey = "pb_receiver_port"
@@ -76,25 +77,46 @@ class WebSocketServer: ObservableObject {
         return newUUID
     }
 
-    private var storedPairedDevices: [PairedDevice] {
-        get {
-            guard let data = UserDefaults.standard.data(forKey: pairedDevicesKey),
-                  let devices = try? JSONDecoder().decode([PairedDevice].self, from: data) else {
-                return []
-            }
-            return devices
+    private var pairingCredentials = PairingCredentialState()
+
+    private func loadAndMigratePairingCredentials() -> PairingCredentialState {
+        let defaults = UserDefaults.standard
+        let devices: [PairedDevice]
+        if let data = defaults.data(forKey: pairedDevicesKey),
+           let decoded = try? JSONDecoder().decode([PairedDevice].self, from: data) {
+            devices = decoded
+        } else {
+            devices = []
         }
-        set {
-            if let data = try? JSONEncoder().encode(newValue) {
-                UserDefaults.standard.set(data, forKey: pairedDevicesKey)
-            }
-            pairedDevicesList = newValue
-        }
+
+        let legacyTokens = Set(
+            defaults.stringArray(forKey: legacyAuthorizedTokensKey) ?? []
+        )
+        let storedVerifiers = Set(
+            defaults.stringArray(forKey: authorizedTokenVerifiersKey) ?? []
+        )
+        return PairingCredentialState.migrated(
+            pairedDevices: devices,
+            legacyAuthorizedTokens: legacyTokens,
+            authorizedTokenVerifiers: storedVerifiers
+        )
     }
 
-    private var authorizedTokens: Set<String> {
-        get { Set(UserDefaults.standard.stringArray(forKey: authorizedTokensKey) ?? []) }
-        set { UserDefaults.standard.set(Array(newValue), forKey: authorizedTokensKey) }
+    private func persistPairingCredentials() {
+        let defaults = UserDefaults.standard
+        guard let devicesData = try? JSONEncoder().encode(pairingCredentials.pairedDevices) else {
+            return
+        }
+
+        // Write both verifier-backed records before removing the legacy plaintext key.
+        // If the process exits between writes, the next launch safely repeats migration.
+        defaults.set(devicesData, forKey: pairedDevicesKey)
+        defaults.set(
+            Array(pairingCredentials.authorizedTokenVerifiers),
+            forKey: authorizedTokenVerifiersKey
+        )
+        defaults.removeObject(forKey: legacyAuthorizedTokensKey)
+        pairedDevicesList = pairingCredentials.pairedDevices
     }
 
     /// Re-broadcasts `playlist_status` whenever the queue changes — including index moves
@@ -105,7 +127,8 @@ class WebSocketServer: ObservableObject {
         self.historyStore = historyStore
         self.playlistStore = playlistStore
         self.localIP = getIPAddress()
-        self.pairedDevicesList = storedPairedDevices
+        self.pairingCredentials = loadAndMigratePairingCredentials()
+        persistPairingCredentials()
 
         // objectWillChange fires *before* the mutation lands; the debounce hop onto the
         // main queue ensures we serialize the post-mutation queue state.
@@ -644,17 +667,6 @@ class WebSocketServer: ObservableObject {
         autoTimeoutWork = nil
 
         let token = UUID().uuidString
-        var tokens = authorizedTokens
-        tokens.insert(token)
-        authorizedTokens = tokens
-
-        let device = PairedDevice(
-            deviceUUID: handshake.deviceUUID,
-            deviceName: handshake.deviceName,
-            token: token,
-            lastConnected: Date()
-        )
-        savePairedDevice(device)
 
         guard let commitBytes = Data(base64Encoded: handshake.commit),
               let senderEphPub = handshake.senderEphPub,
@@ -692,6 +704,12 @@ class WebSocketServer: ObservableObject {
                 plaintext: plaintext,
                 aad: transcriptHash
             )
+            pairingCredentials.authorize(
+                deviceUUID: handshake.deviceUUID,
+                deviceName: handshake.deviceName,
+                token: token
+            )
+            persistPairingCredentials()
             send(json: [
                 "type": "pairing_approved",
                 "nonce": credentialNonce.base64EncodedString(),
@@ -785,8 +803,9 @@ class WebSocketServer: ObservableObject {
             send(json: ["type": "auth_response", "success": false], to: connection)
             return
         }
-        if authorizedTokens.contains(msg.token) {
-            updateLastConnected(token: msg.token)
+        if pairingCredentials.isTokenAuthorized(msg.token) {
+            pairingCredentials.updateLastConnected(token: msg.token)
+            persistPairingCredentials()
             completeAuth(from: connection, token: msg.token)
         } else {
             send(json: ["type": "auth_response", "success": false], to: connection)
@@ -822,41 +841,14 @@ class WebSocketServer: ObservableObject {
 
     // MARK: - Paired Device Management
 
-    private func savePairedDevice(_ device: PairedDevice) {
-        var devices = storedPairedDevices
-        if let idx = devices.firstIndex(where: { $0.deviceUUID == device.deviceUUID }) {
-            devices[idx] = device
-        } else {
-            devices.append(device)
-        }
-        storedPairedDevices = devices
-    }
-
     func forgetDevice(_ device: PairedDevice) {
-        var devices = storedPairedDevices
-        devices.removeAll { $0.deviceUUID == device.deviceUUID }
-        storedPairedDevices = devices
-        var tokens = authorizedTokens
-        tokens.remove(device.token)
-        authorizedTokens = tokens
+        pairingCredentials.forgetDevice(deviceUUID: device.deviceUUID)
+        persistPairingCredentials()
     }
 
     func forgetAllDevices() {
-        storedPairedDevices = []
-        authorizedTokens = []
-        DispatchQueue.main.async { self.pairedDevicesList = [] }
-    }
-
-    private func updateLastConnected(token: String) {
-        var devices = storedPairedDevices
-        if let idx = devices.firstIndex(where: { $0.token == token }) {
-            let d = devices[idx]
-            devices[idx] = PairedDevice(
-                deviceUUID: d.deviceUUID, deviceName: d.deviceName,
-                token: token, lastConnected: Date()
-            )
-            storedPairedDevices = devices
-        }
+        pairingCredentials.forgetAllDevices()
+        persistPairingCredentials()
     }
 
     // MARK: - Command Handling


### PR DESCRIPTION
## Summary
- persist only SHA-256 pairing-token verifiers on Apple TV
- eagerly migrate legacy authorized tokens and paired-device records during startup
- keep authorization tied to visible paired devices so stale/orphaned credentials fail closed
- revoke the previous verifier when the same sender pairs again
- preserve the existing encrypted pairing and raw-token authentication wire contract

This replaces and addresses the migration gap identified in #207.

## Verification
- focused Swift migration/auth/re-pair/revocation harness (`swiftc`): passed
- `xcodebuild -workspace "PlayBridge TV.xcworkspace" -scheme "PlayBridge TV" -configuration Debug -destination 'generic/platform=tvOS' build CODE_SIGNING_ALLOWED=NO`: passed
- `git diff --check`: passed

## Risk
Legacy authorization entries without a matching paired-device record are intentionally discarded because they cannot be individually managed or revoked from the TV UI.
