### PR TITLE
chore(release): uprev Android phone to 0.13.3

### DIFF
--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.13.3] — 2026-08-29 (versionCode 226)
 
 ### Fixed
 - **In-app browser WebRTC**: Keep GeckoView's `org.webrtc.videoengine` JNI classes when stripping duplicate WebRTC types, so sites that use getUserMedia no longer crash the release app.

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -136,8 +136,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 225
-        versionName = "0.13.2"
+        versionCode = 226
+        versionName = "0.13.3"
         buildConfigField(
             "String",
             "GOOGLE_CAST_APPLICATION_ID",


### PR DESCRIPTION
## Summary
Uprev Android phone app (`com.playbridge.sender`) to **0.13.3** (versionCode `226`).

### Changes Included
- **In-app browser WebRTC**: Retain GeckoView's `org.webrtc.videoengine` JNI classes (`VideoCaptureDeviceInfoAndroid`, `VideoCaptureAndroid`, `CaptureCapabilityAndroid`) during the release scoped-artifact transform, preventing a `SIGSEGV` in `libxul.so` on web pages that call `getUserMedia`.
- **Local Release Signing**: Fallback to debug signing for local release assemblies when `PLAYBRIDGE_STORE_PASSWORD` is not set in the environment.

### Verification
- `:app:testFossDebugUnitTest` passed cleanly.
- `:app:stripFossReleaseGeckoViewWebRtc` and `:app:stripPlayReleaseGeckoViewWebRtc` verified with zero duplicate-class collisions.
- `:app:assembleFossRelease` built successfully and installed/tested on a physical device.