### PR TITLE
feat(tv): align TV player at 0.13.0 and backfill changelog

### DIFF
--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -7,9 +7,16 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - **WebRTC screen mirroring**: Receive H.264 phone screen mirrors with lifecycle-safe rendering, orientation-aware video, capability advertisement, and validated signaling.
+- **Mixed-media playlists**: Play combined audio/video/image playlists from phone senders with a dedicated presentation surface for image slides.
+- **Page casting playback policy**: Enforce sender page playback and subtitle resource policies when casting linked browser pages.
+- **Skip pre-play preference**: Honor the skip pre-play cast preference when loading casts from senders.
 
 ### Changed
 - **Release optimization**: Enable R8 code and resource optimization for smaller, optimized FOSS and Play release builds.
+- **Compact progress visibility**: Keep the playback progress bar visible in the compact player controls overlay.
+
+### Fixed
+- **Remote pointer input**: Smooth high-frequency pointer input and anchor image transforms to the touch midpoint during remote-control sessions.
 
 ### Security
 - **Persisted pairing tokens**: Store paired-device credentials as SHA-256 digests, migrate compatible legacy records, and refresh active authentication state after pairing changes.

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,7 +3,9 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## Player [0.12.0] — 2026-08-11 (versionCode 227)
+## Player [0.13.0] — 2026-08-11 (versionCode 228)
+
+> **Works best together**: Screen mirroring, mixed-media playlists, and the skip pre-play preference are cross-device features introduced in this coordinated release. Use PlayBridge Phone 0.13.0+ and Desktop 0.13.0+ on the other side for full support.
 
 ### Added
 - **WebRTC screen mirroring**: Receive H.264 phone screen mirrors with lifecycle-safe rendering, orientation-aware video, capability advertisement, and validated signaling.

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -31,8 +31,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 227
-        versionName = "0.12.0"
+        versionCode = 228
+        versionName = "0.13.0"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
## Summary
Part of a coordinated cross-project release alignment: Phone, TV Player, and Desktop all ship as **0.13.0** so cross-device features (screen mirroring, mixed-media playlists, skip pre-play) have matching sender/receiver versions.

- Bump TV Player versionName `0.12.0` → `0.13.0`, versionCode `227` → `228`
- Backfill the unreleased changelog section with post-uprev merges
- Add a compatibility note tying mirroring/playlist features to Phone/Desktop 0.13.0+

## Test checklist (TV Player 0.13.0)

### WebRTC screen mirroring
- [x] Start mirror from Phone 0.13.0; H.264 video renders with lifecycle-safe start/stop (no zombie service after sender disconnects)
- [x] Rotate phone during mirror; video re-orients without stretching or restart loops
- [x] Capability advertisement: non-mirroring senders don't offer mirroring to this TV; older phone versions degrade gracefully

### Mixed-media playlists
- [x] Cast a playlist mixing audio, video, and image items from Phone 0.13.0; each kind plays via the correct engine and image slides render on the presentation surface
- [x] Skip forward/back across media kinds; transitions complete without black screen or stuck audio

### Page casting policy
- [x] Receive a linked page cast from Phone 0.13.0 with media and subtitles; playback and subtitle resources obey the sender's page policy (blocked resources don't load)
- [ ] Subtitle track from page metadata loads through ExternalSubtitleLoader and toggles from player controls

### Preferences & UI
- [x] Sender with skip pre-play enabled starts playback directly at content; disabled sender still shows pre-play
- [x] Compact controls overlay keeps the progress bar visible while paused/playing; progress updates live

### Remote control
- [x] Phone remote control: fast pointer movement tracks smoothly on TV
- [ ] Image pan/pinch anchors to touch midpoint

### Security & build
- [x] Pairing tokens stored as SHA-256 digests; upgrade from 0.11.x migrates legacy records and keeps existing pairings working; pairing refresh invalidates old auth
- [x] FOSS release build with R8 installs from sideload and Play-internal track; discovery, pairing, playback all work