### PR TITLE
chore(release): uprev Android Phone 0.13.2 and TV Player 0.13.1

### DIFF
--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.13.2] — 2026-08-29 (versionCode 225)
+
+### Fixed
+- **Release connection stability**: Disable R8 code and resource shrinking after release-only reflection failures broke Wire protocol serialization during receiver connections and pairing.
+
 ## [0.13.1] — 2026-08-28 (versionCode 224)
 
 ### Fixed

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -126,8 +126,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 224
-        versionName = "0.13.1"
+        versionCode = 225
+        versionName = "0.13.2"
         buildConfigField(
             "String",
             "GOOGLE_CAST_APPLICATION_ID",

--- a/tv/android/CHANGELOG.md
+++ b/tv/android/CHANGELOG.md
@@ -3,6 +3,11 @@
 Covers both APKs in this tree: the **player** (`com.playbridge.player`) and the **GeckoView plugin** (`com.playbridge.geckoview.plugin`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Player [0.13.1] — 2026-08-29 (versionCode 229)
+
+### Fixed
+- **Release protocol stability**: Disable R8 code and resource shrinking to preserve the shared Wire protocol reflection surface used for pairing and playback commands.
+
 ## Player [0.13.0] — 2026-08-11 (versionCode 228)
 
 > **Works best together**: Screen mirroring, mixed-media playlists, and the skip pre-play preference are cross-device features introduced in this coordinated release. Use PlayBridge Phone 0.13.0+ and Desktop 0.13.0+ on the other side for full support.

--- a/tv/android/player/app/build.gradle.kts
+++ b/tv/android/player/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.playbridge.player"
         minSdk = 26
         targetSdk = 36
-        versionCode = 228
-        versionName = "0.13.0"
+        versionCode = 229
+        versionName = "0.13.1"
 
         ndk {
             abiFilters.add("armeabi-v7a")


### PR DESCRIPTION
## Summary
- uprev Android Phone from `0.13.1`/`224` to `0.13.2`/`225`
- uprev Android TV Player from `0.13.0`/`228` to `0.13.1`/`229`
- add dated changelog entries for the corrective unminified releases

## Release rationale
These releases supersede Android artifacts built with unsafe R8 code/resource shrinking. Phone encountered release-only reflection failures in SnakeYAML and Wire during startup and receiver pairing. TV consumes the same shared Wire protocol reflection surface, so its corrective release is also built without shrinking.

## Verification
- Phone: `:app:bundlePlayRelease` with local debug signing
- TV Player: `:player:app:bundlePlayRelease` with local debug signing
- `git diff --check`

Both Play release bundles completed successfully with minification and resource shrinking disabled.

## After merge
The Android release-build workflow should create separate draft releases for:
- `phone-v0.13.2`
- `tv-player-v0.13.1`

Inspect and test both drafts before running the Android publish workflow for each product independently.
