### PR TITLE
feat(desktop): align Desktop at 0.13.0 and backfill changelog

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -7,12 +7,17 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - **Android screen mirroring**: Receive H.264 WebRTC screen mirrors from Android phones with lifecycle-safe signaling and correctly fitted portrait or landscape video.
 - **Native PlayBridge receiver runtime**: Use the secure Rust-backed TLS/WSS receiver with SAS pairing, persisted credentials, typed commands, and integrated pairing UI.
+- **Mixed-media playlists**: Play combined audio/video/image playlists with a dedicated media presentation surface, plus history and favorites support for playlist items.
+- **Skip pre-play preference**: Honor the sender's skip pre-play cast preference when loading playback requests.
 
 ### Changed
 - **Google Cast sessions**: Use persistent Cast sessions and the shared CAF receiver, with resilient receiver refresh, replacement loads, and serialized media operations.
+- **Page media request policy**: Enforce page-casting network policy through the playback request preparer, receiver server, and stream proxy upstream fetchers.
+- **Compact progress visibility**: Keep the playback progress bar visible in the compact player view.
 
 ### Fixed
 - **Low-latency HLS casting**: Cast demuxed LL-HLS streams through synthetic master playlists so receivers load the selected audio and video renditions reliably.
+- **Remote pointer input**: Smooth high-frequency pointer input and anchor image transforms to the touch midpoint during remote-control sessions.
 
 ## [0.8.1+29] — 2026-07-19
 

--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.9.0+30] — 2026-08-11
+## [0.13.0+31] — 2026-08-11
+
+> **Works best together**: Screen mirroring, mixed-media playlists, and the skip pre-play preference are cross-device features introduced in this coordinated release. Use PlayBridge Phone 0.13.0+ and TV Player 0.13.0+ on the other side for full support.
 
 ### Added
 - **Android screen mirroring**: Receive H.264 WebRTC screen mirrors from Android phones with lifecycle-safe signaling and correctly fitted portrait or landscape video.

--- a/desktop/lib/update/app_version.dart
+++ b/desktop/lib/update/app_version.dart
@@ -2,7 +2,7 @@
 ///
 /// MUST match `version:` in pubspec.yaml (build-metadata part excluded) —
 /// guarded by `test/update_test.dart` so CI fails if they drift.
-const String kAppVersion = '0.9.0';
+const String kAppVersion = '0.13.0';
 
 /// Dotted numeric version (`0.6.4`, `1.10.2`) with sane comparison semantics.
 ///

--- a/desktop/pubspec.yaml
+++ b/desktop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: playbridge_desktop
 description: "PlayBridge desktop receiver — accepts cast commands from the phone and plays via libmpv."
 publish_to: 'none'
-version: 0.9.0+30
+version: 0.13.0+31
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## Summary
Part of a coordinated cross-project release alignment: Phone, TV Player, and Desktop all ship as **0.13.0** so cross-device features (screen mirroring, mixed-media playlists, skip pre-play) have matching sender/receiver versions.

- Bump Desktop version `0.9.0+30` → `0.13.0+31`
- Backfill the unreleased changelog section with post-uprev merges
- Add a compatibility note tying mirroring/playlist features to Phone/TV 0.13.0+

## Test checklist (Desktop 0.13.0)

### Android screen mirroring (receiver)
- [x] Start mirror from Phone 0.13.0; H.264 WebRTC video renders with correct fit in portrait and landscape
- [x] Stop/restart mirroring repeatedly: no leaked signaling state or stuck video surface

### Native receiver runtime & pairing
- [x] Fresh pairing with SAS code works; credentials persist across app restarts and reconnect without re-pairing
- [x] Commands from phone (play/pause/seek/remote pointer) arrive as typed commands and act correctly; never logs raw pairing token

### Mixed-media playlists
- [x] Receive a playlist mixing audio/video/image from Phone 0.13.0; images render on the media presentation surface, A/V via the right engine
- [x] Playlist items appear in history and can be favorited; favorites/history restore across restarts
- [x] Skip pre-play preference from sender is honored (direct content start when enabled)

### Page media policy & proxy
- [x] Cast a page from Phone 0.13.0: playback preparer enforces page media request policy — disallowed upstream requests are refused by receiver server and stream proxy alike
- [x] Remote (non-local) cast routed through local proxy still plays with the policy enforced; direct route unaffected
- [x] LL-HLS demuxed stream casts through synthetic master playlist; both audio and video renditions load on receivers

### UI & remote control
- [x] Compact player view keeps progress bar visible during playback
- [x] Phone remote control: high-frequency pointer input tracks smoothly; image transforms anchor to touch midpoint

### Google Cast & regression
- [x] Send to Chromecast: persistent session survives brief network blips; replacement loads swap media without ending the app; serialized operations don't interleave
- [x] `flutter analyze` and `flutter test` green
- [x] macOS/Windows/Linux packaged builds launch and pass the native receiver smoke test