### PR TITLE
fix(android): release phone 0.13.1 crash fixes

### DIFF
--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.13.1] — 2026-08-28 (versionCode 224)
+
+### Fixed
+- **Android 16 startup**: Preserve SnakeYAML package names during R8 optimization so GeckoView no longer crashes while initializing its debug configuration on Android 16 devices, including 16 KB page-size lab devices.
+- **Foreground-service timeouts**: Classify the long-lived phone-hosted browser receiver as a connected-device session and stop app-owned foreground services immediately when Android reports a timeout.
+- **Long downloads**: Pause Android 15+ downloads before the `dataSync` foreground-service limit and keep timeout-paused work from being automatically re-enqueued.
+
 ## [0.13.0] — 2026-08-11 (versionCode 223)
 
 ### Added

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -130,8 +130,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 223
-        versionName = "0.13.0"
+        versionCode = 224
+        versionName = "0.13.1"
         buildConfigField(
             "String",
             "GOOGLE_CAST_APPLICATION_ID",

--- a/mobile/android/app/proguard-rules.pro
+++ b/mobile/android/app/proguard-rules.pro
@@ -17,6 +17,11 @@
     org.mozilla.geckoview.GeckoSession geckoSession;
 }
 
+# SnakeYAML derives logger names from Class.getPackage(). R8 otherwise moves these
+# classes into the default package, where Android 16 returns null and GeckoRuntime
+# crashes during startup in DebugConfig.fromFile(). Members may still be optimized.
+-keepnames class org.yaml.snakeyaml.**
+
 # Mozilla Nimbus can report through the optional Glean telemetry runtime.
 # PlayBridge does not package or initialize Glean.
 -dontwarn mozilla.telemetry.glean.Glean

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -97,11 +97,14 @@
             android:exported="false"
             android:foregroundServiceType="mediaPlayback|connectedDevice|mediaProjection|microphone" />
 
-        <!-- Phone-hosted browser receiver page (LAN HTTP/WS while casting to a TV browser). -->
+        <!-- Phone-hosted browser receiver page (LAN HTTP/WS while casting to a TV browser).
+             connectedDevice: this is a long-lived LAN session with a TV browser, not a
+             time-limited transfer. dataSync FGS is capped at 6 hours on Android 15+ and
+             crashes with ForegroundServiceDidNotStopInTimeException if the host stays on. -->
         <service
             android:name=".cast.browser.BrowserReceiverHostService"
             android:exported="false"
-            android:foregroundServiceType="dataSync" />
+            android:foregroundServiceType="connectedDevice" />
 
         <!-- Phase-1 download engine: give WorkManager's foreground service the dataSync
              type so DownloadWorker.setForeground() is allowed on Android 14+ (targetSdk 36). -->

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionService.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSessionService.kt
@@ -202,6 +202,19 @@ class CastSessionService : Service(), KoinComponent {
         return START_STICKY
     }
 
+    override fun onTimeout(startId: Int) {
+        handleForegroundTimeout(startId, fgsType = 0)
+    }
+
+    override fun onTimeout(startId: Int, fgsType: Int) {
+        handleForegroundTimeout(startId, fgsType)
+    }
+
+    private fun handleForegroundTimeout(startId: Int, fgsType: Int) {
+        Log.w(TAG, "FGS timeout startId=$startId type=$fgsType — stopping")
+        stopSelf()
+    }
+
     private fun startForegroundWithType(
         info: CastSessionManager.SessionInfo,
         playing: Boolean,

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/MediaPlaybackService.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/MediaPlaybackService.kt
@@ -358,6 +358,20 @@ class MediaPlaybackService : Service() {
         return START_NOT_STICKY
     }
 
+    override fun onTimeout(startId: Int) {
+        handleForegroundTimeout(startId, fgsType = 0)
+    }
+
+    override fun onTimeout(startId: Int, fgsType: Int) {
+        handleForegroundTimeout(startId, fgsType)
+    }
+
+    private fun handleForegroundTimeout(startId: Int, fgsType: Int) {
+        Log.w(TAG, "FGS timeout startId=$startId type=$fgsType — stopping")
+        MediaControlChannel.tryEmit(MediaControlChannel.Action.STOP)
+        stopSelf()
+    }
+
     override fun onTaskRemoved(rootIntent: Intent?) {
         // App swiped from recents: the UI is gone but the process (and Gecko) may keep
         // playing with no way to control it. Stop media and go away instead of leaving

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/browser/BrowserReceiverHostService.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/browser/BrowserReceiverHostService.kt
@@ -26,6 +26,12 @@ import org.koin.core.component.KoinComponent
 /**
  * Keeps the process alive while the phone hosts the browser receiver page
  * (LAN HTTP + WS on 8770–8779). Notification offers a Stop action.
+ *
+ * Uses [ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE] rather than
+ * `dataSync`: the host is a long-lived LAN session with a TV browser, and
+ * Android 15+ kills `dataSync` FGS after 6 hours with
+ * `ForegroundServiceDidNotStopInTimeException` unless [onTimeout] calls
+ * [stopSelf] immediately.
  */
 class BrowserReceiverHostService : Service(), KoinComponent {
     private val repository: BrowserReceiverRepository by inject()
@@ -41,10 +47,9 @@ class BrowserReceiverHostService : Service(), KoinComponent {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_STOP -> {
-                scope.launch {
-                    repository.stopHost()
-                    stopSelf()
-                }
+                // stopSelf first so a slow native teardown cannot miss an FGS deadline.
+                stopSelf()
+                repository.stopHostAsync()
                 return START_NOT_STICKY
             }
         }
@@ -53,7 +58,7 @@ class BrowserReceiverHostService : Service(), KoinComponent {
         val notification = buildNotification(url, port)
         try {
             val type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
             } else {
                 0
             }
@@ -80,6 +85,23 @@ class BrowserReceiverHostService : Service(), KoinComponent {
             }
         }
         return START_STICKY
+    }
+
+    // API 34 shortService timeout. API 35+ also invokes the two-arg overload below.
+    override fun onTimeout(startId: Int) {
+        handleForegroundTimeout(startId, fgsType = 0)
+    }
+
+    override fun onTimeout(startId: Int, fgsType: Int) {
+        handleForegroundTimeout(startId, fgsType)
+    }
+
+    private fun handleForegroundTimeout(startId: Int, fgsType: Int) {
+        Log.w(TAG, "FGS timeout startId=$startId type=$fgsType — stopping host")
+        // Android 15+ crashes with ForegroundServiceDidNotStopInTimeException unless
+        // stopSelf runs immediately. Host teardown uses the process-wide repo scope.
+        stopSelf()
+        repository.stopHostAsync()
     }
 
     override fun onDestroy() {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/browser/BrowserReceiverRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/browser/BrowserReceiverRepository.kt
@@ -75,6 +75,11 @@ class BrowserReceiverRepository(
         }
     }
 
+    /** Stop the host without tying teardown to a caller coroutine (FGS timeout / Stop action). */
+    fun stopHostAsync() {
+        scope.launch { stopHost() }
+    }
+
     suspend fun stopHost(): Result<Unit> = mutex.withLock {
         _state.update { it.copy(busy = true, lastError = null) }
         return try {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/DownloadModels.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/DownloadModels.kt
@@ -47,3 +47,19 @@ data class Progress(
 
 /** Thrown by a strategy when the controller signals pause — distinct from cancel. */
 class DownloadPausedException : Exception("Download paused by user")
+
+/**
+ * Android 15+ caps `dataSync` foreground services at 6 hours, then crashes with
+ * `ForegroundServiceDidNotStopInTimeException` unless the FGS stops immediately.
+ * The worker pauses slightly before that so WorkManager can tear the FGS down
+ * and the user can resume.
+ */
+internal object DownloadForegroundLimits {
+    const val PLATFORM_DATA_SYNC_LIMIT_MS = 6L * 60 * 60 * 1000
+    const val DATA_SYNC_BUDGET_MS = 5L * 60 * 60 * 1000 + 45L * 60 * 1000
+
+    fun appliesTo(sdkInt: Int): Boolean = sdkInt >= 35
+}
+
+internal fun shouldKeepDownloadPaused(status: String, pauseRequested: Boolean): Boolean =
+    status == DownloadStatus.PAUSED.name || pauseRequested

--- a/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/DownloadWorker.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/DownloadWorker.kt
@@ -11,16 +11,20 @@ import android.webkit.MimeTypeMap
 import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import androidx.work.await
 import com.playbridge.sender.R
 import com.playbridge.sender.data.downloads.DownloadDao
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.Dispatchers
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.concurrent.atomic.AtomicReference
@@ -52,7 +56,16 @@ class DownloadWorker(
         }
 
         val dir = DownloadPaths.dirFor(applicationContext, id)
-        val controller = DownloadController(dir).also { it.start() }
+        val controller = DownloadController(dir)
+        // WorkManager re-enqueues a worker stopped by an FGS timeout. Do not let that
+        // replacement execution clear the pause marker and silently resume the download.
+        if (shouldKeepDownloadPaused(entity.status, controller.isPauseRequested())) {
+            if (entity.status != DownloadStatus.PAUSED.name) {
+                dao.updateStatus(id, DownloadStatus.PAUSED.name)
+            }
+            return Result.success()
+        }
+        controller.start()
 
         runCatching { setForeground(foregroundInfo(request.title)) }
             .onFailure { Log.w(TAG, "setForeground failed (continuing): ${it.message}") }
@@ -68,10 +81,23 @@ class DownloadWorker(
                     delay(PROGRESS_INTERVAL_MS)
                 }
             }
+            // Android 15+ kills dataSync FGS after 6h. Pause first so WorkManager can stop
+            // in time and the user can resume; otherwise the process crashes with
+            // ForegroundServiceDidNotStopInTimeException.
+            val budget = if (DownloadForegroundLimits.appliesTo(Build.VERSION.SDK_INT)) {
+                launch {
+                    delay(DownloadForegroundLimits.DATA_SYNC_BUDGET_MS)
+                    Log.w(TAG, "dataSync FGS budget reached — pausing download $id")
+                    controller.requestPause()
+                }
+            } else {
+                null
+            }
 
             try {
                 val file = strategy.download(request, dir, controller) { latest.set(it) }
                 ticker.cancel()
+                budget?.cancel()
 
                 dao.updateStatus(id, DownloadStatus.MERGING.name) // published == "finalizing"
                 val displayName = buildDisplayName(request, file)
@@ -89,25 +115,47 @@ class DownloadWorker(
                 dao.markDone(id, publishedUri)
                 Result.success()
             } catch (e: DownloadPausedException) {
-                ticker.cancel()
                 dao.updateStatus(id, DownloadStatus.PAUSED.name)
                 Result.success() // paused is a clean stop, not a failure; resume re-enqueues
             } catch (e: CancellationException) {
-                ticker.cancel()
                 if (controller.isCancelRequested()) {
                     dir.deleteRecursively()
                     dao.delete(id)
+                    Result.success()
+                } else if (
+                    Build.VERSION.SDK_INT >= 31 &&
+                    stopReason == WorkInfo.STOP_REASON_FOREGROUND_SERVICE_TIMEOUT
+                ) {
+                    Log.w(TAG, "Download $id paused (foreground service timeout)")
+                    pauseAfterForegroundTimeout(id, controller)
                     Result.success()
                 } else {
                     throw e // genuine coroutine/system cancellation — preserve structured concurrency
                 }
             } catch (e: Throwable) {
-                ticker.cancel()
                 Log.e(TAG, "Download $id failed", e)
                 dao.markFailed(id, e.message ?: e.javaClass.simpleName)
                 Result.failure()
+            } finally {
+                ticker.cancel()
+                budget?.cancel()
             }
         }
+    }
+
+    private suspend fun pauseAfterForegroundTimeout(
+        downloadId: String,
+        controller: DownloadController,
+    ) = withContext(NonCancellable) {
+        // WorkManager normally re-enqueues work stopped by an FGS timeout. Cancel this exact
+        // request so PAUSED remains durable; resume() will create a fresh request explicitly.
+        controller.requestPause()
+        runCatching {
+            WorkManager.getInstance(applicationContext).cancelWorkById(id).await()
+        }.onFailure { error ->
+            Log.w(TAG, "Could not cancel timed-out work $downloadId: ${error.message}")
+        }
+        dao.updateStatus(downloadId, DownloadStatus.PAUSED.name)
     }
 
     // --- foreground notification ---

--- a/mobile/android/app/src/test/java/com/playbridge/sender/downloads/DownloadForegroundLimitsTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/downloads/DownloadForegroundLimitsTest.kt
@@ -1,0 +1,34 @@
+package com.playbridge.sender.downloads
+
+import com.playbridge.sender.downloads.engine.DownloadForegroundLimits
+import com.playbridge.sender.downloads.engine.DownloadStatus
+import com.playbridge.sender.downloads.engine.shouldKeepDownloadPaused
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DownloadForegroundLimitsTest {
+
+    @Test
+    fun budgetIsBelowAndroid15DataSyncLimit() {
+        assertTrue(
+            DownloadForegroundLimits.DATA_SYNC_BUDGET_MS <
+                DownloadForegroundLimits.PLATFORM_DATA_SYNC_LIMIT_MS,
+        )
+        assertTrue(DownloadForegroundLimits.DATA_SYNC_BUDGET_MS >= 5L * 60 * 60 * 1000)
+    }
+
+    @Test
+    fun budgetOnlyAppliesOnAndroid15AndNewer() {
+        assertFalse(DownloadForegroundLimits.appliesTo(34))
+        assertTrue(DownloadForegroundLimits.appliesTo(35))
+        assertTrue(DownloadForegroundLimits.appliesTo(36))
+    }
+
+    @Test
+    fun timeoutReplacementKeepsPersistedOrSignalledPause() {
+        assertTrue(shouldKeepDownloadPaused(DownloadStatus.PAUSED.name, pauseRequested = false))
+        assertTrue(shouldKeepDownloadPaused(DownloadStatus.RUNNING.name, pauseRequested = true))
+        assertFalse(shouldKeepDownloadPaused(DownloadStatus.QUEUED.name, pauseRequested = false))
+    }
+}


### PR DESCRIPTION
## Summary
- release PlayBridge Phone `0.13.1` (`versionCode 224`)
- prevent Android 16 startup crashes by preserving SnakeYAML package names through R8
- classify the long-lived browser receiver host as `connectedDevice` and stop app-owned foreground services immediately on timeout
- pause Android 15+ downloads before the `dataSync` limit and prevent timeout-paused WorkManager requests from silently resuming

## Verification
- `cd mobile/android && zsh -c 'source ~/.zshrc && ./gradlew :app:testFossDebugUnitTest'`
- `cd mobile/android && zsh -c 'source ~/.zshrc && ./gradlew :app:lintFossDebug'`
- Play release R8 mapping preserves `org.yaml.snakeyaml.TypeDescription` and `org.yaml.snakeyaml.introspector.PropertySubstitute`
- minified Play APK launched `BrowserActivity` and initialized GeckoView without a fatal exception on an Android 16 ARM emulator
- prior `0.13.0` AAB and bundletool-generated APK passed documented 16 KB ELF and ZIP-alignment checks

## Release note
Local `bundlePlayRelease` completed compilation, R8 minification, lint-vital, and bundle packaging; final signing was unavailable without the release signing credentials. CI owns the signed release candidate and should create the draft `phone-v0.13.1` release after merge.
