### PR TITLE
docs(phone): backfill 0.13.0 changelog for coordinated release

### DIFF
--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -5,6 +5,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.13.0] — 2026-08-11 (versionCode 223)
 
+> **Works best together**: Screen mirroring, mixed-media playlists, and the skip pre-play preference are cross-device features introduced in this coordinated release. Use PlayBridge TV Player 0.13.0+ and Desktop 0.13.0+ on the other side for full support.
+
 ### Added
 - **Screen mirroring**: Mirror the phone to compatible PlayBridge TV and Desktop receivers over WebRTC with H.264 video, optional playback audio, orientation-aware sizing, and selectable quality limits. Google Cast and DLNA receivers can receive the same capture as a video-only H.264/MPEG-TS live stream.
 - **Consent-gated page casting**: Cast the page you are browsing to linked TV/Desktop receivers with per-site consent prompts, a dedicated consent settings screen, and richer page media/subtitle metadata shared over the protocol.

--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -7,10 +7,17 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - **Screen mirroring**: Mirror the phone to compatible PlayBridge TV and Desktop receivers over WebRTC with H.264 video, optional playback audio, orientation-aware sizing, and selectable quality limits. Google Cast and DLNA receivers can receive the same capture as a video-only H.264/MPEG-TS live stream.
+- **Consent-gated page casting**: Cast the page you are browsing to linked TV/Desktop receivers with per-site consent prompts, a dedicated consent settings screen, and richer page media/subtitle metadata shared over the protocol.
+- **Browser fullscreen mode**: Toggle fullscreen chrome in the in-app browser from the menu.
+- **Skip pre-play cast preference**: New casting preference that lets supported receivers skip pre-play screens when loading casts.
 
 ### Changed
 - **Release optimization**: Enable R8 code and resource optimization for smaller, optimized FOSS and Play release builds.
 - **External screen mirroring**: Keep Google Cast playback active across phone orientation changes by using a stable encoded canvas and resizing only the captured display source.
+- **Menu sheet layout**: Fill the browser menu grid left-to-right and add paging only once the 2x5 grid is full, hiding dots and swipe on single-page menus.
+
+### Fixed
+- **Remote control pointer input**: Smooth high-frequency pointer input and anchor image transforms to the touch midpoint so remote-control sessions track gestures accurately.
 
 ## [0.12.0] — 2026-08-03 (versionCode 222)
 


### PR DESCRIPTION
## Summary
Part of a coordinated cross-project release alignment: Phone, TV Player, and Desktop all ship as **0.13.0** so cross-device features have matching sender/receiver versions.

Phone is already at 0.13.0 (versionCode 223), so this PR only updates documentation:
- Backfill the unreleased 0.13.0 section with post-uprev merges
- Add a compatibility note tying mirroring/playlist features to TV/Desktop 0.13.0+

No code or version changes — changelog only.

## Test checklist (Phone 0.13.0)

### Screen mirroring
- [x] Mirror phone to TV Player 0.13.0 and Desktop 0.13.0 over WebRTC; video renders with correct aspect in both portrait and landscape
- [x] Rotate phone mid-mirror: Google Cast playback stays active (stable encoded canvas), capture resizes without freezing or black frames
- [x] Toggle optional playback audio in the mirror; audio arrives on receiver and stops when muted
- [x] Select each quality limit and confirm the receiver-side stream matches without stutter
- [x] Mirror as video-only H.264/MPEG-TS live stream to a Google Cast and a DLNA receiver

### Consent-gated page casting
- [x] Open an external page and start linked page cast: first attempt shows per-site consent prompt; deny blocks casting, allow proceeds
- [x] Consent decision persists per site; revisit casts without re-prompting, and revoking in the Page Cast consent settings screen re-prompts
- [x] Cast a page containing media and subtitles; page media/subtitle metadata reaches the receiver correctly

### Browser
- [x] Toggle fullscreen chrome from the menu; entering/exiting fullscreen keeps nav state and doesn't trap gesture navigation
- [x] Menu sheet: icons fill left-to-right in the 2×5 grid; with few items there are no dots/swipe hints; overflow items page correctly

### Casting preferences & remote control
- [x] Toggle skip pre-play cast preference and cast to a supporting receiver; pre-play is skipped when on, shown when off
- [x] In remote control of a Desktop/TV receiver, drag quickly (high-frequency pointer): cursor tracks smoothly without jumps
- [x] Pinch/pan image transforms anchor to the touch midpoint, not the screen origin

### Build/release
- [x] FOSS release build (`assembleRelease` with R8) installs, signs in, discovers receivers, and casts — no R8 breakage
- [ ] Debug diagnostics still log URLs/headers only in debug builds; persisted logs stay redacted