### PR TITLE
fix(desktop): keep demuxed HLS masters intact so mpv exposes all audio renditions

### DIFF
--- a/desktop/lib/engines/hls_master_resolver.dart
+++ b/desktop/lib/engines/hls_master_resolver.dart
@@ -51,6 +51,14 @@ Future<String> resolveHlsMaster(
     if (body == null) return url;
     if (!body.contains('#EXTM3U')) return url; // not an HLS playlist at all
 
+    // Keep demuxed masters intact so mpv can expose every audio rendition and
+    // manage video/audio synchronization itself. Collapsing these masters to a
+    // video variant silently discards their EXT-X-MEDIA audio tracks.
+    if (_hasAudioRenditions(body)) {
+      debugPrint('[hls] master has audio renditions, keeping original URL');
+      return url;
+    }
+
     final variants = _parseMaster(body, uri);
     if (variants.isEmpty) {
       return url; // media playlist, or no variants → leave it
@@ -122,6 +130,16 @@ class _Variant {
                   codecs.toLowerCase().contains('hvc1')
               ? 'hevc'
               : 'other';
+}
+
+bool _hasAudioRenditions(String body) {
+  for (final line in const LineSplitter().convert(body)) {
+    final trimmed = line.trim();
+    if (!trimmed.startsWith('#EXT-X-MEDIA:')) continue;
+    final attrs = trimmed.substring('#EXT-X-MEDIA:'.length);
+    if (_attr(attrs, 'TYPE')?.toUpperCase() == 'AUDIO') return true;
+  }
+  return false;
 }
 
 /// Parses `#EXT-X-STREAM-INF` variant entries out of a master playlist.

--- a/desktop/test/hls_master_resolver_test.dart
+++ b/desktop/test/hls_master_resolver_test.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/engines/hls_master_resolver.dart';
+
+void main() {
+  late HttpServer server;
+  late String base;
+  final routes = <String, String>{};
+
+  setUp(() async {
+    routes.clear();
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    base = 'http://127.0.0.1:${server.port}';
+    unawaited(server.forEach((request) async {
+      final body = routes[request.uri.path];
+      if (body == null) {
+        request.response.statusCode = HttpStatus.notFound;
+      } else {
+        request.response.headers.contentType =
+            ContentType('application', 'vnd.apple.mpegurl');
+        request.response.write(body);
+      }
+      await request.response.close();
+    }));
+  });
+
+  tearDown(() => server.close(force: true));
+
+  test('keeps a demuxed master so mpv can expose every audio rendition',
+      () async {
+    routes['/demuxed.m3u8'] = '#EXTM3U\n'
+        '#EXT-X-MEDIA:GROUP-ID="audio",TYPE=AUDIO,NAME="English",DEFAULT=YES,'
+        'URI="audio_en.m3u8"\n'
+        '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="Spanish",DEFAULT=NO,'
+        'URI="audio_es.m3u8"\n'
+        '#EXT-X-STREAM-INF:BANDWIDTH=3014542,RESOLUTION=1920x1080,'
+        'CODECS="avc1.4D4032,mp4a.40.2",AUDIO="audio"\n'
+        'video_1080p.m3u8\n';
+
+    expect(
+      await resolveHlsMaster('$base/demuxed.m3u8'),
+      '$base/demuxed.m3u8',
+    );
+  });
+
+  test('still selects the best variant from a video-only master', () async {
+    routes['/master.m3u8'] = '#EXTM3U\n'
+        '#EXT-X-STREAM-INF:BANDWIDTH=3000000,RESOLUTION=1920x1080,'
+        'CODECS="avc1.64002A"\n'
+        'v1080.m3u8\n'
+        '#EXT-X-STREAM-INF:BANDWIDTH=1500000,RESOLUTION=1280x720,'
+        'CODECS="avc1.4D4020"\n'
+        'v720.m3u8\n';
+
+    expect(
+      await resolveHlsMaster('$base/master.m3u8'),
+      '$base/v1080.m3u8',
+    );
+  });
+
+  test('leaves a media playlist unchanged', () async {
+    routes['/media.m3u8'] = '#EXTM3U\n'
+        '#EXT-X-TARGETDURATION:10\n'
+        '#EXTINF:10.0,\n'
+        'segment.ts\n';
+
+    expect(
+      await resolveHlsMaster('$base/media.m3u8'),
+      '$base/media.m3u8',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- `resolveHlsMaster` collapsed master playlists containing `EXT-X-MEDIA:TYPE=AUDIO` down to a single video-only variant, so demuxed fMP4 HLS streams played with only one (default) audio track.
- Masters with audio renditions now keep their **original URL**: mpv receives the complete master, exposes every audio rendition, and owns A/V synchronization itself.
- Video-only masters are unchanged: the best compatible variant is still preselected for faster startup.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test test/hls_master_resolver_test.dart` — 3 focused tests pass:
  - demuxed master keeps original URL (all audio renditions preserved)
  - video-only master still preselects the best variant
  - media playlists pass through unchanged
- [x] Manual: problem stream (fMP4 HLS with separate audio renditions) plays with multiple selectable audio tracks in Built-in mpv

## Risks
- Low: only affects master-playlist resolution; demuxed streams lose quality preselection by design (mpv handles it), video-only behavior is untouched.