### PR TITLE
chore(release): uprev Android phone to 0.13.4

### DIFF
--- a/mobile/android/CHANGELOG.md
+++ b/mobile/android/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the phone app (`com.playbridge.sender`).
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.13.4] — 2026-08-31 (versionCode 227)
+
+### Fixed
+- **New-tab connection modal**: Keep the in-app browser UI mounted when a new tab is selected before its Gecko session exists, so the connections / Cast to picker no longer reopens on New Tab or Open in new tab.
+
 ## [0.13.3] — 2026-08-29 (versionCode 226)
 
 ### Fixed

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -136,8 +136,8 @@ android {
         applicationId = "com.playbridge.sender"
         minSdk = 26
         targetSdk = 36
-        versionCode = 226
-        versionName = "0.13.3"
+        versionCode = 227
+        versionName = "0.13.4"
         buildConfigField(
             "String",
             "GOOGLE_CAST_APPLICATION_ID",


### PR DESCRIPTION
## Summary
Uprev Android phone app (`com.playbridge.sender`) to **0.13.4** (versionCode `227`).

### Changes included
- **New-tab connection modal**: Keep the in-app browser UI mounted when a new tab is selected before its Gecko session exists, so the connections / Cast to picker no longer reopens on New Tab or Open in new tab (`802e901c`).

### Versions
- Phone: `0.13.3` / `226` → **`0.13.4` / `227`**

### Verification
- `:app:compileFossDebugKotlin` succeeded.
- `:app:testFossDebugUnitTest` succeeded.