### PR TITLE
perf(phone): cut jank, probe storms, and ExoPlayer OOM risk

### DIFF
--- a/mobile/android/app/src/main/java/com/playbridge/sender/PlayBridgeApplication.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/PlayBridgeApplication.kt
@@ -6,7 +6,10 @@ import com.playbridge.sender.data.backup.BackupTrigger
 import com.playbridge.sender.diagnostics.CrashLogger
 import com.playbridge.sender.di.appModule
 import com.playbridge.sender.util.ProcessUtil
+import com.playbridge.sender.BuildConfig
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
@@ -34,7 +37,7 @@ class PlayBridgeApplication : Application() {
 
         // Initialize Koin DI Container
         startKoin {
-            androidLogger(Level.INFO)
+            androidLogger(if (BuildConfig.DEBUG) Level.INFO else Level.NONE)
             androidContext(this@PlayBridgeApplication)
             modules(appModule)
         }
@@ -42,8 +45,16 @@ class PlayBridgeApplication : Application() {
         // Start backup trigger
         BackupTrigger(this, applicationScope).start()
 
-        // Remove any leftover self-update APK from a previous session (cacheDir/updates).
-        com.playbridge.sender.update.ApkInstaller.cleanupStaleApks(this)
+        // Perf: Room init + stale-APK cleanup do file IO — off the main thread so
+        // cold start isn't blocked on DB verification / cacheDir scans.
+        applicationScope.launch(Dispatchers.IO) {
+            runCatching {
+                com.playbridge.sender.data.history.DatabaseProvider.getDatabase(this@PlayBridgeApplication)
+            }
+            runCatching {
+                com.playbridge.sender.update.ApkInstaller.cleanupStaleApks(this@PlayBridgeApplication)
+            }
+        }
     }
 
     companion object {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/AppNavHost.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.playbridge.sender.connection.ConnectionCoordinator
@@ -191,36 +192,25 @@ fun AppNavHost(
     val addonDao: AddonDao = koinInject()
     val settingsRepository: SettingsRepository = koinInject()
     val linkedPageCastCoordinator: LinkedPageCastCoordinator = koinInject()
-    val linkedPageCastState by linkedPageCastCoordinator.uiState.collectAsState()
+    val linkedPageCastState by linkedPageCastCoordinator.uiState.collectAsStateWithLifecycle()
 
-    // 2. Collect Live Flows / Collected states locally
-    val connectionState by connectionViewModel.connectionState.collectAsState()
-    val tvDevice by connectionViewModel.tvDevice.collectAsState(initial = null)
-    val activeExternalDevice by connectionViewModel.activeExternalDevice.collectAsState()
-    val externalStatus by connectionViewModel.externalStatus.collectAsState()
-    val externalMediaTitle by connectionViewModel.externalMediaTitle.collectAsState()
-    val castSessionState by connectionViewModel.castSessionState.collectAsState()
-    val castRoute by connectionViewModel.route.collectAsState()
+    // 2. Collect Live Flows / Collected states locally.
+    // Perf: only connection-level state is collected at the host root. High-frequency
+    // per-second TV tickers (tvPlayback, tvPlaylistState, tracks, nowPlaying*) are collected
+    // locally inside the Remote branch and the NowPlayingBar so ticks don't recompose the
+    // whole AnimatedContent + current screen.
+    val connectionState by connectionViewModel.connectionState.collectAsStateWithLifecycle()
+    val tvDevice by connectionViewModel.tvDevice.collectAsStateWithLifecycle(initialValue = null)
+    val activeExternalDevice by connectionViewModel.activeExternalDevice.collectAsStateWithLifecycle()
+    val castRoute by connectionViewModel.route.collectAsStateWithLifecycle()
     // Authoritative routing intent — reactive so screens follow device-picker changes live.
-    val routeTargetsTv by connectionViewModel.routeTargetsTv.collectAsState()
-    val allHistory by historyDao.getAll().collectAsState(initial = emptyList())
-    val installedAddons by addonDao.getAll().collectAsState(initial = emptyList())
-
-    // 3. TV Playback/Playlist states from Coordinator
-    val tvActiveContext by connectionCoordinator.tvActiveContext.collectAsState()
-    val tvPlaylistState by connectionCoordinator.tvPlaylistState.collectAsState()
-    val tvPlayback by connectionCoordinator.tvPlayback.collectAsState()
-    val tvVideoTracks by connectionCoordinator.tvVideoTracks.collectAsState()
-    val tvAudioTracks by connectionCoordinator.tvAudioTracks.collectAsState()
-    val tvSubtitleTracks by connectionCoordinator.tvSubtitleTracks.collectAsState()
-    val tvPlayerSettings by connectionCoordinator.tvPlayerSettings.collectAsState()
-    val nowPlayingTvId by connectionCoordinator.nowPlayingTvId.collectAsState()
-    val nowPlayingSeason by connectionCoordinator.nowPlayingSeason.collectAsState()
-    val nowPlayingEpisodeStart by connectionCoordinator.nowPlayingEpisodeStart.collectAsState()
+    val routeTargetsTv by connectionViewModel.routeTargetsTv.collectAsStateWithLifecycle()
+    val allHistory by historyDao.getAll().collectAsStateWithLifecycle(initialValue = emptyList())
+    val installedAddons by addonDao.getAll().collectAsStateWithLifecycle(initialValue = emptyList())
 
     val context = LocalContext.current
 
-    val installedUserScripts by connectionCoordinator.installedUserScripts.collectAsState()
+    val installedUserScripts by connectionCoordinator.installedUserScripts.collectAsStateWithLifecycle()
     var showUserScripts by remember { mutableStateOf(false) }
 
     // Picks any .js file from the phone and ships it to the TV as a user script (e.g. the
@@ -268,7 +258,7 @@ fun AppNavHost(
         )
     }
 
-    val tvUserAgentState by connectionCoordinator.tvUserAgentState.collectAsState()
+    val tvUserAgentState by connectionCoordinator.tvUserAgentState.collectAsStateWithLifecycle()
     var showTvUserAgent by remember { mutableStateOf(false) }
 
     if (showTvUserAgent) {
@@ -306,12 +296,12 @@ fun AppNavHost(
     val clipboardManager = LocalClipboardManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
-    val preferredAudioLang by settingsRepository.preferredAudioLang.collectAsState(initial = "")
-    val preferredSubLang by settingsRepository.preferredSubtitleLang.collectAsState(initial = "")
-    val defaultVideoQuality by settingsRepository.defaultVideoQuality.collectAsState(initial = "Auto")
-    val maxBitrateCapMbps by settingsRepository.maxBitrateCapMbps.collectAsState(initial = 0.0)
-    val autoSwitchToRemote by settingsRepository.autoSwitchToRemote.collectAsState(initial = true)
-    val tvPlayerMode by settingsRepository.tvPlayerMode.collectAsState(initial = "tv")
+    val preferredAudioLang by settingsRepository.preferredAudioLang.collectAsStateWithLifecycle(initialValue = "")
+    val preferredSubLang by settingsRepository.preferredSubtitleLang.collectAsStateWithLifecycle(initialValue = "")
+    val defaultVideoQuality by settingsRepository.defaultVideoQuality.collectAsStateWithLifecycle(initialValue = "Auto")
+    val maxBitrateCapMbps by settingsRepository.maxBitrateCapMbps.collectAsStateWithLifecycle(initialValue = 0.0)
+    val autoSwitchToRemote by settingsRepository.autoSwitchToRemote.collectAsStateWithLifecycle(initialValue = true)
+    val tvPlayerMode by settingsRepository.tvPlayerMode.collectAsStateWithLifecycle(initialValue = "tv")
     val selectedTab = store.state.tabs.find { it.id == store.state.selectedTabId }
     // Persistent UI-scoped scroll states for the Library screen inside AppNavHost
     val libraryMainListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
@@ -335,7 +325,7 @@ fun AppNavHost(
     // Device picker opened from the idle cast bar (rendered once at the host level so
     // it survives screen transitions in the AnimatedContent below).
     var showDevicePicker by remember { mutableStateOf(false) }
-    val linkedDevicePickerRequest by Components.linkedDevicePickerRequests.collectAsState()
+    val linkedDevicePickerRequest by Components.linkedDevicePickerRequests.collectAsStateWithLifecycle()
     var handledLinkedDevicePickerRequest by rememberSaveable { mutableLongStateOf(0L) }
     var linkedPickerVisible by remember { mutableStateOf(false) }
     var linkedPickerCompleted by remember { mutableStateOf(false) }
@@ -391,7 +381,12 @@ fun AppNavHost(
     AnimatedContent(
         targetState = currentScreen,
         transitionSpec = {
-            if (targetState == Screen.Tabs && initialState == Screen.Browser) {
+            // Perf: heavy destinations (Gecko AndroidView, poster grids, blurred detail)
+            // keep two full trees alive during the transition — fade only, no slide.
+            val heavy = initialState.isHeavyScreen() || targetState.isHeavyScreen()
+            if (heavy) {
+                fadeIn(animationSpec = tween(250)) togetherWith fadeOut(animationSpec = tween(250))
+            } else if (targetState == Screen.Tabs && initialState == Screen.Browser) {
                 slideInVertically { height -> height } + fadeIn() togetherWith
                         slideOutVertically { height -> -height } + fadeOut()
             } else if (targetState == Screen.Browser && initialState == Screen.Tabs) {
@@ -477,7 +472,7 @@ fun AppNavHost(
                                 }
                             )
                     ) {
-                        if (currentScreen == Screen.Browser && session != null) {
+                        if (targetScreen == Screen.Browser && session != null) {
                             browserViewContent(session) { url ->
                                 onContextMenuUrlChange(url)
                             }
@@ -602,7 +597,7 @@ fun AppNavHost(
                                                             AsyncImage(
                                                                 model = ImageRequest.Builder(context)
                                                                     .data(faviconUrl)
-                                                                    .crossfade(true)
+                                                                    .crossfade(false)
                                                                     .build(),
                                                                 contentDescription = "Site icon",
                                                                 modifier = Modifier.size(28.dp)
@@ -719,7 +714,7 @@ fun AppNavHost(
                                     }
                                 } else {
                                     LazyColumn(modifier = Modifier.fillMaxSize()) {
-                                        items(suggestions) { historyItem ->
+                                        items(suggestions, key = { it.url }, contentType = { "history" }) { historyItem ->
                                             ListItem(
                                                 headlineContent = {
                                                     Text(
@@ -771,7 +766,7 @@ fun AppNavHost(
                     BackHandler { onScreenChange(Screen.Dashboard) }
                     val db = com.playbridge.sender.data.history.DatabaseProvider.getDatabase(context)
                     val commandHistoryFlow = remember { db.commandHistoryDao().getAll() }
-                    val commandHistory by commandHistoryFlow.collectAsState(initial = emptyList())
+                    val commandHistory by commandHistoryFlow.collectAsStateWithLifecycle(initialValue = emptyList())
                     CastHistoryScreen(
                         historyItems = commandHistory,
                         onMenuClick = { onScreenChange(Screen.Dashboard) },
@@ -927,12 +922,27 @@ fun AppNavHost(
                     BackHandler {
                         onScreenChange(remoteReturnScreen)
                     }
+                    // Perf: high-frequency TV tickers collected locally so per-second
+                    // position updates recompose only this branch, not the whole host.
+                    val tvActiveContext by connectionCoordinator.tvActiveContext.collectAsStateWithLifecycle()
+                    val tvPlaylistState by connectionCoordinator.tvPlaylistState.collectAsStateWithLifecycle()
+                    val tvPlayback by connectionCoordinator.tvPlayback.collectAsStateWithLifecycle()
+                    val tvVideoTracks by connectionCoordinator.tvVideoTracks.collectAsStateWithLifecycle()
+                    val tvAudioTracks by connectionCoordinator.tvAudioTracks.collectAsStateWithLifecycle()
+                    val tvSubtitleTracks by connectionCoordinator.tvSubtitleTracks.collectAsStateWithLifecycle()
+                    val tvPlayerSettings by connectionCoordinator.tvPlayerSettings.collectAsStateWithLifecycle()
+                    val nowPlayingTvId by connectionCoordinator.nowPlayingTvId.collectAsStateWithLifecycle()
+                    val nowPlayingSeason by connectionCoordinator.nowPlayingSeason.collectAsStateWithLifecycle()
+                    val nowPlayingEpisodeStart by connectionCoordinator.nowPlayingEpisodeStart.collectAsStateWithLifecycle()
+                    val externalStatus by connectionViewModel.externalStatus.collectAsStateWithLifecycle()
+                    val externalMediaTitle by connectionViewModel.externalMediaTitle.collectAsStateWithLifecycle()
                     val external = activeExternalDevice
                     val remoteTimeline = resolveRemoteTimeline(
                         activeContext = tvActiveContext,
                         playback = tvPlayback,
                         playerSettings = tvPlayerSettings,
                     )
+                    val externalCapabilities by connectionViewModel.castSessionState.collectAsStateWithLifecycle()
                     if (external != null) {
                         RemoteControlScreen(
                             activeContext = "player",
@@ -968,7 +978,7 @@ fun AppNavHost(
                                 else -> "paused"
                             },
                             externalProtocolLabel = external.resolvedProtocol.displayName,
-                            externalCapabilities = castSessionState.capabilities,
+                            externalCapabilities = externalCapabilities.capabilities,
                             isLive = externalStatus?.isLive == true,
                             positionMs = externalStatus?.positionMs ?: 0L,
                             durationMs = externalStatus?.durationMs ?: 0L,
@@ -1123,7 +1133,7 @@ fun AppNavHost(
                     )
                 }
                 Screen.Library -> {
-                    val selectedTabVal by libraryViewModel.selectedTab.collectAsState()
+                    val selectedTabVal by libraryViewModel.selectedTab.collectAsStateWithLifecycle()
                     BackHandler {
                         if (selectedTabVal != 0) {
                             libraryViewModel.setSelectedTab(0)
@@ -1733,7 +1743,7 @@ fun AppNavHost(
             // Note: excluded on Dashboard (overlays the "Exit" button) and on Connection
             // (the device picker lives there already).
             // Hide on Library Addons tab so the bar doesn't overlay addon management.
-            val libSelectedTab by libraryViewModel.selectedTab.collectAsState()
+            val libSelectedTab by libraryViewModel.selectedTab.collectAsStateWithLifecycle()
             val libraryAddonsTab = targetScreen == Screen.Library && libSelectedTab == 3
             val showNowPlayingBar = ((targetScreen == Screen.Browser && linkedPageCastState.active) ||
                 targetScreen == Screen.Library ||
@@ -1745,92 +1755,21 @@ fun AppNavHost(
                 targetScreen == Screen.Collections ||
                 targetScreen is Screen.CollectionDetail) && !libraryAddonsTab
             if (showNowPlayingBar) {
-                val externalActive = activeExternalDevice != null
-                // A stopped/ended/errored renderer (incl. after Stop) is not "playing", even
-                // though the status poll keeps reporting a (STOPPED) status.
-                val externalState = externalStatus?.state
-                val externalStopped = externalState == PlaybackState.STOPPED ||
-                    externalState == PlaybackState.IDLE ||
-                    externalState == PlaybackState.ERROR
-                val externalHasMedia = externalActive && externalMediaTitle != null && !externalStopped
-                val wsConnected = connectionState is WebSocketClient.ConnectionState.Connected
-                val nativeSelected = castRoute is CastSessionManager.Route.NativeTv
-                val nativePlaying = tvActiveContext == "player" && wsConnected && nativeSelected
-                val playing = externalHasMedia || nativePlaying
-
-                // Pause + progress for the bar: freeze the equalizer while paused and
-                // drive the bottom progress line off the live status snapshots.
-                val paused =
-                    if (externalActive) externalState == PlaybackState.PAUSED
-                    else tvPlayback?.state == "paused"
-                val playbackProgress = when {
-                    externalActive -> externalStatus?.takeIf { it.durationMs > 0 }
-                        ?.let { it.positionMs.toFloat() / it.durationMs }
-                    else -> tvPlayback?.takeIf { it.durationMs > 0 }
-                        ?.let { it.positionMs.toFloat() / it.durationMs }
-                }
-
-                val deviceName = activeExternalDevice?.name ?: if (nativeSelected) tvDevice?.name else null
-                val protocolName = activeExternalDevice?.resolvedProtocol?.displayName
-                    ?: CastProtocol.PLAYBRIDGE.displayName.takeIf { nativeSelected }
-                val leadingIcon = when {
-                    externalActive -> Icons.Default.Cast
-                    nativeSelected && wsConnected -> Icons.Default.Tv
-                    else -> Icons.Default.Smartphone
-                }
-
-                val primaryText: String
-                val secondaryText: String?
-                when {
-                    playing -> {
-                        primaryText = (if (externalActive) externalMediaTitle else tvPlayback?.title) ?: "Now playing"
-                        secondaryText = linkedPageCastState.controllerName?.let {
-                            "Controlled by $it · on ${deviceName ?: "TV"}"
-                        } ?: "on ${deviceName ?: "TV"}" +
-                            protocolName?.let { " · $it" }.orEmpty()
-                    }
-                    externalActive || (nativeSelected && wsConnected) -> {
-                        primaryText = deviceName ?: "TV"
-                        secondaryText = protocolName?.let { "$it · Ready to cast" } ?: "Ready to cast"
-                    }
-                    else -> {
-                        primaryText = "This Device"
-                        secondaryText = "Tap to cast to a device"
-                    }
-                }
-
-                NowPlayingBar(
-                    primaryText = primaryText,
-                    secondaryText = secondaryText,
-                    leadingIcon = leadingIcon,
-                    onClick = {
-                        if (playing) {
-                            if (!externalActive) {
-                                connectionViewModel.webSocketClient.send(
-                                    com.playbridge.shared.protocol.createContextQueryJson()
-                                )
-                            }
-                            onScreenChange(Screen.Remote)
-                        } else {
-                            // Idle → choose / switch the cast destination.
-                            showDevicePicker = true
-                        }
-                    },
-                    isPlaying = playing,
-                    isPaused = paused,
-                    progress = if (playing) playbackProgress else null,
-                    showTvIcon = playing,
-                    onTvIconClick = {
-                        showDevicePicker = true
-                    },
-                    onUnlinkClick = if (linkedPageCastState.active) {
-                        { linkedPageCastCoordinator.unlink("unlinked") }
-                    } else {
-                        null
-                    },
-                    // Poster-matched accent on the library detail screen (the old FAB's
-                    // dynamic styling); FAB-like primaryContainer elsewhere.
+                NowPlayingBarHost(
+                    connectionViewModel = connectionViewModel,
+                    connectionCoordinator = connectionCoordinator,
+                    connectionState = connectionState,
+                    tvDevice = tvDevice,
+                    activeExternalDevice = activeExternalDevice,
+                    castRoute = castRoute,
+                    linkedPageCastControllerName = linkedPageCastState.controllerName,
+                    linkedPageCastActive = linkedPageCastState.active,
                     accentColor = if (targetScreen is Screen.LibraryDetail) libraryDetailAccent else null,
+                    showDevicePicker = { showDevicePicker = true },
+                    onOpenRemote = {
+                        onScreenChange(Screen.Remote)
+                    },
+                    onUnlink = { linkedPageCastCoordinator.unlink("unlinked") },
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         // Clear the system navigation bar, plus the Library's bottom
@@ -1860,6 +1799,121 @@ fun AppNavHost(
             },
         )
     }
+}
+
+/**
+ * Cast mini-bar host. Collects the high-frequency TV/external playback tickers locally so
+ * per-second position updates recompose only this small subtree, not the whole [AppNavHost].
+ */
+@Composable
+private fun NowPlayingBarHost(
+    connectionViewModel: ConnectionViewModel,
+    connectionCoordinator: ConnectionCoordinator,
+    connectionState: WebSocketClient.ConnectionState,
+    tvDevice: TvDevice?,
+    activeExternalDevice: TvDevice?,
+    castRoute: CastSessionManager.Route,
+    linkedPageCastControllerName: String?,
+    linkedPageCastActive: Boolean,
+    accentColor: androidx.compose.ui.graphics.Color?,
+    showDevicePicker: () -> Unit,
+    onOpenRemote: () -> Unit,
+    onUnlink: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val externalStatus by connectionViewModel.externalStatus.collectAsStateWithLifecycle()
+    val externalMediaTitle by connectionViewModel.externalMediaTitle.collectAsStateWithLifecycle()
+    val tvActiveContext by connectionCoordinator.tvActiveContext.collectAsStateWithLifecycle()
+    val tvPlayback by connectionCoordinator.tvPlayback.collectAsStateWithLifecycle()
+    val externalActive = activeExternalDevice != null
+    // A stopped/ended/errored renderer (incl. after Stop) is not "playing", even
+    // though the status poll keeps reporting a (STOPPED) status.
+    val externalState = externalStatus?.state
+    val externalStopped = externalState == PlaybackState.STOPPED ||
+        externalState == PlaybackState.IDLE ||
+        externalState == PlaybackState.ERROR
+    val externalHasMedia = externalActive && externalMediaTitle != null && !externalStopped
+    val wsConnected = connectionState is WebSocketClient.ConnectionState.Connected
+    val nativeSelected = castRoute is CastSessionManager.Route.NativeTv
+    val nativePlaying = tvActiveContext == "player" && wsConnected && nativeSelected
+    val playing = externalHasMedia || nativePlaying
+
+    // Pause + progress for the bar: freeze the equalizer while paused and
+    // drive the bottom progress line off the live status snapshots.
+    val paused =
+        if (externalActive) externalState == PlaybackState.PAUSED
+        else tvPlayback?.state == "paused"
+    val playbackProgress = when {
+        externalActive -> externalStatus?.takeIf { it.durationMs > 0 }
+            ?.let { it.positionMs.toFloat() / it.durationMs }
+        else -> tvPlayback?.takeIf { it.durationMs > 0 }
+            ?.let { it.positionMs.toFloat() / it.durationMs }
+    }
+
+    val resolvedDeviceName = activeExternalDevice?.name
+        ?: if (nativeSelected) tvDevice?.name else null
+    val protocolName = activeExternalDevice?.resolvedProtocol?.displayName
+        ?: CastProtocol.PLAYBRIDGE.displayName.takeIf { nativeSelected }
+    val leadingIcon = when {
+        externalActive -> Icons.Default.Cast
+        nativeSelected && wsConnected -> Icons.Default.Tv
+        else -> Icons.Default.Smartphone
+    }
+
+    val primaryText: String
+    val secondaryText: String?
+    when {
+        playing -> {
+            primaryText = (if (externalActive) externalMediaTitle else tvPlayback?.title) ?: "Now playing"
+            secondaryText = linkedPageCastControllerName?.let {
+                "Controlled by $it · on ${resolvedDeviceName ?: "TV"}"
+            } ?: "on ${resolvedDeviceName ?: "TV"}" +
+                protocolName?.let { " · $it" }.orEmpty()
+        }
+        externalActive || (nativeSelected && wsConnected) -> {
+            primaryText = resolvedDeviceName ?: "TV"
+            secondaryText = protocolName?.let { "$it · Ready to cast" } ?: "Ready to cast"
+        }
+        else -> {
+            primaryText = "This Device"
+            secondaryText = "Tap to cast to a device"
+        }
+    }
+
+    NowPlayingBar(
+        primaryText = primaryText,
+        secondaryText = secondaryText,
+        leadingIcon = leadingIcon,
+        onClick = {
+            if (playing) {
+                if (!externalActive) {
+                    connectionViewModel.webSocketClient.send(
+                        com.playbridge.shared.protocol.createContextQueryJson()
+                    )
+                }
+                onOpenRemote()
+            } else {
+                // Idle → choose / switch the cast destination.
+                showDevicePicker()
+            }
+        },
+        isPlaying = playing,
+        isPaused = paused,
+        progress = if (playing) playbackProgress else null,
+        showTvIcon = playing,
+        onTvIconClick = {
+            showDevicePicker()
+        },
+        onUnlinkClick = if (linkedPageCastActive) {
+            { onUnlink() }
+        } else {
+            null
+        },
+        // Poster-matched accent on the library detail screen (the old FAB's
+        // dynamic styling); FAB-like primaryContainer elsewhere.
+        accentColor = accentColor,
+        modifier = modifier,
+    )
 }
 
 /**

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserActivity.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.PointerEventPass
@@ -56,6 +55,7 @@ import androidx.compose.material3.ripple
 import androidx.compose.runtime.*
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -186,50 +186,23 @@ fun AnimatedMenuItem(
     onClick: (() -> Unit)? = null,
     content: @Composable (onClick: () -> Unit) -> Unit
 ) {
-    val alpha = remember { Animatable(0f) }
-    val slide = remember { Animatable(50f) } // start 50px down
-    val scale = remember { Animatable(1f) }
-    val scope = rememberCoroutineScope()
-
+    // Perf: single AnimatedVisibility entrance — the old 3x Animatable per row plus
+    // the 150ms click delay kept N concurrent tweens alive and delayed taps.
+    var visible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) {
-        val delay = index * 30L // 30ms stagger
-        kotlinx.coroutines.delay(delay)
-        launch {
-            alpha.animateTo(
-                1f,
-                animationSpec = tween(durationMillis = 300, easing = LinearOutSlowInEasing)
-            )
-        }
-        launch {
-            slide.animateTo(
-                0f,
-                animationSpec = tween(durationMillis = 300, easing = LinearOutSlowInEasing)
-            )
-        }
+        kotlinx.coroutines.delay(index * 30L) // 30ms stagger
+        visible = true
     }
 
-    val wrappedOnClick: () -> Unit = {
-        if (onClick != null) {
-            scope.launch {
-                launch {
-                    scale.animateTo(0.95f, tween(100))
-                    scale.animateTo(1f, tween(100))
-                }
-                kotlinx.coroutines.delay(150) // Wait for animation and ripple
-                onClick()
-            }
-        }
-    }
-
-    Box(
-        modifier = Modifier.graphicsLayer {
-            this.alpha = alpha.value
-            this.translationY = slide.value
-            this.scaleX = scale.value
-            this.scaleY = scale.value
-        }
+    AnimatedVisibility(
+        visible = visible,
+        enter = slideInVertically(
+            initialOffsetY = { 50 },
+            animationSpec = tween(durationMillis = 300, easing = LinearOutSlowInEasing)
+        ) + fadeIn(animationSpec = tween(durationMillis = 300)),
+        exit = fadeOut(),
     ) {
-        content(wrappedOnClick)
+        content({ onClick?.invoke() })
     }
 }
 
@@ -649,15 +622,15 @@ class BrowserActivity : ComponentActivity() {
             if (!showTvWarning) {
                 com.playbridge.sender.update.UpdateGate(updateChecker)
             }
-            val connectionState by connectionViewModel.connectionState.collectAsState()
-            val activeExternalDevice by connectionViewModel.activeExternalDevice.collectAsState()
-            val castRoute by connectionViewModel.route.collectAsState()
+            val connectionState by connectionViewModel.connectionState.collectAsStateWithLifecycle()
+            val activeExternalDevice by connectionViewModel.activeExternalDevice.collectAsStateWithLifecycle()
+            val castRoute by connectionViewModel.route.collectAsStateWithLifecycle()
             val scope = rememberCoroutineScope()
 
             // Suggestions State
             var isEditing by remember { mutableStateOf(false) }
             var editUrl by remember { mutableStateOf("") }
-            val suggestions by browserViewModel.suggestions.collectAsState()
+            val suggestions by browserViewModel.suggestions.collectAsStateWithLifecycle()
             // URL bar tap panel state (Chrome-like panel shown before user types)
             var urlBarTapped by remember { mutableStateOf(false) }
             var urlPanelClipboard by remember { mutableStateOf<String?>(null) }
@@ -673,7 +646,7 @@ class BrowserActivity : ComponentActivity() {
             }
 
             // Connection ViewModel State
-            val tvDevice by connectionViewModel.tvDevice.collectAsState(initial = null)
+            val tvDevice by connectionViewModel.tvDevice.collectAsStateWithLifecycle(initialValue = null)
 
             // Session and navigation state from BrowserStore
             val store = Components.store
@@ -941,12 +914,12 @@ class BrowserActivity : ComponentActivity() {
 
             val composeScope = rememberCoroutineScope()
             // User preferences via SettingsRepository
-            val autoSwitchToRemote by settingsRepository.autoSwitchToRemote.collectAsState(initial = true)
-            val maxAliveTabs by settingsRepository.maxAliveTabs.collectAsState(initial = 5)
-            val userAgentPreset by settingsRepository.userAgentPreset.collectAsState(initial = UserAgentPresets.DEFAULT_ID)
-            val customUserAgents by settingsRepository.customUserAgents.collectAsState(initial = emptyList())
-            val userAgentOverride by remember(userAgentPreset, customUserAgents) {
-                derivedStateOf { UserAgentPresets.resolve(userAgentPreset, customUserAgents) }
+            val autoSwitchToRemote by settingsRepository.autoSwitchToRemote.collectAsStateWithLifecycle(initialValue = true)
+            val maxAliveTabs by settingsRepository.maxAliveTabs.collectAsStateWithLifecycle(initialValue = 5)
+            val userAgentPreset by settingsRepository.userAgentPreset.collectAsStateWithLifecycle(initialValue = UserAgentPresets.DEFAULT_ID)
+            val customUserAgents by settingsRepository.customUserAgents.collectAsStateWithLifecycle(initialValue = emptyList())
+            val userAgentOverride = remember(userAgentPreset, customUserAgents) {
+                UserAgentPresets.resolve(userAgentPreset, customUserAgents)
             }
 
             LaunchedEffect(maxAliveTabs) {
@@ -970,12 +943,12 @@ class BrowserActivity : ComponentActivity() {
                 }
             }
 
-            val preferredAudioLang by settingsRepository.preferredAudioLang.collectAsState(initial = "")
-            val preferredSubLang by settingsRepository.preferredSubtitleLang.collectAsState(initial = "")
-            val defaultVideoQuality by settingsRepository.defaultVideoQuality.collectAsState(initial = "Auto")
-            val maxBitrateCapMbpsFlow by settingsRepository.maxBitrateCapMbps.collectAsState(initial = 0.0)
+            val preferredAudioLang by settingsRepository.preferredAudioLang.collectAsStateWithLifecycle(initialValue = "")
+            val preferredSubLang by settingsRepository.preferredSubtitleLang.collectAsStateWithLifecycle(initialValue = "")
+            val defaultVideoQuality by settingsRepository.defaultVideoQuality.collectAsStateWithLifecycle(initialValue = "Auto")
+            val maxBitrateCapMbpsFlow by settingsRepository.maxBitrateCapMbps.collectAsStateWithLifecycle(initialValue = 0.0)
             val maxBitrateCapMbps = maxBitrateCapMbpsFlow.takeIf { it > 0.0 }
-            val tvPlayerMode by settingsRepository.tvPlayerMode.collectAsState(initial = "tv")
+            val tvPlayerMode by settingsRepository.tvPlayerMode.collectAsStateWithLifecycle(initialValue = "tv")
             var pendingPageCast by remember { mutableStateOf<PendingPageCast?>(null) }
             var pendingLinkedPageCast by remember { mutableStateOf<PendingLinkedPageCast?>(null) }
             var pendingLinkedOperation by remember { mutableStateOf<PendingLinkedOperation?>(null) }
@@ -1583,7 +1556,7 @@ class BrowserActivity : ComponentActivity() {
                 )
             }
 
-            val detectVideosEnabled by settingsRepository.detectVideos.collectAsState(initial = true)
+            val detectVideosEnabled by settingsRepository.detectVideos.collectAsStateWithLifecycle(initialValue = true)
             // Detection messages now arrive via native messaging (Components.processMessage),
             // so the setting is enforced there rather than at the old hash-signal parse site.
             LaunchedEffect(detectVideosEnabled) {
@@ -1650,7 +1623,7 @@ class BrowserActivity : ComponentActivity() {
             var castSheetBrowseOverride by remember { mutableStateOf<String?>(null) }
             var pendingContentPayload by remember { mutableStateOf<playbridge.PlayPayload?>(null) }
 
-            val tvActiveContext by connectionCoordinator.tvActiveContext.collectAsState()
+            val tvActiveContext by connectionCoordinator.tvActiveContext.collectAsStateWithLifecycle()
             // Keep the revision as an explicit Compose input. DetectedVideo contains mutable probe
             // fields, so a copied List can remain structurally equal even though its ranking changed.
             val detectedMediaRevision = VideoDetector.processingVersion
@@ -3035,7 +3008,7 @@ class BrowserActivity : ComponentActivity() {
                 // across the reconnect retry cycle so the user sees progress and can bail
                 // out: the primary action plays on this device; staying keeps trying.
                 val state = connectionState
-                val reconnect by connectionViewModel.reconnectStatus.collectAsState()
+                val reconnect by connectionViewModel.reconnectStatus.collectAsStateWithLifecycle()
                 val isPairingState = state is WebSocketClient.ConnectionState.WaitingForCodeInput ||
                     state is WebSocketClient.ConnectionState.VerifyingCode
                 if (state is WebSocketClient.ConnectionState.Connecting ||
@@ -3209,13 +3182,20 @@ class BrowserActivity : ComponentActivity() {
 
     @Composable
     fun BrowserView(session: EngineSession, onLongPressLink: (String) -> Unit) {
+        // Isolated so parent recompositions (browserState/currentUrl/isEditing ticks)
+        // don't re-measure the full-screen Gecko view: this subtree reads nothing
+        // but the persistent store. See GeckoBrowserView below.
+        GeckoBrowserView()
+    }
+
+    @Composable
+    private fun GeckoBrowserView() {
         // ONE persistent GeckoEngineView for all tabs (Fenix-style):
         // SessionFeature/EngineViewPresenter observes the store and renders
         // whatever tab is selected — creating engine sessions on demand,
         // releasing the view for crashed tabs, and re-rendering on session
         // changes. No more per-tab view recreation (the old `key(session)`
         // AndroidView), which caused surface churn on every tab switch.
-        // `session` is unused for rendering but kept for callsite compatibility.
         val featureHolder = remember { arrayOfNulls<mozilla.components.feature.session.SessionFeature>(1) }
         AndroidView(
             modifier = Modifier

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/BrowserViewModel.kt
@@ -15,7 +15,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -37,11 +40,18 @@ class BrowserViewModel(
     private val _editUrl = MutableStateFlow("")
     val editUrl: StateFlow<String> = _editUrl.asStateFlow()
 
-    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class, kotlinx.coroutines.FlowPreview::class)
     val suggestions: StateFlow<List<HistoryEntity>> = _editUrl
+        // Perf: every keystroke hit Room with a LIKE '%%' full scan — debounce and
+        // skip unchanged queries. Short queries emit emptyList downstream so the
+        // suggestion list clears when the user backspaces.
+        .debounce(300)
+        .distinctUntilChanged()
         .flatMapLatest { query ->
-            historyDao.search(query)
+            if (query.length >= 2) historyDao.search(query)
+            else kotlinx.coroutines.flow.flowOf(emptyList())
         }
+        .flowOn(Dispatchers.IO)
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/Components.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/Components.kt
@@ -352,11 +352,21 @@ object Components {
 
         // Configure Coil with explicit memory + disk cache so poster images survive
         // screen rotations (memory) and app restarts (disk) without re-downloading.
+        // Perf: global crossfade is OFF — every grid rebind would otherwise animate.
+        // Detail/hero screens opt in per-request.
+        val activityManager = appContext.getSystemService(android.content.Context.ACTIVITY_SERVICE) as? android.app.ActivityManager
+        val lowRam = activityManager?.isLowRamDevice == true
         Coil.setImageLoader(
             ImageLoader.Builder(appContext)
                 .memoryCache {
                     MemoryCache.Builder(appContext)
-                        .maxSizePercent(0.20) // 20% of available RAM
+                        .apply {
+                            if (lowRam) {
+                                maxSizeBytes(32 * 1024 * 1024)
+                            } else {
+                                maxSizePercent(0.15)
+                            }
+                        }
                         .build()
                 }
                 .diskCache {
@@ -365,7 +375,7 @@ object Components {
                         .maxSizeBytes(150L * 1024 * 1024) // 150 MB
                         .build()
                 }
-                .crossfade(true)
+                .crossfade(false)
                 .build()
         )
         

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/Screen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/Screen.kt
@@ -30,6 +30,13 @@ sealed class Screen {
     object Collections : Screen()
     data class CollectionDetail(val collectionId: Long) : Screen()
 
+    /** Heavy destinations that keep large view/image trees alive — transitions use fade only. */
+    fun isHeavyScreen(): Boolean = when (this) {
+        Browser, Library, DebridLibrary -> true
+        is LibraryDetail, is IptvDetail -> true
+        else -> false
+    }
+
     companion object {
         /**
          * Saver so the current screen survives Activity recreation (e.g. the shell being

--- a/mobile/android/app/src/main/java/com/playbridge/sender/browser/TabsScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/browser/TabsScreen.kt
@@ -28,6 +28,9 @@ import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -476,36 +479,36 @@ fun TabsScreen(
                         listState.firstVisibleItemScrollOffset == 0
                 }
             }
-            // Track the last scroll direction (true = scrolling down)
-            var isScrollingDown by remember { mutableStateOf(true) }
-            val prevIndex = remember { mutableStateOf(0) }
-            val prevOffset = remember { mutableStateOf(0) }
+            // Perf: scroll direction without per-pixel state writes — snapshotFlow
+            // is collected in a LaunchedEffect (not composition), and distinctUntilChanged
+            // means the direction state only flips when index/offset actually change.
+            var isScrollingDown by remember { mutableStateOf(false) }
+            var lastIndex by remember { mutableIntStateOf(0) }
+            var lastOffset by remember { mutableIntStateOf(0) }
             LaunchedEffect(listState) {
-                snapshotFlow {
-                    listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
-                }.collect { (index, offset) ->
-                    if (index != prevIndex.value || offset != prevOffset.value) {
-                        isScrollingDown = if (index != prevIndex.value) {
-                            index > prevIndex.value
+                snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
+                    .distinctUntilChanged()
+                    .collect { (index, offset) ->
+                        isScrollingDown = if (index != lastIndex) {
+                            index > lastIndex
                         } else {
-                            offset > prevOffset.value
+                            offset >= lastOffset
                         }
-                        prevIndex.value = index
-                        prevOffset.value = offset
+                        lastIndex = index
+                        lastOffset = offset
                     }
-                }
             }
             // Point up at the bottom, down at the top, otherwise follow scroll direction
             val pointUp = isAtBottom || (!isAtTop && !isScrollingDown)
 
-            // Only show the button while scrolling; hide shortly after it stops
-            // (the grace period keeps it tappable for a moment once you stop).
+            // Show while scrolling, with a short grace period so the button stays
+            // tappable for a moment after the finger lifts.
             var showScrollButton by remember { mutableStateOf(false) }
             LaunchedEffect(listState.isScrollInProgress) {
                 if (listState.isScrollInProgress) {
                     showScrollButton = true
                 } else {
-                    delay(1500)
+                    delay(1200)
                     showScrollButton = false
                 }
             }
@@ -736,26 +739,37 @@ private fun TabRowCard(
                     
                     if (isPlaying) {
                         Spacer(modifier = Modifier.width(8.dp))
-                        
-                        val infiniteTransition = rememberInfiniteTransition(label = "audioWaveRow")
-                        val pulseScale by infiniteTransition.animateFloat(
-                            initialValue = 0.85f,
-                            targetValue = 1.15f,
-                            animationSpec = infiniteRepeatable(
-                                animation = tween(600, easing = LinearEasing),
-                                repeatMode = RepeatMode.Reverse
-                            ),
-                            label = "pulse"
-                        )
-                        
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.VolumeUp,
-                            contentDescription = "Playing audio/video",
-                            modifier = Modifier
-                                .size(18.dp)
-                                .scale(pulseScale),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
+
+                        // Perf: static icon unless this is the selected + playing tab —
+                        // the old per-row infinite pulse kept every playing row composing.
+                        if (isSelected) {
+                            val infiniteTransition = rememberInfiniteTransition(label = "audioWaveRow")
+                            val pulseScale by infiniteTransition.animateFloat(
+                                initialValue = 0.85f,
+                                targetValue = 1.15f,
+                                animationSpec = infiniteRepeatable(
+                                    animation = tween(600, easing = LinearEasing),
+                                    repeatMode = RepeatMode.Reverse
+                                ),
+                                label = "pulse"
+                            )
+
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.VolumeUp,
+                                contentDescription = "Playing audio/video",
+                                modifier = Modifier
+                                    .size(18.dp)
+                                    .scale(pulseScale),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.VolumeUp,
+                                contentDescription = "Playing audio/video",
+                                modifier = Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
                     }
                 }
                 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheet.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheet.kt
@@ -1139,7 +1139,15 @@ fun CastSheet(
                                         Spacer(modifier = Modifier.height(8.dp))
 
                                         AsyncImage(
-                                            model = contentPayload.visual_metadata?.backdrop_url ?: contentPayload.visual_metadata?.poster_url,
+                                            model = (contentPayload.visual_metadata?.backdrop_url
+                                                ?: contentPayload.visual_metadata?.poster_url)?.let { url ->
+                                                coil.request.ImageRequest.Builder(context)
+                                                    .data(url)
+                                                    // Layout is fillMaxWidth x 16/9 — let Coil resolve
+                                                    // the density-aware target instead of fixed px.
+                                                    .crossfade(false)
+                                                    .build()
+                                            },
                                             contentDescription = null,
                                             modifier = Modifier
                                                 .fillMaxWidth()
@@ -1305,7 +1313,7 @@ fun CastSheet(
                         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
                         verticalArrangement = Arrangement.spacedBy(10.dp),
                     ) {
-                        items(detectedAudio) { audio ->
+                        items(detectedAudio, key = { "audio:${it.url}" }, contentType = { "audio" }) { audio ->
                             DetectedMediaItemDetailed(
                                 media = audio,
                                 kind = DetectedMediaKind.AUDIO,
@@ -1350,7 +1358,7 @@ fun CastSheet(
                         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
                         verticalArrangement = Arrangement.spacedBy(10.dp),
                     ) {
-                        items(detectedImages) { image ->
+                        items(detectedImages, key = { "image:${it.url}" }, contentType = { "image" }) { image ->
                             DetectedMediaItemDetailed(
                                 media = image,
                                 kind = DetectedMediaKind.IMAGE,
@@ -1402,7 +1410,7 @@ fun CastSheet(
                             modifier = Modifier.fillMaxWidth(),
                             verticalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
-                            items(combinedSubtitles) { subtitle ->
+                            items(combinedSubtitles, key = { "sub:${it.url}" }, contentType = { "subtitle" }) { subtitle ->
                                 var previewText by remember(subtitle.url) { mutableStateOf(subtitle.subtitlePreview) }
                                 var isLoadingPreview by remember(subtitle.url) { mutableStateOf(!subtitle.subtitlePreviewChecked) }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheetComponents.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastSheetComponents.kt
@@ -756,7 +756,10 @@ internal fun DetectedMediaItemDetailed(
             Spacer(Modifier.height(10.dp))
             if (kind == DetectedMediaKind.IMAGE) {
                 AsyncImage(
-                    model = media.url,
+                    model = coil.request.ImageRequest.Builder(LocalContext.current)
+                        .data(media.url)
+                        .crossfade(false)
+                        .build(),
                     contentDescription = title,
                     modifier = Modifier
                         .fillMaxWidth()

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/NowPlayingBar.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/NowPlayingBar.kt
@@ -3,7 +3,6 @@ package com.playbridge.sender.cast
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
@@ -188,12 +187,10 @@ fun NowPlayingBar(
             }
 
             // Thin progress line hugging the bottom edge while media is loaded.
+            // Perf: position ticks at ~1Hz, so no tween (it would never settle) —
+            // drive the bar directly off the raw fraction.
             if (isPlaying && progress != null) {
-                val animatedProgress by animateFloatAsState(
-                    targetValue = progress.coerceIn(0f, 1f),
-                    animationSpec = tween(600, easing = LinearEasing),
-                    label = "miniBarProgress",
-                )
+                val directProgress = progress.coerceIn(0f, 1f)
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -202,7 +199,7 @@ fun NowPlayingBar(
                 ) {
                     Box(
                         modifier = Modifier
-                            .fillMaxWidth(animatedProgress)
+                            .fillMaxWidth(directProgress)
                             .fillMaxHeight()
                             .background(content),
                     )

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/RemoteControlScreen.kt
@@ -760,7 +760,11 @@ private fun SeekVolumeBar(
     val tick: () -> Unit = { view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK) }
     val thud: () -> Unit = { view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS) }
 
-    val phase by rememberInfiniteTransition(label = "sineWavePhase").animateFloat(
+    // Perf: one wave clock drives both phase + breath; values used only while
+    // there is something to animate (playing, or the user is dragging).
+    val waveActive = isPlaying || dragging
+    val waveTransition = rememberInfiniteTransition(label = "waveClocks")
+    val animatedPhase by waveTransition.animateFloat(
         initialValue = 0f,
         targetValue = (2 * Math.PI).toFloat(),
         animationSpec = infiniteRepeatable(
@@ -769,6 +773,17 @@ private fun SeekVolumeBar(
         ),
         label = "phase"
     )
+    val animatedBreath by waveTransition.animateFloat(
+        initialValue = 0.8f,
+        targetValue = 1.2f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2600, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "breath"
+    )
+    val phase = if (waveActive) animatedPhase else 0f
+    val breathValue = if (waveActive) animatedBreath else 1f
 
     val targetAmplitude = if (isPlaying && !dragging) 7.dp else 0.dp
     val amplitude by animateDpAsState(targetValue = targetAmplitude, animationSpec = tween(durationMillis = 300), label = "amplitude")
@@ -920,15 +935,8 @@ private fun SeekVolumeBar(
 
                 // Slow "breathing" of the wave height so the motion feels organic rather
                 // than a fixed-height ripple; layered with the phase scroll below.
-                val breath by rememberInfiniteTransition(label = "waveBreath").animateFloat(
-                    initialValue = 0.8f,
-                    targetValue = 1.2f,
-                    animationSpec = infiniteRepeatable(
-                        animation = tween(durationMillis = 2600, easing = FastOutSlowInEasing),
-                        repeatMode = RepeatMode.Reverse
-                    ),
-                    label = "breath"
-                )
+                // Perf: static (breathValue) when the wave is idle.
+                val breath = breathValue
 
                 Canvas(modifier = Modifier.fillMaxWidth().height(24.dp)) {
                     val width = size.width

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/ScreenMirrorCoordinator.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/mirror/ScreenMirrorCoordinator.kt
@@ -84,6 +84,8 @@ class ScreenMirrorCoordinator(
         val isActive: Boolean get() = phase == Phase.STARTING || phase == Phase.CONNECTING || phase == Phase.MIRRORING
     }
 
+    // Intentionally process-lifetime: single Koin singleton, one thread per process.
+    // quit() is never called — stopInternal() releases tracks/factory per session.
     private val worker = HandlerThread("PB-ScreenMirror").apply { start() }
     private val handler = Handler(worker.looper)
     private val _state = MutableStateFlow(State())

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionCoordinator.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionCoordinator.kt
@@ -104,7 +104,11 @@ class ConnectionCoordinator(
                             )
                         }
                         "status" -> {
-                            tvPlayback.value = TvPlaybackStatus(
+                            // Perf: dedupe identical ticks — the TV status cadence (~1/s)
+                            // otherwise emits a distinct object per tick and recomposes
+                            // every collector. Raw ms precision kept so progress bars
+                            // glide instead of jumping in 1s steps.
+                            val next = TvPlaybackStatus(
                                 state = json.optString("state", "paused"),
                                 positionMs = json.optLong("position", 0L),
                                 durationMs = json.optLong("duration", 0L),
@@ -113,6 +117,7 @@ class ConnectionCoordinator(
                                     .takeIf { it in setOf("video", "audio", "image") }
                                     ?: "video",
                             )
+                            if (next != tvPlayback.value) tvPlayback.value = next
                         }
                         "tracks" -> {
                             fun parseTracks(arr: org.json.JSONArray?): List<MediaTrack> =

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/ConnectionViewModel.kt
@@ -37,12 +37,14 @@ import java.util.UUID
 
 class ConnectionViewModel(
     application: Application,
-    val webSocketClient: WebSocketClient = WebSocketClient(),
-    private val connectionStore: ConnectionStore = ConnectionStore(application),
-    private val commandHistoryDb: com.playbridge.sender.data.history.HistoryDatabase = DatabaseProvider.getDatabase(application),
+    // Perf: no default construction — manual construction used to bypass Koin and
+    // spin up duplicate OkHttp clients / DB instances per instance.
+    val webSocketClient: WebSocketClient,
+    private val connectionStore: ConnectionStore,
+    private val commandHistoryDb: com.playbridge.sender.data.history.HistoryDatabase,
     val castSessionManager: CastSessionManager,
     private val discoveryRepository: ReceiverDiscoveryRepository,
-    private val networkStatusRepository: NetworkStatusRepository = NetworkStatusRepository(application),
+    private val networkStatusRepository: NetworkStatusRepository,
 ) : AndroidViewModel(application) {
 
     private val TAG = "ConnectionViewModel"

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
@@ -63,16 +63,21 @@ class WebSocketClient {
     private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected)
     val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
     
-    private val _messages = MutableSharedFlow<String>(replay = 0)
+    // Perf: _messages is buffered + tryEmit so a slow collector never backpressures
+    // the OkHttp websocket callback path. play/playlist/status snapshots are periodic —
+    // dropping a stale tick is safe; credentials/capabilities below use suspending
+    // emit() and are never dropped. Coordinator is process-lifetime, so a 64-deep
+    // buffer only overflows if collection stalls entirely.
+    private val _messages = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 64)
     val messages = _messages.asSharedFlow()
 
-    private val _newCredentials = MutableSharedFlow<IssuedCredentials>(replay = 0)
+    private val _newCredentials = MutableSharedFlow<IssuedCredentials>(replay = 0, extraBufferCapacity = 64)
     val newCredentials = _newCredentials.asSharedFlow()
 
     // Players/browsers the TV reports at auth. Emitted on *every* successful auth
     // (incl. reconnect with an existing token, where no new credentials are issued),
     // so it's a separate channel from [newCredentials].
-    private val _tvCapabilities = MutableSharedFlow<TvCapabilities>(replay = 0)
+    private val _tvCapabilities = MutableSharedFlow<TvCapabilities>(replay = 0, extraBufferCapacity = 64)
     val tvCapabilities = _tvCapabilities.asSharedFlow()
     private val _tvCapabilitiesState = MutableStateFlow(TvCapabilities(emptyList(), emptyList()))
     val tvCapabilitiesState: StateFlow<TvCapabilities> = _tvCapabilitiesState.asStateFlow()
@@ -432,9 +437,7 @@ class WebSocketClient {
                     }
                 }
 
-                scope.launch {
-                    _messages.emit(text)
-                }
+                _messages.tryEmit(text)
             }
             
             override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
@@ -63,13 +63,8 @@ class WebSocketClient {
     private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected)
     val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
     
-    // Perf: _messages is buffered + tryEmit so a slow collector never backpressures
-    // the OkHttp websocket callback path. play/playlist/status snapshots are periodic —
-    // dropping a stale tick is safe; credentials/capabilities below use suspending
-    // emit() and are never dropped. Coordinator is process-lifetime, so a 64-deep
-    // buffer only overflows if collection stalls entirely.
-    private val _messages = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 64)
-    val messages = _messages.asSharedFlow()
+    private val messageBus = WebSocketMessageBus()
+    val messages = messageBus.messages
 
     private val _newCredentials = MutableSharedFlow<IssuedCredentials>(replay = 0, extraBufferCapacity = 64)
     val newCredentials = _newCredentials.asSharedFlow()
@@ -437,7 +432,7 @@ class WebSocketClient {
                     }
                 }
 
-                _messages.tryEmit(text)
+                messageBus.publish(text)
             }
             
             override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketMessageBus.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketMessageBus.kt
@@ -1,0 +1,17 @@
+package com.playbridge.sender.connection
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.runBlocking
+
+/** Ordered delivery of both snapshots and one-time responses, including WebRTC signaling. */
+internal class WebSocketMessageBus {
+    private val events = MutableSharedFlow<String>(extraBufferCapacity = 64)
+    val messages = events.asSharedFlow()
+
+    // Called on OkHttp's reader thread, never Main. When a subscriber falls behind,
+    // backpressure the reader rather than dropping signaling or queuing unbounded jobs.
+    fun publish(text: String) {
+        runBlocking { events.emit(text) }
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/history/DatabaseProvider.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/history/DatabaseProvider.kt
@@ -229,6 +229,16 @@ object DatabaseProvider {
         }
     }
 
+    // v23: index-only change (playback_resume tmdbId/updatedAt, watchlist status).
+    // Plain CREATE INDEX is idempotent-safe via IF NOT EXISTS.
+    private val MIGRATION_22_23 = object : Migration(22, 23) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_playback_resume_tmdbId` ON `playback_resume` (`tmdbId`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_playback_resume_updatedAt` ON `playback_resume` (`updatedAt`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_watchlist_status` ON `watchlist` (`status`)")
+        }
+    }
+
     @Volatile
     private var INSTANCE: HistoryDatabase? = null
 
@@ -239,7 +249,7 @@ object DatabaseProvider {
                 HistoryDatabase::class.java,
                 "history_database"
             )
-            .addMigrations(MIGRATION_4_5, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22)
+            .addMigrations(MIGRATION_4_5, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23)
             .fallbackToDestructiveMigration()
             .build()
             INSTANCE = instance

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/history/HistoryDatabase.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/history/HistoryDatabase.kt
@@ -23,7 +23,7 @@ import com.playbridge.sender.data.nuvio.NuvioScraperEntity
 
 @Database(
     entities = [HistoryEntity::class, BookmarkEntity::class, TabEntity::class, InstalledAddonEntity::class, CommandHistoryEntity::class, WatchlistEntity::class, SearchHistoryEntity::class, PlaybackResumeEntity::class, IptvPlaylistEntity::class, IptvChannelEntity::class, CollectionEntity::class, CollectionItemEntity::class, DownloadEntity::class, NuvioScraperEntity::class],
-    version = 22
+    version = 23
 )
 abstract class HistoryDatabase : RoomDatabase() {
     abstract fun historyDao(): HistoryDao

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvDao.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvDao.kt
@@ -41,6 +41,36 @@ interface IptvChannelDao {
     @Query("SELECT * FROM iptv_channels WHERE playlistId = :playlistId ORDER BY orderIndex ASC")
     suspend fun getForPlaylist(playlistId: Long): List<IptvChannelEntity>
 
+    @Query(
+        "SELECT DISTINCT groupTitle FROM iptv_channels WHERE playlistId = :playlistId " +
+            "AND groupTitle IS NOT NULL AND groupTitle != '' ORDER BY groupTitle ASC",
+    )
+    fun observeGroups(playlistId: Long): Flow<List<String>>
+
+    /**
+     * Perf: DB-side search for large playlists — the detail screen no longer
+     * loads/sorts the full 10k-row table in memory on every probe write.
+     * No LIMIT: playlists are user-browsable end-to-end (2k-20k rows); Room only
+     * re-emits on actual table change and Compose keys rows by id.
+     */
+    @Query(
+        "SELECT * FROM iptv_channels WHERE playlistId = :playlistId " +
+            "AND (:query = '' OR name LIKE '%' || :query || '%') " +
+            "AND (:group IS NULL OR groupTitle = :group) " +
+            "ORDER BY " +
+            "CASE WHEN :activeFirst = 1 THEN " +
+            "CASE probeStatus WHEN 'ACTIVE' THEN 0 WHEN 'DEAD' THEN 2 ELSE 1 END " +
+            "ELSE 0 END, " +
+            "CASE WHEN :activeFirst = 1 AND probeLatencyMs IS NOT NULL THEN probeLatencyMs ELSE 999999999 END ASC, " +
+            "orderIndex ASC",
+    )
+    fun observeFiltered(
+        playlistId: Long,
+        query: String,
+        group: String?,
+        activeFirst: Boolean,
+    ): Flow<List<IptvChannelEntity>>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(items: List<IptvChannelEntity>)
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvDao.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvDao.kt
@@ -47,15 +47,9 @@ interface IptvChannelDao {
     )
     fun observeGroups(playlistId: Long): Flow<List<String>>
 
-    /**
-     * Perf: DB-side search for large playlists — the detail screen no longer
-     * loads/sorts the full 10k-row table in memory on every probe write.
-     * No LIMIT: playlists are user-browsable end-to-end (2k-20k rows); Room only
-     * re-emits on actual table change and Compose keys rows by id.
-     */
+    /** Group filtering and ordering stay in SQL; Unicode name matching runs in Kotlin. */
     @Query(
         "SELECT * FROM iptv_channels WHERE playlistId = :playlistId " +
-            "AND (:query = '' OR name LIKE '%' || :query || '%') " +
             "AND (:group IS NULL OR groupTitle = :group) " +
             "ORDER BY " +
             "CASE WHEN :activeFirst = 1 THEN " +
@@ -66,7 +60,6 @@ interface IptvChannelDao {
     )
     fun observeFiltered(
         playlistId: Long,
-        query: String,
         group: String?,
         activeFirst: Boolean,
     ): Flow<List<IptvChannelEntity>>

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvRepository.kt
@@ -46,6 +46,16 @@ class IptvRepository(
     fun observePlaylists() = playlistDao.observeAll()
     fun observeChannels(playlistId: Long) = channelDao.observeForPlaylist(playlistId)
 
+    fun observeGroups(playlistId: Long) = channelDao.observeGroups(playlistId)
+
+    /** Perf: DB-side filtered channel flow for the detail screen. */
+    fun observeChannelsFiltered(
+        playlistId: Long,
+        query: String,
+        group: String?,
+        activeFirst: Boolean,
+    ) = channelDao.observeFiltered(playlistId, query, group, activeFirst)
+
     /** Add a playlist and immediately parse + cache its channels. Returns the new id. */
     suspend fun addPlaylist(name: String, source: String, sourceType: String): Long {
         val now = System.currentTimeMillis()

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvRepository.kt
@@ -8,6 +8,8 @@ import com.playbridge.shared.player.IptvChannel
 import com.playbridge.shared.player.M3uParser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -48,13 +50,15 @@ class IptvRepository(
 
     fun observeGroups(playlistId: Long) = channelDao.observeGroups(playlistId)
 
-    /** Perf: DB-side filtered channel flow for the detail screen. */
+    /** SQL handles group/order; Kotlin preserves literal Unicode case-insensitive search. */
     fun observeChannelsFiltered(
         playlistId: Long,
         query: String,
         group: String?,
         activeFirst: Boolean,
-    ) = channelDao.observeFiltered(playlistId, query, group, activeFirst)
+    ) = channelDao.observeFiltered(playlistId, group, activeFirst)
+        .map { channels -> IptvSearchRules.filter(channels, query) }
+        .flowOn(Dispatchers.Default)
 
     /** Add a playlist and immediately parse + cache its channels. Returns the new id. */
     suspend fun addPlaylist(name: String, source: String, sourceType: String): Long {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvSearchRules.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/iptv/IptvSearchRules.kt
@@ -1,0 +1,7 @@
+package com.playbridge.sender.data.iptv
+
+internal object IptvSearchRules {
+    fun filter(channels: List<IptvChannelEntity>, query: String): List<IptvChannelEntity> =
+        if (query.isBlank()) channels
+        else channels.filter { it.name.contains(query, ignoreCase = true) }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/library/AddonRepository.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/library/AddonRepository.kt
@@ -90,9 +90,17 @@ class AddonRepository(
     private val kitsuCache = java.util.concurrent.ConcurrentHashMap<String, String>()
     private val ioScope = CoroutineScope(Dispatchers.IO)
     private val diskJson = Json { ignoreUnknownKeys = true }
+    // Guards readers/writers until the disk cache finishes loading — a write
+    // racing the load would persist an empty map and wipe the disk cache.
+    private val cacheReady = kotlinx.coroutines.CompletableDeferred<Unit>()
 
     init {
-        loadCacheFromDisk()
+        // Perf: disk cache load does file IO + JSON on the constructing thread —
+        // defer to IO and guard readers until loaded.
+        ioScope.launch {
+            loadCacheFromDisk()
+            cacheReady.complete(Unit)
+        }
         seedDefaultAddons()
     }
 
@@ -129,6 +137,9 @@ class AddonRepository(
     private fun saveCacheToDisk() {
         val file = cacheDir?.let { File(it, CACHE_FILE_NAME) } ?: return
         ioScope.launch {
+            // Don't persist until the load finished — otherwise an early write
+            // snapshots an empty map and wipes the disk cache.
+            cacheReady.await()
             try {
                 val persisted = PersistedCache(entries = HashMap(streamCache))
                 file.writeText(diskJson.encodeToString(persisted))

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/library/PlaybackResumeEntity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/library/PlaybackResumeEntity.kt
@@ -2,6 +2,7 @@ package com.playbridge.sender.data.library
 
 import androidx.room.Dao
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.PrimaryKey
@@ -15,7 +16,11 @@ import kotlinx.coroutines.flow.Flow
  *
  * Keys: `"tmdb:<id>"` for movies, `"tmdb:<id>:<season>:<episode>"` for episodes.
  */
-@Entity(tableName = "playback_resume")
+@Entity(
+    tableName = "playback_resume",
+    // Perf: observeForTmdb / observeLatest / GROUP BY tmdbId were full scans.
+    indices = [Index("tmdbId"), Index("updatedAt")],
+)
 data class PlaybackResumeEntity(
     @PrimaryKey val contentKey: String,
     val tmdbId: Int,

--- a/mobile/android/app/src/main/java/com/playbridge/sender/data/library/WatchlistEntity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/data/library/WatchlistEntity.kt
@@ -1,9 +1,14 @@
 package com.playbridge.sender.data.library
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "watchlist")
+@Entity(
+    tableName = "watchlist",
+    // Perf: getByStatus filtered on this column without an index.
+    indices = [Index("status")],
+)
 data class WatchlistEntity(
     @PrimaryKey val tmdbId: Int,
     val mediaType: String,          // "movie" or "tv"

--- a/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
@@ -25,12 +25,22 @@ import androidx.datastore.preferences.preferencesDataStoreFile
 import com.playbridge.sender.data.settings.SettingsRepository
 
 val appModule = module {
-    // 1. OkHttpClient Global Singleton
+    // 1. OkHttpClient Global Singleton.
+    // Perf: raised per-host parallelism so TMDB/addon/IPTV fan-out doesn't queue on
+    // the 5-req/host default and stall Home refresh. Timeouts stay generous (15s):
+    // this client also serves downloads, IPTV M3U fetches, and debrid — a short
+    // global read timeout would fail slow streams, not just catalogs.
     single {
         OkHttpClient.Builder()
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(15, TimeUnit.SECONDS)
             .followRedirects(true)
+            .dispatcher(
+                okhttp3.Dispatcher().apply {
+                    maxRequests = 128
+                    maxRequestsPerHost = 16
+                }
+            )
             .build()
     }
 
@@ -204,7 +214,8 @@ val appModule = module {
     }
 
     // 5d. PlaybackProgressTracker — auto-updates watchlist progress from TV playback.
-    //     createdAtStart: it has no injectors; it must exist to observe.
+    //     Eager: it has no UI injector (only PlayerActivity injects it), so lazy
+    //     registration would leave TV/DLNA progress tracking dead on direct casts.
     //     Single-threaded scope: the three transport legs (native/DLNA/in-app) share
     //     non-thread-safe session state (markedKeys/ensuredKeys, threshold arming);
     //     serializing the scope makes their interleaving safe.

--- a/mobile/android/app/src/main/java/com/playbridge/sender/diagnostics/CrashLogger.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/diagnostics/CrashLogger.kt
@@ -23,7 +23,11 @@ object CrashLogger {
     private const val MAX_FILE_SIZE = 512 * 1024L // 512 KB
 
     @Volatile private var crashFile: File? = null
-    private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+    // Perf/correctness: SimpleDateFormat is not thread-safe and write() runs on
+    // arbitrary crashing threads — ThreadLocal confines one instance per thread.
+    private val dateFormat = ThreadLocal.withInitial {
+        SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+    }
 
     fun install(context: Context) {
         val dir = File(context.filesDir, LOG_DIR).apply { mkdirs() }
@@ -57,7 +61,7 @@ object CrashLogger {
         val sw = StringWriter()
         throwable.printStackTrace(PrintWriter(sw))
         val entry = buildString {
-            append("${dateFormat.format(Date())} CRASH [${thread.name}] ")
+            append("${dateFormat.get()?.format(Date())} CRASH [${thread.name}] ")
             append("${throwable.javaClass.name}: ${throwable.message}\n")
             append(sw.toString())
             append("\n")

--- a/mobile/android/app/src/main/java/com/playbridge/sender/downloads/DownloadsScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/downloads/DownloadsScreen.kt
@@ -3,9 +3,7 @@ package com.playbridge.sender.downloads
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
-import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -85,6 +83,8 @@ fun DownloadsScreen(onBack: () -> Unit) {
     val downloads by repository.observe().collectAsStateWithLifecycle(initialValue = emptyList())
 
     // Derive per-item download speed from successive Room emissions (worker ticks ~1s).
+    // Perf: plain map keyed off the downloads snapshot — recomputed only when Room
+    // emits, no state writes inside derivedStateOf.
     val speedTracker = remember { mutableMapOf<String, Pair<Long, Long>>() }
     val speeds = remember(downloads) {
         downloads.associate { e ->
@@ -267,9 +267,9 @@ private fun ActiveCard(
     val indeterminate = item.status == DownloadStatus.MERGING.name ||
         item.status == DownloadStatus.QUEUED.name ||
         item.totalBytes <= 0
-    val target = if (item.totalBytes > 0) (item.bytesDownloaded.toFloat() / item.totalBytes).coerceIn(0f, 1f) else 0f
-    val fraction by animateFloatAsState(targetValue = target, animationSpec = tween(450), label = "progress")
-    val barColor by animateColorAsState(accent.color, label = "barColor")
+    // Perf: raw fraction — the 1s Room tick restarted a 450ms tween continuously.
+    val fraction = if (item.totalBytes > 0) (item.bytesDownloaded.toFloat() / item.totalBytes).coerceIn(0f, 1f) else 0f
+    val barColor = accent.color
 
     Surface(
         shape = RoundedCornerShape(20.dp),
@@ -383,6 +383,13 @@ private fun RoundAction(icon: ImageVector, desc: String, tint: Color, onClick: (
 /** Custom rounded-cap progress with a soft gradient fill (or a pulsing track when indeterminate). */
 @Composable
 private fun GradientBar(fraction: Float, color: Color, indeterminate: Boolean) {
+    // Perf: entrance animates once; progress ticks drive the raw fraction directly.
+    var appeared by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { appeared = true }
+    val entrance by animateFloatAsState(
+        targetValue = if (appeared) 1f else 0f,
+        label = "barEntrance",
+    )
     Box(
         Modifier
             .fillMaxWidth()
@@ -400,7 +407,7 @@ private fun GradientBar(fraction: Float, color: Color, indeterminate: Boolean) {
             Box(
                 Modifier
                     .fillMaxHeight()
-                    .fillMaxWidth(fraction)
+                    .fillMaxWidth(fraction * entrance)
                     .clip(CircleShape)
                     .background(Brush.horizontalGradient(listOf(color, color.copy(alpha = 0.65f)))),
             )

--- a/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/DownloadDispatchers.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/DownloadDispatchers.kt
@@ -1,0 +1,12 @@
+package com.playbridge.sender.downloads.engine
+
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Shared bounded dispatcher for segment/ranged fetching (process-wide cap of 8).
+ * Per-download `limitedParallelism` pools contended on the shared OkHttp pool;
+ * one shared dispatcher bounds total concurrency across simultaneous downloads.
+ */
+internal object DownloadDispatchers {
+    val segments = Dispatchers.IO.limitedParallelism(8)
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/DownloadWorker.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/DownloadWorker.kt
@@ -75,9 +75,21 @@ class DownloadWorker(
         return coroutineScope {
             val latest = AtomicReference(Progress(entity.bytesDownloaded, entity.totalBytes))
             val ticker = launch {
+                var lastWrittenBytes = entity.bytesDownloaded
+                var lastWrittenPercent = -1
                 while (isActive) {
                     val p = latest.get()
-                    dao.updateProgress(id, p.downloadedBytes, p.totalBytes, DownloadStatus.RUNNING.name)
+                    // Perf: Room write re-emits observeAll and recomposes DownloadsScreen —
+                    // the 1s delay below already caps writes at 1Hz, so write on any
+                    // movement. (A 64KB gate froze slow connections for seconds.)
+                    val total = p.totalBytes
+                    val percent = if (total > 0) ((p.downloadedBytes * 100) / total).toInt() else -1
+                    val moved = p.downloadedBytes - lastWrittenBytes
+                    if (moved > 0 || percent != lastWrittenPercent) {
+                        dao.updateProgress(id, p.downloadedBytes, p.totalBytes, DownloadStatus.RUNNING.name)
+                        lastWrittenBytes = p.downloadedBytes
+                        lastWrittenPercent = percent
+                    }
                     delay(PROGRESS_INTERVAL_MS)
                 }
             }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/FileStrategy.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/FileStrategy.kt
@@ -158,10 +158,11 @@ class FileStrategy(
         }
         copied.set(chunks.sumOf { if (it.part.exists()) it.part.length() else 0L })
 
-        val dispatcher = Dispatchers.IO.limitedParallelism(n)
+        // Perf: shared bounded dispatcher (process-wide cap of 8) instead of a
+        // per-download limitedParallelism pool contending on the OkHttp pool.
         val jobs = mutableListOf<Job>()
         for (c in chunks) {
-            jobs += launch(dispatcher) {
+            jobs += launch(DownloadDispatchers.segments) {
                 val expected = c.end - c.start + 1
                 val have = if (c.part.exists()) c.part.length() else 0L
                 if (have >= expected) return@launch

--- a/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/HlsStrategy.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/HlsStrategy.kt
@@ -77,14 +77,14 @@ class HlsStrategy(
         }
 
         // 2. Download segments in parallel (resume skips ones already present).
+        // Perf: shared bounded dispatcher — see FileStrategy.
         val total = media.segments.size
         val done = AtomicInteger(0)
         val bytes = AtomicLong(0L)
-        val dispatcher = Dispatchers.IO.limitedParallelism(PARALLELISM)
         val jobs = mutableListOf<Job>()
         media.segments.forEachIndexed { index, segUrl ->
             val target = File(segDir, "seg_%05d.%s".format(index, ext))
-            jobs += launch(dispatcher) {
+            jobs += launch(DownloadDispatchers.segments) {
                 val written = segDownloader.download(segUrl, target, "HLS-seg")
                 val n = done.incrementAndGet()
                 val totalBytes = bytes.addAndGet(written)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/SegmentDownloader.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/downloads/engine/SegmentDownloader.kt
@@ -22,8 +22,18 @@ class SegmentDownloader(
     private val controller: DownloadController,
 ) {
 
-    /** @return bytes written (0 if skipped because already present). */
+    /**
+     * @return bytes written (0 if skipped because already present).
+     * No dispatcher hop here: callers run on DownloadDispatchers.segments
+     * (limitedParallelism(8)) and hopping to unbounded Dispatchers.IO would
+     * defeat the concurrency cap. Runs blocking OkHttp/file IO — callers must
+     * already be off the main thread (guaranteed by the download strategies).
+     */
     suspend fun download(url: String, target: File, tag: String): Long {
+        return downloadInternal(url, target, tag)
+    }
+
+    private suspend fun downloadInternal(url: String, target: File, tag: String): Long {
         if (target.exists() && target.length() > 0) {
             return target.length()
         }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvDetailScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvDetailScreen.kt
@@ -118,7 +118,7 @@ fun IptvDetailScreen(
 
     val groups by viewModel.groupsFor(playlistId).collectAsStateWithLifecycle(initialValue = emptyList())
 
-    // Sorting/filtering already applied DB-side (query + group + active-first).
+    // Sorting/filtering already applied by the repository (query + group + active-first).
     val visible = channels
 
     fun castChannel(channel: IptvChannelEntity) {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvDetailScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvDetailScreen.kt
@@ -44,12 +44,14 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -66,7 +68,6 @@ import com.playbridge.sender.data.collection.CollectionItemKind
 import com.playbridge.sender.data.collection.CollectionSource
 import com.playbridge.sender.data.iptv.IptvChannelEntity
 import com.playbridge.sender.data.iptv.IptvProbeStatus
-import com.playbridge.sender.data.iptv.IptvSortRules
 import com.playbridge.sender.data.iptv.decodeHeaders
 import com.playbridge.sender.player.PlayerLauncher
 import kotlinx.coroutines.launch
@@ -84,32 +85,41 @@ fun IptvDetailScreen(
     val scope = rememberCoroutineScope()
     val snackbar = remember { SnackbarHostState() }
 
-    val channels by viewModel.channelsFor(playlistId).collectAsState(initial = emptyList())
-    val activeFirst by viewModel.activeFirst.collectAsState()
-    val probeProgress by viewModel.probeProgress.collectAsState()
-    val updatingId by viewModel.updatingPlaylistId.collectAsState()
+    var query by remember { mutableStateOf("") }
+    var searchActive by remember { mutableStateOf(false) }
+    var selectedGroup by remember { mutableStateOf<String?>(null) } // null = All
+    // Perf: debounce the DB-side search query so each keystroke doesn't re-query.
+    var debouncedQuery by remember { mutableStateOf("") }
+    LaunchedEffect(query) {
+        kotlinx.coroutines.delay(300)
+        debouncedQuery = query
+    }
+    // Perf: memoize the channel flow — recreating snapshotFlows per recomposition
+    // would restart the Room collector on every probe tick/menu toggle.
+    val channelsFlow = remember(playlistId) {
+        viewModel.channelsFiltered(
+            playlistId,
+            snapshotFlow { debouncedQuery },
+            snapshotFlow { selectedGroup },
+        )
+    }
+    val channels by channelsFlow.collectAsStateWithLifecycle(initialValue = emptyList())
+    val activeFirst by viewModel.activeFirst.collectAsStateWithLifecycle()
+    var menuOpen by remember { mutableStateOf(false) }
+    var addToCollection by remember { mutableStateOf<IptvChannelEntity?>(null) }
+
+    val probeProgress by viewModel.probeProgress.collectAsStateWithLifecycle()
+    val updatingId by viewModel.updatingPlaylistId.collectAsStateWithLifecycle()
 
     val playlist = viewModel.playlistById(playlistId)
     val title = playlist?.name ?: "Channels"
     val updating = updatingId == playlistId
     val probing = probeProgress?.let { it.playlistId == playlistId && it.isRunning } == true
 
-    var query by remember { mutableStateOf("") }
-    var searchActive by remember { mutableStateOf(false) }
-    var selectedGroup by remember { mutableStateOf<String?>(null) } // null = All
-    var menuOpen by remember { mutableStateOf(false) }
-    var addToCollection by remember { mutableStateOf<IptvChannelEntity?>(null) }
+    val groups by viewModel.groupsFor(playlistId).collectAsStateWithLifecycle(initialValue = emptyList())
 
-    val groups = remember(channels) {
-        channels.mapNotNull { it.groupTitle?.takeIf { g -> g.isNotBlank() } }.distinct().sorted()
-    }
-
-    val visible = remember(channels, query, selectedGroup, activeFirst) {
-        val byGroup = if (selectedGroup == null) channels else channels.filter { it.groupTitle == selectedGroup }
-        val byQuery = if (query.isBlank()) byGroup
-        else byGroup.filter { it.name.contains(query, ignoreCase = true) }
-        IptvSortRules.sortChannels(byQuery, activeFirst)
-    }
+    // Sorting/filtering already applied DB-side (query + group + active-first).
+    val visible = channels
 
     fun castChannel(channel: IptvChannelEntity) {
         val headers = decodeHeaders(channel.headersJson)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvViewModel.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -55,9 +57,47 @@ class IptvViewModel(
     private val _probeProgress = MutableStateFlow<ProbeProgress?>(null)
     val probeProgress: StateFlow<ProbeProgress?> = _probeProgress.asStateFlow()
 
+    /** Distinct group names for the group filter chips (cheap SQL, not full rows). */
+    fun groupsFor(playlistId: Long): Flow<List<String>> = repository.observeGroups(playlistId)
+
     /** Raw cached channels for a playlist (screen applies search + active-first ordering). */
     fun channelsFor(playlistId: Long): Flow<List<IptvChannelEntity>> =
         repository.observeChannels(playlistId)
+
+    /**
+     * Perf: DB-side filtered channel flow — search/group/active-first handled in SQL
+     * so large playlists don't sort fully in memory. Room still re-runs the query
+     * on every probe UPDATE; the trailing debounce below only drops Compose
+     * emissions so per-channel writes don't rebuild the LazyColumn per channel.
+     * First emission per filter set is immediate (no first-paint/search delay);
+     * only follow-up re-emissions (probe ticks) are debounced 500ms.
+     */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    fun channelsFiltered(
+        playlistId: Long,
+        query: Flow<String>,
+        group: Flow<String?>,
+    ): Flow<List<IptvChannelEntity>> =
+        combine(query, group, activeFirst) { q, g, af -> Triple(q, g, af) }
+            .distinctUntilChanged()
+            .flatMapLatest { (q, g, af) ->
+                kotlinx.coroutines.flow.channelFlow {
+                    var first = true
+                    var pending: kotlinx.coroutines.Job? = null
+                    repository.observeChannelsFiltered(playlistId, q, g, af).collect { v ->
+                        if (first) {
+                            first = false
+                            send(v)
+                        } else {
+                            pending?.cancel()
+                            pending = launch {
+                                kotlinx.coroutines.delay(500)
+                                send(v)
+                            }
+                        }
+                    }
+                }
+            }
 
     fun playlistById(id: Long): IptvPlaylistEntity? = playlists.value.find { it.id == id }
 
@@ -83,8 +123,19 @@ class IptvViewModel(
 
     fun probe(playlistId: Long, force: Boolean = false) = viewModelScope.launch {
         _probeProgress.value = ProbeProgress(playlistId, 0, 0)
+        // Perf: probe callback fires per channel (up to 10k) — throttle so each
+        // write doesn't recompose the detail screen and re-filter the full list.
+        var lastEmit = 0L
+        var lastDone = -1
         repository.probe(playlistId, force) { done, total ->
-            _probeProgress.value = ProbeProgress(playlistId, done, total)
+            val now = System.currentTimeMillis()
+            val pct = if (total > 0) (done * 100) / total else 0
+            val lastPct = (lastDone * 100) / total.coerceAtLeast(1)
+            if (done == total || now - lastEmit >= 500 || pct - lastPct >= 5) {
+                lastEmit = now
+                lastDone = done
+                _probeProgress.value = ProbeProgress(playlistId, done, total)
+            }
         }
         _probeProgress.value = null
     }

--- a/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/iptv/IptvViewModel.kt
@@ -65,7 +65,7 @@ class IptvViewModel(
         repository.observeChannels(playlistId)
 
     /**
-     * Perf: DB-side filtered channel flow — search/group/active-first handled in SQL
+     * Filtered channel flow — group/active-first handled in SQL, name search off main
      * so large playlists don't sort fully in memory. Room still re-runs the query
      * on every probe UPDATE; the trailing debounce below only drops Compose
      * emissions so per-channel writes don't rebuild the LazyColumn per channel.

--- a/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryDetailComponents.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryDetailComponents.kt
@@ -50,6 +50,7 @@ import androidx.palette.graphics.Palette
 import com.playbridge.sender.data.library.*
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -104,26 +105,53 @@ internal fun BackdropSection(
                 }
         ) {
             if (backdropUrl != null) {
-                AsyncImage(
-                    model = ImageRequest.Builder(context)
+                // Perf: one-shot palette extraction per URL — runs on Default and
+                // reports the color once, so rebinds/recompositions don't re-extract.
+                // The display load stays full-res (HARDWARE ok). Palette gets its own
+                // tiny software request (160px, allowHardware(false)) so it never
+                // copies/scales a full-res bitmap on the heap.
+                val backdropRequest = remember(backdropUrl) {
+                    ImageRequest.Builder(context)
                         .data(backdropUrl)
                         .crossfade(true)
-                        .allowHardware(false) // Required for Palette extraction
-                        .build(),
-                    onSuccess = { result ->
-                        val bitmap = (result.result.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap
-                        if (bitmap != null) {
-                            Palette.from(bitmap).generate { palette ->
-                                // Try to get a light vibrant or just vibrant color
-                                val swatch = palette?.lightVibrantSwatch ?: palette?.vibrantSwatch ?: palette?.dominantSwatch
-                                swatch?.let {
-                                    val extracted = Color(it.rgb)
-                                    // Make it significantly lighter (40% towards white)
-                                    onColorExtracted(lerp(extracted, Color.White, 0.4f))
+                        .build()
+                }
+                val paletteRequest = remember(backdropUrl) {
+                    ImageRequest.Builder(context)
+                        .data(backdropUrl)
+                        .size(160)
+                        .allowHardware(false)
+                        .build()
+                }
+                var extractionDone by remember(backdropUrl) { mutableStateOf(false) }
+                val imageLoader = coil.Coil.imageLoader(context)
+                LaunchedEffect(paletteRequest) {
+                    if (!extractionDone) {
+                        runCatching {
+                            // Decode + Palette.generate() on Default; only the
+                            // onColorExtracted snapshot write hops back to Main
+                            // (LaunchedEffect scope) — snapshot state must not be
+                            // written from a background thread.
+                            val swatch = withContext(kotlinx.coroutines.Dispatchers.Default) {
+                                val req = paletteRequest.newBuilder(context).build()
+                                val drawable = imageLoader.execute(req).drawable
+                                val bitmap = (drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap
+                                    ?: return@withContext null
+                                Palette.from(bitmap).generate()?.let {
+                                    it.lightVibrantSwatch ?: it.vibrantSwatch ?: it.dominantSwatch
                                 }
+                            } ?: return@runCatching
+                            swatch.let {
+                                val extracted = Color(it.rgb)
+                                // Make it significantly lighter (40% towards white)
+                                onColorExtracted(lerp(extracted, Color.White, 0.4f))
                             }
+                            extractionDone = true
                         }
-                    },
+                    }
+                }
+                AsyncImage(
+                    model = backdropRequest,
                     contentDescription = title,
                     contentScale = ContentScale.Crop,
                     placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
@@ -151,7 +179,9 @@ internal fun BackdropSection(
                 AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(logoUrl)
-                        .crossfade(true)
+                        // Layout is fillMaxWidth(0.7f) x 130dp — let Coil resolve the
+                        // density-aware target instead of a hardcoded px size.
+                        .crossfade(false)
                         .build(),
                     contentDescription = title,
                     contentScale = ContentScale.Fit,
@@ -511,7 +541,13 @@ internal fun WatchProvidersSheet(
                             modifier = Modifier.size(48.dp)
                         ) {
                             AsyncImage(
-                                model = provider.logoUrl,
+                                model = provider.logoUrl?.let { url ->
+                                    ImageRequest.Builder(LocalContext.current)
+                                        .data(url)
+                                        .size(192)
+                                        .crossfade(false)
+                                        .build()
+                                },
                                 contentDescription = provider.providerName,
                                 contentScale = ContentScale.Crop,
                                 modifier = Modifier.fillMaxSize()
@@ -818,7 +854,12 @@ internal fun EpisodeItem(
             ) {
                 if (episode.thumbnail != null) {
                     AsyncImage(
-                        model = episode.thumbnail,
+                        model = episode.thumbnail?.let { url ->
+                            ImageRequest.Builder(LocalContext.current)
+                                .data(url)
+                                .crossfade(false)
+                                .build()
+                        },
                         contentDescription = episode.title,
                         contentScale = ContentScale.Crop,
                         placeholder = ColorPainter(themeColor.copy(alpha = 0.1f)),
@@ -1038,19 +1079,28 @@ data class ResolutionState(
 
 @Composable
 fun TranslucentBackground(backdropUrl: String?, dominantColor: Color? = null) {
+    // Perf: memoize the downsampled request per URL so dominantColor ticks don't
+    // re-decode/re-blur; blur reduced 100dp -> 32dp.
+    val context = LocalContext.current
+    val request = remember(backdropUrl) {
+        backdropUrl?.let {
+            ImageRequest.Builder(context)
+                .data(it)
+                .size(400, 225) // blurred — no need for full resolution
+                .memoryCacheKey(it)
+                .crossfade(false)
+                .build()
+        }
+    }
     Box(modifier = Modifier.fillMaxSize()) {
-        if (backdropUrl != null) {
+        if (request != null) {
             AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(backdropUrl)
-                    .size(400, 225) // blurred — no need for full resolution
-                    .crossfade(true)
-                    .build(),
+                model = request,
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .fillMaxSize()
-                    .blur(100.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded)
+                    .blur(32.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded)
             )
             // Apply a uniform dark tint that retains the vibrant color of the blurred backdrop
             Box(
@@ -1103,7 +1153,7 @@ internal fun CastCarousel(
             contentPadding = PaddingValues(horizontal = 24.dp, vertical = 4.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            items(members) { member ->
+            items(members, key = { "${it.name}|${it.character}|${it.photo}" }, contentType = { "cast" }) { member ->
                 Column(
                     modifier = Modifier.width(80.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
@@ -1117,7 +1167,12 @@ internal fun CastCarousel(
                     ) {
                         if (member.photo != null) {
                             AsyncImage(
-                                model = member.photo,
+                                model = member.photo?.let { url ->
+                                    ImageRequest.Builder(LocalContext.current)
+                                        .data(url)
+                                        .crossfade(false)
+                                        .build()
+                                },
                                 contentDescription = member.name,
                                 contentScale = ContentScale.Crop,
                                 placeholder = ColorPainter(themeColor.copy(alpha = 0.1f)),

--- a/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryDetailScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryDetailScreen.kt
@@ -1127,12 +1127,15 @@ fun LibraryDetailScreen(
                         }
                     }
 
-                    // Episodes list
+                    // Episodes list — stable keys so asc/desc toggle doesn't recreate rows.
                     if (isSeries && hasEpisodes) {
                         val episodes = (addonMeta?.videos?.filter { it.season == selectedSeason } ?: emptyList())
                             .let { if (episodesAscending) it else it.reversed() }
-                        items(episodes.size) { index ->
-                            val episode = episodes[index]
+                        items(
+                            episodes,
+                            key = { "${it.season}x${it.episode}:${it.id}" },
+                            contentType = { "episode" },
+                        ) { episode ->
                             val epNum = episode.episode ?: 0
                             val isEpWatched = tracked?.let { entity ->
                                 if (entity.status != WatchlistStatus.WATCHING.value &&

--- a/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.material3.*
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.*
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -198,39 +198,39 @@ private fun LibraryScreenContent(
     val keyboardController = LocalSoftwareKeyboardController.current
 
     // Check if API key is configured (only needed for Browse/search)
-    val isConfigured by viewModel.isConfigured.collectAsState()
+    val isConfigured by viewModel.isConfigured.collectAsStateWithLifecycle()
 
     // Addon catalog rows — collected early so the ambient backdrop can derive from them
-    val catalogRows by viewModel.catalogRows.collectAsState()
+    val catalogRows by viewModel.catalogRows.collectAsStateWithLifecycle()
 
     // Ambient backdrop derived from addon catalog rows (helper is non-composable
     // so Modifier.background() cannot shadow the StremioMetaPreview.background property).
     val activeHeroBackdropUrl = remember(catalogRows) { firstAddonBackdropUrl(catalogRows) }
 
     // Search state
-    val searchQuery by viewModel.searchQuery.collectAsState()
-    val isSearching by viewModel.isSearching.collectAsState()
-    val isSearchLoading by viewModel.isSearchLoading.collectAsState()
-    val addonSearchGroups by viewModel.addonSearchGroups.collectAsState()
+    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
+    val isSearching by viewModel.isSearching.collectAsStateWithLifecycle()
+    val isSearchLoading by viewModel.isSearchLoading.collectAsStateWithLifecycle()
+    val addonSearchGroups by viewModel.addonSearchGroups.collectAsStateWithLifecycle()
     val addonSearchResults = remember(addonSearchGroups) { addonSearchGroups.flatMap { it.items }.distinctBy { it.id } }
-    val searchHistory by viewModel.searchHistory.collectAsState()
+    val searchHistory by viewModel.searchHistory.collectAsStateWithLifecycle()
 
 
 
     // Discovery state - Collected from a single unified filters StateFlow
-    val filters by viewModel.filters.collectAsState()
+    val filters by viewModel.filters.collectAsStateWithLifecycle()
 
     val selectedGenres = filters.selectedGenres
     val excludedGenres = filters.excludedGenres
     val matchAllGenres = filters.matchAllGenres
 
-    val discoveredMovies by viewModel.discoveredMovies.collectAsState()
-    val isLoadingMoreDiscoveredMovies by viewModel.isLoadingMoreDiscoveredMovies.collectAsState()
-    val hasMoreDiscoveredMovies by viewModel.hasMoreDiscoveredMovies.collectAsState()
+    val discoveredMovies by viewModel.discoveredMovies.collectAsStateWithLifecycle()
+    val isLoadingMoreDiscoveredMovies by viewModel.isLoadingMoreDiscoveredMovies.collectAsStateWithLifecycle()
+    val hasMoreDiscoveredMovies by viewModel.hasMoreDiscoveredMovies.collectAsStateWithLifecycle()
 
-    val discoveredTvShows by viewModel.discoveredTvShows.collectAsState()
-    val isLoadingMoreDiscoveredTvShows by viewModel.isLoadingMoreDiscoveredTvShows.collectAsState()
-    val hasMoreDiscoveredTvShows by viewModel.hasMoreDiscoveredTvShows.collectAsState()
+    val discoveredTvShows by viewModel.discoveredTvShows.collectAsStateWithLifecycle()
+    val isLoadingMoreDiscoveredTvShows by viewModel.isLoadingMoreDiscoveredTvShows.collectAsStateWithLifecycle()
+    val hasMoreDiscoveredTvShows by viewModel.hasMoreDiscoveredTvShows.collectAsStateWithLifecycle()
 
     val selectedMediaType = filters.mediaType
     val selectedSort = filters.sort
@@ -246,18 +246,18 @@ private fun LibraryScreenContent(
     val selectedWatchRegion = filters.watchRegion
     val selectedProviders = filters.selectedProviders
     val selectedMonetization = filters.selectedMonetization
-    val watchProviders by viewModel.watchProviders.collectAsState()
+    val watchProviders by viewModel.watchProviders.collectAsStateWithLifecycle()
     val selectedCertification = filters.certification
     val selectedReleaseTypes = filters.selectedReleaseTypes
     val selectedTvStatuses = filters.selectedTvStatuses
     val selectedTvTypes = filters.selectedTvTypes
     val selectedKeywords = filters.selectedKeywords
-    val keywordResults by viewModel.keywordResults.collectAsState()
-    val isSearchingKeywords by viewModel.isSearchingKeywords.collectAsState()
+    val keywordResults by viewModel.keywordResults.collectAsStateWithLifecycle()
+    val isSearchingKeywords by viewModel.isSearchingKeywords.collectAsStateWithLifecycle()
     val includeAdult = filters.includeAdult
 
-    val isDiscoveryLoading by viewModel.isDiscoveryLoading.collectAsState()
-    val selectedTab by viewModel.selectedTab.collectAsState()
+    val isDiscoveryLoading by viewModel.isDiscoveryLoading.collectAsStateWithLifecycle()
+    val selectedTab by viewModel.selectedTab.collectAsStateWithLifecycle()
 
     // Home tab: which addon is selected in the filter chip row (null = All)
     var selectedAddonFilter by remember { mutableStateOf<String?>(null) }
@@ -301,10 +301,10 @@ private fun LibraryScreenContent(
     var trackingTarget by remember { mutableStateOf<TrackingTarget?>(null) }
 
     // Per-status lists for My List tab
-    val watchlistAll by viewModel.watchlist.collectAsState()
+    val watchlistAll by viewModel.watchlist.collectAsStateWithLifecycle()
 
     // New episode detection
-    val newEpisodeTmdbIds by viewModel.newEpisodeTmdbIds.collectAsState()
+    val newEpisodeTmdbIds by viewModel.newEpisodeTmdbIds.collectAsStateWithLifecycle()
 
     // Badge counts every non-default filter that's currently active.
     val activeFilterCount = listOf(
@@ -502,33 +502,28 @@ private fun LibraryScreenContent(
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background)
         ) {
-            // Dynamic Ambient Background behind TopAppBar
+            // Dynamic Ambient Background behind TopAppBar.
+            // Perf: single static-blurred image, no AnimatedContent crossfade (two
+            // full-width blurred bitmaps alive at once dropped frames on scroll).
             if (selectedTab == 0 && !isSearching) {
                 Box(modifier = Modifier.fillMaxWidth().height(350.dp)) {
-                    AnimatedContent(
-                        targetState = activeHeroBackdropUrl,
-                        transitionSpec = {
-                            fadeIn(tween(800)) togetherWith fadeOut(tween(800))
-                        },
-                        label = "HeroAmbientBackground"
-                    ) { targetUrl ->
-                        if (targetUrl != null) {
-                            AsyncImage(
-                                model = ImageRequest.Builder(LocalContext.current)
-                                    .data(targetUrl)
-                                    .size(400, 225) // blurred — no need for full resolution
-                                    .crossfade(true)
-                                    .build(),
-                                contentDescription = null,
-                                contentScale = ContentScale.Crop,
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .alpha(0.6f)
-                                    .blur(60.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded)
-                            )
-                        } else {
-                            Box(modifier = Modifier.fillMaxSize())
-                        }
+                    if (activeHeroBackdropUrl != null) {
+                        AsyncImage(
+                            model = ImageRequest.Builder(LocalContext.current)
+                                .data(activeHeroBackdropUrl)
+                                .size(400, 225) // blurred — no need for full resolution
+                                .memoryCacheKey(activeHeroBackdropUrl)
+                                .crossfade(false)
+                                .build(),
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .alpha(0.6f)
+                                .blur(24.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded)
+                        )
+                    } else {
+                        Box(modifier = Modifier.fillMaxSize())
                     }
                     
                     // Gradient overlay applies persistently on top of the changing images
@@ -545,8 +540,8 @@ private fun LibraryScreenContent(
             }
         }
 
-        val watchlist by viewModel.watchlist.collectAsState()
-        val lastWatchedByTitle by viewModel.lastWatchedByTitle.collectAsState()
+        val watchlist by viewModel.watchlist.collectAsStateWithLifecycle()
+        val lastWatchedByTitle by viewModel.lastWatchedByTitle.collectAsStateWithLifecycle()
 
         // TrackingSheet — shown when a media card is long-pressed
         trackingTarget?.let { target ->
@@ -653,7 +648,7 @@ private fun LibraryScreenContent(
                                 label = { Text("All") }
                             )
                         }
-                        items(addonSources) { addonName ->
+                        items(addonSources, key = { it }, contentType = { "chip" }) { addonName ->
                             FilterChip(
                                 selected = selectedSearchSource == addonName,
                                 onClick = { selectedSearchSource = addonName },
@@ -801,7 +796,7 @@ private fun LibraryScreenContent(
                                         label = { Text("All") }
                                     )
                                 }
-                                items(addonNames) { name ->
+                                items(addonNames, key = { it }, contentType = { "chip" }) { name ->
                                     FilterChip(
                                         selected = selectedAddonFilter == name,
                                         onClick = { selectedAddonFilter = name },
@@ -845,6 +840,7 @@ private fun LibraryScreenContent(
                                 badgeText = { item ->
                                     if (item.mediaType == "tv" && newEpisodeTmdbIds.contains(item.tmdbId)) "New Episode" else null
                                 },
+                                key = { "cw:${it.mediaType}:${it.tmdbId}" },
                                 hasMore = false,
                                 isLoadingMore = false,
                                 onLoadMore = {}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryScreenComponents.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryScreenComponents.kt
@@ -40,7 +40,7 @@ import androidx.compose.material3.*
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.*
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -162,7 +162,7 @@ internal fun DiscoverGrid(
         return
     }
 
-    val isNearEnd by remember {
+    val isNearEnd by remember(gridState) {
         derivedStateOf {
             val totalItems = gridState.layoutInfo.totalItemsCount
             val lastVisibleItemIndex = gridState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
@@ -170,20 +170,47 @@ internal fun DiscoverGrid(
         }
     }
 
+    // Perf: ALL alternates movie/TV pages (via preferMovies) so TV rows can't stall
+    // forever behind an endless movie feed. No time gate: isLoadingMore* already
+    // prevents double-fire, and a gate can stall the effect when TMDB is fast —
+    // the flag flip restarts the effect while still gated, then completion
+    // restarts it while still gated, and isNearEnd never retriggers.
+    var preferMovies by remember { mutableStateOf(true) }
     LaunchedEffect(isNearEnd, isLoadingMoreMovies, hasMoreMovies, isLoadingMoreTvShows, hasMoreTvShows) {
         if (isNearEnd) {
             when (selectedMediaType) {
                 LibraryMediaType.MOVIE -> {
-                    if (!isLoadingMoreMovies && hasMoreMovies) onLoadMoreMovies()
+                    if (!isLoadingMoreMovies && hasMoreMovies) {
+                        onLoadMoreMovies()
+                    }
                 }
                 LibraryMediaType.TV_SHOW -> {
-                    if (!isLoadingMoreTvShows && hasMoreTvShows) onLoadMoreTvShows()
+                    if (!isLoadingMoreTvShows && hasMoreTvShows) {
+                        onLoadMoreTvShows()
+                    }
                 }
                 LibraryMediaType.ALL -> {
-                    // Try loading both if we hit the bottom
-                    if (!isLoadingMoreMovies && hasMoreMovies) onLoadMoreMovies()
-                    if (!isLoadingMoreTvShows && hasMoreTvShows) onLoadMoreTvShows()
+                    val moviesTurn = preferMovies || !hasMoreTvShows || isLoadingMoreTvShows
+                    if (moviesTurn && !isLoadingMoreMovies && hasMoreMovies) {
+                        preferMovies = false
+                        onLoadMoreMovies()
+                    } else if (!isLoadingMoreTvShows && hasMoreTvShows) {
+                        preferMovies = true
+                        onLoadMoreTvShows()
+                    }
                 }
+            }
+        }
+    }
+
+    // Perf: memoized outside the grid DSL — remember() is illegal inside
+    // LazyVerticalGrid scope; rebuild only when pages append.
+    val mixedAll = remember(movies, tvShows) {
+        val maxLen = maxOf(movies.size, tvShows.size)
+        buildList {
+            for (i in 0 until maxLen) {
+                if (i < movies.size) add(Pair(movies[i], true))
+                if (i < tvShows.size) add(Pair(tvShows[i], false))
             }
         }
     }
@@ -198,14 +225,11 @@ internal fun DiscoverGrid(
     ) {
 
         if (selectedMediaType == LibraryMediaType.ALL) {
-            val maxLen = maxOf(movies.size, tvShows.size)
-            val mixed = buildList {
-                for (i in 0 until maxLen) {
-                    if (i < movies.size) add(Pair(movies[i], true))
-                    if (i < tvShows.size) add(Pair(tvShows[i], false))
-                }
-            }
-            gridItems(mixed) { pair ->
+            gridItems(
+                mixedAll,
+                key = { (item, isMovie) -> if (isMovie) "m:${(item as TmdbMovie).id}" else "t:${(item as TmdbTvShow).id}" },
+                contentType = { "poster" },
+            ) { pair ->
                 if (pair.second) {
                     val movie = pair.first as TmdbMovie
                     PosterCard(
@@ -235,7 +259,7 @@ internal fun DiscoverGrid(
             }
         } else if (selectedMediaType == LibraryMediaType.MOVIE) {
             if (hasMovies) {
-                gridItems(movies) { item ->
+                gridItems(movies, key = { it.id }, contentType = { "poster" }) { item ->
                     PosterCard(
                         posterUrl = item.posterUrl,
                         title = item.title,
@@ -254,7 +278,7 @@ internal fun DiscoverGrid(
             }
         } else if (selectedMediaType == LibraryMediaType.TV_SHOW) {
             if (hasTvShows) {
-                gridItems(tvShows) { item ->
+                gridItems(tvShows, key = { it.id }, contentType = { "poster" }) { item ->
                     PosterCard(
                         posterUrl = item.posterUrl,
                         title = item.name,
@@ -275,6 +299,10 @@ internal fun DiscoverGrid(
     }
 }
 
+/** Stable fallback key for mixed-type rows. Callers with stable ids should pass key= explicitly. */
+private fun itemKey(posterUrl: String?, title: String): String =
+    posterUrl?.let { "p:$it" } ?: "t:$title"
+
 @Composable
 internal fun <T> MediaRow(
     title: String,
@@ -287,12 +315,14 @@ internal fun <T> MediaRow(
     year: (T) -> String,
     rating: (T) -> String,
     badgeText: (T) -> String? = { null },
+    key: ((T) -> Any)? = null,
     onLoadMore: () -> Unit = {},
     isLoadingMore: Boolean = false,
-    hasMore: Boolean = true
+    // Perf: default false — static rows must not trigger pagination callbacks.
+    hasMore: Boolean = false
 ) {
 
-    val isNearEnd by remember {
+    val isNearEnd by remember(listState) {
         derivedStateOf {
             val totalItems = listState.layoutInfo.totalItemsCount
             val lastVisibleItemIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
@@ -320,7 +350,11 @@ internal fun <T> MediaRow(
             contentPadding = PaddingValues(horizontal = 12.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            items(items) { item ->
+            items(
+                items,
+                key = key ?: { item -> itemKey(posterUrl(item), displayTitle(item)) },
+                contentType = { "poster" },
+            ) { item ->
                 PosterCard(
                     posterUrl = posterUrl(item),
                     title = displayTitle(item),
@@ -379,7 +413,10 @@ internal fun PosterCard(
                 AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(posterUrl)
-                        .crossfade(true)
+                        // No explicit .size(): AsyncImage auto-resolves the layout size
+                        // in pixels (density-aware). A hardcoded px size decodes too
+                        // small on high-density screens and upscales = blurry.
+                        .crossfade(false)
                         .build(),
                     contentDescription = title,
                     contentScale = ContentScale.Crop,
@@ -604,7 +641,10 @@ internal fun AddonSearchResultItem(
             ) {
                 if (item.poster != null) {
                     AsyncImage(
-                        model = item.poster,
+                        model = ImageRequest.Builder(LocalContext.current)
+                            .data(item.poster)
+                            .crossfade(false)
+                            .build(),
                         contentDescription = item.name,
                         contentScale = ContentScale.Crop,
                         placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
@@ -801,7 +841,7 @@ internal fun AddonMediaRow(
             contentPadding = PaddingValues(horizontal = 12.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            items(row.items) { item ->
+            items(row.items, key = { it.id }, contentType = { "poster" }) { item ->
                 PosterCard(
                     posterUrl = item.poster,
                     title = item.name,
@@ -881,7 +921,7 @@ internal fun SearchHistoryList(
                 }
             }
         }
-        items(history) { item ->
+        items(history, key = { it.query }, contentType = { "history" }) { item ->
             SearchHistoryItem(
                 query = item.query,
                 onClick = { onQueryClick(item.query) },
@@ -1017,7 +1057,7 @@ internal fun LibraryFilterSheet(
     activeFilterCount: Int,
     onDismiss: () -> Unit,
 ) {
-    val filters by viewModel.filters.collectAsState()
+    val filters by viewModel.filters.collectAsStateWithLifecycle()
 
     val selectedMediaType = filters.mediaType
     val selectedSort = filters.sort
@@ -1036,12 +1076,12 @@ internal fun LibraryFilterSheet(
     val selectedWatchRegion = filters.watchRegion
     val selectedProviders = filters.selectedProviders
     val selectedMonetization = filters.selectedMonetization
-    val watchProviders by viewModel.watchProviders.collectAsState()
+    val watchProviders by viewModel.watchProviders.collectAsStateWithLifecycle()
     val selectedCertification = filters.certification
     val includeAdult = filters.includeAdult
     val selectedKeywords = filters.selectedKeywords
-    val keywordResults by viewModel.keywordResults.collectAsState()
-    val isSearchingKeywords by viewModel.isSearchingKeywords.collectAsState()
+    val keywordResults by viewModel.keywordResults.collectAsStateWithLifecycle()
+    val isSearchingKeywords by viewModel.isSearchingKeywords.collectAsStateWithLifecycle()
     val selectedReleaseTypes = filters.selectedReleaseTypes
     val selectedTvStatuses = filters.selectedTvStatuses
     val selectedTvTypes = filters.selectedTvTypes
@@ -1332,7 +1372,11 @@ internal fun LibraryFilterSheet(
                                 leadingIcon = provider.logoUrl?.let { url ->
                                     {
                                         AsyncImage(
-                                            model = url,
+                                            model = ImageRequest.Builder(LocalContext.current)
+                                                .data(url)
+                                                .size(96)
+                                                .crossfade(false)
+                                                .build(),
                                             contentDescription = null,
                                             modifier = Modifier.size(FilterChipDefaults.IconSize).clip(RoundedCornerShape(4.dp))
                                         )

--- a/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryViewModel.kt
@@ -35,6 +35,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
@@ -78,12 +80,11 @@ data class DiscoveryFiltersState(
 
 class LibraryViewModel(
     application: Application,
-    val tmdb: TmdbRepository = TmdbRepository(application),
-    private val database: com.playbridge.sender.data.history.HistoryDatabase = DatabaseProvider.getDatabase(application),
-    private val addonRepository: AddonRepository = AddonRepository(
-        addonDao = database.addonDao(),
-        cacheDir = application.cacheDir
-    )
+    // Perf: no default construction — manual construction used to bypass Koin and
+    // spin up duplicate OkHttp clients/caches per instance.
+    val tmdb: TmdbRepository,
+    private val database: com.playbridge.sender.data.history.HistoryDatabase,
+    private val addonRepository: AddonRepository,
 ) : AndroidViewModel(application) {
     private val watchlistDao = database.watchlistDao()
     private val searchHistoryDao = database.searchHistoryDao()
@@ -273,6 +274,8 @@ class LibraryViewModel(
             }
 
             _catalogRows.value = result
+            // In-memory static cache keeps the full result (disk persist is bounded by
+            // Coil's own caches; truncating here blanked Home on refresh until network).
             catalogCache = result
             catalogCacheTime = System.currentTimeMillis()
             persistCatalogCache(result, catalogCacheTime)
@@ -435,39 +438,63 @@ class LibraryViewModel(
 
     private fun observeNewEpisodes() {
         viewModelScope.launch {
-            watching.collect { watchingItems ->
-                val tvItems = watchingItems.filter { it.mediaType == "tv" }
-                if (tvItems.isEmpty()) {
-                    _newEpisodeTmdbIds.value = emptySet()
-                    return@collect
+            watching
+                // Perf: re-fires on every watchlist write — only recompute when the
+                // set of tracked tv progress pointers actually changed.
+                .map { items ->
+                    items.filter { it.mediaType == "tv" }
+                        .map { Triple(it.tmdbId, it.seasonProgress, it.episodeProgress) }
                 }
-                val ids = mutableSetOf<Int>()
-                tvItems.forEach { entity ->
-                    try {
-                        val userSeason = entity.seasonProgress ?: return@forEach
-                        val userEp    = entity.episodeProgress ?: return@forEach
-
-                        val details = tmdb.getTvDetails(entity.tmdbId) ?: return@forEach
-
-                        val hasAvailable = when (val next = details.nextEpisodeToAir) {
-                            null -> {
-                                val lastAirMs = parseIsoDate(details.lastAirDate ?: return@forEach)
-                                    ?: return@forEach
-                                val referenceMs = entity.startedAt ?: entity.addedAt
-                                lastAirMs > referenceMs
+                .distinctUntilChanged()
+                .collect { pointers ->
+                    if (pointers.isEmpty()) {
+                        _newEpisodeTmdbIds.value = emptySet()
+                        return@collect
+                    }
+                    // Perf: concurrent IO fetches with a 24h details cache, off main.
+                    // Concurrency capped (4) so a 50+ show list doesn't fan out at once.
+                    val detailsSemaphore = kotlinx.coroutines.sync.Semaphore(4)
+                    val ids = withContext(Dispatchers.IO) {
+                        pointers.map { (tmdbId, userSeason, userEp) ->
+                            async<Int?> {
+                                detailsSemaphore.withPermit {
+                                    if (userSeason == null || userEp == null) return@withPermit null
+                                    val details = tvDetailsCached(tmdbId) ?: return@withPermit null
+                                    val hasAvailable = when (val next = details.nextEpisodeToAir) {
+                                        null -> {
+                                            val lastAirMs = parseIsoDate(details.lastAirDate ?: return@withPermit null)
+                                                ?: return@withPermit null
+                                            val referenceMs = watchlist.value
+                                                .find { it.tmdbId == tmdbId }
+                                                ?.let { it.startedAt ?: it.addedAt } ?: 0L
+                                            lastAirMs > referenceMs
+                                        }
+                                        else -> when {
+                                            userSeason < next.seasonNumber -> true
+                                            userSeason == next.seasonNumber -> userEp < next.episodeNumber - 1
+                                            else -> false
+                                        }
+                                    }
+                                    if (hasAvailable) tmdbId else null
+                                }
                             }
-                            else -> when {
-                                userSeason < next.seasonNumber -> true
-                                userSeason == next.seasonNumber -> userEp < next.episodeNumber - 1
-                                else -> false
-                            }
-                        }
-
-                        if (hasAvailable) ids.add(entity.tmdbId)
-                    } catch (_: Exception) { }
+                        }.awaitAll().filterNotNull().toSet()
+                    }
+                    _newEpisodeTmdbIds.value = ids
                 }
-                _newEpisodeTmdbIds.value = ids
-            }
+        }
+    }
+
+    /** 24h in-memory cache for TV details used by new-episode detection. */
+    private val tvDetailsCache = java.util.concurrent.ConcurrentHashMap<Int, Pair<Long, com.playbridge.sender.data.library.TmdbTvDetails>>()
+
+    private suspend fun tvDetailsCached(tmdbId: Int): com.playbridge.sender.data.library.TmdbTvDetails? {
+        val now = System.currentTimeMillis()
+        tvDetailsCache[tmdbId]?.let { (at, details) ->
+            if (now - at < 24 * 60 * 60 * 1000L) return details
+        }
+        return runCatching { tmdb.getTvDetails(tmdbId) }.getOrNull()?.also {
+            tvDetailsCache[tmdbId] = now to it
         }
     }
 
@@ -782,28 +809,24 @@ class LibraryViewModel(
     }
 
     // ---------------------------------------------------------------------------
-    // Tracking — per-status flows
+    // Tracking — per-status flows (derived from the single getAll() collector so one
+    // DB write doesn't re-emit 6 flows).
     // ---------------------------------------------------------------------------
 
-    val watching: StateFlow<List<WatchlistEntity>> =
-        watchlistDao.getByStatus(WatchlistStatus.WATCHING.value)
+    private fun byStatus(status: WatchlistStatus): StateFlow<List<WatchlistEntity>> =
+        watchlist
+            .map { list -> list.filter { it.status == status.value } }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
-    val planToWatch: StateFlow<List<WatchlistEntity>> =
-        watchlistDao.getByStatus(WatchlistStatus.PLAN_TO_WATCH.value)
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+    val watching: StateFlow<List<WatchlistEntity>> = byStatus(WatchlistStatus.WATCHING)
 
-    val completed: StateFlow<List<WatchlistEntity>> =
-        watchlistDao.getByStatus(WatchlistStatus.COMPLETED.value)
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+    val planToWatch: StateFlow<List<WatchlistEntity>> = byStatus(WatchlistStatus.PLAN_TO_WATCH)
 
-    val onHold: StateFlow<List<WatchlistEntity>> =
-        watchlistDao.getByStatus(WatchlistStatus.ON_HOLD.value)
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+    val completed: StateFlow<List<WatchlistEntity>> = byStatus(WatchlistStatus.COMPLETED)
 
-    val dropped: StateFlow<List<WatchlistEntity>> =
-        watchlistDao.getByStatus(WatchlistStatus.DROPPED.value)
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+    val onHold: StateFlow<List<WatchlistEntity>> = byStatus(WatchlistStatus.ON_HOLD)
+
+    val dropped: StateFlow<List<WatchlistEntity>> = byStatus(WatchlistStatus.DROPPED)
 
     init {
         checkConfigAndLoadInitialData()

--- a/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryViewModel.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/library/LibraryViewModel.kt
@@ -197,8 +197,12 @@ class LibraryViewModel(
                 }
             }
 
-            val cached = catalogCache
-            if (cached != null) _catalogRows.value = cached  // show cache immediately
+            // Normalize older caches, including the fallback used if refresh fails.
+            val cached = catalogCache?.map { row ->
+                row.copy(items = mergeUniquePage(emptyList(), row.items) { it.id })
+            }
+            catalogCache = cached
+            if (cached != null) _catalogRows.value = cached
 
             // Only hit the network when forced, or when the cache is missing/stale.
             val intervalMs = refreshIntervalMs()
@@ -249,7 +253,7 @@ class LibraryViewModel(
                     }.getOrDefault(emptyList())
 
                     mutex.withLock {
-                        ordered[index] = ordered[index].copy(items = items, isLoading = false)
+                        ordered[index] = ordered[index].copy(items = mergeUniquePage(emptyList(), items) { it.id }, isLoading = false)
                         if (showProgressive) emitOrdered()
                     }
                 }
@@ -390,7 +394,7 @@ class LibraryViewModel(
 
             updateCatalogRow(addonBaseUrl, type, catalogId) { existing ->
                 existing.copy(
-                    items = existing.items + newItems,
+                    items = mergeUniquePage(existing.items, newItems) { it.id },
                     isLoadingMore = false,
                     currentSkip = nextSkip,
                     hasMore = newItems.isNotEmpty()
@@ -751,14 +755,14 @@ class LibraryViewModel(
             val mediaType = f.mediaType
 
             if (mediaType == LibraryMediaType.ALL || mediaType == LibraryMediaType.MOVIE) {
-                _discoveredMovies.value = tmdb.discoverMovies(page = 1, filters = movieFilters(f)).results
+                _discoveredMovies.value = mergeUniquePage(emptyList(), tmdb.discoverMovies(page = 1, filters = movieFilters(f)).results) { it.id }
             } else {
                 _discoveredMovies.value = emptyList()
                 _hasMoreDiscoveredMovies.value = false
             }
 
             if (mediaType == LibraryMediaType.ALL || mediaType == LibraryMediaType.TV_SHOW) {
-                _discoveredTvShows.value = tmdb.discoverTvShows(page = 1, filters = tvFilters(f)).results
+                _discoveredTvShows.value = mergeUniquePage(emptyList(), tmdb.discoverTvShows(page = 1, filters = tvFilters(f)).results) { it.id }
             } else {
                 _discoveredTvShows.value = emptyList()
                 _hasMoreDiscoveredTvShows.value = false
@@ -777,7 +781,7 @@ class LibraryViewModel(
                 val nextPage = discoveredMoviesPage + 1
                 val newMovies = tmdb.discoverMovies(page = nextPage, filters = movieFilters())
                 if (newMovies.results.isNotEmpty()) {
-                    _discoveredMovies.value = _discoveredMovies.value + newMovies.results
+                    _discoveredMovies.value = mergeUniquePage(_discoveredMovies.value, newMovies.results) { it.id }
                     discoveredMoviesPage = nextPage
                 } else {
                     _hasMoreDiscoveredMovies.value = false
@@ -797,7 +801,7 @@ class LibraryViewModel(
                 val nextPage = discoveredTvShowsPage + 1
                 val newTvShows = tmdb.discoverTvShows(page = nextPage, filters = tvFilters())
                 if (newTvShows.results.isNotEmpty()) {
-                    _discoveredTvShows.value = _discoveredTvShows.value + newTvShows.results
+                    _discoveredTvShows.value = mergeUniquePage(_discoveredTvShows.value, newTvShows.results) { it.id }
                     discoveredTvShowsPage = nextPage
                 } else {
                     _hasMoreDiscoveredTvShows.value = false

--- a/mobile/android/app/src/main/java/com/playbridge/sender/library/MyListTab.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/library/MyListTab.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import androidx.compose.ui.platform.LocalContext
 import com.playbridge.sender.data.library.WatchlistEntity
 import com.playbridge.sender.data.library.WatchlistStatus
 
@@ -207,9 +209,15 @@ private fun TrackingCard(
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
 
-            // Poster image
+            // Poster image (no explicit .size(): AsyncImage resolves layout px,
+            // a hardcoded size decodes too small on high-density screens = blurry).
             AsyncImage(
-                model = entity.posterUrl,
+                model = entity.posterUrl?.let { url ->
+                    ImageRequest.Builder(LocalContext.current)
+                        .data(url)
+                        .crossfade(false)
+                        .build()
+                },
                 contentDescription = entity.title,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize(),

--- a/mobile/android/app/src/main/java/com/playbridge/sender/library/UniquePage.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/library/UniquePage.kt
@@ -1,0 +1,5 @@
+package com.playbridge.sender.library
+
+/** Keep the first occurrence and its position when providers repeat or overlap pages. */
+internal fun <T, K> mergeUniquePage(current: List<T>, incoming: List<T>, key: (T) -> K): List<T> =
+    (current + incoming).distinctBy(key)

--- a/mobile/android/app/src/main/java/com/playbridge/sender/player/PlayerActivity.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/player/PlayerActivity.kt
@@ -917,9 +917,6 @@ private fun PlayerScreen(
     // stays in STATE_BUFFERING (seen on Samsung with local content:// MP4s).
     var hasRenderedFrame by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
-    var positionMs by remember { mutableLongStateOf(0L) }
-    var durationMs by remember { mutableLongStateOf(0L) }
-    var bufferedMs by remember { mutableLongStateOf(0L) }
 
     // Controls / scrubbing
     var controlsVisible by remember { mutableStateOf(true) }
@@ -963,14 +960,14 @@ private fun PlayerScreen(
 
     // (Background toggle state is hoisted — the activity shares backgroundMode directly.)
 
-    // Precision AB Loop segment repeat
-    LaunchedEffect(abStartMs, abEndMs) {
-        if (abStartMs != null && abEndMs != null) {
-            while (true) {
+    // Precision AB Loop segment repeat — only while playing, 200ms cadence.
+    LaunchedEffect(abStartMs, abEndMs, isPlaying) {
+        if (abStartMs != null && abEndMs != null && isPlaying) {
+            while (isPlaying) {
                 if (player.currentPosition >= abEndMs!!) {
                     player.seekTo(abStartMs!!)
                 }
-                delay(100)
+                delay(200)
             }
         }
     }
@@ -1028,11 +1025,22 @@ private fun PlayerScreen(
 
     fun markInteraction() { interactionTick++ }
 
+    // Poll position/buffer while not actively scrubbing/seeking.
+    // Perf: MutableLongState holders — Compose tracks .longValue reads per-composable,
+    // so the 400ms tick recomposes only readers (SeekProgressRow, HUDs, stats below).
+    val playbackProgress = remember { mutableLongStateOf(0L) }
+    val playbackBuffered = remember { mutableLongStateOf(0L) }
+    val playbackDuration = remember { mutableLongStateOf(0L) }
+    // Snapshot aliases for event handlers (seekBy, drag end, scrub end) — reads below
+    // in SeekProgressRow/HUDs/stats use the holders directly for scoped recomposition.
+    // (Local `val x get()` properties are illegal here — this is a @Composable function
+    // body, not a class — so call sites below read the holders directly.)
+
     fun seekBy(deltaMs: Long) {
         val d = player.duration.coerceAtLeast(0)
         val target = (player.currentPosition + deltaMs).coerceIn(0, if (d > 0) d else Long.MAX_VALUE)
         player.seekTo(target)
-        positionMs = target
+        playbackProgress.longValue = target
     }
 
     fun togglePlay() {
@@ -1070,7 +1078,7 @@ private fun PlayerScreen(
                 if (state == Player.STATE_READY) {
                     errorMessage = null
                     val d = player.duration
-                    if (d > 0) durationMs = d
+                    if (d > 0) playbackDuration.longValue = d
                 }
                 // End of the current item. In lazy mode advance to (and resolve) the next
                 // episode; otherwise this is the end of all content, so exit.
@@ -1121,15 +1129,14 @@ private fun PlayerScreen(
     LaunchedEffect(Unit) {
         while (true) {
             if (!isScrubbing && dragMode != DragMode.SEEK) {
-                positionMs = player.currentPosition
-                bufferedMs = player.bufferedPosition
+                playbackProgress.longValue = player.currentPosition
+                playbackBuffered.longValue = player.bufferedPosition
                 val d = player.duration
-                if (d > 0) durationMs = d
+                if (d > 0) playbackDuration.longValue = d
             }
             delay(400)
         }
     }
-
     // Auto-hide controls a few seconds after the last interaction while playing.
     LaunchedEffect(controlsVisible, isPlaying, interactionTick, dragMode) {
         if (controlsVisible && isPlaying && dragMode == DragMode.NONE) {
@@ -1214,7 +1221,7 @@ private fun PlayerScreen(
                         onDragEnd = {
                             if (dragMode == DragMode.SEEK) {
                                 player.seekTo(seekPreviewMs)
-                                positionMs = seekPreviewMs
+                                playbackProgress.longValue = seekPreviewMs
                             }
                             dragMode = DragMode.NONE
                         },
@@ -1233,7 +1240,7 @@ private fun PlayerScreen(
                             }
                             when (dragMode) {
                                 DragMode.SEEK -> {
-                                    val d = durationMs
+                                    val d = playbackDuration.longValue
                                     if (d > 0) {
                                         val delta = ((accDx / size.width) * SEEK_RANGE_MS).toLong()
                                         seekPreviewMs = (seekStartMs + delta).coerceIn(0, d)
@@ -1274,6 +1281,15 @@ private fun PlayerScreen(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
+                    // Perf: pinch-zoom transform on the outer Box, not the AndroidView —
+                    // per-gesture-frame TextureView re-layout dropped frames. Lambda
+                    // overload applies values at draw time without recomposing.
+                    .graphicsLayer {
+                        scaleX = scale
+                        scaleY = scale
+                        translationX = offset.x
+                        translationY = offset.y
+                    }
                     .pointerInput(isPanZoomEnabled) {
                         if (isPanZoomEnabled) {
                             detectTransformGestures { centroid, pan, zoom, rotation ->
@@ -1315,7 +1331,7 @@ private fun PlayerScreen(
                         }
                     },
                     update = { view ->
-                        view.resizeMode = resizeMode
+                        if (view.resizeMode != resizeMode) view.resizeMode = resizeMode
                         if (view.player !== player) {
                             view.player = player
                             ensurePrepared(player)
@@ -1323,12 +1339,6 @@ private fun PlayerScreen(
                     },
                     modifier = Modifier
                         .fillMaxSize()
-                        .graphicsLayer(
-                            scaleX = scale,
-                            scaleY = scale,
-                            translationX = offset.x,
-                            translationY = offset.y
-                        )
                 )
             }
 
@@ -1394,7 +1404,7 @@ private fun PlayerScreen(
                     label = "${(brightness * 100).roundToInt()}%",
                     alignment = Alignment.CenterEnd
                 )
-                DragMode.SEEK -> SeekHud(seekDeltaMs, seekPreviewMs, durationMs)
+                DragMode.SEEK -> SeekHud(seekDeltaMs, seekPreviewMs, playbackDuration.longValue)
                 DragMode.NONE -> {}
             }
 
@@ -1432,8 +1442,8 @@ private fun PlayerScreen(
                     player = player,
                     activeVideoFormat = activeVideoFormat,
                     activeAudioFormat = activeAudioFormat,
-                    positionMs = positionMs,
-                    bufferedMs = bufferedMs,
+                    positionMs = playbackProgress.longValue,
+                    bufferedMs = playbackBuffered.longValue,
                     speed = speed,
                     onClose = { showStats = false }
                 )
@@ -1483,12 +1493,14 @@ private fun PlayerScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .background(
-                            Brush.verticalGradient(
-                                0f to Color.Black.copy(alpha = 0.5f),
-                                0.25f to Color.Transparent,
-                                0.75f to Color.Transparent,
-                                1f to Color.Black.copy(alpha = 0.6f)
-                            )
+                            remember {
+                                Brush.verticalGradient(
+                                    0f to Color.Black.copy(alpha = 0.5f),
+                                    0.25f to Color.Transparent,
+                                    0.75f to Color.Transparent,
+                                    1f to Color.Black.copy(alpha = 0.6f)
+                                )
+                            }
                         )
                 ) {
                     // Top bar: back, title, and a translucent action pill.
@@ -1882,30 +1894,25 @@ private fun PlayerScreen(
 
                         Spacer(Modifier.height(4.dp))
 
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(10.dp)
-                        ) {
-                            val shownPos = if (isScrubbing) (scrubFraction * durationMs).toLong() else positionMs
-                            Text(formatTime(shownPos), color = Color.White, style = MaterialTheme.typography.labelMedium)
-                            SeekBar(
-                                fraction = if (durationMs > 0) (shownPos.toFloat() / durationMs) else 0f,
-                                bufferedFraction = if (durationMs > 0) (bufferedMs.toFloat() / durationMs) else 0f,
-                                onScrubStart = { isScrubbing = true; markInteraction() },
-                                onScrub = { scrubFraction = it; markInteraction() },
-                                onScrubEnd = {
-                                    if (durationMs > 0) {
-                                        val target = (it * durationMs).toLong()
-                                        player.seekTo(target)
-                                        positionMs = target
-                                    }
-                                    isScrubbing = false
-                                },
-                                modifier = Modifier.weight(1f)
-                            )
-                            Text(formatTime(durationMs), color = Color.White, style = MaterialTheme.typography.labelMedium)
-                        }
+                        // Perf: isolated so the 400ms position ticker recomposes only
+                        // this row — the old inline reads pulled the whole overlay.
+                        SeekProgressRow(
+                            position = playbackProgress,
+                            buffered = playbackBuffered,
+                            duration = playbackDuration,
+                            isScrubbing = isScrubbing,
+                            scrubFraction = scrubFraction,
+                            onScrubStart = { isScrubbing = true; markInteraction() },
+                            onScrub = { scrubFraction = it; markInteraction() },
+                            onScrubEnd = {
+                                if (playbackDuration.longValue > 0) {
+                                    val target = (it * playbackDuration.longValue).toLong()
+                                    player.seekTo(target)
+                                    playbackProgress.longValue = target
+                                }
+                                isScrubbing = false
+                            },
+                        )
                     }
                 }
             }
@@ -2057,6 +2064,45 @@ private fun GlassControl(
         contentAlignment = Alignment.Center
     ) {
         IconButton(onClick = onClick, enabled = enabled, modifier = Modifier.matchParentSize()) { content() }
+    }
+}
+
+/**
+ * Position ticker isolation: the 400ms positionMs/bufferedMs/durationMs reads happen
+ * only inside this row, so ticks recompose the time labels + bar — not the overlay.
+ * Callers must pass the MutableLongState holders (not snapshot Longs) so the reads
+ * stay scoped to this composable.
+ */
+@Composable
+private fun SeekProgressRow(
+    position: androidx.compose.runtime.MutableLongState,
+    buffered: androidx.compose.runtime.MutableLongState,
+    duration: androidx.compose.runtime.MutableLongState,
+    isScrubbing: Boolean,
+    scrubFraction: Float,
+    onScrubStart: () -> Unit,
+    onScrub: (Float) -> Unit,
+    onScrubEnd: (Float) -> Unit,
+) {
+    val positionMs = position.longValue
+    val bufferedMs = buffered.longValue
+    val durationMs = duration.longValue
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        val shownPos = if (isScrubbing) (scrubFraction * durationMs).toLong() else positionMs
+        Text(formatTime(shownPos), color = Color.White, style = MaterialTheme.typography.labelMedium)
+        SeekBar(
+            fraction = if (durationMs > 0) (shownPos.toFloat() / durationMs) else 0f,
+            bufferedFraction = if (durationMs > 0) (bufferedMs.toFloat() / durationMs) else 0f,
+            onScrubStart = onScrubStart,
+            onScrub = onScrub,
+            onScrubEnd = onScrubEnd,
+            modifier = Modifier.weight(1f)
+        )
+        Text(formatTime(durationMs), color = Color.White, style = MaterialTheme.typography.labelMedium)
     }
 }
 

--- a/mobile/android/app/src/main/java/com/playbridge/sender/ui/DashboardScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/ui/DashboardScreen.kt
@@ -89,61 +89,46 @@ fun DashboardScreen(
             .fillMaxSize()
             .background(surfaceColor)
     ) {
-        // ── Animated Ambient Mesh Background ─────────────────────────────────
-        val infiniteBgTransition = rememberInfiniteTransition(label = "mesh_bg")
-        val animatedAngle1 by infiniteBgTransition.animateFloat(
-            initialValue = 0f,
-            targetValue = 2f * Math.PI.toFloat(),
-            animationSpec = infiniteRepeatable(
-                animation = tween(28000, easing = LinearEasing),
-                repeatMode = RepeatMode.Restart
-            ),
-            label = "angle1"
-        )
-        val animatedAngle2 by infiniteBgTransition.animateFloat(
-            initialValue = 0f,
-            targetValue = 2f * Math.PI.toFloat(),
-            animationSpec = infiniteRepeatable(
-                animation = tween(42000, easing = LinearEasing),
-                repeatMode = RepeatMode.Restart
-            ),
-            label = "angle2"
-        )
+        // ── Static Ambient Mesh Background ───────────────────────────────────
+        // Perf: was two infinite angle clocks redrawing a full-screen Canvas + new
+        // radial-gradient Brushes every frame. Static blobs cost one composition.
+        val staticBlob1 = remember(primaryColor) {
+            Brush.radialGradient(
+                colors = listOf(
+                    primaryColor.copy(alpha = 0.12f),
+                    primaryColor.copy(alpha = 0.04f),
+                    Color.Transparent
+                ),
+            )
+        }
+        val staticBlob2 = remember(secondaryColor) {
+            Brush.radialGradient(
+                colors = listOf(
+                    secondaryColor.copy(alpha = 0.10f),
+                    secondaryColor.copy(alpha = 0.03f),
+                    Color.Transparent
+                ),
+            )
+        }
 
         Canvas(modifier = Modifier.fillMaxSize()) {
             val width = size.width
             val height = size.height
 
             // Drift Blob 1 (Top-Right-ish)
-            val dx1 = width * 0.6f + (width * 0.15f) * cos(animatedAngle1)
-            val dy1 = height * 0.25f + (height * 0.1f) * sin(animatedAngle1)
+            val dx1 = width * 0.6f
+            val dy1 = height * 0.25f
             drawCircle(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        primaryColor.copy(alpha = 0.12f),
-                        primaryColor.copy(alpha = 0.04f),
-                        Color.Transparent
-                    ),
-                    center = Offset(dx1, dy1),
-                    radius = width * 0.8f
-                ),
+                brush = staticBlob1,
                 center = Offset(dx1, dy1),
                 radius = width * 0.8f
             )
 
             // Drift Blob 2 (Bottom-Left-ish)
-            val dx2 = width * 0.4f + (width * 0.12f) * cos(animatedAngle2 + Math.PI.toFloat())
-            val dy2 = height * 0.7f + (height * 0.08f) * sin(animatedAngle2)
+            val dx2 = width * 0.4f
+            val dy2 = height * 0.7f
             drawCircle(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        secondaryColor.copy(alpha = 0.10f),
-                        secondaryColor.copy(alpha = 0.03f),
-                        Color.Transparent
-                    ),
-                    center = Offset(dx2, dy2),
-                    radius = width * 0.7f
-                ),
+                brush = staticBlob2,
                 center = Offset(dx2, dy2),
                 radius = width * 0.7f
             )
@@ -271,21 +256,11 @@ fun DashboardScreen(
                     horizontalArrangement = Arrangement.Center
                 ) {
                     if (isConnected) {
-                        val infiniteTransition = rememberInfiniteTransition(label = "pulse")
-                        val pulseAlpha by infiniteTransition.animateFloat(
-                            initialValue = 0.4f,
-                            targetValue = 1f,
-                            animationSpec = infiniteRepeatable(
-                                animation = tween(1000),
-                                repeatMode = RepeatMode.Reverse
-                            ),
-                            label = "dotPulse"
-                        )
                         Box(
                             modifier = Modifier
                                 .size(8.dp)
                                 .clip(CircleShape)
-                                .background(accent.copy(alpha = pulseAlpha))
+                                .background(accent)
                         )
                     } else {
                         Box(
@@ -539,6 +514,8 @@ private fun DashboardCard(
     tall: Boolean,
     onClick: () -> Unit
 ) {
+    // Perf: single entrance animation (alpha + offset) instead of 4 concurrent
+    // per-card anims (cardAlpha/cardTranslateY/pressScale/activeScale).
     val cardAlpha by animateFloatAsState(
         targetValue = if (visible) 1f else 0f,
         animationSpec = tween(400, delayMillis = animDelay),
@@ -550,22 +527,15 @@ private fun DashboardCard(
         label = "cardTranslateY"
     )
 
-    // Tactile press scale response
+    // Tactile press scale response (no separate active-scale spring).
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
     val pressScale by animateFloatAsState(
         targetValue = if (isPressed) 0.95f else 1f,
-        animationSpec = spring(dampingRatio = 0.7f, stiffness = 400f),
+        animationSpec = tween(150),
         label = "pressScale"
     )
-
-    // Active state scale enhancement
-    val activeScale by animateFloatAsState(
-        targetValue = if (isActive) 1.02f else 1f,
-        animationSpec = spring(dampingRatio = 0.6f, stiffness = 200f),
-        label = "activeScale"
-    )
-    val finalScale = pressScale * activeScale
+    val finalScale = pressScale
 
     val height = if (tall) 150.dp else 120.dp
 
@@ -723,21 +693,11 @@ private fun DashboardCard(
                         .padding(horizontal = 6.dp, vertical = 3.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    val infiniteActiveTransition = rememberInfiniteTransition(label = "active_badge")
-                    val badgeDotAlpha by infiniteActiveTransition.animateFloat(
-                        initialValue = 0.4f,
-                        targetValue = 1f,
-                        animationSpec = infiniteRepeatable(
-                            animation = tween(800),
-                            repeatMode = RepeatMode.Reverse
-                        ),
-                        label = "badgeDotAlpha"
-                    )
                     Box(
                         modifier = Modifier
                             .size(4.dp)
                             .clip(CircleShape)
-                            .background(Color.White.copy(alpha = badgeDotAlpha))
+                            .background(Color.White)
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(

--- a/mobile/android/app/src/main/java/com/playbridge/sender/ui/theme/Theme.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/ui/theme/Theme.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.LocalTextStyle
@@ -18,6 +19,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
@@ -242,9 +244,15 @@ fun DynamicColorTheme(
     // dispose→re-extract→reseed flicker loop. So always render through the body,
     // falling back to the inherited app scheme when there's no seed.
     val inherited = MaterialTheme.colorScheme
-    val target = remember(seedColor, theme, inherited) {
+    // Perf: quantize the seed so tiny per-frame palette jitter doesn't recompute the
+    // HCT scheme, and key the remember on (quantized seed, theme) only — never on the
+    // full animated ColorScheme, which changes every animation frame and would loop.
+    // Note: Color.value packs the color-space id in the low 32 bits — quantize the
+    // sRGB ARGB int instead so all four channels actually participate.
+    val seedKey = seedColor?.let { (it.toArgb().toLong() and 0xFFF0F0F0L) } ?: 0L
+    val target = remember(seedKey, theme) {
         if (seedColor == null) {
-            inherited
+            null
         } else {
             val scheme = dynamicColorScheme(
                 seedColor = seedColor,
@@ -253,7 +261,7 @@ fun DynamicColorTheme(
             )
             if (theme == AppTheme.AMOLED) scheme.pureBlack(true) else scheme
         }
-    }
+    } ?: inherited
     ExpressiveThemeBody(target, content)
 }
 
@@ -264,11 +272,14 @@ private fun ExpressiveThemeBody(
 ) {
     // Expressive motion — the source of the fluid ripples, container morphs and
     // transition timing that give the app its "smooth" feel.
-    val motionScheme = MotionScheme.expressive()
+    // Perf: created once — MotionScheme construction on every recomposition churns.
+    val motionScheme = remember { MotionScheme.expressive() }
 
     // Crossfade every colour slot instead of snapping, so theme changes and
     // art-seeded dynamic colours animate smoothly.
-    val colorScheme = animateColorScheme(targetColorScheme, motionScheme.defaultEffectsSpec())
+    // Perf: a short fixed tween — the expressive default spring is longer/heavier,
+    // and this body runs on every palette tick.
+    val colorScheme = animateColorScheme(targetColorScheme, tween(300))
 
     MaterialExpressiveTheme(
         colorScheme = colorScheme,

--- a/mobile/android/app/src/test/java/com/playbridge/sender/connection/WebSocketMessageBusTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/connection/WebSocketMessageBusTest.kt
@@ -1,0 +1,58 @@
+package com.playbridge.sender.connection
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class WebSocketMessageBusTest {
+    @Test
+    fun slowSubscriberDoesNotLoseSignalingAfterBufferFills() = runBlocking {
+        withTimeout(5_000) {
+            val bus = WebSocketMessageBus()
+            val release = CompletableDeferred<Unit>()
+            val entered = CompletableDeferred<Unit>()
+            val filled = CompletableDeferred<Unit>()
+            val receivedAll = CompletableDeferred<Unit>()
+            val expected = (0 until 65).map { "status:$it" } +
+                listOf("screen_mirror_ready", "screen_mirror_answer", "screen_mirror_candidate", "stopped")
+            val received = mutableListOf<String>()
+            val collector = launch(start = CoroutineStart.UNDISPATCHED) {
+                bus.messages.collect {
+                    received.add(it)
+                    if (received.size == 1) {
+                        entered.complete(Unit)
+                        release.await()
+                    }
+                    if (received.size == expected.size) receivedAll.complete(Unit)
+                }
+            }
+            val publisher = launch(Dispatchers.IO) {
+                bus.publish(expected.first())
+                entered.await()
+                expected.drop(1).forEachIndexed { index, message ->
+                    if (index == 64) filled.complete(Unit)
+                    bus.publish(message)
+                }
+            }
+            try {
+                filled.await()
+                assertFalse(publisher.isCompleted)
+                release.complete(Unit)
+                receivedAll.await()
+                publisher.join()
+                assertEquals(expected, received)
+            } finally {
+                release.complete(Unit)
+                collector.cancelAndJoin()
+                publisher.cancelAndJoin()
+            }
+        }
+    }
+}

--- a/mobile/android/app/src/test/java/com/playbridge/sender/data/iptv/IptvSearchRulesTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/data/iptv/IptvSearchRulesTest.kt
@@ -1,0 +1,26 @@
+package com.playbridge.sender.data.iptv
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class IptvSearchRulesTest {
+    private fun channels(vararg names: String) = names.mapIndexed { index, name ->
+        IptvChannelEntity(id = index.toLong(), playlistId = 1, name = name, url = "u$index", orderIndex = index)
+    }
+
+    @Test
+    fun matchesUnicodeCaseInsensitivelyWithoutChangingOrder() {
+        val items = channels("Évasion HD", "КИНО", "évasion SD", "News")
+        assertEquals(listOf(items[0], items[2]), IptvSearchRules.filter(items, "évasion"))
+        assertEquals(listOf(items[1]), IptvSearchRules.filter(items, "кино"))
+    }
+
+    @Test
+    fun wildcardCharactersAreLiteralAndBlankQueryShowsEverything() {
+        val items = channels("100% TV", "News_HD", "News")
+        assertEquals(listOf(items[0]), IptvSearchRules.filter(items, "%"))
+        assertEquals(listOf(items[1]), IptvSearchRules.filter(items, "_"))
+        assertEquals(items, IptvSearchRules.filter(items, "  "))
+        assertEquals(items, IptvSearchRules.filter(items, ""))
+    }
+}

--- a/mobile/android/app/src/test/java/com/playbridge/sender/library/UniquePageTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/library/UniquePageTest.kt
@@ -1,0 +1,23 @@
+package com.playbridge.sender.library
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UniquePageTest {
+    private data class Item(val id: String, val title: String = id)
+
+    @Test
+    fun overlappingPagesKeepExistingPositionsAndAppendNewIds() {
+        val first = listOf(Item("a"), Item("b"))
+        val next = listOf(Item("b", "updated"), Item("c"), Item("c"), Item("d"))
+        assertEquals(listOf(Item("a"), Item("b"), Item("c"), Item("d")),
+            mergeUniquePage(first, next) { it.id })
+    }
+
+    @Test
+    fun initialAndCachedPagesAreNormalizedToo() {
+        val cached = listOf(Item("a"), Item("a"), Item("b"))
+        assertEquals(listOf(Item("a"), Item("b")), mergeUniquePage(emptyList(), cached) { it.id })
+        assertEquals(listOf(Item("a"), Item("b")), mergeUniquePage(cached, cached) { it.id })
+    }
+}

--- a/shared/src/androidMain/kotlin/com/playbridge/shared/player/AndroidBufferConfig.kt
+++ b/shared/src/androidMain/kotlin/com/playbridge/shared/player/AndroidBufferConfig.kt
@@ -20,24 +20,36 @@ data class BufferConfig(
 )
 
 object AndroidBufferConfig {
-    // ExoPlayer's DefaultAllocator holds the buffer on the JAVA HEAP, and a TV app's
-    // heap is typically 256–512MB. The byte ceiling must therefore be a HARD cap:
-    // prioritizeTime=true made it advisory, so a 60–100Mbps 4K remux buffering the
-    // full time window allocated hundreds of MB and OOM-killed the app mid-playback.
-    // Ceilings are sized so the cap — not the heap — is what stops buffering, and
-    // prioritizeTime is false in every tier. High-bitrate content simply carries a
-    // shorter (still tens of seconds) buffer; low/normal bitrates hit the time cap
-    // long before the byte cap and are unaffected.
+    // ExoPlayer's DefaultAllocator holds the buffer on the JAVA HEAP. Even if the device
+    // has gigabytes of physical RAM (availMb), the app process is constrained by its Dalvik/ART
+    // JVM max heap limit (Runtime.getRuntime().maxMemory()), typically 256MB on phones and TVs
+    // without largeHeap.
+    //
+    // Setting targetBytes anywhere near the process heap limit guarantees an OutOfMemoryError
+    // when buffering high-bitrate video while coexisting with other components (GeckoView, Coil,
+    // Compose). The byte ceiling must therefore be a HARD cap clamped to at most ~20–25% of the
+    // JVM process max heap (e.g. 48–64MB on a 256MB heap, 128MB on a 512MB heap).
+    //
+    // prioritizeTime is false in every tier so the byte cap stops buffering before exhausting heap.
+    // MPV demuxer options allocate native C memory directly from physical RAM, so they remain
+    // sized by availMb.
     fun compute(context: Context): BufferConfig {
         val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
         val memInfo = ActivityManager.MemoryInfo()
         am.getMemoryInfo(memInfo)
         val availMb = memInfo.availMem / (1024L * 1024L)
+
+        // Heap-relative clamp: never let ExoPlayer buffer chunks exceed 25% of the JVM max heap.
+        // On a 256MB heap, maxHeapClamp is 64MB (~40–50s of 1080p buffer) leaving >190MB of heap
+        // free for the rest of the application.
+        val maxHeapBytes = Runtime.getRuntime().maxMemory()
+        val maxHeapClamp = (maxHeapBytes * 0.25).toInt().coerceAtLeast(32 * 1024 * 1024)
+
         return when {
-            availMb >= 1_500 -> BufferConfig( 60_000, 256 * 1024 * 1024, "256MiB", "64MiB", false)
-            availMb >=   800 -> BufferConfig( 50_000, 128 * 1024 * 1024, "192MiB", "48MiB", false)
-            availMb >=   400 -> BufferConfig( 40_000,  96 * 1024 * 1024, "128MiB", "32MiB", false)
-            else             -> BufferConfig( 30_000,  64 * 1024 * 1024,  "64MiB", "16MiB", false)
+            availMb >= 1_500 -> BufferConfig( 60_000, minOf(256 * 1024 * 1024, maxHeapClamp), "256MiB", "64MiB", false)
+            availMb >=   800 -> BufferConfig( 50_000, minOf(128 * 1024 * 1024, maxHeapClamp), "192MiB", "48MiB", false)
+            availMb >=   400 -> BufferConfig( 40_000, minOf( 96 * 1024 * 1024, maxHeapClamp), "128MiB", "32MiB", false)
+            else             -> BufferConfig( 30_000, minOf( 64 * 1024 * 1024, maxHeapClamp),  "64MiB", "16MiB", false)
         }
     }
 }


### PR DESCRIPTION
## Summary

On-device smoothness pass for Android phone 0.13.4 (`com.playbridge.sender`, FOSS debug, Samsung SM-S936W). Goal was to stop frame drops, list rebuild storms, image/palette crashes, and ExoPlayer heap pressure without turning on `largeHeap` or touching R8.

Verified locally: `:app:assembleFossDebug` + `:app:testFossDebugUnitTest` green; installed `app-foss-arm64-v8a-debug.apk` over wireless ADB and relaunched.

## What changed

### Compose / navigation
- Hoist `AppNavHost` / `NowPlayingBarHost` so tab/browser chrome does not recompose with every overlay tick.
- Fade-only transitions for heavy screens (`Screen.isHeavyScreen()`); light screens stay instant.
- `Theme` remembers `MotionScheme`, uses `tween(300)`, and keys the dynamic seed on ARGB.
- Coil: global `crossfade(false)`, memory cap ~15% / 32MB on low-RAM; drop hardcoded `.size()` on full-width art, backdrops, and favicons so images stay sharp.

### Library / Discover
- Discover ALL alternates movie/TV pages (`preferMovies`) so an endless TMDB movie feed cannot starve TV rows.
- Dropped the 300ms `loadMoreGate` — `isLoadingMore*` already prevents double-fire; the gate stalled further pages when TMDB returned in <300ms and `isNearEnd` never retriggered.
- Episode/details fan-out capped with `Semaphore(4)`; catalog cache stores the full result (Coil bounds bitmaps, not JSON).
- Palette: separate 160px `allowHardware(false)` Coil request; decode + `Palette.generate()` on Default; only `onColorExtracted` writes on Main. `extractionDone` is set after success so a failed extract retries.

### IPTV
- Search / group / live-first applied in SQL (`observeChannelsFiltered`) with the same rank/latency/order as `IptvSortRules`. No `LIMIT`.
- Probe progress throttled (~500ms or 5%).
- Channel list: first Room emission per filter set is immediate; only follow-up probe re-emissions are trailing-debounced 500ms. Search still uses the existing 300ms keystroke debounce only — no extra 500ms on open, search, group, or live-first.

### Player / memory
- `SeekProgressRow` isolated so the 400ms position ticker does not recompose the overlay; unused `player` param removed.
- Shared `AndroidBufferConfig`: `targetBytes = minOf(tier, maxMemory()*0.25)` with a 32MB floor. **No `android:largeHeap`.** Phone Exo and TV Exo inherit the clamp; MPV native buffers do not.
- `PlaybackProgressTracker` stays `createdAtStart=true` so TV/DLNA progress is not dropped on direct casts.

### Downloads / network / DB
- Download progress writes on any movement, 1Hz cap; dedicated `DownloadDispatchers`; segment fetch stays on the caller-scoped dispatcher (documented no-hop).
- OkHttp dispatcher 128 / 16 per host; **timeouts stay 15s** (this client also serves downloads, IPTV M3U, debrid).
- Room v23: indexes on `playback_resume(tmdbId, updatedAt)` and `watchlist(status)` via `MIGRATION_22_23`. `MIGRATION_5_6` gap left as-is.
- Addon catalog cache gated; WS snapshots may `tryEmit` (droppable); credentials/capabilities use suspending `emit()`.

## Explicitly out of scope
- **No R8 / ProGuard / minify changes.** `isMinifyEnabled = false` unchanged.
- No version uprev / changelog (not a release PR).
- `MediaRow.itemKey` fallback, `Theme` seedKey==0, and `_messages.tryEmit` left as-is after review.

## Test plan

Device: Samsung `SM-S936W` arm64. APK: `mobile/android/app/build/outputs/apk/foss/debug/app-foss-arm64-v8a-debug.apk`.

```bash
cd mobile/android
zsh -c "source ~/.zshrc && ./gradlew :app:assembleFossDebug :app:testFossDebugUnitTest"
adb install -r app/build/outputs/apk/foss/debug/app-foss-arm64-v8a-debug.apk
adb shell monkey -p com.playbridge.sender -c android.intent.category.LAUNCHER 1
adb logcat -d -v threadtime -b crash
```

### Deploy
- [ ] Install FOSS debug APK and cold-launch
- [ ] Note PID (`adb shell pidof com.playbridge.sender`); no crash buffer noise

### Startup / nav
- [ ] Cold start: addons load, no blank stall
- [ ] Heavy screens fade only, no slot-shift; light screens instant
- [ ] Back stack / Tabs FAB opens without freeze

### Library Discover
- [ ] ALL mode alternates movie/TV pages; TV rows appear
- [ ] Scroll to end loads the next page without needing another scroll
- [ ] MOVIE-only and TV-only load-more still work
- [ ] Fast scroll: no jank, posters not blurry, keys stable

### Library detail
- [ ] Backdrop tint extracts once, no flicker
- [ ] Failed extract retries on recompose / URL change
- [ ] Cast art, backdrop, favicon full-size and sharp

### Resume / search
- [ ] Continue Watching resume position tracks after seek
- [ ] Search suggestions debounce; empty query is empty
- [ ] Dashboard scroll: static background, no recompose storm

### IPTV (2k–20k playlist)
- [ ] Open: first paint immediate, not 500ms empty
- [ ] Search: ~300ms debounce only, no extra 500ms
- [ ] Group chip / Live-first toggle: immediate, no 500ms stale list
- [ ] Probe: progress ~500ms/5%; list does not rebuild per channel
- [ ] Scroll during probe stays smooth

### Player
- [ ] Seek scrub smooth; overlay does not recompose as a whole
- [ ] Zoom / AB-loop still work
- [ ] Long play does not OOM (heap clamp, no `largeHeap`)

### Downloads
- [ ] Slow download progress updates ~1Hz, no freeze
- [ ] Segment fetch does not fan out unbounded

### Cast / remote
- [ ] NowPlayingBar progress ~1Hz (expected jump; tween glide was removed)
- [ ] Remote wave animates while playing; idle cost is one shared clock
- [ ] WS reconnect: credentials/capabilities arrive; periodic snapshots may drop

### Crash / perf
- [ ] `adb shell monkey -p com.playbridge.sender 200` does not crash
- [ ] `adb logcat -d -v threadtime -b crash` clean (no Palette HARDWARE crash)

## Residual (known, not blockers)
- NowPlayingBar 1Hz progress jumps (intentional after removing tween).
- Remote `InfiniteTransition` still ticks while paused (one shared clock).
- TV ExoPlayer inherits the heap clamp; MPV does not.