### PR TITLE
feat(cast): skip receiver history for private casts

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ Ensure your sender device (Phone, Desktop app, Browser Extension, or Rust CLI) a
 | Stream quality selection | ✓ | ✓ | Via the browser extension | HLS quality selection |
 | Subtitle detection and attachment | ✓ | ✓ | — | Detection only; attachment is not relayed to Desktop yet |
 | Local file casting | ✓ | ✓ | ✓, including drag-and-drop and multi-file playlists | — |
-| Library, discovery, and add-ons | ✓ | — | — | — |
-| Debrid integrations | ✓ in supported builds | — | — | — |
+| Library, discovery, and add-ons | ✓ | — (intentionally omitted for App Store approval) | — | — |
+| Debrid integrations | ✓ in supported builds | — (intentionally omitted for App Store approval) | — | — |
 | IPTV and custom collections | ✓ | ✓ | — | — |
 | Downloads | ✓ | — | — | — |
 | Ad blocking | uBlock Origin | WebKit content blocker with EasyList and custom rules | — | — |
@@ -176,6 +176,8 @@ Ensure your sender device (Phone, Desktop app, Browser Extension, or Rust CLI) a
 | Companion app required | No | No | No | PlayBridge Desktop |
 
 Browser detection depends on what each browser exposes. Protected streams may require captured request headers, and some MSE / blob players cannot be replayed outside their original page.
+
+iPhone / iPad intentionally omits the open Library / add-on ecosystem (third-party Stremio add-ons, JS scrapers) and Debrid integrations — they trigger App Store Guideline 5.2.3. Use the browser, IPTV, collections, and local files instead.
 
 ## Receiver feature matrix
 

--- a/desktop/lib/engines/playback_request_preparer.dart
+++ b/desktop/lib/engines/playback_request_preparer.dart
@@ -134,6 +134,7 @@ class PlaybackRequestPreparer {
         playlistBody: item.playlistBody,
         audioUrl: item.audioUrl,
         skipPreplay: item.skipPreplay,
+        skipHistory: item.skipHistory,
         enforcePageNetworkPolicy: item.enforcePageNetworkPolicy,
         allowedPrivateOrigins: item.allowedPrivateOrigins,
         bingeGroup: item.bingeGroup,

--- a/desktop/lib/history_store.dart
+++ b/desktop/lib/history_store.dart
@@ -115,7 +115,9 @@ class HistoryStore extends ChangeNotifier {
     String? contentType,
     String? mediaKind,
     int? displayDurationMs,
+    bool skipHistory = false,
   }) async {
+    if (skipHistory) return;
     final prefs = await SharedPreferences.getInstance();
     if (!(prefs.getBool('pb.enable_history') ?? true)) return;
     if (url.isEmpty) return;

--- a/desktop/lib/main.dart
+++ b/desktop/lib/main.dart
@@ -530,9 +530,12 @@ class _ReceiverAppState extends State<ReceiverApp> with WindowListener {
       if (idx >= 0 && idx < _player.queue.length) {
         final item = _player.queue[idx];
         final historyUrl = item.originalUrl ?? item.url;
-        if (historyUrl != _lastTrackedUrl) {
+        if (item.skipHistory) {
+          _lastTrackedUrl = null;
+        } else if (historyUrl != _lastTrackedUrl) {
           _lastTrackedUrl = historyUrl;
           unawaited(widget.history.addOrBump(
+            skipHistory: item.skipHistory,
             url: historyUrl,
             title: item.title,
             playlistBody: item.playlistBody,

--- a/desktop/lib/pairing_store.dart
+++ b/desktop/lib/pairing_store.dart
@@ -58,6 +58,7 @@ class PairingStore {
   static const _kAutoFullScreen = 'pb.auto_fullscreen';
   static const _kPauseOnWindowHide = 'pb.pause_on_window_hide';
   static const _kEnableHistory = 'pb.enable_history';
+  static const _kPreventReceiverHistory = 'pb.prevent_receiver_history';
   static const _kPreselectHlsQuality = 'pb.preselect_hls_quality';
   static const _kStreamProxyMode = 'pb.stream_proxy_mode';
   static const _kCastRouteThroughProxy = 'pb.cast_route_through_proxy';
@@ -128,6 +129,13 @@ class PairingStore {
 
   Future<void> setEnableHistory(bool value) =>
       _prefs.setBool(_kEnableHistory, value);
+
+  /// Ask supporting PlayBridge receivers to skip history for new casts.
+  bool get preventReceiverHistory =>
+      _prefs.getBool(_kPreventReceiverHistory) ?? false;
+
+  Future<void> setPreventReceiverHistory(bool value) =>
+      _prefs.setBool(_kPreventReceiverHistory, value);
 
   /// Resolve HLS master playlists to the best compatible rendition before
   /// handing them to mpv. Disabled by default so mpv receives the original

--- a/desktop/lib/player_controller.dart
+++ b/desktop/lib/player_controller.dart
@@ -751,6 +751,7 @@ class PlayerController extends ChangeNotifier {
         album: item.album,
         artworkUrl: item.artworkUrl,
         skipPreplay: item.skipPreplay,
+        skipHistory: item.skipHistory,
         // Keep demuxed LL-HLS handoff across proxy toggles.
         playlistBody: item.playlistBody,
         audioUrl: item.audioUrl,
@@ -809,6 +810,7 @@ class PlayerController extends ChangeNotifier {
         album: item.album,
         artworkUrl: item.artworkUrl,
         skipPreplay: item.skipPreplay,
+        skipHistory: item.skipHistory,
         playlistBody: item.playlistBody,
         audioUrl: proxiedAudio,
         enforcePageNetworkPolicy: item.enforcePageNetworkPolicy,

--- a/desktop/lib/player_engine.dart
+++ b/desktop/lib/player_engine.dart
@@ -36,6 +36,7 @@ class QueueItem {
     this.playlistBody,
     this.audioUrl,
     this.skipPreplay = false,
+    this.skipHistory = false,
     this.enforcePageNetworkPolicy = false,
     this.allowedPrivateOrigins = const [],
   });
@@ -72,6 +73,9 @@ class QueueItem {
 
   /// Suppress the initial presentation screen without discarding visual metadata.
   final bool skipPreplay;
+
+  /// Sender requests no receiver history for this item, including after rerouting.
+  final bool skipHistory;
 
   /// Untrusted webpage media must remain behind the receiver-side proxy so
   /// every manifest, segment, subtitle, and redirect uses its network policy.

--- a/desktop/lib/receiver_server.dart
+++ b/desktop/lib/receiver_server.dart
@@ -267,7 +267,8 @@ class ReceiverServer extends ChangeNotifier {
         onNewMedia?.call();
         unawaited(player.playPlaylist(
           items
-              .map((item) => _toQueueItem(item, skipPreplay: skipPreplay))
+              .map((item) =>
+                  receiverQueueItemFromPayload(item, skipPreplay: skipPreplay))
               .toList(),
           startIndex,
           isRemote: true,
@@ -283,7 +284,8 @@ class ReceiverServer extends ChangeNotifier {
         } else {
           onPlaybackActivity?.call();
         }
-        unawaited(player.queueAdd(_toQueueItem(item), isRemote: true));
+        unawaited(player.queueAdd(receiverQueueItemFromPayload(item),
+            isRemote: true));
       case ScreenMirrorStartCmd():
         onNewMedia?.call();
         unawaited(player.stop());
@@ -443,51 +445,6 @@ class ReceiverServer extends ChangeNotifier {
     }
   }
 
-  QueueItem _toQueueItem(PlayPayload payload, {bool skipPreplay = false}) {
-    debugLogNetworkRequest(
-      source: 'receiver',
-      url: payload.url,
-      headers: payload.headersOrNull,
-    );
-    return QueueItem(
-      url: payload.url,
-      title: payload.titleOrNull ?? payload.url,
-      headers: payload.headersOrNull,
-      subtitles: payload.subtitlesOrNull,
-      subtitleResources: payload.subtitleResources
-          .map((resource) => SubtitleRequest(
-                url: resource.url,
-                headers: Map.unmodifiable(resource.headers),
-                label: resource.hasLabel() ? resource.label : null,
-                language: resource.hasLanguage() ? resource.language : null,
-              ))
-          .toList(growable: false),
-      contentType: payload.contentTypeOrNull,
-      declaredMediaKind: payload.mediaKindOrNull,
-      displayDurationMs: payload.displayDurationMsOrNull,
-      artist: payload.artistOrNull,
-      album: payload.albumOrNull,
-      artworkUrl: payload.artworkUrlOrNull,
-      skipPreplay: skipPreplay,
-      enforcePageNetworkPolicy: payload.detectedByOrNull == 'page_cast' ||
-          payload.detectedByOrNull == 'linked_page',
-      allowedPrivateOrigins: payload.allowedPrivateOrigins,
-      startPositionMs: payload.startPositionMsOrNull,
-      bingeGroup: payload.bingeGroupOrNull,
-      season: payload.seasonOrNull,
-      episode: payload.episodeOrNull,
-      imdbId: payload.imdbIdOrNull,
-      backdropUrl: payload.backdropUrlOrNull,
-      posterUrl: payload.posterUrlOrNull,
-      logoUrl: payload.logoUrlOrNull,
-      overview: payload.overviewOrNull,
-      year: payload.yearOrNull,
-      rating: payload.ratingOrNull,
-      runtime: payload.runtimeOrNull,
-      episodeTitle: payload.episodeTitleOrNull,
-    );
-  }
-
   void _broadcastStatus() {
     _runtime?.broadcast({
       'type': 'status',
@@ -557,4 +514,52 @@ class ReceiverServer extends ChangeNotifier {
       'totalCount': player.queue.length,
     });
   }
+}
+
+/// Convert wire media without losing per-cast history policy.
+QueueItem receiverQueueItemFromPayload(PlayPayload payload,
+    {bool skipPreplay = false}) {
+  debugLogNetworkRequest(
+    source: 'receiver',
+    url: payload.url,
+    headers: payload.headersOrNull,
+  );
+  return QueueItem(
+    url: payload.url,
+    title: payload.titleOrNull ?? payload.url,
+    headers: payload.headersOrNull,
+    subtitles: payload.subtitlesOrNull,
+    subtitleResources: payload.subtitleResources
+        .map((resource) => SubtitleRequest(
+              url: resource.url,
+              headers: Map.unmodifiable(resource.headers),
+              label: resource.hasLabel() ? resource.label : null,
+              language: resource.hasLanguage() ? resource.language : null,
+            ))
+        .toList(growable: false),
+    contentType: payload.contentTypeOrNull,
+    declaredMediaKind: payload.mediaKindOrNull,
+    displayDurationMs: payload.displayDurationMsOrNull,
+    artist: payload.artistOrNull,
+    album: payload.albumOrNull,
+    artworkUrl: payload.artworkUrlOrNull,
+    skipPreplay: skipPreplay,
+    skipHistory: payload.skipHistory,
+    enforcePageNetworkPolicy: payload.detectedByOrNull == 'page_cast' ||
+        payload.detectedByOrNull == 'linked_page',
+    allowedPrivateOrigins: payload.allowedPrivateOrigins,
+    startPositionMs: payload.startPositionMsOrNull,
+    bingeGroup: payload.bingeGroupOrNull,
+    season: payload.seasonOrNull,
+    episode: payload.episodeOrNull,
+    imdbId: payload.imdbIdOrNull,
+    backdropUrl: payload.backdropUrlOrNull,
+    posterUrl: payload.posterUrlOrNull,
+    logoUrl: payload.logoUrlOrNull,
+    overview: payload.overviewOrNull,
+    year: payload.yearOrNull,
+    rating: payload.ratingOrNull,
+    runtime: payload.runtimeOrNull,
+    episodeTitle: payload.episodeTitleOrNull,
+  );
 }

--- a/desktop/lib/settings_screen.dart
+++ b/desktop/lib/settings_screen.dart
@@ -311,13 +311,28 @@ class _SettingsScreenState extends State<SettingsScreen> {
               icon: Icons.history,
               title: 'Save Cast History',
               subtitle:
-                  'Keep track of recently played videos and your progress.',
+                  'Keep recently played media on this Desktop. Casts requesting no history are always excluded.',
               trailing: Switch(
                 value: widget.store.enableHistory,
                 onChanged: (v) async {
                   await widget.store.setEnableHistory(v);
                   if (mounted) setState(() {});
                   widget.onSettingsChanged?.call();
+                },
+              ),
+            ),
+
+            _Section('Sending'),
+            _Tile(
+              icon: Icons.history_toggle_off,
+              title: 'Prevent receiver cast history',
+              subtitle:
+                  'Keep new casts out of history on updated PlayBridge Android TV and Desktop receivers. Existing history stays unchanged.',
+              trailing: Switch(
+                value: widget.store.preventReceiverHistory,
+                onChanged: (value) async {
+                  await widget.store.setPreventReceiverHistory(value);
+                  if (mounted) setState(() {});
                 },
               ),
             ),

--- a/desktop/lib/tv_sender_controller.dart
+++ b/desktop/lib/tv_sender_controller.dart
@@ -368,7 +368,7 @@ class TvSenderController extends ChangeNotifier {
   // A single video is sent as a one-item playlist (see senderSingleVideoCommandJson).
 
   Future<bool> castVideo(PlayPayload video) async {
-    final ok = await _transport.castVideo(video);
+    final ok = await _transport.castVideo(_withHistoryPreference(video));
     if (ok) {
       _castingTitle =
           video.hasTitle() && video.title.isNotEmpty ? video.title : null;
@@ -377,8 +377,24 @@ class TvSenderController extends ChangeNotifier {
     return ok;
   }
 
-  Future<bool> castPlaylist(PlaylistPayload playlist) =>
-      _transport.castPlaylist(playlist);
+  PlayPayload _withHistoryPreference(PlayPayload item) {
+    if (!_identity.preventReceiverHistory ||
+        _transport.protocol != TvProtocol.playBridge) {
+      return item;
+    }
+    return PlayPayload()
+      ..mergeFromMessage(item)
+      ..skipHistory = true;
+  }
+
+  Future<bool> castPlaylist(PlaylistPayload playlist) {
+    final outgoing = PlaylistPayload()..mergeFromMessage(playlist);
+    final items = playlist.items.map(_withHistoryPreference).toList();
+    outgoing.items
+      ..clear()
+      ..addAll(items);
+    return _transport.castPlaylist(outgoing);
+  }
 
   /// Cast a remote URL (e.g. a stream the browser extension detected) with
   /// optional request [headers] (Referer / cookies / auth) and a [title].
@@ -491,7 +507,8 @@ class TvSenderController extends ChangeNotifier {
     return await castVideo(payload);
   }
 
-  Future<bool> queueAdd(PlayPayload item) => _transport.queueAdd(item);
+  Future<bool> queueAdd(PlayPayload item) =>
+      _transport.queueAdd(_withHistoryPreference(item));
 
   Future<bool> playlistJump(int index) => _transport.playlistJump(index);
 

--- a/desktop/test/cast_history_test.dart
+++ b/desktop/test/cast_history_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playbridge_desktop/history_store.dart';
+import 'package:playbridge_desktop/pairing_store.dart';
+import 'package:playbridge_desktop/protocol.dart';
+import 'package:playbridge_desktop/receiver_server.dart';
+import 'package:playbridge_desktop/tv_connection_store.dart';
+import 'package:playbridge_desktop/tv_discovery.dart';
+import 'package:playbridge_desktop/tv_sender_controller.dart';
+import 'package:playbridge_desktop/tv_transport.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _RecordingTransport implements TvTransport {
+  PlayPayload? video;
+  PlaylistPayload? playlist;
+  PlayPayload? queued;
+  @override
+  TvProtocol get protocol => TvProtocol.playBridge;
+  @override
+  Future<bool> castVideo(PlayPayload video) async {
+    this.video = video;
+    return true;
+  }
+
+  @override
+  Future<bool> castPlaylist(PlaylistPayload playlist) async {
+    this.playlist = playlist;
+    return true;
+  }
+
+  @override
+  Future<bool> queueAdd(PlayPayload item) async {
+    queued = item;
+    return true;
+  }
+
+  @override
+  Future<void> dispose() async {}
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test(
+      'sender preference persists and marks all media paths without mutating inputs',
+      () async {
+    final identity = await PairingStore.load();
+    expect(identity.preventReceiverHistory, isFalse);
+    final transport = _RecordingTransport();
+    final sender = TvSenderController(
+      identity: identity,
+      store: await TvConnectionStore.load(),
+      transport: transport,
+    );
+    addTearDown(sender.dispose);
+    final video = PlayPayload(url: 'https://example.com/video', title: 'Video');
+    await sender.castVideo(video);
+    expect(transport.video!.skipHistory, isFalse);
+
+    await identity.setPreventReceiverHistory(true);
+    expect((await PairingStore.load()).preventReceiverHistory, isTrue);
+    await sender.castVideo(video);
+    expect(transport.video!.skipHistory, isTrue);
+    expect(video.hasSkipHistory(), isFalse);
+
+    final playlist = PlaylistPayload(
+        items: [video, video], startIndex: 1, skipPreplay: true);
+    await sender.castPlaylist(playlist);
+    expect(transport.playlist!.items.every((item) => item.skipHistory), isTrue);
+    expect(transport.playlist!.startIndex, 1);
+    expect(transport.playlist!.skipPreplay, isTrue);
+    expect(playlist.items.every((item) => !item.hasSkipHistory()), isTrue);
+    await sender.queueAdd(video);
+    expect(transport.queued!.skipHistory, isTrue);
+
+    await identity.setPreventReceiverHistory(false);
+    await sender.castVideo(video);
+    expect(transport.video!.skipHistory, isFalse);
+  });
+
+  test(
+      'receiver carries wire privacy into history storage and preserves existing entries',
+      () async {
+    final history = await HistoryStore.load();
+    const url = 'https://example.com/video';
+    await history.addOrBump(url: url, title: 'Existing');
+    await history.toggleFavorite(url);
+    final prefs = await SharedPreferences.getInstance();
+    final before = prefs.getString('pb.history_v1');
+
+    final command = parseCommand(senderSingleVideoCommandJson(
+      PlayPayload(url: url, title: 'Private', skipHistory: true),
+    )) as PlaylistCmd;
+    final item = receiverQueueItemFromPayload(command.items.single);
+    expect(item.skipHistory, isTrue);
+    await history.addOrBump(
+        url: item.url, title: item.title, skipHistory: item.skipHistory);
+    await history.addOrBump(
+        url: 'https://example.com/new-private',
+        title: 'Private',
+        skipHistory: true);
+    expect(prefs.getString('pb.history_v1'), before);
+    expect(history.items.single.title, 'Existing');
+    expect(history.items.single.isFavorite, isTrue);
+
+    final queued = parseCommand(senderQueueAddJson(
+      PlayPayload(url: url, skipHistory: true),
+    )) as QueueAddCmd;
+    expect(receiverQueueItemFromPayload(queued.item).skipHistory, isTrue);
+    final publicItem =
+        receiverQueueItemFromPayload(PlayPayload(url: url, title: 'Public'));
+    await history.addOrBump(
+        url: publicItem.url,
+        title: publicItem.title,
+        skipHistory: publicItem.skipHistory);
+    expect((await HistoryStore.load()).items.single.title, 'Public');
+    expect(history.items.single.isFavorite, isTrue);
+  });
+}

--- a/desktop/test/player_controller_test.dart
+++ b/desktop/test/player_controller_test.dart
@@ -255,12 +255,14 @@ void main() {
     final headers = {'User-Agent': 'Test browser'};
 
     await c.playItem(
-      QueueItem(url: directUrl, title: 'Stream', headers: headers),
+      QueueItem(
+          url: directUrl, title: 'Stream', headers: headers, skipHistory: true),
     );
     expect(c.isCurrentItemProxied, isFalse);
 
     expect(await c.toggleProxy(), isTrue);
     expect(c.isCurrentItemProxied, isTrue);
+    expect(c.queue.single.skipHistory, isTrue);
     expect(c.queue.single.originalUrl, directUrl);
     expect(c.queue.single.originalHeaders, headers);
     expect(c.queue.single.startPositionMs, isNull);
@@ -268,6 +270,7 @@ void main() {
 
     expect(await c.toggleProxy(), isTrue);
     expect(c.isCurrentItemProxied, isFalse);
+    expect(c.queue.single.skipHistory, isTrue);
     expect(c.queue.single.url, directUrl);
     expect(c.queue.single.headers, headers);
     expect(engine.lastSeekMs, 250);

--- a/docs/FEATURE_GAPS.md
+++ b/docs/FEATURE_GAPS.md
@@ -20,7 +20,7 @@ Android phone rows describe the **FOSS** flavor unless noted. Play Store builds 
 
 ## How to use this file
 
-- **iOS porting:** close sender holes against Android FOSS.
+- **iOS porting:** close sender holes against Android FOSS, except rows marked intentionally omitted (e.g. Library/addons for App Store approval).
 - **Receiver parity:** close Apple TV / CLI against Android TV + Desktop.
 - **Do not** duplicate rows into the README matrices unless the product claim should change.
 - When a cell changes, update the mark, the note, and the evidence path in the same edit.
@@ -43,8 +43,8 @@ Android phone rows describe the **FOSS** flavor unless noted. Play Store builds 
 | Local files | Y | ~ | iOS serves one file at a time. |
 | IPTV (M3U) | Y | Y | No EPG / Xtream on either phone in this audit. |
 | Collections | ~ | ~ | Both cast one item; no collection-as-playlist. |
-| Library / TMDB / Stremio addons | Y | — | iOS menu “Extensions” is Coming Soon. |
-| Debrid | Y | — | Android Play flavor: hidden. |
+| Library / TMDB / Stremio addons | Y | — | Intentionally omitted on iOS for App Store approval (Guideline 5.2.3: open third-party addons + scrapers + debrid resolvers). Not a porting target. |
+| Debrid | Y | — | Intentionally omitted on iOS for App Store approval (Guideline 5.2.3: torrent/magnet resolvers). Not a porting target. Android Play flavor: hidden. |
 | Downloads | Y | — | Android HLS remux is VOD-only; DASH download is a stub kind. |
 | Ad blocking | Y | Y | Android: uBlock AMO. iOS: EasyList/EasyPrivacy WK rules + picker. Phone README still says “curated list only”. |
 | Remote: transport + D-pad + touchpad | Y | Y | iOS seek bar is display-only; no mouse scroll. |
@@ -101,7 +101,7 @@ Desktop is also a sender (`tv_sender_controller.dart`); that role is out of scop
 
 ## Highest-leverage gaps
 
-1. **iOS sender vs Android:** library/addons, debrid, downloads, DLNA + Google Cast + Roku, screen mirror, volume/keyboard/seek/tracks remote, in-app player, mixed media, stream routing.
+1. **iOS sender vs Android (excluding intentional omissions):** downloads, DLNA + Google Cast + Roku, screen mirror, volume/keyboard/seek/tracks remote, in-app player, mixed media, stream routing.
 2. **Apple TV vs Android TV:** no browser, no WebRTC mirror, no mixed media, no volume remote, no mouse, D-pad incomplete, auth caps advertise `players` only, phone player-settings prefixes ignored.
 3. **Desktop vs Android TV:** no receiver browser (so phone page-cast must stay gated off); phone speed/boost/sub-offset ignored.
 4. **CLI vs Desktop:** same Rust WSS runtime, but no EOF advance, no tracks/subs, no mixed-media or mirror caps, no still watching.

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastHistoryCommand.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastHistoryCommand.kt
@@ -1,0 +1,26 @@
+package com.playbridge.sender.cast
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+/** Decorate all native media send paths, including incremental queue additions. */
+internal fun applyCastHistoryPreference(message: String, preventHistory: Boolean): String {
+    if (!preventHistory) return message
+    val command = Json.parseToJsonElement(message) as? JsonObject ?: return message
+    if ((command["type"] as? JsonPrimitive)?.contentOrNull != "command") return message
+    val payload = command["payload"] as? JsonObject ?: return message
+    fun mark(item: JsonElement): JsonObject =
+        JsonObject((item as JsonObject) + ("skipHistory" to JsonPrimitive(true)))
+    val updated = when ((command["action"] as? JsonPrimitive)?.contentOrNull) {
+        "playlist" -> JsonObject(payload + ("items" to JsonArray(
+            (payload["items"] as JsonArray).map(::mark),
+        )))
+        "queue_add" -> JsonObject(payload + ("item" to mark(payload.getValue("item"))))
+        else -> return message
+    }
+    return JsonObject(command + ("payload" to updated)).toString()
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastHistorySettings.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/CastHistorySettings.kt
@@ -1,0 +1,17 @@
+package com.playbridge.sender.cast
+
+import android.content.Context
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** Read synchronously at send time so a newly enabled setting applies to the next cast. */
+class CastHistorySettings(context: Context) {
+    private val prefs = context.getSharedPreferences("cast_history_settings", Context.MODE_PRIVATE)
+    private val mutablePreventHistory = MutableStateFlow(prefs.getBoolean("prevent_tv_history", false))
+    val preventHistory = mutablePreventHistory.asStateFlow()
+
+    fun setPreventHistory(value: Boolean) {
+        prefs.edit().putBoolean("prevent_tv_history", value).apply()
+        mutablePreventHistory.value = value
+    }
+}

--- a/mobile/android/app/src/main/java/com/playbridge/sender/cast/TVSettingsScreen.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/cast/TVSettingsScreen.kt
@@ -168,6 +168,22 @@ fun TVSettingsScreen(
 
             Spacer(modifier = Modifier.height(8.dp))
 
+            val castHistorySettings: CastHistorySettings = koinInject()
+            val preventHistory by castHistorySettings.preventHistory.collectAsState()
+            ListItem(
+                headlineContent = { Text("Prevent TV cast history") },
+                supportingContent = {
+                    Text("Keep new casts out of PlayBridge Android TV history and saved playback progress. Requires an updated TV app. Existing history stays unchanged.")
+                },
+                trailingContent = {
+                    Switch(
+                        checked = preventHistory,
+                        onCheckedChange = castHistorySettings::setPreventHistory,
+                    )
+                },
+                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            )
+
             // Auto-switch to Remote
             val autoSwitchToRemote by settingsRepository.autoSwitchToRemote.collectAsState(initial = true)
             ListItem(

--- a/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/connection/WebSocketClient.kt
@@ -1,6 +1,8 @@
 package com.playbridge.sender.connection
 
 import android.util.Log
+import com.playbridge.sender.cast.CastHistorySettings
+import com.playbridge.sender.cast.applyCastHistoryPreference
 import com.playbridge.sender.logging.DebugNetworkLogger
 import com.playbridge.shared.protocol.createAuthJson
 import com.playbridge.shared.protocol.createContextQueryJson
@@ -39,7 +41,7 @@ private const val POINTER_FLUSH_INTERVAL_MS = 16L
 /**
  * OkHttp-based WebSocket client for connecting to TV
  */
-class WebSocketClient {
+class WebSocketClient(private val castHistorySettings: CastHistorySettings) {
     
     private val client = OkHttpClient.Builder()
         .dns(LinkLocalDns())
@@ -594,8 +596,11 @@ class WebSocketClient {
             Log.w(TAG, "Cannot send, webSocket is null. State: ${_connectionState.value}")
             return false
         }
-        DebugNetworkLogger.command(TAG, message)
-        return ws.send(message)
+        val outgoing = applyCastHistoryPreference(
+            message, castHistorySettings.preventHistory.value,
+        )
+        DebugNetworkLogger.command(TAG, outgoing)
+        return ws.send(outgoing)
     }
 
     fun send(bytes: ByteArray): Boolean {

--- a/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
+++ b/mobile/android/app/src/main/java/com/playbridge/sender/di/AppModule.kt
@@ -1,5 +1,6 @@
 package com.playbridge.sender.di
 
+import com.playbridge.sender.cast.CastHistorySettings
 import com.playbridge.sender.connection.ConnectionStore
 import com.playbridge.sender.connection.ConnectionViewModel
 import com.playbridge.sender.connection.WebSocketClient
@@ -117,7 +118,8 @@ val appModule = module {
     }
 
     // 4. WebSocket client, persistence, and the process-wide Rust discovery owner
-    single { WebSocketClient() }
+    single { CastHistorySettings(androidContext()) }
+    single { WebSocketClient(get()) }
     single { ConnectionStore(androidContext()) }
     single {
         com.playbridge.sender.connection.ReceiverDiscoveryRepository(

--- a/mobile/android/app/src/test/java/com/playbridge/sender/cast/CastHistoryCommandTest.kt
+++ b/mobile/android/app/src/test/java/com/playbridge/sender/cast/CastHistoryCommandTest.kt
@@ -1,0 +1,43 @@
+package com.playbridge.sender.cast
+
+import com.playbridge.shared.protocol.IncomingMessage
+import com.playbridge.shared.protocol.createPlaylistCommandJson
+import com.playbridge.shared.protocol.createQueueAddCommandJson
+import com.playbridge.shared.protocol.parseIncomingMessage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import playbridge.PlayPayload
+import playbridge.PlaylistPayload
+
+class CastHistoryCommandTest {
+    @Test
+    fun playlistRetainsMediaAndMarksEveryItemThroughWireRoundTrip() {
+        val items = listOf(
+            PlayPayload(url = "https://example.com/a", title = "First"),
+            PlayPayload(url = "https://example.com/b", start_position_ms = 5000),
+        )
+        val message = createPlaylistCommandJson(PlaylistPayload(items = items, start_index = 1))
+        val decoded = parseIncomingMessage(applyCastHistoryPreference(message, true)) as IncomingMessage.Playlist
+        assertEquals(1, decoded.payload.start_index)
+        assertEquals(items.map { it.url }, decoded.payload.items.map { it.url })
+        assertEquals("First", decoded.payload.items[0].title)
+        assertEquals(5000L, decoded.payload.items[1].start_position_ms)
+        assertTrue(decoded.payload.items.all { it.skip_history == true })
+    }
+
+    @Test
+    fun queueAddCarriesPrivacyFlag() {
+        val message = createQueueAddCommandJson(PlayPayload(url = "https://example.com/a"))
+        val decoded = parseIncomingMessage(applyCastHistoryPreference(message, true)) as IncomingMessage.QueueAdd
+        assertEquals(true, decoded.payload.item?.skip_history)
+    }
+
+    @Test
+    fun disabledSettingAndNonMediaCommandsAreUnchanged() {
+        val message = createPlaylistCommandJson(PlaylistPayload(items = listOf(PlayPayload(url = "https://example.com/a"))))
+        assertEquals(message, applyCastHistoryPreference(message, false))
+        val control = """{"type":"command","action":"control","payload":{"command":"stop"}}"""
+        assertEquals(control, applyCastHistoryPreference(control, true))
+    }
+}

--- a/protocol/asyncapi.yaml
+++ b/protocol/asyncapi.yaml
@@ -654,6 +654,10 @@ components:
           type: [integer, 'null']
           minimum: 0
           description: For image items, a positive display time enables timed auto-advance; null or zero waits for navigation.
+        skipHistory:
+          type: [boolean, 'null']
+          default: false
+          description: When true, supporting receivers must not persist this cast in playback history, resume progress, or captured history artwork. A playlist containing any such item must not be persisted in full. Omitted or false preserves receiver defaults. Older receivers may ignore this field.
         detectedBy: { type: [string, 'null'] }
         playerMode: { type: [string, 'null'] }
         preferredAudioLanguage: { type: [string, 'null'] }

--- a/protocol/docs/WSS_FLOW.md
+++ b/protocol/docs/WSS_FLOW.md
@@ -295,3 +295,18 @@ or replacement by a new connection.
   implementation detail.
 - Examples and tests should validate against the AsyncAPI schemas. No protobuf binary encoding is
   used on the WSS transport.
+
+## Receiver cast history preference
+
+A sender may set `skipHistory: true` on each `PlayPayload` in a `playlist` command
+and on the item in `queue_add`. Supporting receivers keep those items out of
+playback history, saved resume progress, and captured history artwork. Because
+history can store the whole queue for replay, a queue containing a marked item
+must not be persisted in full. The flag stays with the item across playback,
+queue navigation, and renderer changes; it does not change pairing or titles.
+
+Omitted or false retains the receiver's normal history policy. Enabling this
+preference affects subsequently sent items, leaves existing history untouched,
+and does not disable sender-side watch tracking. Android TV and Desktop implement this
+preference; older or other receivers may ignore it, so senders must not promise
+history suppression on those receivers.

--- a/protocol/generated/dart/lib/messages.pb.dart
+++ b/protocol/generated/dart/lib/messages.pb.dart
@@ -574,6 +574,7 @@ class PlayPayload extends $pb.GeneratedMessage {
     $core.Iterable<SubtitleResource>? subtitleResources,
     $core.String? mediaKind,
     $fixnum.Int64? displayDurationMs,
+    $core.bool? skipHistory,
   }) {
     final result = create();
     if (url != null) result.url = url;
@@ -594,6 +595,7 @@ class PlayPayload extends $pb.GeneratedMessage {
     if (subtitleResources != null) result.subtitleResources.addAll(subtitleResources);
     if (mediaKind != null) result.mediaKind = mediaKind;
     if (displayDurationMs != null) result.displayDurationMs = displayDurationMs;
+    if (skipHistory != null) result.skipHistory = skipHistory;
     return result;
   }
 
@@ -621,6 +623,7 @@ class PlayPayload extends $pb.GeneratedMessage {
     ..pc<SubtitleResource>(16, _omitFieldNames ? '' : 'subtitleResources', $pb.PbFieldType.PM, subBuilder: SubtitleResource.create)
     ..aOS(17, _omitFieldNames ? '' : 'mediaKind')
     ..aInt64(18, _omitFieldNames ? '' : 'displayDurationMs')
+    ..aOB(19, _omitFieldNames ? '' : 'skipHistory')
     ..hasRequiredFields = false
   ;
 
@@ -792,6 +795,16 @@ class PlayPayload extends $pb.GeneratedMessage {
   $core.bool hasDisplayDurationMs() => $_has(17);
   @$pb.TagNumber(18)
   void clearDisplayDurationMs() => $_clearField(18);
+
+  /// Do not persist receiver history, resume progress, or captured history artwork.
+  @$pb.TagNumber(19)
+  $core.bool get skipHistory => $_getBF(18);
+  @$pb.TagNumber(19)
+  set skipHistory($core.bool value) => $_setBool(18, value);
+  @$pb.TagNumber(19)
+  $core.bool hasSkipHistory() => $_has(18);
+  @$pb.TagNumber(19)
+  void clearSkipHistory() => $_clearField(19);
 }
 
 class PlaylistPayload extends $pb.GeneratedMessage {

--- a/protocol/generated/dart/lib/messages.pbjson.dart
+++ b/protocol/generated/dart/lib/messages.pbjson.dart
@@ -209,6 +209,7 @@ const PlayPayload$json = {
     {'1': 'subtitle_resources', '3': 16, '4': 3, '5': 11, '6': '.playbridge.SubtitleResource', '10': 'subtitleResources'},
     {'1': 'media_kind', '3': 17, '4': 1, '5': 9, '9': 11, '10': 'mediaKind', '17': true},
     {'1': 'display_duration_ms', '3': 18, '4': 1, '5': 3, '9': 12, '10': 'displayDurationMs', '17': true},
+    {'1': 'skip_history', '3': 19, '4': 1, '5': 8, '9': 13, '10': 'skipHistory', '17': true},
   ],
   '3': [PlayPayload_HeadersEntry$json],
   '8': [
@@ -225,6 +226,7 @@ const PlayPayload$json = {
     {'1': '_start_position_ms'},
     {'1': '_media_kind'},
     {'1': '_display_duration_ms'},
+    {'1': '_skip_history'},
   ],
 };
 
@@ -256,13 +258,14 @@ final $typed_data.Uint8List playPayloadDescriptor = $convert.base64Decode(
     '9yaWdpbnMSSwoSc3VidGl0bGVfcmVzb3VyY2VzGBAgAygLMhwucGxheWJyaWRnZS5TdWJ0aXRs'
     'ZVJlc291cmNlUhFzdWJ0aXRsZVJlc291cmNlcxIiCgptZWRpYV9raW5kGBEgASgJSAtSCW1lZG'
     'lhS2luZIgBARIzChNkaXNwbGF5X2R1cmF0aW9uX21zGBIgASgDSAxSEWRpc3BsYXlEdXJhdGlv'
-    'bk1ziAEBGjoKDEhlYWRlcnNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCV'
-    'IFdmFsdWU6AjgBQggKBl90aXRsZUIPCg1fY29udGVudF90eXBlQg4KDF9kZXRlY3RlZF9ieUIO'
-    'CgxfcGxheWVyX21vZGVCGwoZX3ByZWZlcnJlZF9hdWRpb19sYW5ndWFnZUIeChxfcHJlZmVycm'
-    'VkX3N1YnRpdGxlX2xhbmd1YWdlQhgKFl9kZWZhdWx0X3ZpZGVvX3F1YWxpdHlCFwoVX21heF9i'
-    'aXRyYXRlX2NhcF9tYnBzQhIKEF92aXN1YWxfbWV0YWRhdGFCDgoMX2JpbmdlX2dyb3VwQhQKEl'
-    '9zdGFydF9wb3NpdGlvbl9tc0INCgtfbWVkaWFfa2luZEIWChRfZGlzcGxheV9kdXJhdGlvbl9t'
-    'cw==');
+    'bk1ziAEBEiYKDHNraXBfaGlzdG9yeRgTIAEoCEgNUgtza2lwSGlzdG9yeYgBARo6CgxIZWFkZX'
+    'JzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AUIICgZf'
+    'dGl0bGVCDwoNX2NvbnRlbnRfdHlwZUIOCgxfZGV0ZWN0ZWRfYnlCDgoMX3BsYXllcl9tb2RlQh'
+    'sKGV9wcmVmZXJyZWRfYXVkaW9fbGFuZ3VhZ2VCHgocX3ByZWZlcnJlZF9zdWJ0aXRsZV9sYW5n'
+    'dWFnZUIYChZfZGVmYXVsdF92aWRlb19xdWFsaXR5QhcKFV9tYXhfYml0cmF0ZV9jYXBfbWJwc0'
+    'ISChBfdmlzdWFsX21ldGFkYXRhQg4KDF9iaW5nZV9ncm91cEIUChJfc3RhcnRfcG9zaXRpb25f'
+    'bXNCDQoLX21lZGlhX2tpbmRCFgoUX2Rpc3BsYXlfZHVyYXRpb25fbXNCDwoNX3NraXBfaGlzdG'
+    '9yeQ==');
 
 @$core.Deprecated('Use playlistPayloadDescriptor instead')
 const PlaylistPayload$json = {

--- a/protocol/generated/kotlin/playbridge/PlayPayload.kt
+++ b/protocol/generated/kotlin/playbridge/PlayPayload.kt
@@ -153,6 +153,16 @@ public class PlayPayload(
     schemaIndex = 17,
   )
   public val display_duration_ms: Long? = null,
+  /**
+   * Do not persist receiver history, resume progress, or captured history artwork.
+   */
+  @field:WireField(
+    tag = 19,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    jsonName = "skipHistory",
+    schemaIndex = 18,
+  )
+  public val skip_history: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY,
 ) : Message<PlayPayload, Nothing>(ADAPTER, unknownFields) {
   @field:WireField(
@@ -228,6 +238,7 @@ public class PlayPayload(
     if (subtitle_resources != other.subtitle_resources) return false
     if (media_kind != other.media_kind) return false
     if (display_duration_ms != other.display_duration_ms) return false
+    if (skip_history != other.skip_history) return false
     return true
   }
 
@@ -253,6 +264,7 @@ public class PlayPayload(
       result = result * 37 + subtitle_resources.hashCode()
       result = result * 37 + (media_kind?.hashCode() ?: 0)
       result = result * 37 + (display_duration_ms?.hashCode() ?: 0)
+      result = result * 37 + (skip_history?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -282,6 +294,7 @@ public class PlayPayload(
     if (subtitle_resources.isNotEmpty()) result += """subtitle_resources=$subtitle_resources"""
     if (media_kind != null) result += """media_kind=${sanitize(media_kind)}"""
     if (display_duration_ms != null) result += """display_duration_ms=$display_duration_ms"""
+    if (skip_history != null) result += """skip_history=$skip_history"""
     return result.joinToString(prefix = "PlayPayload{", separator = ", ", postfix = "}")
   }
 
@@ -304,11 +317,13 @@ public class PlayPayload(
     subtitle_resources: List<SubtitleResource> = this.subtitle_resources,
     media_kind: String? = this.media_kind,
     display_duration_ms: Long? = this.display_duration_ms,
+    skip_history: Boolean? = this.skip_history,
     unknownFields: ByteString = this.unknownFields,
   ): PlayPayload = PlayPayload(url, title, headers, content_type, subtitles, detected_by,
       player_mode, preferred_audio_language, preferred_subtitle_language, default_video_quality,
       max_bitrate_cap_mbps, visual_metadata, binge_group, start_position_ms,
-      allowed_private_origins, subtitle_resources, media_kind, display_duration_ms, unknownFields)
+      allowed_private_origins, subtitle_resources, media_kind, display_duration_ms, skip_history,
+      unknownFields)
 
   public companion object {
     @JvmField
@@ -347,6 +362,7 @@ public class PlayPayload(
             value.subtitle_resources)
         size += ProtoAdapter.STRING.encodedSizeWithTag(17, value.media_kind)
         size += ProtoAdapter.INT64.encodedSizeWithTag(18, value.display_duration_ms)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(19, value.skip_history)
         return size
       }
 
@@ -371,11 +387,13 @@ public class PlayPayload(
         SubtitleResource.ADAPTER.asRepeated().encodeWithTag(writer, 16, value.subtitle_resources)
         ProtoAdapter.STRING.encodeWithTag(writer, 17, value.media_kind)
         ProtoAdapter.INT64.encodeWithTag(writer, 18, value.display_duration_ms)
+        ProtoAdapter.BOOL.encodeWithTag(writer, 19, value.skip_history)
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: PlayPayload) {
         writer.writeBytes(value.unknownFields)
+        ProtoAdapter.BOOL.encodeWithTag(writer, 19, value.skip_history)
         ProtoAdapter.INT64.encodeWithTag(writer, 18, value.display_duration_ms)
         ProtoAdapter.STRING.encodeWithTag(writer, 17, value.media_kind)
         SubtitleResource.ADAPTER.asRepeated().encodeWithTag(writer, 16, value.subtitle_resources)
@@ -417,6 +435,7 @@ public class PlayPayload(
         val subtitle_resources = mutableListOf<SubtitleResource>()
         var media_kind: String? = null
         var display_duration_ms: Long? = null
+        var skip_history: Boolean? = null
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
             1 -> url = ProtoAdapter.STRING.decode(reader)
@@ -437,6 +456,7 @@ public class PlayPayload(
             16 -> subtitle_resources.add(SubtitleResource.ADAPTER.decode(reader))
             17 -> media_kind = ProtoAdapter.STRING.decode(reader)
             18 -> display_duration_ms = ProtoAdapter.INT64.decode(reader)
+            19 -> skip_history = ProtoAdapter.BOOL.decode(reader)
             else -> reader.readUnknownField(tag)
           }
         }
@@ -459,6 +479,7 @@ public class PlayPayload(
           subtitle_resources = subtitle_resources,
           media_kind = media_kind,
           display_duration_ms = display_duration_ms,
+          skip_history = skip_history,
           unknownFields = unknownFields
         )
       }

--- a/protocol/generated/swift/messages.pb.swift
+++ b/protocol/generated/swift/messages.pb.swift
@@ -571,6 +571,16 @@ nonisolated struct Playbridge_PlayPayload: @unchecked Sendable {
   /// Clears the value of `displayDurationMs`. Subsequent reads from it will return its default value.
   mutating func clearDisplayDurationMs() {_uniqueStorage()._displayDurationMs = nil}
 
+  /// Do not persist receiver history, resume progress, or captured history artwork.
+  var skipHistory: Bool {
+    get {_storage._skipHistory ?? false}
+    set {_uniqueStorage()._skipHistory = newValue}
+  }
+  /// Returns true if `skipHistory` has been explicitly set.
+  var hasSkipHistory: Bool {_storage._skipHistory != nil}
+  /// Clears the value of `skipHistory`. Subsequent reads from it will return its default value.
+  mutating func clearSkipHistory() {_uniqueStorage()._skipHistory = nil}
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -1440,7 +1450,7 @@ nonisolated extension Playbridge_SubtitleResource: SwiftProtobuf.Message, SwiftP
 
 nonisolated extension Playbridge_PlayPayload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PlayPayload"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}url\0\u{1}title\0\u{1}headers\0\u{3}content_type\0\u{1}subtitles\0\u{3}detected_by\0\u{3}player_mode\0\u{3}preferred_audio_language\0\u{3}preferred_subtitle_language\0\u{3}default_video_quality\0\u{3}max_bitrate_cap_mbps\0\u{3}visual_metadata\0\u{3}binge_group\0\u{3}start_position_ms\0\u{3}allowed_private_origins\0\u{3}subtitle_resources\0\u{3}media_kind\0\u{3}display_duration_ms\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}url\0\u{1}title\0\u{1}headers\0\u{3}content_type\0\u{1}subtitles\0\u{3}detected_by\0\u{3}player_mode\0\u{3}preferred_audio_language\0\u{3}preferred_subtitle_language\0\u{3}default_video_quality\0\u{3}max_bitrate_cap_mbps\0\u{3}visual_metadata\0\u{3}binge_group\0\u{3}start_position_ms\0\u{3}allowed_private_origins\0\u{3}subtitle_resources\0\u{3}media_kind\0\u{3}display_duration_ms\0\u{3}skip_history\0")
 
   fileprivate class _StorageClass {
     var _url: String = String()
@@ -1461,6 +1471,7 @@ nonisolated extension Playbridge_PlayPayload: SwiftProtobuf.Message, SwiftProtob
     var _subtitleResources: [Playbridge_SubtitleResource] = []
     var _mediaKind: String? = nil
     var _displayDurationMs: Int64? = nil
+    var _skipHistory: Bool? = nil
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -1489,6 +1500,7 @@ nonisolated extension Playbridge_PlayPayload: SwiftProtobuf.Message, SwiftProtob
       _subtitleResources = source._subtitleResources
       _mediaKind = source._mediaKind
       _displayDurationMs = source._displayDurationMs
+      _skipHistory = source._skipHistory
     }
   }
 
@@ -1525,6 +1537,7 @@ nonisolated extension Playbridge_PlayPayload: SwiftProtobuf.Message, SwiftProtob
         case 16: try { try decoder.decodeRepeatedMessageField(value: &_storage._subtitleResources) }()
         case 17: try { try decoder.decodeSingularStringField(value: &_storage._mediaKind) }()
         case 18: try { try decoder.decodeSingularInt64Field(value: &_storage._displayDurationMs) }()
+        case 19: try { try decoder.decodeSingularBoolField(value: &_storage._skipHistory) }()
         default: break
         }
       }
@@ -1591,6 +1604,9 @@ nonisolated extension Playbridge_PlayPayload: SwiftProtobuf.Message, SwiftProtob
       try { if let v = _storage._displayDurationMs {
         try visitor.visitSingularInt64Field(value: v, fieldNumber: 18)
       } }()
+      try { if let v = _storage._skipHistory {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 19)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1618,6 +1634,7 @@ nonisolated extension Playbridge_PlayPayload: SwiftProtobuf.Message, SwiftProtob
         if _storage._subtitleResources != rhs_storage._subtitleResources {return false}
         if _storage._mediaKind != rhs_storage._mediaKind {return false}
         if _storage._displayDurationMs != rhs_storage._displayDurationMs {return false}
+        if _storage._skipHistory != rhs_storage._skipHistory {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/protocol/proto/messages.proto
+++ b/protocol/proto/messages.proto
@@ -91,6 +91,8 @@ message PlayPayload {
   // For image items only. Positive values auto-advance after this display time;
   // omitted or zero keeps the image visible until explicit navigation.
   optional int64 display_duration_ms = 18 [json_name = "displayDurationMs"];
+  // Do not persist receiver history, resume progress, or captured history artwork.
+  optional bool skip_history = 19 [json_name = "skipHistory"];
 }
 
 message PlaylistPayload {

--- a/shared/src/commonMain/kotlin/com/playbridge/shared/player/PlayerViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/playbridge/shared/player/PlayerViewModel.kt
@@ -355,6 +355,7 @@ class PlayerViewModel(
 
     private suspend fun saveCurrentProgress() {
         val payload = currentPayload ?: return
+        if (payload.skip_history == true) return
         val pos = position.value
         val dur = duration.value
         if (dur > 0 && pos > 0) {

--- a/shared/src/commonTest/kotlin/com/playbridge/shared/player/PlayerViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/playbridge/shared/player/PlayerViewModelTest.kt
@@ -330,4 +330,22 @@ class PlayerViewModelTest {
         vm.next() // triggers saveCurrentProgress internally
         assertEquals(123_000, resumeStore.loadPosition(directPayload.url))
     }
+    @Test
+    fun `private cast preserves existing progress and later public cast saves again`() = runTest(testDispatcher) {
+        resumeStore.savePosition(directPayload.url, 42_000)
+        vm.onPayload(directPayload.copy(skip_history = true))
+        engine.emitState(PlaybackState.Playing)
+        engine.emitPosition(123_000)
+        engine.emitDuration(300_000)
+        vm.next()
+        assertEquals(42_000, resumeStore.loadPosition(directPayload.url))
+
+        vm.onPayload(directPayload)
+        engine.emitState(PlaybackState.Playing)
+        engine.emitPosition(150_000)
+        engine.emitDuration(300_000)
+        vm.next()
+        assertEquals(150_000, resumeStore.loadPosition(directPayload.url))
+    }
+
 }

--- a/tv/android/geckoview-plugin/app/src/main/java/com/playbridge/geckoview/plugin/BrowserActivity.kt
+++ b/tv/android/geckoview-plugin/app/src/main/java/com/playbridge/geckoview/plugin/BrowserActivity.kt
@@ -53,6 +53,7 @@ class BrowserActivity : ComponentActivity() {
     private var canGoBack = false
     private var currentUrl: String? = null
     private var explicitlyClosing = false
+    private var replacedByAnotherMode = false
 
     // Drag state — tracks an in-progress click-drag (e.g. seekbar scrubbing)
     private var isDragging = false
@@ -449,6 +450,13 @@ class BrowserActivity : ComponentActivity() {
     }
 
     private fun handleBrowserControlCommand(action: String?) {
+        if (action == "dismiss") {
+            // The replacement owns the context; teardown must not announce idle.
+            replacedByAnotherMode = true
+            engine?.pauseForBackground()
+            finish()
+            return
+        }
         Log.d(TAG, "Browser control: $action")
         when (action) {
             "refresh" -> engine?.reload()
@@ -564,6 +572,7 @@ class BrowserActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
+        if (isFinishing || replacedByAnotherMode) return
         engine?.resumeAfterBackground()
     }
 
@@ -576,7 +585,7 @@ class BrowserActivity : ComponentActivity() {
         // Notify the player app's ServerService that the browser session has ended so it can
         // reset activeContext to "idle".
         try {
-            if (explicitlyClosing || isFinishing) {
+            if (!replacedByAnotherMode && (explicitlyClosing || isFinishing)) {
                 val idleIntent = Intent("com.playbridge.player.ACTION_CONTEXT_IDLE").apply {
                     setPackage("com.playbridge.player")
                 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/browser/BrowserActivity.kt
@@ -58,6 +58,7 @@ class BrowserActivity : ComponentActivity() {
     private var canGoBack = false
     private var currentUrl: String? = null
     private var explicitlyClosing = false
+    private var replacedByAnotherMode = false
 
     // Drag state — tracks an in-progress click-drag (e.g. seekbar scrubbing)
     private var isDragging = false
@@ -871,6 +872,13 @@ class BrowserActivity : ComponentActivity() {
     }
 
     private fun handleBrowserControlCommand(action: String?) {
+        if (action == "dismiss") {
+            // The replacement owns the context; teardown must not announce idle.
+            replacedByAnotherMode = true
+            engine?.pauseForBackground()
+            finish()
+            return
+        }
         Log.d(TAG, "Browser control: $action")
         // Absolute seek from the phone scrubber (value in ms) — prefix, so handled
         // before the exact-match when below.
@@ -1004,10 +1012,11 @@ class BrowserActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
+        if (isFinishing || replacedByAnotherMode) return
         engine?.resumeAfterBackground()
         // Claim the server context for the browser whenever we're foregrounded — so a
         // context_query reports "browser" regardless of how this activity was launched,
-        // and we reclaim it after returning from a player launched on top of us.
+        // including when opened directly from TV settings.
         com.playbridge.player.server.ServerService.notifyContextBrowser(this)
     }
 
@@ -1028,7 +1037,7 @@ class BrowserActivity : ComponentActivity() {
         // Reset ServerService.activeContext so PairingScreen can open again after a
         // browser session. Same contract as the external Gecko APK uses.
         try {
-            if (explicitlyClosing || isFinishing) {
+            if (!replacedByAnotherMode && (explicitlyClosing || isFinishing)) {
                 val idleIntent = Intent("com.playbridge.player.ACTION_CONTEXT_IDLE").apply {
                     setPackage("com.playbridge.player")
                 }

--- a/tv/android/player/app/src/main/java/com/playbridge/player/data/HistoryStore.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/data/HistoryStore.kt
@@ -94,6 +94,9 @@ class HistoryStore(private val context: Context) {
         thumbnailUrl: String? = null,
         playbackContext: PlaybackContext? = null,
     ) {
+        if (com.playbridge.shared.protocol.decodePlaylistPayloadJson(payloadJson)
+                ?.items?.any { it.skip_history == true } == true
+        ) return
         val logKey = historyLogKey(id)
         if (url.isBlank() || payloadJson.isBlank()) {
             FileLogger.w(

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerHostActivity.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/PlayerHostActivity.kt
@@ -1434,7 +1434,7 @@ class PlayerHostActivity : ComponentActivity(), PlaybackProgressSource {
         val thumbnailUrl = visualMetadata?.backdrop_url
             ?: visualMetadata?.poster_url
             ?: historyThumbnailStore.existingUrl(historyId)
-        currentHistoryId = historyId
+        currentHistoryId = historyId.takeUnless { items.any { it.skip_history == true } }
         currentHistoryHasThumbnail = thumbnailUrl != null
         resetHistoryThumbnailCaptureClock()
         progressManager.setCurrentMedia(
@@ -2288,6 +2288,11 @@ class PlayerHostActivity : ComponentActivity(), PlaybackProgressSource {
     }
 
     private fun handleControl(command: String?) {
+        // Mode switches must also finish a host still waiting for its renderer to bind.
+        if (command == "stop") {
+            finishPlaybackSession()
+            return
+        }
         if (currentMediaKind == MediaKind.IMAGE) {
             val currentSession = session ?: return
             when (command) {
@@ -2308,7 +2313,6 @@ class PlayerHostActivity : ComponentActivity(), PlaybackProgressSource {
                     controlsViewModel.showControls(full = true, playing = false)
                 }
                 "toggle" -> handleControl(if (imageTimerRunning) "pause" else "play")
-                "stop" -> finishPlaybackSession()
             }
             broadcastCurrentState()
             return
@@ -2353,11 +2357,6 @@ class PlayerHostActivity : ComponentActivity(), PlaybackProgressSource {
                     controlsViewModel.setPlaying(true)
                     runCatching { renderer.play(currentSession.sessionId) }
                 }
-            }
-            command == "stop" -> {
-                finishingSession = true
-                runCatching { renderer.stop(currentSession.sessionId) }
-                finish()
             }
             command?.startsWith("seek_to:") == true -> command
                 .removePrefix("seek_to:")

--- a/tv/android/player/app/src/main/java/com/playbridge/player/player/ProgressManager.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/player/ProgressManager.kt
@@ -33,6 +33,7 @@ class ProgressManager(
     private val lifecycleScope: LifecycleCoroutineScope,
     private val playbackSource: PlaybackProgressSource,
 ) {
+    private var skipHistory = false
     private var currentUrl: String? = null
     private var currentTitle: String? = null
     private var currentContentType: String? = null
@@ -77,6 +78,8 @@ class ProgressManager(
         videoScalingMode: Int? = null,
         playbackContext: PlaybackContext? = null,
     ) {
+        skipHistory = com.playbridge.shared.protocol.decodePlaylistPayloadJson(payloadJson)
+            ?.items?.any { it.skip_history == true } == true
         currentUrl = url
         currentTitle = title
         currentContentType = contentType
@@ -154,6 +157,7 @@ class ProgressManager(
      * used to be the only save points are skipped on a force-stop / swipe-away.
      */
     fun recordLanded(startPositionMs: Long) {
+        if (skipHistory) return
         val url = currentUrl ?: return
         val payloadJson = currentPayloadJson ?: return
         val historyId = currentHistoryId ?: return
@@ -189,6 +193,7 @@ class ProgressManager(
      * Persist the current playback position and whichever artwork the host most recently set.
      */
     fun saveProgress() {
+        if (skipHistory) return
         val duration = playbackSource.getMediaDuration()
         val position = playbackSource.getCurrentPosition()
         val url = currentUrl

--- a/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
+++ b/tv/android/player/app/src/main/java/com/playbridge/player/server/ServerService.kt
@@ -492,6 +492,14 @@ class ServerService : Service() {
                 DebugNetworkLogger.urlAndHeaders(TAG, "Browser command", url, null)
 
                 val useGecko = browserMode == "gecko"
+                stopPlayerForBrowser()
+                dismissBrowsers(
+                    exceptPackage = if (useGecko && isGeckoApkInstalled()) {
+                        "com.playbridge.geckoview.plugin"
+                    } else {
+                        packageName
+                    },
+                )
 
                 if (useGecko) {
                     if (isGeckoApkInstalled()) {
@@ -631,6 +639,7 @@ class ServerService : Service() {
                         putExtra(EXTRA_COMMAND, "stop")
                         setPackage(packageName)
                     })
+                    dismissBrowsers()
                     activeContext = "screen_mirror"
                     broadcastContext()
                 }
@@ -885,7 +894,28 @@ class ServerService : Service() {
         }
     }
 
+    /** Remove browser activities from their tasks when another mode takes over. */
+    private fun dismissBrowsers(exceptPackage: String? = null) {
+        for (browserPackage in listOf(packageName, "com.playbridge.geckoview.plugin")) {
+            if (browserPackage == exceptPackage) continue
+            sendBroadcast(Intent(ACTION_BROWSER_CONTROL).apply {
+                setPackage(browserPackage)
+                putExtra(EXTRA_BROWSER_ACTION, "dismiss")
+            })
+        }
+    }
+
+    private fun stopPlayerForBrowser() {
+        sendBroadcast(Intent(ACTION_CONTROL).apply {
+            setPackage(packageName)
+            putExtra(EXTRA_COMMAND, "stop")
+            putExtra(EXTRA_TARGET_PLAYER_ENGINE, activePlayerEngine)
+        })
+        activePlayerEngine = null
+    }
+
     internal fun setContextPlayerInternal(engine: String? = null) {
+        dismissBrowsers()
         activeContext = "player"
         if (engine != null) activePlayerEngine = engine
         broadcastContext()
@@ -893,6 +923,8 @@ class ServerService : Service() {
     }
 
     internal fun setContextBrowserInternal() {
+        if (activeContext == "player") stopPlayerForBrowser()
+        dismissBrowsers(exceptPackage = packageName)
         activeContext = "browser"
         broadcastContext()
         FileLogger.d(TAG, "activeContext set to browser by activity lifecycle")


### PR DESCRIPTION
## Summary

Add an optional `skipHistory` flag on `PlayPayload` so senders can keep new casts out of supporting PlayBridge receiver history, resume progress, and captured history artwork. Existing history is left unchanged. Older receivers ignore the field.

Also included in this change set:

- Android TV mode-switch: dismiss browser sessions and stop a waiting player host when another mode takes over, so teardown does not announce idle.
- Docs: mark iOS Library/addons and Debrid as intentional App Store omissions (Guideline 5.2.3), not porting targets.

## Behavior

- **Protocol:** `skipHistory` on `PlayPayload` (protobuf field 19 / JSON `skipHistory`). A playlist containing any marked item must not be persisted in full.
- **Android phone:** TV settings switch "Prevent TV cast history" stamps `skipHistory` onto `playlist` and `queue_add` at send time.
- **Desktop sender:** matching "Prevent receiver cast history" preference; does not mutate the original payload objects.
- **Android TV + Desktop receivers:** skip history rows, resume saves, and artwork capture for marked items. A later public cast of the same URL can save again.
- Preference applies to subsequently sent items only. Sender-side watch tracking is unchanged.

## Tests

- `mobile/android`: `:app:testFossDebugUnitTest --tests CastHistoryCommandTest --tests PlayerViewModelTest`
- `desktop`: `flutter test test/cast_history_test.dart test/player_controller_test.dart`

## Risks / manual verification

- Confirm an updated Android TV and Desktop receiver omit history/progress for private casts, and that existing favorites/history stay put.
- Confirm an older TV/Desktop build still plays the cast (flag ignored).
- Confirm TV browser → player and player → browser switches no longer leave a stale context or idle announcement.
- iOS sender does not implement this preference yet.