### PR TITLE
fix(android): disable unsafe release shrinking

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -103,10 +103,6 @@ val googleCastApplicationId = providers.gradleProperty("PLAYBRIDGE_GOOGLE_CAST_A
         applicationId
     }
 
-val buildingAppBundle = gradle.startParameter.taskNames.any { taskName ->
-    taskName.substringAfterLast(':').contains("bundle", ignoreCase = true)
-}
-
 android {
     namespace = "com.playbridge.sender"
     buildFeatures {
@@ -159,8 +155,9 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
-            isShrinkResources = true
+            // Disabled until release-only reflection paths have dedicated coverage.
+            isMinifyEnabled = false
+            isShrinkResources = false
             signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -198,9 +195,7 @@ android {
 
     splits {
         abi {
-            // AGP cannot combine optimized resource shrinking, APK splits, and bundles.
-            // Keep split APKs for FOSS assembly; Play bundles perform their own ABI splits.
-            isEnable = !buildingAppBundle
+            isEnable = true
             reset()
             include("armeabi-v7a", "arm64-v8a")
             isUniversalApk = true

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -7,10 +7,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-val buildingAppBundle = gradle.startParameter.taskNames.any { taskName ->
-    taskName.substringAfterLast(':').contains("bundle", ignoreCase = true)
-}
-
 android {
     namespace = "com.playbridge.player"
     compileSdk {
@@ -59,8 +55,9 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
-            isShrinkResources = true
+            // Disabled until release-only reflection paths have dedicated coverage.
+            isMinifyEnabled = false
+            isShrinkResources = false
             signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -104,9 +101,7 @@ android {
 
     splits {
         abi {
-            // AGP cannot combine optimized resource shrinking, APK splits, and bundles.
-            // Keep split APKs for FOSS assembly; Play bundles perform their own ABI splits.
-            isEnable = !buildingAppBundle
+            isEnable = true
             reset()
             include("armeabi-v7a", "arm64-v8a")
             isUniversalApk = true


### PR DESCRIPTION
## Summary
- disable R8 code minification and resource shrinking for Phone and TV release variants
- restore unconditional APK ABI split configuration
- remove the bundle-task name workaround that was only needed with optimized resource shrinking
- retain the Phone GeckoView/WebRTC duplicate-class transform required for release packaging

## Why
Phone 0.13.0/0.13.1 minified releases exposed a sequence of reflection failures that debug builds did not reproduce, including SnakeYAML package lookup and Wire model/runtime lookups (`ADAPTER`, `@WireField` fields, Kotlin getters, and `ProtoAdapter`). TV consumes the same shared reflective Wire parser, so release shrinking is disabled for both Android applications until these paths have dedicated minified-release coverage.

## Verification
- `mobile/android`: `:app:assembleFossRelease` with local debug signing
- installed and launched the unminified FOSS release on a Samsung Android 16 arm64 device; startup remained healthy
- `mobile/android`: `:app:bundlePlayRelease` with local debug signing
- `tv/android`: `:player:app:bundlePlayRelease` with local debug signing
- `git diff --check`

## Risk / follow-up
- Release APKs and bundles will be larger because code and resources are no longer shrunk.
- Full Phone-to-Desktop pairing should be repeated with the unminified release before publication.
- R8 can be reintroduced later after adding release-mode reflection coverage for GeckoView/SnakeYAML and Wire/Moshi protocol parsing.
